### PR TITLE
JBPM-8914: Stunner - User task throws exception when you try to move it.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/service/AssigneeLiveSearchProjectService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/service/AssigneeLiveSearchProjectService.java
@@ -59,8 +59,8 @@ public class AssigneeLiveSearchProjectService implements AssigneeLiveSearchServi
     private Consumer<Throwable> searchErrorHandler;
 
     @Inject
-    public AssigneeLiveSearchProjectService(ClientUserSystemManager userSystemManager,
-                                            AssigneeLiveSearchEntryCreationEditor editor) {
+    public AssigneeLiveSearchProjectService(final ClientUserSystemManager userSystemManager,
+                                            final AssigneeLiveSearchEntryCreationEditor editor) {
         this.userSystemManager = userSystemManager;
         this.editor = editor;
     }
@@ -70,32 +70,45 @@ public class AssigneeLiveSearchProjectService implements AssigneeLiveSearchServi
         localSearchService = AssigneeLocalSearchService.build(editor);
     }
 
-    public void init(AssigneeType type) {
+    public void init(final AssigneeType type) {
         this.type = type;
     }
 
-    public void setSearchErrorHandler(Consumer<Throwable> searchErrorHandler) {
+    public void setSearchErrorHandler(final Consumer<Throwable> searchErrorHandler) {
         this.searchErrorHandler = searchErrorHandler;
     }
 
     @Override
-    public void search(String pattern,
-                       int maxResults,
-                       LiveSearchCallback<String> callback) {
+    public void search(final String pattern,
+                       final int maxResults,
+                       final LiveSearchCallback<String> callback) {
 
         final List<String> filteredCustomEntries = localSearchService.search(pattern);
 
-        RemoteCallback<AbstractEntityManager.SearchResponse<?>> searchResponseRemoteCallback = response -> processFilterResponse(response, filteredCustomEntries, maxResults, callback);
+        final RemoteCallback<AbstractEntityManager.SearchResponse<?>> remoteCallback =
+                newSafeRemoteCallback(response -> processSearchPatternResponse(response, filteredCustomEntries, maxResults, callback));
 
-        ErrorCallback<Message> searchErrorCallback = (message, throwable) -> processSearchError(filteredCustomEntries, maxResults, callback, throwable);
+        final ErrorCallback<Message> errorCallback =
+                newSafeErrorCallback((message, throwable) -> processSearchPatternError(filteredCustomEntries, maxResults, callback, throwable));
 
-        SearchRequestImpl request = new SearchRequestImpl(pattern, 1, maxResults);
+        doSearch(new SearchRequestImpl(pattern, 1, maxResults),
+                 remoteCallback,
+                 errorCallback);
+    }
 
-        if (AssigneeType.USER.equals(type)) {
-            userSystemManager.users(searchResponseRemoteCallback, searchErrorCallback).search(request);
-        } else {
-            userSystemManager.groups(searchResponseRemoteCallback, searchErrorCallback).search(request);
-        }
+    @Override
+    public void searchEntry(final String key,
+                            final LiveSearchCallback<String> callback) {
+
+        final RemoteCallback<AbstractEntityManager.SearchResponse<?>> remoteCallback =
+                newSafeRemoteCallback(response -> processEntrySearchResponse(key, response, callback));
+
+        final ErrorCallback<Message> errorCallback =
+                newSafeErrorCallback((message, throwable) -> processEntrySearchError(key, callback, throwable));
+
+        doSearch(new SearchRequestImpl(key, 1, 1),
+                 remoteCallback,
+                 errorCallback);
     }
 
     @Override
@@ -108,94 +121,18 @@ public class AssigneeLiveSearchProjectService implements AssigneeLiveSearchServi
         return editor;
     }
 
-    @Override
-    public void searchEntry(String key,
-                            LiveSearchCallback<String> callback) {
-
-        SearchRequestImpl request = new SearchRequestImpl(key, 1, 1);
-
-        ErrorCallback<Message> searchErrorCallback = (message, throwable) -> processSearchEntryError(key, callback, throwable);
-
-        RemoteCallback<AbstractEntityManager.SearchResponse<?>> searchResponseRemoteCallback = response -> searchEntry(key, response, callback);
-
-        if (AssigneeType.USER.equals(type)) {
-            userSystemManager.users(searchResponseRemoteCallback, searchErrorCallback).search(request);
-        } else {
-            userSystemManager.groups(searchResponseRemoteCallback, searchErrorCallback).search(request);
-        }
-    }
-
     @PreDestroy
     public void destroy() {
         localSearchService.destroy();
         localSearchService = null;
+        searchErrorHandler = null;
     }
 
-    private boolean processSearchEntryError(String key, LiveSearchCallback<String> callback, Throwable throwable) {
-        LiveSearchResults<String> results = new LiveSearchResults<>(1);
-        if (!isEmpty(key)) {
-            addCustomEntry(key);
-            results.add(key, key);
-        }
-        callback.afterSearch(results);
-        processError("It was not possible to get user or group: " + key + " from the users system.", throwable);
-        return false;
-    }
-
-    private boolean processSearchError(List<String> filteredCustomEntries, int maxResults, LiveSearchCallback<String> callback, Throwable throwable) {
-        int maxSize = maxResults > filteredCustomEntries.size() ? filteredCustomEntries.size() : maxResults;
-        maxSize = maxSize < 0 ? 0 : maxSize;
-        LiveSearchResults<String> result = new LiveSearchResults<>(maxSize);
-        filteredCustomEntries.subList(0, maxSize).forEach(entry -> result.add(entry, entry));
-        callback.afterSearch(result);
-        processError("It was not possible to execute search on the users system.", throwable);
-        return false;
-    }
-
-    private void processError(String errorMessage, Throwable throwable) {
-        LOGGER.log(Level.SEVERE, errorMessage, throwable);
-        if (searchErrorHandler != null) {
-            searchErrorHandler.accept(throwable);
-        }
-    }
-
-    private void searchEntry(String key,
-                             AbstractEntityManager.SearchResponse<?> response,
-                             LiveSearchCallback<String> liveSearchCallback) {
-
-        LiveSearchResults<String> results = new LiveSearchResults<>(1);
-
-        if (key != null) {
-            if (!getCustomEntries().contains(key)) {
-                Optional<?> exists = response.getResults().stream().filter(item -> {
-
-                    String value = null;
-
-                    if (item instanceof User) {
-                        value = ((User) item).getIdentifier();
-                    } else if (item instanceof Group) {
-                        value = ((Group) item).getName();
-                    }
-
-                    return key.equals(value);
-                }).findAny();
-
-                if (!exists.isPresent()) {
-                    addCustomEntry(key);
-                }
-            }
-            results.add(key, key);
-        }
-
-        liveSearchCallback.afterSearch(results);
-    }
-
-    protected void processFilterResponse(AbstractEntityManager.SearchResponse<?> response,
-                                         List<String> filteredCustomEntries,
-                                         int maxResults,
-                                         LiveSearchCallback<String> liveSearchCallback) {
-
-        Set<String> values = new TreeSet<>(filteredCustomEntries);
+    private void processSearchPatternResponse(AbstractEntityManager.SearchResponse<?> response,
+                                              List<String> filteredCustomEntries,
+                                              int maxResults,
+                                              LiveSearchCallback<String> liveSearchCallback) {
+        final Set<String> values = new TreeSet<>(filteredCustomEntries);
 
         response.getResults().forEach(item -> {
             String value = null;
@@ -220,7 +157,87 @@ public class AssigneeLiveSearchProjectService implements AssigneeLiveSearchServi
         liveSearchCallback.afterSearch(results);
     }
 
-    List<String> getCustomEntries() {
-        return localSearchService.getCustomEntries();
+    private void processEntrySearchResponse(String key,
+                                            AbstractEntityManager.SearchResponse<?> response,
+                                            LiveSearchCallback<String> liveSearchCallback) {
+        final LiveSearchResults<String> results = new LiveSearchResults<>(1);
+        if (key != null) {
+            if (!localSearchService.getCustomEntries().contains(key)) {
+                final Optional<?> exists = response.getResults().stream().filter(item -> {
+                    String value = null;
+                    if (item instanceof User) {
+                        value = ((User) item).getIdentifier();
+                    } else if (item instanceof Group) {
+                        value = ((Group) item).getName();
+                    }
+                    return key.equals(value);
+                }).findAny();
+                if (!exists.isPresent()) {
+                    addCustomEntry(key);
+                }
+            }
+            results.add(key, key);
+        }
+
+        liveSearchCallback.afterSearch(results);
+    }
+
+    private void doSearch(final SearchRequestImpl request,
+                          final RemoteCallback<AbstractEntityManager.SearchResponse<?>> remoteCallback,
+                          final ErrorCallback<Message> errorCallback) {
+        if (AssigneeType.USER.equals(type)) {
+            userSystemManager.users(remoteCallback, errorCallback).search(request);
+        } else {
+            userSystemManager.groups(remoteCallback, errorCallback).search(request);
+        }
+    }
+
+    private boolean processEntrySearchError(String key, LiveSearchCallback<String> callback, Throwable throwable) {
+        LiveSearchResults<String> results = new LiveSearchResults<>(1);
+        if (!isEmpty(key)) {
+            addCustomEntry(key);
+            results.add(key, key);
+        }
+        callback.afterSearch(results);
+        processError("It was not possible to get user or group: " + key + " from the users system.", throwable);
+        return false;
+    }
+
+    private boolean processSearchPatternError(List<String> filteredCustomEntries, int maxResults, LiveSearchCallback<String> callback, Throwable throwable) {
+        int maxSize = maxResults > filteredCustomEntries.size() ? filteredCustomEntries.size() : maxResults;
+        maxSize = maxSize < 0 ? 0 : maxSize;
+        LiveSearchResults<String> result = new LiveSearchResults<>(maxSize);
+        filteredCustomEntries.subList(0, maxSize).forEach(entry -> result.add(entry, entry));
+        callback.afterSearch(result);
+        processError("It was not possible to execute search on the users system.", throwable);
+        return false;
+    }
+
+    private <T> RemoteCallback<T> newSafeRemoteCallback(final RemoteCallback<T> callback) {
+        return response -> {
+            if (isInstanceAlive()) {
+                callback.callback(response);
+            }
+        };
+    }
+
+    private <T> ErrorCallback<T> newSafeErrorCallback(final ErrorCallback<T> callback) {
+        return (message, throwable) -> {
+            if (isInstanceAlive()) {
+                return callback.error(message, throwable);
+            }
+            return false;
+        };
+    }
+
+    private boolean isInstanceAlive() {
+        return null != localSearchService;
+    }
+
+    private void processError(String errorMessage, Throwable throwable) {
+        LOGGER.log(Level.SEVERE, errorMessage, throwable);
+        if (searchErrorHandler != null) {
+            searchErrorHandler.accept(throwable);
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/service/AssigneeLiveSearchProjectServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/service/AssigneeLiveSearchProjectServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.security.shared.api.GroupImpl;
@@ -365,6 +366,21 @@ public class AssigneeLiveSearchProjectServiceTest {
         // Destroy the instance before response callback executed...
         assigneeLiveSearchService.destroy();
         successCallback.callback(prepareSingleUserResponse());
+        // So the callback will never be called.
+        verify(callback, never()).afterSearch(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSearchResponseErrorCapturedButInstanceAlreadyDestroyed() {
+        assigneeLiveSearchService.init(AssigneeType.USER);
+        assigneeLiveSearchService.searchEntry("user", callback);
+        ArgumentCaptor<ErrorCallback> callbackArgumentCaptor = ArgumentCaptor.forClass(ErrorCallback.class);
+        verify(userSystemManager).users(any(), callbackArgumentCaptor.capture());
+        ErrorCallback<Message> errorCallback = callbackArgumentCaptor.getValue();
+        // Destroy the instance before response error callback executed...
+        assigneeLiveSearchService.destroy();
+        errorCallback.error(mock(Message.class), new RuntimeException());
         // So the callback will never be called.
         verify(callback, never()).afterSearch(any());
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/service/AssigneeLiveSearchProjectServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/service/AssigneeLiveSearchProjectServiceTest.java
@@ -81,6 +81,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchUsers() {
         assigneeLiveSearchService.init(AssigneeType.USER);
 
@@ -113,6 +114,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchUsersIncludeCustomEntries() {
         assigneeLiveSearchService.init(AssigneeType.USER);
 
@@ -147,6 +149,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchUsersIncludeCustomEntriesNotMatchSearchPattern() {
         assigneeLiveSearchService.init(AssigneeType.USER);
 
@@ -181,6 +184,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchGroups() {
         assigneeLiveSearchService.init(AssigneeType.GROUP);
 
@@ -213,6 +217,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchGroupsIncludeCustomEntries() {
         assigneeLiveSearchService.init(AssigneeType.GROUP);
 
@@ -247,6 +252,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchGroupsIncludeCustomEntriesNotMatchSearchPattern() {
         assigneeLiveSearchService.init(AssigneeType.GROUP);
 
@@ -281,6 +287,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchSingleUser() {
         assigneeLiveSearchService.init(AssigneeType.USER);
 
@@ -314,6 +321,7 @@ public class AssigneeLiveSearchProjectServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSearchSingleGroup() {
         assigneeLiveSearchService.init(AssigneeType.GROUP);
 
@@ -344,6 +352,21 @@ public class AssigneeLiveSearchProjectServiceTest {
 
         assertEquals(1, result.size());
         assertEquals("it", result.get(0).getValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSearchResponseCapturedButInstanceAlreadyDestroyed() {
+        assigneeLiveSearchService.init(AssigneeType.USER);
+        assigneeLiveSearchService.searchEntry("user", callback);
+        ArgumentCaptor<RemoteCallback> callbackArgumentCaptor = ArgumentCaptor.forClass(RemoteCallback.class);
+        verify(userSystemManager).users(callbackArgumentCaptor.capture(), any());
+        RemoteCallback<AbstractEntityManager.SearchResponse<?>> successCallback = callbackArgumentCaptor.getValue();
+        // Destroy the instance before response callback executed...
+        assigneeLiveSearchService.destroy();
+        successCallback.callback(prepareSingleUserResponse());
+        // So the callback will never be called.
+        verify(callback, never()).afterSearch(any());
     }
 
     @Test
@@ -436,7 +459,8 @@ public class AssigneeLiveSearchProjectServiceTest {
         expectedResults.forEach(expectedValue -> assertTrue(result.stream().anyMatch(entry -> entry.getValue().equals(expectedValue))));
     }
 
-    private AbstractEntityManager.SearchResponse<?> prepareUsersResponse() {
+    @SuppressWarnings("unchecked")
+    private static AbstractEntityManager.SearchResponse<?> prepareUsersResponse() {
 
         List result = new ArrayList();
 
@@ -447,7 +471,8 @@ public class AssigneeLiveSearchProjectServiceTest {
         return new SearchResponseImpl(result, 1, 1, 1, true);
     }
 
-    private AbstractEntityManager.SearchResponse<?> prepareSingleUserResponse() {
+    @SuppressWarnings("unchecked")
+    private static AbstractEntityManager.SearchResponse<?> prepareSingleUserResponse() {
 
         List result = new ArrayList();
 
@@ -456,7 +481,8 @@ public class AssigneeLiveSearchProjectServiceTest {
         return new SearchResponseImpl(result, 1, 1, 1, true);
     }
 
-    private AbstractEntityManager.SearchResponse<?> prepareGroupsResponse() {
+    @SuppressWarnings("unchecked")
+    private static AbstractEntityManager.SearchResponse<?> prepareGroupsResponse() {
 
         List result = new ArrayList();
 
@@ -467,7 +493,8 @@ public class AssigneeLiveSearchProjectServiceTest {
         return new SearchResponseImpl(result, 1, 1, 1, true);
     }
 
-    private AbstractEntityManager.SearchResponse<?> prepareSingleGroupResponse() {
+    @SuppressWarnings("unchecked")
+    private static AbstractEntityManager.SearchResponse<?> prepareSingleGroupResponse() {
 
         List result = new ArrayList();
 


### PR DESCRIPTION
Hey @hasys @treblereel @LuboTerifaj 

I'd been doing some deep analysis of [JBPM-8914](https://issues.redhat.com/browse/JBPM-8914) and found some conclusions:
* Forms (and all fields) are being rendered (created&destroyed) twice, so although not being strictly a bug, it has some implications on this bug - See reported [JBPM-8954](https://issues.redhat.com/browse/JBPM-8954)
* The NPE happens because, in this case, the form field is sending a request to the backend (to fetch users/groups), but on the meanwhile, the form field is being destroyed (due to above point), so once the response is being sent, the form field's state has been "destroyed"

I thin the best way to fix this situation, rather than getting into Errai's bus stuff and how it works, it's jsut assuming that the request can take long, and also that the component state may be destroyed on the meanwhile, so it's just a matter of checking if instance's state is still valid, once processing the reponse, otherwise just DO NOTHING. Also this fix keeps nullifying the class' fields, because I think ti's better to have the state clean (for further GC), and just do nothing if state is nullified.

So this PR replaces https://github.com/kiegroup/kie-wb-common/pull/3055, as IMO the fix is slightly better (it keeps destroying the state), and also because @treblereel is off, so we can manage it easily for now.

Thanks!!