### PR TITLE
Clean up assertions in CLI tests

### DIFF
--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/AllFieldTypesFormGenerationTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/AllFieldTypesFormGenerationTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.checkBox.definition.CheckBoxFieldDefinition;
@@ -55,9 +54,7 @@ import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutRow;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
@@ -72,7 +69,6 @@ public class AllFieldTypesFormGenerationTest extends AbstractFormDefinitionGener
 
     @Mock
     private Path userFormPath;
-
 
     private Form userForm;
 
@@ -113,12 +109,9 @@ public class AllFieldTypesFormGenerationTest extends AbstractFormDefinitionGener
     public void testMigration() {
         generator.execute(context);
 
-        Assertions.assertThat(context.getSummaries())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(context.getSummaries()).hasSize(1);
 
-        Assertions.assertThat(context.getExtraSummaries())
-                .isEmpty();
+        assertThat(context.getExtraSummaries()).isEmpty();
 
         // 1 legacyforms + 1 migrated forms
         verify(migrationServicesCDIWrapper, times(2)).write(any(Path.class), anyString(), anyString());
@@ -129,19 +122,15 @@ public class AllFieldTypesFormGenerationTest extends AbstractFormDefinitionGener
 
         FormDefinition newForm = summary.getNewForm().get();
 
-        assertNotNull(newForm);
+        assertThat(newForm).isNotNull();
 
-        Assertions.assertThat(newForm.getFields())
-                .isNotEmpty()
-                .hasSize(fieldMappings.size());
+        assertThat(newForm.getFields()).hasSize(fieldMappings.size());
 
         LayoutTemplate newLayout = newForm.getLayoutTemplate();
 
-        assertNotNull(newLayout);
+        assertThat(newLayout).isNotNull();
 
-        Assertions.assertThat(newLayout.getRows())
-                .isNotEmpty()
-                .hasSize(fieldMappings.size() + 2); // fields + 2 decorators in original form
+        assertThat(newLayout.getRows()).hasSize(fieldMappings.size() + 2); // fields + 2 decorators in original form
 
         List<LayoutRow> rows = newLayout.getRows();
 
@@ -153,11 +142,11 @@ public class AllFieldTypesFormGenerationTest extends AbstractFormDefinitionGener
         indexStream.forEach(index -> {
             FieldDefinition newField = newForm.getFields().get(index);
 
-            assertNotNull(newField);
+            assertThat(newField).isNotNull();
 
             Field originalField = originalForm.getField(newField.getName());
 
-            assertNotNull(originalField);
+            assertThat(originalField).isNotNull();
 
             checkFieldDefinition(newField, newField.getName(), newField.getLabel(), newField.getBinding(), fieldMappings.get(newField.getName()), newForm, originalField);
 
@@ -166,29 +155,22 @@ public class AllFieldTypesFormGenerationTest extends AbstractFormDefinitionGener
             LayoutComponent component = checkRow(row);
 
             checkLayoutFormField(component, newField, newForm);
-
         });
     }
 
     protected void checkDecoratorRow(LayoutRow row) {
         LayoutComponent component = checkRow(row);
 
-        Assertions.assertThat(component)
-                .isNotNull()
-                .hasFieldOrPropertyWithValue("dragTypeName", FormsMigrationConstants.HTML_COMPONENT);
+        assertThat(component.getDragTypeName()).isEqualTo(FormsMigrationConstants.HTML_COMPONENT);
     }
 
     private LayoutComponent checkRow(LayoutRow row) {
-        Assertions.assertThat(row.getLayoutColumns())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(row.getLayoutColumns()).hasSize(1);
 
         LayoutColumn column = row.getLayoutColumns().get(0);
-        assertEquals("12", column.getSpan());
+        assertThat(column.getSpan()).isEqualTo("12");
 
-        Assertions.assertThat(column.getLayoutComponents())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(column.getLayoutComponents()).hasSize(1);
 
         return column.getLayoutComponents().get(0);
     }

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForBPMNForWrongTaskFormNameTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForBPMNForWrongTaskFormNameTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.forms.migration.tool.pipelines.basic;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.jbpm.model.authoring.JBPMFormModel;
@@ -35,8 +34,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
@@ -85,18 +83,15 @@ public class FormDefinitionGeneratorForBPMNForWrongTaskFormNameTest extends Abst
     public void testMigration() {
         generator.execute(context);
 
-        Assertions.assertThat(context.getSummaries())
-                .isNotEmpty()
-                .hasSize(2);
+        assertThat(context.getSummaries()).hasSize(2);
 
-        Assertions.assertThat(context.getExtraSummaries())
-                .isEmpty();
+        assertThat(context.getExtraSummaries()).isEmpty();
 
         verify(migrationServicesCDIWrapper, never()).write(any(Path.class), anyString(), anyString());
 
         context.getSummaries().forEach(summary -> {
-            assertFalse(summary.getResult().isSuccess());
-            assertNull(summary.getNewForm());
+            assertThat(summary.getResult().isSuccess()).isFalse();
+            assertThat(summary.getNewForm()).isNull();
         });
     }
 }

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForDataObjectsTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForDataObjectsTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.forms.migration.tool.pipelines.basic;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.migration.legacy.model.Form;
@@ -31,7 +30,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
@@ -73,18 +72,15 @@ public class FormDefinitionGeneratorForDataObjectsTest extends AbstractFormDefin
     public void testMigration() {
         generator.execute(context);
 
-        Assertions.assertThat(context.getSummaries())
-                .isNotEmpty()
-                .hasSize(3);
+        assertThat(context.getSummaries()).hasSize(3);
 
-        Assertions.assertThat(context.getExtraSummaries())
-                .isEmpty();
+        assertThat(context.getExtraSummaries()).isEmpty();
 
         // 3 legacyforms + 3 migrated forms
         verify(migrationServicesCDIWrapper, times(6)).write(any(Path.class), anyString(), anyString());
 
         context.getSummaries().forEach(summary -> {
-            assertTrue(summary.getResult().isSuccess());
+            assertThat(summary.getResult().isSuccess()).isTrue();
             switch (summary.getBaseFormName() + ".form") {
                 case INVOICE_FORM:
                     verifyInvoiceForm(summary);

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForDataObjectsWithErrorsTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForDataObjectsWithErrorsTest.java
@@ -19,7 +19,6 @@ package org.kie.workbench.common.forms.migration.tool.pipelines.basic;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.migration.legacy.model.Form;
@@ -31,8 +30,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
@@ -78,18 +76,15 @@ public class FormDefinitionGeneratorForDataObjectsWithErrorsTest extends Abstrac
     public void testMigration() {
         generator.execute(context);
 
-        Assertions.assertThat(context.getSummaries())
-                .isNotEmpty()
-                .hasSize(3);
+        assertThat(context.getSummaries()).hasSize(3);
 
-        Assertions.assertThat(context.getExtraSummaries())
-                .isEmpty();
+        assertThat(context.getExtraSummaries()).isEmpty();
 
         verify(migrationServicesCDIWrapper, never()).write(any(Path.class), anyString(), anyString());
 
         context.getSummaries().forEach(summary -> {
-            assertFalse(summary.getResult().isSuccess());
-            assertNull(summary.getNewForm());
+            assertThat(summary.getResult().isSuccess()).isFalse();
+            assertThat(summary.getNewForm()).isNull();
         });
     }
 }

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForFormsWithoutBPMNFileTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorForFormsWithoutBPMNFileTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.jbpm.model.authoring.JBPMFormModel;
@@ -34,8 +33,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
@@ -82,18 +80,15 @@ public class FormDefinitionGeneratorForFormsWithoutBPMNFileTest extends Abstract
     public void testMigration() {
         generator.execute(context);
 
-        Assertions.assertThat(context.getSummaries())
-                .isNotEmpty()
-                .hasSize(2);
+        assertThat(context.getSummaries()).hasSize(2);
 
-        Assertions.assertThat(context.getExtraSummaries())
-                .isEmpty();
+        assertThat(context.getExtraSummaries()).isEmpty();
 
         verify(migrationServicesCDIWrapper, never()).write(any(Path.class), anyString(), anyString());
 
         context.getSummaries().forEach(summary -> {
-            assertFalse(summary.getResult().isSuccess());
-            assertNull(summary.getNewForm());
+            assertThat(summary.getResult().isSuccess()).isFalse();
+            assertThat(summary.getNewForm()).isNull();
         });
     }
 }

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorWithUnsupportedFieldsTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/src/test/java/org/kie/workbench/common/forms/migration/tool/pipelines/basic/FormDefinitionGeneratorWithUnsupportedFieldsTest.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.Condition;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textBox.definition.TextBoxFieldDefinition;
@@ -42,10 +40,7 @@ import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutRow;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
@@ -58,7 +53,6 @@ public class FormDefinitionGeneratorWithUnsupportedFieldsTest extends AbstractFo
 
     @Mock
     private Path userFormPath;
-
 
     private Form userForm;
 
@@ -76,12 +70,9 @@ public class FormDefinitionGeneratorWithUnsupportedFieldsTest extends AbstractFo
     public void testMigration() {
         generator.execute(context);
 
-        Assertions.assertThat(context.getSummaries())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(context.getSummaries()).hasSize(1);
 
-        Assertions.assertThat(context.getExtraSummaries())
-                .isEmpty();
+        assertThat(context.getExtraSummaries()).isEmpty();
 
         // 1 legacyforms + 1 migrated forms
         verify(migrationServicesCDIWrapper, times(2)).write(any(Path.class), anyString(), anyString());
@@ -92,74 +83,60 @@ public class FormDefinitionGeneratorWithUnsupportedFieldsTest extends AbstractFo
 
         FormDefinition newForm = summary.getNewForm().get();
 
-        assertNotNull(newForm);
+        assertThat(newForm).isNotNull();
 
-        Assertions.assertThat(newForm.getFields())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(newForm.getFields()).hasSize(1);
 
         LayoutTemplate newLayout = newForm.getLayoutTemplate();
 
-        assertNotNull(newLayout);
+        assertThat(newLayout).isNotNull();
 
-        Assertions.assertThat(newLayout.getRows())
-                .isNotEmpty()
-                .hasSize(2);
+        assertThat(newLayout.getRows()).hasSize(2);
 
         // Checking first field (login), althought the original field type isn't supported it can be migrated to a textbox
         Field originalLogin = originalForm.getField(USER_LOGIN);
         FieldDefinition newLogin = newForm.getFieldByName(USER_LOGIN);
 
-        assertNotNull(newLogin);
+        assertThat(newLogin).isNotNull();
 
         checkFieldDefinition(newLogin, USER_LOGIN, "login", "login", TextBoxFieldDefinition.class, newForm, originalLogin);
 
         LayoutRow loginRow = newLayout.getRows().get(0);
 
-        assertNotNull(loginRow);
+        assertThat(loginRow).isNotNull();
 
-        Assertions.assertThat(loginRow.getLayoutColumns())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(loginRow.getLayoutColumns()).hasSize(1);
 
         LayoutColumn loginColumn = loginRow.getLayoutColumns().get(0);
 
-        assertNotNull(loginColumn);
-        assertEquals("12", loginColumn.getSpan());
+        assertThat(loginColumn).isNotNull();
+        assertThat(loginColumn.getSpan()).isEqualTo("12");
 
-        Assertions.assertThat(loginColumn.getLayoutComponents())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(loginColumn.getLayoutComponents()).hasSize(1);
 
         checkLayoutFormField(loginColumn.getLayoutComponents().get(0), newLogin, newForm);
 
         // Checking second field (password), the original field type isn't supported and it cannot be migrated to any
         // other form control. There shouldn't be any FieldDefinition for it but it should be an HTML component on
         // the layout warning about the error
-        assertNull(newForm.getFieldByName(USER_PASSWORD));
+        assertThat(newForm.getFieldByName(USER_PASSWORD)).isNull();
 
         LayoutRow passwordRow = newLayout.getRows().get(1);
 
-        assertNotNull(passwordRow);
+        assertThat(passwordRow).isNotNull();
 
-        Assertions.assertThat(passwordRow.getLayoutColumns())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(passwordRow.getLayoutColumns()).hasSize(1);
 
         LayoutColumn passwordColumn = passwordRow.getLayoutColumns().get(0);
 
-        assertNotNull(passwordColumn);
-        assertEquals("12", passwordColumn.getSpan());
+        assertThat(passwordColumn).isNotNull();
+        assertThat(passwordColumn.getSpan()).isEqualTo("12");
 
-        Assertions.assertThat(passwordColumn.getLayoutComponents())
-                .isNotEmpty()
-                .hasSize(1);
+        assertThat(passwordColumn.getLayoutComponents()).hasSize(1);
 
         LayoutComponent passwordComponent = passwordColumn.getLayoutComponents().get(0);
 
-        Assertions.assertThat(passwordComponent)
-                .isNotNull()
-                .hasFieldOrPropertyWithValue("dragTypeName", FormsMigrationConstants.HTML_COMPONENT);
+        assertThat(passwordComponent.getDragTypeName()).isEqualTo(FormsMigrationConstants.HTML_COMPONENT);
 
         Field originalPassword = originalForm.getField(USER_PASSWORD);
 
@@ -168,8 +145,8 @@ public class FormDefinitionGeneratorWithUnsupportedFieldsTest extends AbstractFo
 
         final String expectedHtmlMessage = formatter.toString();
 
-        Assertions.assertThat(passwordComponent.getProperties())
-                .hasEntrySatisfying(FormsMigrationConstants.HTML_CODE_PARAMETER, new Condition<>(htmlMessage -> htmlMessage.equals(expectedHtmlMessage), "Invalid error HTML message"));
+        assertThat(passwordComponent.getProperties())
+                .containsEntry(FormsMigrationConstants.HTML_CODE_PARAMETER, expectedHtmlMessage);
 
         formatter.close();
     }

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-to-space-configuration-migration/src/test/java/org/kie/workbench/common/system/space/configuration/ConfigGroupsMigrationServiceTest.java
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-to-space-configuration-migration/src/test/java/org/kie/workbench/common/system/space/configuration/ConfigGroupsMigrationServiceTest.java
@@ -19,15 +19,14 @@ package org.kie.workbench.common.system.space.configuration;
 import java.io.File;
 import java.nio.file.Paths;
 
-import org.assertj.core.api.Assertions;
 import org.guvnor.structure.backend.backcompat.BackwardCompatibleUtil;
 import org.guvnor.structure.backend.config.ConfigurationServiceImpl;
+import org.guvnor.structure.contributors.Contributor;
 import org.guvnor.structure.contributors.ContributorType;
 import org.guvnor.structure.organizationalunit.config.RepositoryInfo;
 import org.guvnor.structure.organizationalunit.config.SpaceConfigStorageRegistry;
 import org.guvnor.structure.organizationalunit.config.SpaceInfo;
 import org.guvnor.structure.server.config.ConfigType;
-import org.guvnor.structure.server.config.ConfigurationService;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.Before;
@@ -41,7 +40,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.spaces.SpacesAPI;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
@@ -107,22 +106,18 @@ public class ConfigGroupsMigrationServiceTest {
 
         SpaceInfo info = infoCaptor.getValue();
 
-        Assertions.assertThat(info)
-                .hasFieldOrPropertyWithValue("name", SPACE_NAME)
-                .hasFieldOrPropertyWithValue("defaultGroupId", SPACE_GROUP);
+        assertThat(info.getName()).isEqualTo(SPACE_NAME);
+        assertThat(info.getDefaultGroupId()).isEqualTo(SPACE_GROUP);
 
-        Assertions.assertThat(info.getContributors())
-                .hasSize(CONTRIBUTORS);
+        assertThat(info.getContributors()).hasSize(CONTRIBUTORS);
 
-        Assertions.assertThat(info.getContributors().iterator().next())
-                .hasFieldOrPropertyWithValue("username", CONTRIBUTOR)
-                .hasFieldOrPropertyWithValue("type", ContributorType.OWNER);
+        Contributor contributor = info.getContributors().iterator().next();
+        assertThat(contributor.getUsername()).isEqualTo(CONTRIBUTOR);
+        assertThat(contributor.getType()).isEqualTo(ContributorType.OWNER);
 
-        Assertions.assertThat(info.getSecurityGroups())
-                .isEmpty();
+        assertThat(info.getSecurityGroups()).isEmpty();
 
-        Assertions.assertThat(info.getRepositories())
-                .hasSize(SPACE_REPOS);
+        assertThat(info.getRepositories()).hasSize(SPACE_REPOS);
 
         checkSpaceRepo(TEST_LEGACY_REPO, info);
         checkSpaceRepo(TEST_MULTIPLE_INSTANCE_REPO, info);
@@ -131,26 +126,21 @@ public class ConfigGroupsMigrationServiceTest {
     private void checkSpaceRepo(String repoName, SpaceInfo info) {
         RepositoryInfo spaceRepo = info.getRepositories().stream().filter(repo -> repo.getName().equals(repoName)).findAny().orElse(null);
 
-        Assertions.assertThat(spaceRepo)
-                .isNotNull()
-                .hasFieldOrPropertyWithValue("name", repoName)
-                .hasFieldOrPropertyWithValue("deleted", DELETED);
+        assertThat(spaceRepo).isNotNull();
+        assertThat(spaceRepo.getName()).isEqualTo(repoName);
+        assertThat(spaceRepo.isDeleted()).isEqualTo(DELETED);
 
-        assertEquals(SPACE_NAME, spaceRepo.getSpace());
-        assertEquals(SpacesAPI.Scheme.GIT.toString(), spaceRepo.getScheme());
-        assertEquals(REPO_AVOID_INDEX, spaceRepo.isAvoidIndex());
+        assertThat(spaceRepo.getSpace()).isEqualTo(SPACE_NAME);
+        assertThat(spaceRepo.getScheme()).isEqualTo(SpacesAPI.Scheme.GIT.toString());
+        assertThat(spaceRepo.isAvoidIndex()).isEqualTo(REPO_AVOID_INDEX);
 
-        Assertions.assertThat(spaceRepo.getContributors())
-                .hasSize(CONTRIBUTORS);
+        assertThat(spaceRepo.getContributors()).hasSize(CONTRIBUTORS);
 
-        Assertions.assertThat(spaceRepo.getContributors().iterator().next())
-                .hasFieldOrPropertyWithValue("username", CONTRIBUTOR)
-                .hasFieldOrPropertyWithValue("type", ContributorType.OWNER);
+        Contributor contributor = spaceRepo.getContributors().iterator().next();
+        assertThat(contributor.getUsername()).isEqualTo(CONTRIBUTOR);
+        assertThat(contributor.getType()).isEqualTo(ContributorType.OWNER);
 
-        Assertions.assertThat(info.getSecurityGroups())
-                .isEmpty();
-
-
+        assertThat(info.getSecurityGroups()).isEmpty();
     }
 }
 


### PR DESCRIPTION
When I was reviewing #3042 I noticed a test that uses very strange style of asserting object's properties using the `hasFieldOrPropertyWithValue()` assertion. This is an anti-pattern. I think we need to clean this up otherwise the tests will be difficult to maintain and refactor in the future as it has already happened (see discussion on #3042).

@pefernan Correct me if there is a good reason for which the tests were written this way and should stay like that.

Types of changes:
- Ban string based object inspection.
- Remove redundant assertions (e.g. isNotEmpty before hasSize).
- Don't mix JUnit assertions with AssertJ in one file.
- Simplify Map entry assertions.