### PR TITLE
KOGITO-616: DMN Tooling produce single line source

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/resources/org/kie/workbench/common/dmn/webapp/kogito/common/js/FormatterJs.js
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/resources/org/kie/workbench/common/dmn/webapp/kogito/common/js/FormatterJs.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+FormatterJs = {
+
+    cachedXsltProcessor: null,
+
+    format: function (xmlDocument) {
+        if (this.cachedXsltProcessor === null) {
+            this.cachedXsltProcessor = this.newXsltProcessor();
+        }
+        var resultDocument = this.cachedXsltProcessor.transformToDocument(xmlDocument);
+        return new XMLSerializer().serializeToString(resultDocument);
+    },
+
+    newXsltProcessor: function newXsltProcessor() {
+        var xsltDoc = new DOMParser().parseFromString(
+                [
+                    '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">',
+                    '  <xsl:strip-space elements="*"/>',
+                    '  <xsl:template match="para[content-style][not(text())]">',
+                    '    <xsl:value-of select="normalize-space(.)"/>',
+                    "  </xsl:template>",
+                    '  <xsl:template match="node()|@*">',
+                    '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
+                    "  </xsl:template>",
+                    '  <xsl:output indent="yes"/>',
+                    "</xsl:stylesheet>"
+                ].join("\n"),
+                "application/xml"
+        );
+
+        var xsltProcessor = new XSLTProcessor();
+        xsltProcessor.importStylesheet(xsltDoc);
+        return xsltProcessor;
+    }
+
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/src/main/resources/org/kie/workbench/common/dmn/webapp/kogito/marshaller/js/MainJs.js
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/src/main/resources/org/kie/workbench/common/dmn/webapp/kogito/marshaller/js/MainJs.js
@@ -9,8 +9,6 @@ MainJs = {
 
     mappings: [DC, DI, DMNDI12, DMN12, KIE],
 
-    cachedXsltProcessor: null,
-
     initializeJsInteropConstructors: function (constructorsMap) {
 
         var extraTypes = [{typeName: 'Name', namespace: null}];
@@ -104,36 +102,14 @@ MainJs = {
 
         // Create unmarshaller
         var marshaller = context.createMarshaller();
-
         var xmlDocument = marshaller.marshalDocument(value);
-        callback(this.format(xmlDocument));
-    },
-
-    newXsltProcessor: function newXsltProcessor() {
-        var xsltDoc = new DOMParser().parseFromString(
-                [
-                    '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">',
-                    '  <xsl:strip-space elements="*"/>',
-                    '  <xsl:template match="para[content-style][not(text())]">',
-                    '    <xsl:value-of select="normalize-space(.)"/>',
-                    "  </xsl:template>",
-                    '  <xsl:template match="node()|@*">',
-                    '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
-                    "  </xsl:template>",
-                    '  <xsl:output indent="yes"/>',
-                    "</xsl:stylesheet>"
-                ].join("\n"),
-                "application/xml"
-        );
-
-        var xsltProcessor = new XSLTProcessor();
-        xsltProcessor.importStylesheet(xsltDoc);
-        return xsltProcessor;
-    },
-
-    format: function (xmlDocument) {
-        this.cachedXsltProcessor = this.cachedXsltProcessor === null ? this.newXsltProcessor() : this.cachedXsltProcessor;
-        var resultDocument = this.cachedXsltProcessor.transformToDocument(xmlDocument);
-        return new XMLSerializer().serializeToString(resultDocument);
+        if (typeof FormatterJs !== "undefined") {
+            var toReturn = FormatterJs.format(xmlDocument);
+            callback(toReturn);
+        } else {
+            var s = new XMLSerializer();
+            var toReturn = s.serializeToString(xmlDocument);
+            callback(toReturn);
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/.gitignore
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/.gitignore
@@ -15,6 +15,7 @@
 /src/main/webapp/model/KIE.js
 /src/main/webapp/model/Jsonix-all.js
 /src/main/webapp/model/MainJs.js
+/src/main/webapp/model/FormatterJs.js
 
 # Eclipse, Netbeans and IntelliJ files
 /.*

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
@@ -755,6 +755,26 @@
                   </artifactItems>
                 </configuration>
               </execution>
+              <execution>
+                <id>Unpack FormatterJS JS from dependency</id>
+                <phase>process-sources</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.kie.workbench</groupId>
+                      <artifactId>kie-wb-common-dmn-webapp-kogito-common</artifactId>
+                      <version>${version.org.kie}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${project.build.directory}/DMNMarshaller</outputDirectory>
+                      <includes>**/*.js</includes>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/index.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/index.html
@@ -29,6 +29,7 @@
     <script type="text/javascript" src="model/DMN12.js"></script>
     <script type="text/javascript" src="model/KIE.js"></script>
     <script type="text/javascript" src="model/MainJs.js"></script>
+    <script type="text/javascript" src="model/FormatterJs.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-616

@tiagobento I'm up for suggestions how we can avoid the duplication when running the DMN kogito editor in the `kogito-tooling` wrapper.. Is there anyway I can check if [your](https://github.com/kiegroup/kogito-tooling/blob/master/packages/kie-bc-editors/src/DefaultXmlFormatter.ts) `cachedXsltProcessor` is available/defined from JavaScript and re-use it?