### PR TITLE
KOGITO-460: [DMN Designer] Remove the ability to add imported models

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.widgets.client.kogito.IsKogito;
 import org.uberfire.client.annotations.DefaultPosition;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
@@ -69,6 +70,8 @@ public class DecisionNavigatorPresenter {
 
     private final TranslationService translationService;
 
+    private final IsKogito isKogito;
+
     private CanvasHandler handler;
 
     @Inject
@@ -78,7 +81,8 @@ public class DecisionNavigatorPresenter {
                                       final DecisionNavigatorObserver decisionNavigatorObserver,
                                       final DecisionNavigatorChildrenTraverse navigatorChildrenTraverse,
                                       final DecisionNavigatorItemFactory itemFactory,
-                                      final TranslationService translationService) {
+                                      final TranslationService translationService,
+                                      final IsKogito isKogito) {
         this.view = view;
         this.treePresenter = treePresenter;
         this.decisionComponents = decisionComponents;
@@ -86,6 +90,7 @@ public class DecisionNavigatorPresenter {
         this.navigatorChildrenTraverse = navigatorChildrenTraverse;
         this.itemFactory = itemFactory;
         this.translationService = translationService;
+        this.isKogito = isKogito;
     }
 
     @WorkbenchPartView
@@ -171,7 +176,12 @@ public class DecisionNavigatorPresenter {
 
     void setupView() {
         view.setupMainTree(treePresenter.getView());
-        view.setupDecisionComponents(decisionComponents.getView());
+        if (!isKogito.get()) {
+            view.showDecisionComponentsContainer();
+            view.setupDecisionComponents(decisionComponents.getView());
+        } else {
+            view.hideDecisionComponentsContainer();
+        }
     }
 
     public void refreshTreeView() {
@@ -218,5 +228,10 @@ public class DecisionNavigatorPresenter {
         void setupMainTree(final DecisionNavigatorTreePresenter.View mainTreeComponent);
 
         void setupDecisionComponents(final DecisionComponents.View decisionComponentsComponent);
+
+        void showDecisionComponentsContainer();
+
+        void hideDecisionComponentsContainer();
+
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorView.html
@@ -33,7 +33,7 @@
             </div>
         </div>
     </div>
-    <div>
+    <div data-field="decision-components-container">
         <div class="panel-group" id="decision-component-header">
             <div class="panel panel-default">
                 <div class="panel-heading" data-component="collapse-heading">

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorView.java
@@ -24,11 +24,17 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.client.docks.navigator.included.components.DecisionComponents;
 import org.kie.workbench.common.dmn.client.docks.navigator.tree.DecisionNavigatorTreePresenter;
 
+import static org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper.hide;
+import static org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper.show;
+
 @Templated
 public class DecisionNavigatorView implements DecisionNavigatorPresenter.View {
 
     @DataField("main-tree")
     private final HTMLDivElement mainTree;
+
+    @DataField("decision-components-container")
+    private final HTMLDivElement decisionComponentsContainer;
 
     @DataField("decision-components")
     private final HTMLDivElement decisionComponents;
@@ -37,8 +43,10 @@ public class DecisionNavigatorView implements DecisionNavigatorPresenter.View {
 
     @Inject
     public DecisionNavigatorView(final HTMLDivElement mainTree,
+                                 final HTMLDivElement decisionComponentsContainer,
                                  final HTMLDivElement decisionComponents) {
         this.mainTree = mainTree;
+        this.decisionComponentsContainer = decisionComponentsContainer;
         this.decisionComponents = decisionComponents;
     }
 
@@ -55,5 +63,15 @@ public class DecisionNavigatorView implements DecisionNavigatorPresenter.View {
     @Override
     public void setupDecisionComponents(final DecisionComponents.View decisionComponentsComponent) {
         decisionComponents.appendChild(decisionComponentsComponent.getElement());
+    }
+
+    @Override
+    public void showDecisionComponentsContainer() {
+        show(decisionComponentsContainer);
+    }
+
+    @Override
+    public void hideDecisionComponentsContainer() {
+        hide(decisionComponentsContainer);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.widgets.client.kogito.IsKogito;
 import org.mockito.Mock;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.Position;
@@ -77,6 +78,9 @@ public class DecisionNavigatorPresenterTest {
     @Mock
     private TranslationService translationService;
 
+    @Mock
+    private IsKogito isKogito;
+
     private DecisionNavigatorPresenter presenter;
 
     @Before
@@ -87,7 +91,8 @@ public class DecisionNavigatorPresenterTest {
                                                        decisionNavigatorObserver,
                                                        navigatorChildrenTraverse,
                                                        itemFactory,
-                                                       translationService));
+                                                       translationService,
+                                                       isKogito));
     }
 
     @Test
@@ -136,7 +141,25 @@ public class DecisionNavigatorPresenterTest {
         presenter.setupView();
 
         verify(view).setupMainTree(treeView);
+        verify(view).showDecisionComponentsContainer();
         verify(view).setupDecisionComponents(decisionComponentsView);
+    }
+
+    @Test
+    public void testSetupViewWhenIsKogito() {
+
+        final DecisionNavigatorTreePresenter.View treeView = mock(DecisionNavigatorTreePresenter.View.class);
+        final DecisionComponents.View decisionComponentsView = mock(DecisionComponents.View.class);
+
+        when(treePresenter.getView()).thenReturn(treeView);
+        when(decisionComponents.getView()).thenReturn(decisionComponentsView);
+        when(isKogito.get()).thenReturn(true);
+
+        presenter.setupView();
+
+        verify(view).setupMainTree(treeView);
+        verify(view).hideDecisionComponentsContainer();
+        verify(view, never()).setupDecisionComponents(decisionComponentsView);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorViewTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.docks.navigator;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.DOMTokenList;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import org.junit.Before;
@@ -26,6 +27,7 @@ import org.kie.workbench.common.dmn.client.docks.navigator.included.components.D
 import org.kie.workbench.common.dmn.client.docks.navigator.tree.DecisionNavigatorTreePresenter;
 import org.mockito.Mock;
 
+import static org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper.HIDDEN_CSS_CLASS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -36,6 +38,9 @@ public class DecisionNavigatorViewTest {
 
     @Mock
     private HTMLDivElement divMainTree;
+
+    @Mock
+    private HTMLDivElement decisionComponentsContainer;
 
     @Mock
     private HTMLDivElement decisionComponents;
@@ -50,7 +55,7 @@ public class DecisionNavigatorViewTest {
 
     @Before
     public void setup() {
-        view = spy(new DecisionNavigatorView(divMainTree, decisionComponents));
+        view = spy(new DecisionNavigatorView(divMainTree, decisionComponentsContainer, decisionComponents));
     }
 
     @Test
@@ -73,5 +78,27 @@ public class DecisionNavigatorViewTest {
         view.setupDecisionComponents(decisionComponentsView);
 
         verify(decisionComponents).appendChild(element);
+    }
+
+    @Test
+    public void testShowDecisionComponentsContainer() {
+        final DOMTokenList classList = mock(DOMTokenList.class);
+
+        decisionComponentsContainer.classList = classList;
+
+        view.showDecisionComponentsContainer();
+
+        verify(classList).remove(HIDDEN_CSS_CLASS);
+    }
+
+    @Test
+    public void testHideDecisionComponentsContainer() {
+        final DOMTokenList classList = mock(DOMTokenList.class);
+
+        decisionComponentsContainer.classList = classList;
+
+        view.hideDecisionComponentsContainer();
+
+        verify(classList).add(HIDDEN_CSS_CLASS);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -29,8 +29,6 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
-import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
-import org.kie.workbench.common.dmn.client.editors.included.imports.IncludedModelsPageStateProviderImpl;
 import org.kie.workbench.common.dmn.client.editors.search.DMNEditorSearchIndex;
 import org.kie.workbench.common.dmn.client.editors.search.DMNSearchableElement;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
@@ -93,7 +91,7 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
 
     public static final String EDITOR_ID = "DMNDiagramEditor";
 
-    //Editor tabs: [0] Main editor, [1] Documentation, [2] Data-Types, [3] Imported Models
+    //Editor tabs: [0] Main editor, [1] Documentation, [2] Data-Types
     public static final int DATA_TYPES_PAGE_INDEX = 2;
 
     protected final SessionManager sessionManager;
@@ -108,8 +106,6 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
     protected final OpenDiagramLayoutExecutor openDiagramLayoutExecutor;
 
     protected final DataTypesPage dataTypesPage;
-    protected final IncludedModelsPage includedModelsPage;
-    protected final IncludedModelsPageStateProviderImpl importsPageProvider;
 
     protected final DMNEditorSearchIndex editorSearchIndex;
     protected final SearchBarComponent<DMNSearchableElement> searchBarComponent;
@@ -142,8 +138,6 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
                                     final LayoutHelper layoutHelper,
                                     final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                                     final DataTypesPage dataTypesPage,
-                                    final IncludedModelsPage includedModelsPage,
-                                    final IncludedModelsPageStateProviderImpl importsPageProvider,
                                     final KogitoClientDiagramService diagramServices) {
         super(view,
               fileMenuBuilder,
@@ -172,8 +166,6 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
         this.openDiagramLayoutExecutor = openDiagramLayoutExecutor;
 
         this.dataTypesPage = dataTypesPage;
-        this.includedModelsPage = includedModelsPage;
-        this.importsPageProvider = importsPageProvider;
 
         this.editorSearchIndex = editorSearchIndex;
         this.searchBarComponent = searchBarComponent;
@@ -200,7 +192,6 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
         superInitialiseKieEditorForSession(diagram);
 
         getWidget().getMultiPage().addPage(dataTypesPage);
-        getWidget().getMultiPage().addPage(includedModelsPage);
 
         setupEditorSearchIndex();
         setupSearchComponent();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -25,8 +25,6 @@ import org.kie.workbench.common.dmn.api.DMNDefinitionSet;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
-import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
-import org.kie.workbench.common.dmn.client.editors.included.imports.IncludedModelsPageStateProviderImpl;
 import org.kie.workbench.common.dmn.client.editors.search.DMNEditorSearchIndex;
 import org.kie.workbench.common.dmn.client.editors.search.DMNSearchableElement;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
@@ -185,12 +183,6 @@ public abstract class AbstractDMNDiagramEditorTest {
     protected DataTypesPage dataTypesPage;
 
     @Mock
-    protected IncludedModelsPage includedModelsPage;
-
-    @Mock
-    protected IncludedModelsPageStateProviderImpl importsPageProvider;
-
-    @Mock
     protected KogitoClientDiagramService clientDiagramService;
 
     @Mock
@@ -267,7 +259,6 @@ public abstract class AbstractDMNDiagramEditorTest {
         when(sessionManager.getCurrentSession()).thenReturn(session);
         when(session.getExpressionEditor()).thenReturn(expressionEditor);
 
-        when(importsPageProvider.withDiagram(diagram)).thenReturn(importsPageProvider);
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(editorPresenter.getInstance()).thenReturn(session);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
@@ -395,7 +386,7 @@ public abstract class AbstractDMNDiagramEditorTest {
         openDiagram();
 
         //Setting focus activates the diagram identically to opening a diagram; so reset applicable mocks.
-        reset(decisionNavigatorDock, diagramPropertiesDock, diagramPreviewDock, dataTypesPage, includedModelsPage);
+        reset(decisionNavigatorDock, diagramPropertiesDock, diagramPreviewDock, dataTypesPage);
 
         editor.onFocus();
 
@@ -472,7 +463,6 @@ public abstract class AbstractDMNDiagramEditorTest {
     protected void openDiagram() {
         editor.onStartup(place);
 
-        when(importsPageProvider.withDiagram(diagram)).thenReturn(importsPageProvider);
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
         when(editorPresenter.getInstance()).thenReturn(session);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
@@ -485,6 +475,5 @@ public abstract class AbstractDMNDiagramEditorTest {
     protected void assertOnDiagramLoad() {
         verify(decisionNavigatorDock).setupCanvasHandler(canvasHandler);
         verify(dataTypesPage).reload();
-        verify(includedModelsPage).setup(importsPageProvider);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -26,8 +26,6 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
-import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
-import org.kie.workbench.common.dmn.client.editors.included.imports.IncludedModelsPageStateProviderImpl;
 import org.kie.workbench.common.dmn.client.editors.search.DMNEditorSearchIndex;
 import org.kie.workbench.common.dmn.client.editors.search.DMNSearchableElement;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
@@ -102,8 +100,6 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final LayoutHelper layoutHelper,
                             final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                             final DataTypesPage dataTypesPage,
-                            final IncludedModelsPage includedModelsPage,
-                            final IncludedModelsPageStateProviderImpl importsPageProvider,
                             final KogitoClientDiagramService diagramServices) {
         super(view,
               fileMenuBuilder,
@@ -131,8 +127,6 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               layoutHelper,
               openDiagramLayoutExecutor,
               dataTypesPage,
-              includedModelsPage,
-              importsPageProvider,
               diagramServices);
     }
 
@@ -145,7 +139,6 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
             expressionEditor.setToolbarStateHandler(new DMNProjectToolbarStateHandler(getMenuSessionItems()));
             decisionNavigatorDock.setupCanvasHandler(c);
             dataTypesPage.reload();
-            includedModelsPage.setup(importsPageProvider.withDiagram(c.getDiagram()));
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -66,8 +66,6 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                                     layoutHelper,
                                     layoutExecutor,
                                     dataTypesPage,
-                                    includedModelsPage,
-                                    importsPageProvider,
                                     clientDiagramService) {
             @Override
             protected ElementWrapperWidget<?> getWidget(final HTMLElement element) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -27,8 +27,6 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
-import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
-import org.kie.workbench.common.dmn.client.editors.included.imports.IncludedModelsPageStateProviderImpl;
 import org.kie.workbench.common.dmn.client.editors.search.DMNEditorSearchIndex;
 import org.kie.workbench.common.dmn.client.editors.search.DMNSearchableElement;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
@@ -124,8 +122,6 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final LayoutHelper layoutHelper,
                             final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                             final DataTypesPage dataTypesPage,
-                            final IncludedModelsPage includedModelsPage,
-                            final IncludedModelsPageStateProviderImpl importsPageProvider,
                             final KogitoClientDiagramService diagramServices,
                             final DMNVFSService vfsService,
                             final Promises promises) {
@@ -155,8 +151,6 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               layoutHelper,
               openDiagramLayoutExecutor,
               dataTypesPage,
-              includedModelsPage,
-              importsPageProvider,
               diagramServices);
         this.notificationEvent = notificationEvent;
         this.vfsService = vfsService;
@@ -209,7 +203,6 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
             expressionEditor.setToolbarStateHandler(new DMNProjectToolbarStateHandler(getMenuSessionItems()));
             decisionNavigatorDock.setupCanvasHandler(c);
             dataTypesPage.reload();
-            includedModelsPage.setup(importsPageProvider.withDiagram(c.getDiagram()));
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -140,8 +140,6 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                                     layoutHelper,
                                     layoutExecutor,
                                     dataTypesPage,
-                                    includedModelsPage,
-                                    importsPageProvider,
                                     clientDiagramService,
                                     vfsService,
                                     promises) {


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-460

This JIRA/PR now simply removes the "Imports" tab from _kogito_ editors. It also removes the "Decision Components" from the "Decision Navigator" as that shows imported types.