### PR TITLE
KOGITO-599: [DMN Designer] BC DOs as DMN DTs - Hide import button on Kogito

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeList.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTyp
 import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDDataTypesHandler;
 import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.kie.workbench.common.dmn.client.editors.types.search.DataTypeSearchBar;
+import org.kie.workbench.common.widgets.client.kogito.IsKogito;
 import org.uberfire.client.mvp.UberElemental;
 
 import static java.util.Collections.singletonList;
@@ -68,6 +69,8 @@ public class DataTypeList {
 
     private final DNDDataTypesHandler dndDataTypesHandler;
 
+    private final IsKogito isKogito;
+
     private Consumer<DataTypeListItem> onDataTypeListItemUpdate = (e) -> { /* Nothing. */ };
 
     private List<DataTypeListItem> items = new ArrayList<>();
@@ -85,7 +88,8 @@ public class DataTypeList {
                         final DataTypeSearchBar searchBar,
                         final DNDListComponent dndListComponent,
                         final DataTypeStackHash dataTypeStackHash,
-                        final DNDDataTypesHandler dndDataTypesHandler) {
+                        final DNDDataTypesHandler dndDataTypesHandler,
+                        final IsKogito isKogito) {
         this.view = view;
         this.listItems = listItems;
         this.dataTypeManager = dataTypeManager;
@@ -93,6 +97,7 @@ public class DataTypeList {
         this.dndListComponent = dndListComponent;
         this.dataTypeStackHash = dataTypeStackHash;
         this.dndDataTypesHandler = dndDataTypesHandler;
+        this.isKogito = isKogito;
         this.importedNamesOccurrencesCount = new HashMap<>();
         this.renamedImportedDataTypes = new HashMap<>();
     }
@@ -102,6 +107,12 @@ public class DataTypeList {
         view.init(this);
         dndDataTypesHandler.init(this);
         dndListComponent.setOnDropItem(getOnDropDataType());
+
+        if (!isKogito.get()) {
+            view.showImportDataObjectButton();
+        } else {
+            view.hideImportDataObjectButton();
+        }
     }
 
     BiConsumer<Element, Element> getOnDropDataType() {
@@ -531,6 +542,10 @@ public class DataTypeList {
         void showNoDataTypesFound();
 
         void showReadOnlyMessage(final boolean show);
+
+        void showImportDataObjectButton();
+
+        void hideImportDataObjectButton();
 
         HTMLElement getListItems();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.java
@@ -402,4 +402,14 @@ public class DataTypeListView implements DataTypeList.View {
     public HTMLDivElement getListItems() {
         return listItems;
     }
+
+    @Override
+    public void showImportDataObjectButton() {
+        show(importDataObjectButton);
+    }
+
+    @Override
+    public void hideImportDataObjectButton() {
+        hide(importDataObjectButton);
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListTest.java
@@ -42,6 +42,7 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DN
 import org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListComponent;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.DataTypeStore;
 import org.kie.workbench.common.dmn.client.editors.types.search.DataTypeSearchBar;
+import org.kie.workbench.common.widgets.client.kogito.IsKogito;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
@@ -97,6 +98,9 @@ public class DataTypeListTest {
     @Mock
     private DNDDataTypesHandler dndDataTypesHandler;
 
+    @Mock
+    private IsKogito isKogito;
+
     private DataTypeStore dataTypeStore;
 
     private DataTypeStackHash dataTypeStackHash;
@@ -110,7 +114,14 @@ public class DataTypeListTest {
     public void setup() {
         dataTypeStore = new DataTypeStore();
         dataTypeStackHash = new DataTypeStackHash(dataTypeStore);
-        dataTypeList = spy(new DataTypeList(view, listItems, dataTypeManager, searchBar, dndListComponent, dataTypeStackHash, dndDataTypesHandler));
+        dataTypeList = spy(new DataTypeList(view,
+                                            listItems,
+                                            dataTypeManager,
+                                            searchBar,
+                                            dndListComponent,
+                                            dataTypeStackHash,
+                                            dndDataTypesHandler,
+                                            isKogito));
         when(listItems.get()).thenReturn(treeGridItem);
     }
 
@@ -124,6 +135,23 @@ public class DataTypeListTest {
         dataTypeList.setup();
 
         verify(view).init(dataTypeList);
+        verify(view).showImportDataObjectButton();
+        verify(dndDataTypesHandler).init(dataTypeList);
+        verify(dndListComponent).setOnDropItem(consumer);
+    }
+
+    @Test
+    public void testSetupViewWhenIsKogito() {
+
+        final BiConsumer<Element, Element> consumer = (a, b) -> {/* Nothing. */};
+
+        doReturn(consumer).when(dataTypeList).getOnDropDataType();
+        when(isKogito.get()).thenReturn(true);
+
+        dataTypeList.setup();
+
+        verify(view).init(dataTypeList);
+        verify(view).hideImportDataObjectButton();
         verify(dndDataTypesHandler).init(dataTypeList);
         verify(dndListComponent).setOnDropItem(consumer);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListViewTest.java
@@ -623,6 +623,28 @@ public class DataTypeListViewTest {
         verify(presenter).importDataObjects(imported);
     }
 
+    @Test
+    public void testShowImportDataObjectButton() {
+        final DOMTokenList classList = mock(DOMTokenList.class);
+
+        importDataObjectButton.classList = classList;
+
+        view.showImportDataObjectButton();
+
+        verify(classList).remove(HIDDEN_CSS_CLASS);
+    }
+
+    @Test
+    public void testHideImportDataObjectButton() {
+        final DOMTokenList classList = mock(DOMTokenList.class);
+
+        importDataObjectButton.classList = classList;
+
+        view.hideImportDataObjectButton();
+
+        verify(classList).add(HIDDEN_CSS_CLASS);
+    }
+
     private HTMLElement makeHTMLElement() {
         final HTMLElement element = mock(HTMLElement.class);
         element.parentNode = mock(Node.class);


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-599

The _kogito_ editor no longer has an "Import" button on the "Data Types" tab.