### PR TITLE
KOGITO-743 : Delete button on Mac keyboard does not work

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/event/keyboard/KeyboardEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/event/keyboard/KeyboardEvent.java
@@ -23,6 +23,7 @@ public interface KeyboardEvent {
     enum Key {
         ESC(KeyCodes.KEY_ESCAPE),
         CONTROL(KeyCodes.KEY_CTRL),
+        KEY_BACKSPACE(KeyCodes.KEY_BACKSPACE),
         ALT(KeyCodes.KEY_ALT),
         SHIFT(KeyCodes.KEY_SHIFT),
         DELETE(KeyCodes.KEY_DELETE),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommand.java
@@ -156,8 +156,7 @@ public class DeleteSelectionSessionCommand extends AbstractSelectionAwareSession
     }
 
     private void handleDelete(final KeyboardEvent.Key... keys) {
-        if (doKeysMatch(keys,
-                        KeyboardEvent.Key.DELETE)) {
+        if ((doKeysMatch(keys, KeyboardEvent.Key.DELETE)) || doKeysMatch(keys, KeyboardEvent.Key.KEY_BACKSPACE)) {
             this.execute();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/BaseSessionCommandKeyboardTest.java
@@ -83,6 +83,10 @@ public abstract class BaseSessionCommandKeyboardTest {
     @Test
     @SuppressWarnings("unchecked")
     public void checkRespondsToExpectedKeys() {
+        checkRespondsToExpectedKeysMatch(getExpectedKeys());
+    }
+
+    public void checkRespondsToExpectedKeysMatch(final KeyboardEvent.Key[] keys) {
         doReturn(true).when(command).isEnabled();
 
         command.bind(session);
@@ -91,7 +95,7 @@ public abstract class BaseSessionCommandKeyboardTest {
                times(1)).addKeyShortcutCallback(keyShortcutCallbackCaptor.capture());
 
         final KeyShortcutCallback keyShortcutCallback = keyShortcutCallbackCaptor.getValue();
-        keyShortcutCallback.onKeyShortcut(getExpectedKeys());
+        keyShortcutCallback.onKeyShortcut(keys);
 
         verify(command,
                times(1)).execute(any(ClientSessionCommand.Callback.class));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
@@ -113,6 +113,11 @@ public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboar
         verify(canvasClearSelectionEventEvent, never()).fire(any());
     }
 
+    @Test
+    public void testExecuteBackSpaceKeys() {
+       this.checkRespondsToExpectedKeysMatch(new KeyboardEvent.Key[]{KeyboardEvent.Key.KEY_BACKSPACE});
+    }
+
     @Test(expected = IllegalStateException.class)
     public void testEmptyConstructor() {
         DeleteSelectionSessionCommand del = new DeleteSelectionSessionCommand();


### PR DESCRIPTION
Hi @hasys @romartin can you check this PR? Backspace is now enabled for Mac/Linux/Windows