### PR TITLE
DROOLS-3957: Remove unused dependencies

### DIFF
--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/pom.xml
@@ -33,10 +33,6 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
     </dependency>
     <dependency>

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/pom.xml
@@ -35,10 +35,6 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-structure-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-services-api</artifactId>
     </dependency>
     <dependency>
@@ -80,10 +76,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.soup</groupId>


### PR DESCRIPTION
During https://github.com/kiegroup/kie-wb-common/pull/2784 review these unused dependencies were found.