### PR TITLE
DROOLS-4696: [DMN Designer] BC DOs as DMN DTs - Show a warning message into the import dialog

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/editors/types/DataObject.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/editors/types/DataObject.java
@@ -52,5 +52,15 @@ public class DataObject {
     public void setProperties(final List<DataObjectProperty> properties) {
         this.properties = properties;
     }
+
+    public String getClassNameWithoutPackage() {
+
+        int lastIndex = 0;
+        if (classType.contains(".")) {
+            lastIndex = classType.lastIndexOf('.') + 1;
+        }
+
+        return classType.substring(lastIndex);
+    }
 }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/editors/types/DataObjectTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/editors/types/DataObjectTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.editors.types;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataObjectTest {
+
+    @Test
+    public void testExtractName() {
+
+        final String name1 = "org.java.SomeClass";
+        final DataObject dataObject = new DataObject(name1);
+        final String expected1 = "SomeClass";
+
+        final String actual1 = dataObject.getClassNameWithoutPackage();
+        assertEquals(expected1, actual1);
+
+        final String name2 = "SomeOtherClass";
+        final String expected2 = "SomeOtherClass";
+
+        final DataObject dataObject2 = new DataObject(name2);
+        final String actual2 = dataObject2.getClassNameWithoutPackage();
+        assertEquals(expected2, actual2);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModal.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModal.java
@@ -36,6 +36,8 @@ public class ImportDataObjectModal extends Elemental2Modal<ImportDataObjectModal
 
     private Consumer<List<DataObject>> dataObjectsConsumer;
 
+    private List<String> existingDataTypes;
+
     @Inject
     public ImportDataObjectModal(final View view,
                                  final DMNClientServicesProxy client) {
@@ -52,7 +54,20 @@ public class ImportDataObjectModal extends Elemental2Modal<ImportDataObjectModal
         callSuperSetup();
     }
 
-    void callSuperSetup(){
+    Consumer<List<DataObject>> getOnDataObjectSelectionChanged() {
+        return this::onDataObjectSelectionChanged;
+    }
+
+    void onDataObjectSelectionChanged(final List<DataObject> dataObjects) {
+
+        if (dataObjects.stream().anyMatch(dataObject -> getExistingDataTypes().contains(dataObject.getClassNameWithoutPackage()))) {
+            getView().showDataTypeWithSameNameWarning();
+        } else {
+            getView().hideDataTypeWithSameNameWarning();
+        }
+    }
+
+    void callSuperSetup() {
         super.setup();
     }
 
@@ -68,9 +83,14 @@ public class ImportDataObjectModal extends Elemental2Modal<ImportDataObjectModal
         super.hide();
     }
 
-    @Override
-    public void show() {
+    public void show(final List<String> existingDataTypes) {
+        this.existingDataTypes = existingDataTypes;
         client.loadDataObjects(wrap(getConsumer()));
+        superShow();
+    }
+
+    public List<String> getExistingDataTypes() {
+        return existingDataTypes;
     }
 
     ServiceCallback<List<DataObject>> wrap(final Consumer<List<DataObject>> consumer) {
@@ -105,5 +125,9 @@ public class ImportDataObjectModal extends Elemental2Modal<ImportDataObjectModal
         void addItems(final List<DataObject> dataObjects);
 
         void clear();
+
+        void showDataTypeWithSameNameWarning();
+
+        void hideDataTypeWithSameNameWarning();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModal.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModal.java
@@ -84,6 +84,7 @@ public class ImportDataObjectModal extends Elemental2Modal<ImportDataObjectModal
     }
 
     public void show(final List<String> existingDataTypes) {
+        getView().hideDataTypeWithSameNameWarning();
         this.existingDataTypes = existingDataTypes;
         client.loadDataObjects(wrap(getConsumer()));
         superShow();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalView.html
@@ -17,6 +17,10 @@
     <div data-field="view">
         <div data-field="header" data-i18n-key="Header"></div>
         <div data-field="body" class="kie-import-data-object-modal-view-body">
+            <div data-field="warning-container" class="alert alert-warning">
+                <span class="pficon pficon-warning-triangle-o"></span>
+                <strong data-i18n-key="DataTypeWithSameNameFound"></strong>
+            </div>
             <div data-field="top-elements-container">
                 <span data-i18n-key="ProjectDataObjects"></span>
                 <div><a data-field="clear-selection" href="#" data-i18n-key="ClearSelection"></a></div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalView.less
@@ -15,6 +15,24 @@
  */
 
 .kie-import-data-object-modal-view-body {
+
+  .alert {
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: all 0.15s linear;
+    padding: 0 0 0 47px;
+    margin: 5px;
+  }
+
+  .alert.opened {
+    opacity: 1;
+    max-height: 100px;
+    padding: 11px 14px 10px 47px;
+    margin-bottom: 20px;
+    transition: all 0.15s linear;
+  }
+
   #data-object-items-container {
     height: 200px;
     overflow-y: scroll;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeList.java
@@ -16,6 +16,8 @@
 package org.kie.workbench.common.dmn.client.editors.types.imported.treelist;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.Dependent;
@@ -30,6 +32,8 @@ public class TreeList {
     private final View view;
 
     private List<TreeListItem> currentItems;
+
+    private Consumer<List<TreeListItem>> onSelectionChanged;
 
     @Inject
     public TreeList(final View view) {
@@ -46,6 +50,18 @@ public class TreeList {
         for (final TreeListItem item : getCurrentItems()) {
             item.updateView();
             view.add(item);
+            item.setOnIsSelectedChanged(this::selectionChanged);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    void selectionChanged(final TreeListItem treeListItem) {
+        callOnSelectionChanged();
+    }
+
+    void callOnSelectionChanged() {
+        if (!Objects.isNull(getOnSelectionChanged())) {
+            getOnSelectionChanged().accept(getSelectedItems());
         }
     }
 
@@ -69,6 +85,14 @@ public class TreeList {
         return getCurrentItems().stream()
                 .filter(item -> item.getIsSelected())
                 .collect(Collectors.toList());
+    }
+
+    public void setOnSelectionChanged(final Consumer<List<TreeListItem>> onSelectionChanged) {
+        this.onSelectionChanged = onSelectionChanged;
+    }
+
+    Consumer<List<TreeListItem>> getOnSelectionChanged() {
+        return onSelectionChanged;
     }
 
     public interface View extends UberElemental<TreeList> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeListItem.java
@@ -17,6 +17,8 @@ package org.kie.workbench.common.dmn.client.editors.types.imported.treelist;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
@@ -34,6 +36,7 @@ public class TreeListItem {
     private String description;
     private boolean isSelected;
     private DataObject dataSource;
+    private Consumer<TreeListItem> onIsSelectedChanged;
 
     @Inject
     public TreeListItem(final View view) {
@@ -72,6 +75,13 @@ public class TreeListItem {
 
     public void setIsSelected(final boolean value) {
         this.isSelected = value;
+        callOnIsSelectedChanged();
+    }
+
+    void callOnIsSelectedChanged() {
+        if (!Objects.isNull(getOnIsSelectedChanged())) {
+            getOnIsSelectedChanged().accept(this);
+        }
     }
 
     public boolean getIsSelected() {
@@ -84,6 +94,14 @@ public class TreeListItem {
 
     public DataObject getDataSource() {
         return this.dataSource;
+    }
+
+    public void setOnIsSelectedChanged(final Consumer<TreeListItem> onIsSelectedChanged) {
+        this.onIsSelectedChanged = onIsSelectedChanged;
+    }
+
+    public Consumer<TreeListItem> getOnIsSelectedChanged() {
+        return onIsSelectedChanged;
     }
 
     public interface View extends UberElemental<TreeListItem> {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -413,7 +414,7 @@ public class DataTypeList {
         renamed.clear();
 
         for (final DataObject dataObject : imported) {
-            final String nameCandidate = extractName(dataObject.getClassType());
+            final String nameCandidate = dataObject.getClassNameWithoutPackage();
             final String newName = buildName(nameCandidate, namesCount);
             renamed.put(dataObject.getClassType(), newName);
             dataObject.setClassType(newName);
@@ -460,16 +461,6 @@ public class DataTypeList {
         namesCount.put(nameCandidate, 1);
 
         return nameCandidate;
-    }
-
-    String extractName(final String fullQualifiedName) {
-
-        int lastIndex = 0;
-        if (fullQualifiedName.contains(".")) {
-            lastIndex = fullQualifiedName.lastIndexOf('.') + 1;
-        }
-
-        return fullQualifiedName.substring(lastIndex);
     }
 
     void insertProperties(final DataObject dataObject) {
@@ -519,6 +510,12 @@ public class DataTypeList {
         getItems().stream()
                 .filter(item -> Objects.equals(item.getDataType().getParentUUID(), uuid))
                 .forEach(child -> child.disableEditMode());
+    }
+
+    public List<String> getExistingDataTypesNames() {
+        return getItems().stream()
+                .map(item -> item.getDataType().getName())
+                .collect(Collectors.toList());
     }
 
     public interface View extends UberElemental<DataTypeList>,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
@@ -514,6 +514,7 @@ public class DataTypeList {
 
     public List<String> getExistingDataTypesNames() {
         return getItems().stream()
+                .filter(item -> item.getDataType().isTopLevel())
                 .map(item -> item.getDataType().getName())
                 .collect(Collectors.toList());
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.java
@@ -241,9 +241,10 @@ public class DataTypeListView implements DataTypeList.View {
         presenter.addDataType();
     }
 
+    @SuppressWarnings("unused")
     @EventHandler("import-data-object-button")
     public void onImportDataObjectClick(final ClickEvent e) {
-        importDataObjectModal.show();
+        importDataObjectModal.show(presenter.getExistingDataTypesNames());
     }
 
     @EventHandler("read-only-message-close-button")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
@@ -278,3 +278,4 @@ ImportDataObjectModalView.Cancel=Cancel
 ImportDataObjectModalView.Import=Import
 ImportDataObjectModalView.ClearSelection=Clear selection
 ImportDataObjectModalView.ProjectDataObjects=Project Data Objects
+ImportDataObjectModalView.DataTypeWithSameNameFound=A DMN Data Type with the same name already exists! If you proceed it will be overwritten.

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalTest.java
@@ -68,6 +68,7 @@ public class ImportDataObjectModalTest {
 
         verify(modal).superShow();
         verify(client).loadDataObjects(serviceCallback);
+        verify(view).hideDataTypeWithSameNameWarning();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.imported;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -32,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,11 +59,14 @@ public class ImportDataObjectModalTest {
 
         final Consumer consumer = mock(Consumer.class);
         final ServiceCallback serviceCallback = mock(ServiceCallback.class);
+        final List<String> existingDataTypes = mock(List.class);
         doReturn(serviceCallback).when(modal).wrap(consumer);
         doReturn(consumer).when(modal).getConsumer();
+        doNothing().when(modal).superShow();
 
-        modal.show();
+        modal.show(existingDataTypes);
 
+        verify(modal).superShow();
         verify(client).loadDataObjects(serviceCallback);
     }
 
@@ -94,7 +99,10 @@ public class ImportDataObjectModalTest {
     public void testSetup() {
 
         final Consumer<List<DataObject>> consumer = mock(Consumer.class);
+        final Consumer onDataObjectSelectionChanged = mock(Consumer.class);
         doNothing().when(modal).callSuperSetup();
+        doReturn(onDataObjectSelectionChanged).when(modal).getOnDataObjectSelectionChanged();
+
         modal.setup(consumer);
 
         verify(modal).callSuperSetup();
@@ -106,8 +114,10 @@ public class ImportDataObjectModalTest {
 
         final List<DataObject> importedObjects = mock(List.class);
         final Consumer<List<DataObject>> consumer = mock(Consumer.class);
+
         doNothing().when(modal).callSuperSetup();
         doNothing().when(modal).superHide();
+
         modal.setup(consumer);
 
         modal.hide(importedObjects);
@@ -127,5 +137,50 @@ public class ImportDataObjectModalTest {
         modal.hide(importedObjects);
 
         verify(modal).superHide();
+    }
+
+    @Test
+    public void testOnDataObjectSelectionChangedAndHasDuplicatedName() {
+
+        final String name1 = "name1";
+        final String name2 = "name2";
+        final String name3 = "name3";
+        final List<String> existingDataTypes = Arrays.asList(name1, name2, name3);
+        final DataObject do1 = createDataObject(name1);
+        final DataObject do2 = createDataObject(name2);
+        final DataObject do3 = createDataObject(name3);
+        final List<DataObject> dataObjects = Arrays.asList(do1, do2, do3);
+        doReturn(existingDataTypes).when(modal).getExistingDataTypes();
+
+        modal.onDataObjectSelectionChanged(dataObjects);
+
+        verify(view).showDataTypeWithSameNameWarning();
+        verify(view, never()).hideDataTypeWithSameNameWarning();
+    }
+
+    @Test
+    public void testOnDataObjectSelectionChangedAndDoesntHasDuplicatedName() {
+
+        final String name1 = "name1";
+        final String name2 = "name2";
+        final String name3 = "name3";
+        final List<String> existingDataTypes = Arrays.asList("unique1", "unique2", "unique3");
+        final DataObject do1 = createDataObject(name1);
+        final DataObject do2 = createDataObject(name2);
+        final DataObject do3 = createDataObject(name3);
+        final List<DataObject> dataObjects = Arrays.asList(do1, do2, do3);
+        doReturn(existingDataTypes).when(modal).getExistingDataTypes();
+
+        modal.onDataObjectSelectionChanged(dataObjects);
+
+        verify(view, never()).showDataTypeWithSameNameWarning();
+        verify(view).hideDataTypeWithSameNameWarning();
+    }
+
+    private DataObject createDataObject(final String name) {
+
+        final DataObject dataObject = mock(DataObject.class);
+        when(dataObject.getClassNameWithoutPackage()).thenReturn(name);
+        return dataObject;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/ImportDataObjectModalViewTest.java
@@ -39,6 +39,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.types.imported.ImportDataObjectModalView.OPENED_CONTAINER_CSS_CLASS;
@@ -309,9 +310,7 @@ public class ImportDataObjectModalViewTest {
         final List<DataObject> values = dataObjectsCaptor.getValue();
 
         assertEquals(3, values.size());
-        assertTrue(values.contains(do1));
-        assertTrue(values.contains(do2));
-        assertTrue(values.contains(do3));
+        assertThat(values).containsExactly(do1, do2, do3);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeListItemTest.java
@@ -16,22 +16,29 @@
 
 package org.kie.workbench.common.dmn.client.editors.types.imported.treelist;
 
+import java.util.function.Consumer;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.Node;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class TreeListItemTest {
 
     @Mock
@@ -45,7 +52,7 @@ public class TreeListItemTest {
     @Before
     public void setup() {
 
-        treeListItem = new TreeListItem(view);
+        treeListItem = spy(new TreeListItem(view));
         when(view.getElement()).thenReturn(viewElement);
     }
 
@@ -92,10 +99,35 @@ public class TreeListItemTest {
     @Test
     public void testGetSetIsSelected() {
 
+        doNothing().when(treeListItem).callOnIsSelectedChanged();
         treeListItem.setIsSelected(true);
         assertTrue(treeListItem.getIsSelected());
 
         treeListItem.setIsSelected(false);
         assertFalse(treeListItem.getIsSelected());
+
+        verify(treeListItem, times(2)).callOnIsSelectedChanged();
+    }
+
+    @Test
+    public void testCallOnIsSelectedChanged() {
+
+        final Consumer consumer = mock(Consumer.class);
+        doReturn(consumer).when(treeListItem).getOnIsSelectedChanged();
+
+        treeListItem.callOnIsSelectedChanged();
+
+        verify(consumer).accept(treeListItem);
+    }
+
+    @Test
+    public void testCallOnIsSelectedChangedWhenConsumerIsNotSet() {
+
+        final Consumer consumer = mock(Consumer.class);
+        doReturn(null).when(treeListItem).getOnIsSelectedChanged();
+
+        treeListItem.callOnIsSelectedChanged();
+
+        verify(consumer, never()).accept(treeListItem);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/imported/treelist/TreeListTest.java
@@ -18,14 +18,15 @@ package org.kie.workbench.common.dmn.client.editors.types.imported.treelist;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.Node;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,11 +34,12 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class TreeListTest {
 
     @Mock
@@ -125,5 +127,42 @@ public class TreeListTest {
         assertTrue(selectedItems.contains(itemThree));
         assertFalse(selectedItems.contains(itemOne));
         assertFalse(selectedItems.contains(itemTwo));
+    }
+
+    @Test
+    public void testSelectionChanged() {
+
+        final TreeListItem treeListItem = mock(TreeListItem.class);
+        doNothing().when(treeList).callOnSelectionChanged();
+
+        treeList.selectionChanged(treeListItem);
+
+        verify(treeList).callOnSelectionChanged();
+    }
+
+    @Test
+    public void testCallOnSelectionChanged() {
+
+        final List selectedItems = mock(List.class);
+        final Consumer consumer = mock(Consumer.class);
+        doReturn(consumer).when(treeList).getOnSelectionChanged();
+        doReturn(selectedItems).when(treeList).getSelectedItems();
+
+        treeList.callOnSelectionChanged();
+
+        verify(consumer).accept(selectedItems);
+    }
+
+    @Test
+    public void testCallOnSelectionChangedWhenConsumerIsNotSet() {
+
+        final List selectedItems = mock(List.class);
+        final Consumer consumer = mock(Consumer.class);
+        doReturn(null).when(treeList).getOnSelectionChanged();
+        doReturn(selectedItems).when(treeList).getSelectedItems();
+
+        treeList.callOnSelectionChanged();
+
+        verify(consumer, never()).accept(selectedItems);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
@@ -1106,6 +1106,10 @@ public class DataTypeListTest {
         final DataTypeListItem listItem3 = mock(DataTypeListItem.class);
         final List<DataTypeListItem> items = Arrays.asList(listItem1, listItem2, listItem3);
 
+        when(dataType1.isTopLevel()).thenReturn(true);
+        when(dataType2.isTopLevel()).thenReturn(false);
+        when(dataType3.isTopLevel()).thenReturn(true);
+
         when(listItem1.getDataType()).thenReturn(dataType1);
         when(listItem2.getDataType()).thenReturn(dataType2);
         when(listItem3.getDataType()).thenReturn(dataType3);
@@ -1114,9 +1118,9 @@ public class DataTypeListTest {
 
         final List<String> names = dataTypeList.getExistingDataTypesNames();
 
-        assertEquals(3, names.size());
+        assertEquals(2, names.size());
         assertTrue(names.contains(name1));
-        assertTrue(names.contains(name2));
+        assertFalse(names.contains(name2));
         assertTrue(names.contains(name3));
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
@@ -857,9 +857,10 @@ public class DataTypeListTest {
         doReturn(renamed).when(dataTypeList).getRenamedImportedDataTypes();
 
         final List<DataObject> imported = Arrays.asList(do1, do2, do3);
-        doReturn(extractedName1).when(dataTypeList).extractName(do1Class);
-        doReturn(extractedName2).when(dataTypeList).extractName(do2Class);
-        doReturn(extractedName3).when(dataTypeList).extractName(do3Class);
+        when(do1.getClassNameWithoutPackage()).thenReturn(extractedName1);
+        when(do2.getClassNameWithoutPackage()).thenReturn(extractedName2);
+        when(do3.getClassNameWithoutPackage()).thenReturn(extractedName3);
+
         doReturn(builtName1).when(dataTypeList).buildName(extractedName1, namesCount);
         doReturn(builtName2).when(dataTypeList).buildName(extractedName2, namesCount);
         doReturn(builtName3).when(dataTypeList).buildName(extractedName3, namesCount);
@@ -868,19 +869,19 @@ public class DataTypeListTest {
 
         dataTypeList.removeFullQualifiedNames(imported);
 
-        verify(dataTypeList).extractName(do1Class);
+        verify(do1).getClassNameWithoutPackage();
         verify(dataTypeList).buildName(extractedName1, namesCount);
         assertTrue(renamed.containsKey(do1Class));
         assertEquals(builtName1, renamed.get(do1Class));
         verify(do1).setClassType(builtName1);
 
-        verify(dataTypeList).extractName(do2Class);
+        verify(do2).getClassNameWithoutPackage();
         verify(dataTypeList).buildName(extractedName2, namesCount);
         assertTrue(renamed.containsKey(do2Class));
         assertEquals(builtName2, renamed.get(do2Class));
         verify(do2).setClassType(builtName2);
 
-        verify(dataTypeList).extractName(do3Class);
+        verify(do3).getClassNameWithoutPackage();
         verify(dataTypeList).buildName(extractedName3, namesCount);
         assertTrue(renamed.containsKey(do3Class));
         assertEquals(builtName3, renamed.get(do3Class));
@@ -895,22 +896,6 @@ public class DataTypeListTest {
         final DataObject dataObject = mock(DataObject.class);
         when(dataObject.getClassType()).thenReturn(className);
         return dataObject;
-    }
-
-    @Test
-    public void testExtractName() {
-
-        final String name1 = "org.java.SomeClass";
-        final String expected1 = "SomeClass";
-
-        final String actual1 = dataTypeList.extractName(name1);
-        assertEquals(expected1, actual1);
-
-        final String name2 = "SomeOtherClass";
-        final String expected2 = "SomeOtherClass";
-
-        final String actual2 = dataTypeList.extractName(name2);
-        assertEquals(expected2, actual2);
     }
 
     @Test
@@ -1105,6 +1090,34 @@ public class DataTypeListTest {
         verify(child1).disableEditMode();
         verify(child2).disableEditMode();
         verify(notChildItem, never()).disableEditMode();
+    }
+
+    @Test
+    public void testGetExistingDataTypeNames() {
+
+        final String name1 = "name1";
+        final String name2 = "name2";
+        final String name3 = "name3";
+        final DataType dataType1 = makeDataType(name1, "whatever");
+        final DataType dataType2 = makeDataType(name2, "whatever");
+        final DataType dataType3 = makeDataType(name3, "whatever");
+        final DataTypeListItem listItem1 = mock(DataTypeListItem.class);
+        final DataTypeListItem listItem2 = mock(DataTypeListItem.class);
+        final DataTypeListItem listItem3 = mock(DataTypeListItem.class);
+        final List<DataTypeListItem> items = Arrays.asList(listItem1, listItem2, listItem3);
+
+        when(listItem1.getDataType()).thenReturn(dataType1);
+        when(listItem2.getDataType()).thenReturn(dataType2);
+        when(listItem3.getDataType()).thenReturn(dataType3);
+
+        doReturn(items).when(dataTypeList).getItems();
+
+        final List<String> names = dataTypeList.getExistingDataTypesNames();
+
+        assertEquals(3, names.size());
+        assertTrue(names.contains(name1));
+        assertTrue(names.contains(name2));
+        assertTrue(names.contains(name3));
     }
 
     private DataTypeListItem listItem(final DataType dataType) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
@@ -692,6 +692,19 @@ public class DataTypeListViewTest {
         verify(classList).add(HIDDEN_CSS_CLASS);
     }
 
+    @Test
+    public void testOnImportDataObjectClick() {
+
+        final ClickEvent event = mock(ClickEvent.class);
+        final List<String> list = mock(List.class);
+
+        when(presenter.getExistingDataTypesNames()).thenReturn(list);
+
+        view.onImportDataObjectClick(event);
+
+        verify(importDataObjectModal).show(list);
+    }
+
     private HTMLElement makeHTMLElement() {
         final HTMLElement element = mock(HTMLElement.class);
         element.parentNode = mock(Node.class);


### PR DESCRIPTION
If you want to simplify the tests, you can change the class [MockDataObjectsServiceImpl](https://github.com/kiegroup/kie-wb-common/blob/62c0b90027441bdb0dbb3171fa796464e8215d92/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/src/main/java/org/kie/workbench/common/dmn/showcase/backend/workarounds/MockDataObjectsServiceImpl.java) to return some DataObjects during the review.

For example:
```
        DataObject do1 = new DataObject("something.MyType");
        DataObject do2 = new DataObject("something.MyOtherType");
        DataObject do3 = new DataObject("something.Abc");
        return Arrays.asList(do1, do2, do3);
```