### PR TITLE
DROOLS-4807: [DMN Designer] Do not group V&V messages by UUID

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/ProjectValidationServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/main/java/org/kie/workbench/common/stunner/project/backend/service/ProjectValidationServiceImpl.java
@@ -57,10 +57,7 @@ public class ProjectValidationServiceImpl implements ProjectValidationService {
         return domainViolations(diagram).stream()
                 .filter(v -> Objects.nonNull(v.getUUID()))
                 .filter(v -> !"null".equals(v.getUUID()))
-                .collect(Collectors.groupingBy(DomainViolation::getUUID))
-                .entrySet()
-                .stream()
-                .map(e -> new ElementViolationImpl.Builder().setUuid(e.getKey()).setDomainViolations(e.getValue()).build())
+                .map(v -> new ElementViolationImpl.Builder().setUuid(v.getUUID()).setDomainViolations(Collections.singletonList(v)).build())
                 .collect(Collectors.toList());
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/ProjectValidationServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/ProjectValidationServiceImplTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.project.backend.service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -135,22 +136,23 @@ public class ProjectValidationServiceImplTest {
         final Collection<DiagramElementViolation<RuleViolation>> violations = validationService.validate(diagram);
         verify(diagram).getMetadata();
         verify(metadata).getDefinitionSetId();
-        assertEquals(violations.size(), 2);
+        assertEquals(violations.size(), 4);
 
-        List<DomainViolation> violations0 = Arrays.asList(domainViolation);
-        List<DomainViolation> violations1 =
-                Arrays.asList(domainViolation2, domainViolation3, domainViolation4);
+        final List<DiagramElementViolation<RuleViolation>> ordered = new ArrayList<>(violations);
+        assertEquals(ordered.get(0).getUUID(), UUID_0);
+        assertEquals(ordered.get(0).getDomainViolations().size(), 1);
+        assertEquals(ordered.get(0).getDomainViolations().iterator().next(), domainViolation);
 
-        assertEquals(violations.stream()
-                             .filter(v -> UUID_1.equals(v.getUUID()))
-                             .findFirst()
-                             .map(DiagramElementViolation::getDomainViolations)
-                             .get(), violations1);
+        assertEquals(ordered.get(1).getUUID(), UUID_1);
+        assertEquals(ordered.get(1).getDomainViolations().size(), 1);
+        assertEquals(ordered.get(1).getDomainViolations().iterator().next(), domainViolation2);
 
-        assertEquals(violations.stream()
-                             .filter(v -> UUID_0.equals(v.getUUID()))
-                             .findFirst()
-                             .map(DiagramElementViolation::getDomainViolations)
-                             .get(), violations0);
+        assertEquals(ordered.get(2).getUUID(), UUID_1);
+        assertEquals(ordered.get(2).getDomainViolations().size(), 1);
+        assertEquals(ordered.get(2).getDomainViolations().iterator().next(), domainViolation3);
+
+        assertEquals(ordered.get(3).getUUID(), UUID_1);
+        assertEquals(ordered.get(3).getDomainViolations().size(), 1);
+        assertEquals(ordered.get(3).getDomainViolations().iterator().next(), domainViolation4);
     }
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-4807

@hasys @romartin Please see the comment [here](https://issues.redhat.com/browse/DROOLS-4807?focusedCommentId=13823269&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13823269) suggesting the change in this PR should apply to BPMN in addition to DMN. 