### PR TITLE
KOGITO-780: [DMN Designer] Ensure -runtime WAR is created with 'production' parameters

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -508,10 +508,9 @@
               <strict>true</strict>
               <localWorkers>${gwt.compiler.localWorkers}</localWorkers>
               <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
-              <draftCompile>true</draftCompile>
-              <extraJvmArgs>-Xmx4096m -Xms1024m -Xss1M -XX:CompileThreshold=7000 -Derrai.dynamic_validation.enabled=true -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
               <module>org.kie.workbench.common.dmn.showcase.DMNKogitoRuntimeWebapp</module>
-              <logLevel>INFO</logLevel>
+              <extraJvmArgs>-Xmx4096m -Xms1024m -Xss1M -XX:CompileThreshold=7000 -Derrai.dynamic_validation.enabled=true -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
+
               <noServer>false</noServer>
               <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
               <disableCastChecking>true</disableCastChecking>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -510,6 +510,8 @@
               <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
               <module>org.kie.workbench.common.dmn.showcase.DMNKogitoRuntimeWebapp</module>
               <extraJvmArgs>-Xmx4096m -Xms1024m -Xss1M -XX:CompileThreshold=7000 -Derrai.dynamic_validation.enabled=true -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
+              <optimizationLevel>9</optimizationLevel>
+              <style>OBFUSCATED</style>
 
               <noServer>false</noServer>
               <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/resources/org/kie/workbench/common/dmn/showcase/DMNKogitoRuntimeWebapp.gwt.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/resources/org/kie/workbench/common/dmn/showcase/DMNKogitoRuntimeWebapp.gwt.xml
@@ -20,9 +20,8 @@
 
   <inherits name="org.kie.workbench.common.dmn.webapp.kogito.common.DMNWebappKogitoCommon"/>
 
-  <!-- We don't need to support IE10 or older -->
-  <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
-  <set-property name="user.agent" value="gecko1_8,safari"/>
+  <!-- We only need Chrome -->
+  <set-property name="user.agent" value="safari"/>
 
   <!-- To change the default logLevel -->
   <set-property name="gwt.logging.logLevel" value="SEVERE"/>


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-780..

Basically I removed the `draftCompile` flag and a duplicate `logLevel` entry.