### PR TITLE
KOGITO-277: Stunner - Enable support for Service Tasks (Work Item Handlers)

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParser.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParser.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.workitem;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+import org.guvnor.common.services.project.model.Dependencies;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNCategories;
+import org.kie.workbench.common.stunner.bpmn.workitem.IconDefinition;
+import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
+
+import static org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientUtils.getDefaultIconData;
+
+public class WorkItemDefinitionClientParser {
+
+    private static final String NAME = "name";
+    private static final String DISPLAY_NAME = "displayName";
+    private static final String ICON = "icon";
+    private static final String PARAMETERS = "parameters";
+    private static final String RESULTS = "results";
+    private static final String CATEGORY = "category";
+    private static final String NEW = "new";
+    private static final String STRING_DATA_TYPE = "StringDataType";
+    private static final String OBJECT_DATA_TYPE = "ObjectDataType";
+
+    public static List<WorkItemDefinition> parse(String widStr) {
+        if (empty(widStr)) {
+            return Collections.emptyList();
+        }
+
+        List<WorkItemDefinition> widList = new ArrayList<>();
+        String[] lines = widStr.split("\n");
+        Queue<String> linesQueue = new LinkedList<>(Arrays.asList(lines));
+        while (!linesQueue.isEmpty()) {
+            String line = linesQueue.peek().trim();
+            if (!(empty(line) || isStartingObject(line) || isEndingObject(line))) {
+                WorkItemDefinition wid = parseWorkItemDefinitionObject(linesQueue);
+                widList.add(wid);
+            }
+            linesQueue.poll();
+        }
+        return widList;
+    }
+
+    private static boolean empty(String line) {
+        return line == null || "".equals(line.trim());
+    }
+
+    private static WorkItemDefinition parseWorkItemDefinitionObject(Queue<String> objectQueue) {
+        WorkItemDefinition wid = emptyWid();
+        wid.setDependencies(new Dependencies());
+        String line = objectQueue.poll();
+        while (!isEndingObject(line) && !objectQueue.isEmpty()) {
+            Map.Entry<String, String> attributes = getAttribute(line);
+            switch (attributes.getKey()) {
+                case NAME:
+                    wid.setName(attributes.getValue());
+                    break;
+                case DISPLAY_NAME:
+                    wid.setDisplayName(attributes.getValue());
+                    break;
+                case ICON:
+                    wid.getIconDefinition().setUri(attributes.getValue());
+                    break;
+                case PARAMETERS:
+                    if (!isEndingObject(attributes.getValue())) {
+                        Collection<Map.Entry<String, String>> parameters = retrieveParameters(objectQueue);
+                        wid.setParameters(parseParameters(parameters));
+                    }
+                    break;
+                case RESULTS:
+                    if (!isEndingObject(attributes.getValue())) {
+                        Collection<Map.Entry<String, String>> results = retrieveParameters(objectQueue);
+                        wid.setResults(parseParameters(results));
+                    }
+                    break;
+                case CATEGORY:
+                    wid.setCategory(attributes.getValue());
+                default:
+                    break;
+            }
+            line = objectQueue.poll();
+        }
+
+        if (empty(wid.getCategory())) {
+            wid.setCategory(BPMNCategories.SERVICE_TASKS);
+        }
+        return wid;
+    }
+
+    private static WorkItemDefinition emptyWid() {
+        WorkItemDefinition wid = new WorkItemDefinition();
+        wid.setIconDefinition(new IconDefinition());
+        wid.getIconDefinition().setUri("");
+        wid.getIconDefinition().setIconData(getDefaultIconData());
+        wid.setUri("");
+        wid.setName("");
+        wid.setCategory("");
+        wid.setDescription("");
+        wid.setDocumentation("");
+        wid.setDisplayName("");
+        wid.setResults("");
+        wid.setDefaultHandler("");
+        wid.setDependencies(new Dependencies(Collections.emptyList()));
+        wid.setParameters("");
+        return wid;
+    }
+
+    private static Collection<Map.Entry<String, String>> retrieveParameters(Queue<String> objectQueue) {
+        String param = objectQueue.poll();
+        List<Map.Entry<String, String>> params = new ArrayList<>();
+        while (!(isEndingObject(param) || objectQueue.isEmpty())) {
+            String[] paramsParts = param.trim().split(":");
+            String paramName = cleanProp(paramsParts[0]);
+            String paramType = paramsParts[1].replaceAll(NEW, "")
+                    .replaceAll(",", "")
+                    .replaceAll("\\(\\)", "").trim();
+            params.add(new SimpleEntry<>(paramName, toJavaType(paramType)));
+            param = objectQueue.poll();
+        }
+        return params;
+    }
+
+    private static Map.Entry<String, String> getAttribute(String value) {
+        Map.Entry<String, String> attrs = new SimpleEntry<>("", "");
+        if (value.indexOf(':') != -1) {
+            String[] values = value.split(":");
+            attrs = new SimpleEntry<>(cleanProp(values[0]), cleanProp(values[1]));
+        }
+        return attrs;
+    }
+
+    private static String cleanProp(String prop) {
+        return prop.trim().replaceAll("\"", "").replaceAll(",", "");
+    }
+
+    private static boolean isStartingObject(String line) {
+        return line.startsWith("[");
+    }
+
+    private static boolean isEndingObject(String line) {
+        return line == null || line.endsWith("]") || line.endsWith("],");
+    }
+
+    private static String parseParameters(final Collection<Map.Entry<String, String>> parameters) {
+        return "|" + parameters.stream()
+                .map(param -> param.getKey() + ":" + param.getValue())
+                .sorted(String::compareTo)
+                .collect(Collectors.joining(",")) + "|";
+    }
+
+    /**
+     * Converts a MVEL datatype to Java type. Could be extended for all MVEL possible types.
+     * @param mvelType The MVEL type, e.g. StringDataType
+     * @return The Java corresponding type e.g. String
+     */
+    private static String toJavaType(String mvelType) {
+        switch (mvelType) {
+            case STRING_DATA_TYPE:
+                return "String";
+            case OBJECT_DATA_TYPE:
+                return "java.lang.Object";
+            default:
+                return mvelType;
+        }
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientService.java
@@ -21,10 +21,8 @@ import java.util.Collection;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinitionRegistry;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.kie.workbench.common.stunner.kogito.api.Kogito;
 import org.kie.workbench.common.stunner.kogito.client.service.KogitoClientService;
 
-@Kogito
 public interface WorkItemDefinitionClientService extends KogitoClientService<Metadata, Collection<WorkItemDefinition>> {
 
     WorkItemDefinitionRegistry getRegistry();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/workitem/WorkItemDefinitionClientParserTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.workitem;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNCategories;
+import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class WorkItemDefinitionClientParserTest {
+
+    final static String WID = "  [\n" +
+            "    [\n" +
+            "      \"name\" : \"Email\",\n" +
+            "      \"parameters\" : [\n" +
+            "        \"From\" : new StringDataType(),\n" +
+            "        \"To\" : new StringDataType(),\n" +
+            "        \"Subject\" : new StringDataType(),\n" +
+            "        \"Body\" : new StringDataType()\n" +
+            "      ],\n" +
+            "      \"displayName\" : \"Email\",\n" +
+            "      \"icon\" : \"defaultemailicon.gif\"\n" +
+            "    ],\n" +
+            "    [\n" +
+            "      \"name\" : \"Rest\",\n" +
+            "      \"parameters\" : [\n" +
+            "          \"ContentData\" : new StringDataType(),\n" +
+            "          \"Url\" : new StringDataType(),\n" +
+            "          \"Method\" : new StringDataType(),\n" +
+            "          \"ConnectTimeout\" : new StringDataType(),\n" +
+            "          \"ReadTimeout\" : new StringDataType(),\n" +
+            "          \"Username\" : new StringDataType(),\n" +
+            "          \"Password\" : new StringDataType()\n" +
+            "      ],\n" +
+            "      \"results\" : [\n" +
+            "          \"Result\" : new ObjectDataType(),\n" +
+            "      ],\n" +
+            "      \"displayName\" : \"REST\",\n" +
+            "      \"icon\" : \"defaultservicenodeicon.png\"\n" +
+            "    ],\n" +
+            "     [\n" +
+            "      \"name\" : \"Milestone\",\n" +
+            "      \"parameters\" : [\n" +
+            "          \"Condition\" : new StringDataType()\n" +
+            "      ],\n" +
+            "      \"displayName\" : \"Milestone\",\n" +
+            "      \"icon\" : \"defaultmilestoneicon.png\",\n" +
+            "      \"category\" : \"Milestone\"\n" +
+            "      ]\n" +
+            "  ]";
+
+    final static String EMAIL_WID_EXTRACTED_PARAMETERS = "|Body:String,From:String,Subject:String,To:String|";
+
+    final static String REST_WID_EXTRACTED_PARAMETERS = "|ConnectTimeout:String,ContentData:String,Method:String," +
+            "Password:String,ReadTimeout:String,Url:String,Username:String|";
+
+    @Test
+    public void emptyWidsTest() {
+        List<WorkItemDefinition> defs = WorkItemDefinitionClientParser.parse("");
+        assertTrue(defs.isEmpty());
+        defs = WorkItemDefinitionClientParser.parse("[]");
+        assertTrue(defs.isEmpty());
+        defs = WorkItemDefinitionClientParser.parse("[\n]");
+        assertTrue(defs.isEmpty());
+        defs = WorkItemDefinitionClientParser.parse(null);
+        assertTrue(defs.isEmpty());
+    }
+
+    @Test
+    public void widParseTest() {
+        List<WorkItemDefinition> defs = WorkItemDefinitionClientParser.parse(WID);
+        assertEquals(3, defs.size());
+        WorkItemDefinition wid1 = defs.get(0);
+        assertEquals("Email", wid1.getName());
+        assertEquals("Email", wid1.getDisplayName());
+        assertEquals("defaultemailicon.gif", wid1.getIconDefinition().getUri());
+        assertEquals(BPMNCategories.SERVICE_TASKS, wid1.getCategory());
+        assertTrue(wid1.getResults().isEmpty());
+        assertEquals(EMAIL_WID_EXTRACTED_PARAMETERS, wid1.getParameters());
+
+        WorkItemDefinition wid2 = defs.get(1);
+        assertEquals("Rest", wid2.getName());
+        assertEquals("REST", wid2.getDisplayName());
+        assertEquals("defaultservicenodeicon.png", wid2.getIconDefinition().getUri());
+        assertTrue(wid1.getResults().isEmpty());
+
+        assertEquals(REST_WID_EXTRACTED_PARAMETERS, wid2.getParameters());
+        assertEquals("|Result:java.lang.Object|", wid2.getResults());
+
+        WorkItemDefinition wid3 = defs.get(2);
+
+        assertEquals("Milestone", wid3.getName());
+        assertEquals("Milestone", wid3.getDisplayName());
+        assertEquals("defaultmilestoneicon.png", wid3.getIconDefinition().getUri());
+        assertEquals("|Condition:String|", wid3.getParameters());
+        assertEquals("Milestone", wid3.getCategory());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
@@ -11,6 +11,8 @@ the [Stunner directory README documentation](../../../).
 * Start GWT super dev mode by: `mvn gwt:run`
 * To create new diagram copy/paste this command into the browser console:
   * `gwtEditorBeans.get("BPMNDiagramEditor").get().setContent("", "")` 
+  * `window.frames.editorFrame.contentWindow.gwtEditorBeans.get("BPMNDiagramEditor").get().setContent("", "")`
 * To get content of the diagram copy/paste this command into the browser console:
   * `gwtEditorBeans.get("BPMNDiagramEditor").get().getContent()`
+  * `window.frames.editorFrame.contentWindow.gwtEditorBeans.get("BPMNDiagramEditor").get().getContent()`
 * Alternatively you can load file from the disk, change url to `http://127.0.0.1:8888/test.html` and select file from the disk.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -620,7 +620,14 @@
       <artifactId>kie-wb-common-stunner-kogito-client</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    
+    <!--  Appformer Kogito Bridge -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>appformer-kogito-bridge</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    
     <!-- Test dependencies -->
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
@@ -782,8 +789,12 @@
             <compileSourcesArtifact>org.kie.workbench.stunner:kie-wb-common-stunner-forms-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.stunner:kie-wb-common-stunner-kogito-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.stunner:kie-wb-common-stunner-kogito-client</compileSourcesArtifact>
-
+            
+            <!-- Appformer JS Bridge -->
             <compileSourcesArtifact>org.uberfire:appformer-js-bridge</compileSourcesArtifact>
+            
+            <!-- Appformer Kogito Bridge -->
+            <compileSourcesArtifact>org.uberfire:appformer-kogito-bridge</compileSourcesArtifact>
 
           </compileSourcesArtifacts>
         </configuration>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientService.java
@@ -17,36 +17,59 @@
 package org.kie.workbench.common.stunner.kogito.client.services;
 
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Logger;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import elemental2.promise.Promise;
+import org.appformer.kogito.bridge.client.resource.ResourceContentService;
 import org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientService;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinitionCacheRegistry;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinitionRegistry;
+import org.kie.workbench.common.stunner.core.client.canvas.BaseCanvasHandler;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.uberfire.client.promise.Promises;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientParser.parse;
+import static org.kie.workbench.common.stunner.core.util.StringUtils.nonEmpty;
 
 @ApplicationScoped
 public class WorkItemDefinitionStandaloneClientService implements WorkItemDefinitionClientService {
 
+    private static Logger LOGGER = Logger.getLogger(BaseCanvasHandler.class.getName());
+    private static final String RESOURCE_ALL_WID_PATTERN = "**/*.wid";
+
     private final Promises promises;
     private final WorkItemDefinitionCacheRegistry registry;
+    private final ResourceContentService resourceContentService;
+
+    // Cache the promise, as by definition will be performed just once,
+    // so the available work item definitions will be also just registered once, by app.
+    private Promise<Collection<WorkItemDefinition>> loader;
 
     @Inject
     public WorkItemDefinitionStandaloneClientService(final Promises promises,
-                                                     final WorkItemDefinitionCacheRegistry registry) {
+                                                     final WorkItemDefinitionCacheRegistry registry,
+                                                     final ResourceContentService resourceContentService) {
+
         this.promises = promises;
         this.registry = registry;
+        this.resourceContentService = resourceContentService;
     }
 
-    @Override
-    public Promise<Collection<WorkItemDefinition>> call(final Metadata input) {
-        return promises.resolve(registry.items());
+    @PostConstruct
+    public void init() {
+        loader = allWorkItemsLoader();
     }
 
     @Produces
@@ -54,5 +77,100 @@ public class WorkItemDefinitionStandaloneClientService implements WorkItemDefini
     @Override
     public WorkItemDefinitionRegistry getRegistry() {
         return registry;
+    }
+
+    @Override
+    public Promise<Collection<WorkItemDefinition>> call(final Metadata input) {
+        return loader;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        registry.clear();
+        loader = null;
+    }
+
+    private Promise<Collection<WorkItemDefinition>> allWorkItemsLoader() {
+        log("Starting loading of all Work Items");
+        return promises.create((success, failure) -> {
+            log("Loading all Work Items");
+            registry.clear();
+            final List<WorkItemDefinition> loaded = new LinkedList<>();
+            resourceContentService
+                    .list(RESOURCE_ALL_WID_PATTERN)
+                    .then(paths -> {
+                        if (paths.length > 0) {
+                            log("Work Items found at [" + paths + "]");
+                            promises.all(asList(paths),
+                                         path -> workItemsLoader(path, loaded))
+                                    .then(wids -> {
+                                        wids.forEach(registry::register);
+                                        success.onInvoke(wids);
+                                        return null;
+                                    })
+                                    .catch_(error -> {
+                                        failure.onInvoke(error);
+                                        return null;
+                                    });
+                        } else {
+                            log("NO Work Items found at [" + paths + "]");
+                            success.onInvoke(emptyList());
+                        }
+                        return promises.resolve();
+                    })
+                    .catch_(error -> {
+                        failure.onInvoke(error);
+                        return null;
+                    });
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private Promise<Collection<WorkItemDefinition>> workItemsLoader(final String path,
+                                                                    final Collection<WorkItemDefinition> loaded) {
+        log("Processing [" + path + "]");
+        if (nonEmpty(path)) {
+            return resourceContentService
+                    .get(path)
+                    .then(value -> {
+                        log("Content for path = [" + value + "]");
+                        log("Loading Work Items for path [" + path + "]");
+                        final List<WorkItemDefinition> wids = parse(value);
+                        return promises.create((success, failure) -> {
+                            promises.all(wids, this::workItemIconLoader)
+                                    .then(wid -> {
+                                        loaded.addAll(wids);
+                                        success.onInvoke(loaded);
+                                        return promises.resolve();
+                                    })
+                                    .catch_(error -> {
+                                        failure.onInvoke(error);
+                                        return null;
+                                    });
+                        });
+                    });
+        }
+        return promises.resolve(emptyList());
+    }
+
+    private Promise workItemIconLoader(final WorkItemDefinition wid) {
+        final String iconUri = wid.getIconDefinition().getUri();
+        log("Loading icon for URI [" + iconUri + "]");
+        if (nonEmpty(iconUri)) {
+            return resourceContentService
+                    .get(iconUri)
+                    .then(iconData -> {
+                        log("Content for icon = [" + iconData + "]");
+                        if (nonEmpty(iconData)) {
+                            wid.getIconDefinition().setIconData(iconData);
+                        }
+                        return promises.resolve();
+                    });
+        }
+        return promises.resolve();
+    }
+
+    private static void log(String s) {
+        LOGGER.fine(s);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/resources/org/kie/workbench/common/stunner/kogito/KogitoBPMNEditor.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/resources/org/kie/workbench/common/stunner/kogito/KogitoBPMNEditor.gwt.xml
@@ -30,6 +30,9 @@
   <inherits name="org.uberfire.ext.widgets.core.client.UberfireWidgetsEditors"/>
   <inherits name="org.uberfire.ext.preferences.UberfirePreferences"/>
   <inherits name="org.uberfire.preferences.UberfirePreferencesClient"/>
+  
+  <!-- Appformer Kogito Bridge -->
+  <inherits name="org.appformer.kogito.bridge.AppformerKogitoBridge"/>
 
   <!-- Errai, Drools etc -->
   <inherits name="org.kie.workbench.common.profile.ProfileAPI"/>
@@ -49,7 +52,7 @@
   <!-- BPMN -->
   <inherits name="org.kie.workbench.common.stunner.bpmn.StunnerBpmnClient"/>
   <inherits name="org.kie.workbench.common.stunner.bpmn.StunnerBpmnMarshalling"/>
-
+  
   <extend-property name="locale" values="es"/>
   <extend-property name="locale" values="fr"/>
   <extend-property name="locale" values="ja"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/BPMNStaticResourceContentService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/BPMNStaticResourceContentService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.kogito.client.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import elemental2.promise.Promise;
+import org.appformer.kogito.bridge.client.resource.ResourceContentService;
+import org.uberfire.client.promise.Promises;
+
+public class BPMNStaticResourceContentService implements ResourceContentService {
+
+    static final String LOG_SERVICE_TASK_DATA_URI = "data:image/gif;base64,R0lGODlhEAAQAMQAAG+Fr3CFr3yRuIOSsYaUroidwIuWrI+ZqJGlx5WdpZugoKGknaeomK6slLKvkL21idSyaNq9fN3o+ODIj+Ps+evx+vP2+/f4+/n6/AAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABkALAAAAAAQABAAAAVlYCaOZEk+aIqa4oO9MPSwLvxGsvlcwYUglwluRnJYjkiko9SwBCy/guDZKDEq2GyWUVpUApXotLIoKSjodFpRSlACFDGAkigdJHg8Gn8oGSQBEnISBiUEeYh4BCUDjY6PAyySIyEAOw==";
+    static final String EMAIL_SERVICE_TASK_DATA_URI = "data:image/gif;base64,R0lGODlhEAAQAPcAAAAAAIAAAACAAICAAAAAgIAAgACAgICAgMDAwP8AAAD/AP//AAAA/////wD//////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMwAAZgAAmQAAzAAA/wAzAAAzMwAzZgAzmQAzzAAz/wBmAABmMwBmZgBmmQBmzABm/wCZAACZMwCZZgCZmQCZzACZ/wDMAADMMwDMZgDMmQDMzADM/wD/AAD/MwD/ZgD/mQD/zAD//zMAADMAMzMAZjMAmTMAzDMA/zMzADMzMzMzZjMzmTMzzDMz/zNmADNmMzNmZjNmmTNmzDNm/zOZADOZMzOZZjOZmTOZzDOZ/zPMADPMMzPMZjPMmTPMzDPM/zP/ADP/MzP/ZjP/mTP/zDP//2YAAGYAM2YAZmYAmWYAzGYA/2YzAGYzM2YzZmYzmWYzzGYz/2ZmAGZmM2ZmZmZmmWZmzGZm/2aZAGaZM2aZZmaZmWaZzGaZ/2bMAGbMM2bMZmbMmWbMzGbM/2b/AGb/M2b/Zmb/mWb/zGb//5kAAJkAM5kAZpkAmZkAzJkA/5kzAJkzM5kzZpkzmZkzzJkz/5lmAJlmM5lmZplmmZlmzJlm/5mZAJmZM5mZZpmZmZmZzJmZ/5nMAJnMM5nMZpnMmZnMzJnM/5n/AJn/M5n/Zpn/mZn/zJn//8wAAMwAM8wAZswAmcwAzMwA/8wzAMwzM8wzZswzmcwzzMwz/8xmAMxmM8xmZsxmmcxmzMxm/8yZAMyZM8yZZsyZmcyZzMyZ/8zMAMzMM8zMZszMmczMzMzM/8z/AMz/M8z/Zsz/mcz/zMz///8AAP8AM/8AZv8Amf8AzP8A//8zAP8zM/8zZv8zmf8zzP8z//9mAP9mM/9mZv9mmf9mzP9m//+ZAP+ZM/+ZZv+Zmf+ZzP+Z///MAP/MM//MZv/Mmf/MzP/M////AP//M///Zv//mf//zP///yH5BAEAAA0ALAAAAAAQABAAQAhPABsIHEiwYAMADxICQKiQ4QMABx0mnDhxYcSFGDNmNMiRIEOJFRUefEixJEKIHVOqLKix5caTJSmePOhPocmKI0k+XGjzYcSYJlGuHNoxIAA7";
+
+    static final String DEFAULT_DECLARATIONS = "[\n" +
+            "  [\n" +
+            "    \"name\" : \"Email\",\n" +
+            "    \"parameters\" : [\n" +
+            "      \"From\" : new StringDataType(),\n" +
+            "      \"To\" : new StringDataType(),\n" +
+            "      \"Subject\" : new StringDataType(),\n" +
+            "      \"Body\" : new StringDataType()\n" +
+            "    ],\n" +
+            "    \"displayName\" : \"Email\",\n" +
+            "    \"icon\" : \"defaultemailicon.gif\"\n" +
+            "  ],\n" +
+            "\n" +
+            "  [\n" +
+            "    \"name\" : \"Log\",\n" +
+            "    \"parameters\" : [\n" +
+            "      \"Message\" : new StringDataType()\n" +
+            "    ],\n" +
+            "    \"displayName\" : \"Log\",\n" +
+            "    \"icon\" : \"defaultlogicon.gif\"\n" +
+            "  ],\n" +
+            "\n" +
+            "  [\n" +
+            "     \"name\" : \"BusinessRuleTask\",\n" +
+            "     \"parameters\" : [\n" +
+            "       \"Language\" : new StringDataType(),\n" +
+            "       \"KieSessionName\" : new StringDataType(),\n" +
+            "       \"KieSessionType\" : new StringDataType()\n" +
+            "     ],\n" +
+            "     \"displayName\" : \"Business Rule Task\",\n" +
+            "     \"icon\" : \"defaultbusinessrulesicon.png\",\n" +
+            "     \"category\" : \"Decision tasks\"\n" +
+            "   ],\n" +
+            "\n" +
+            "   [\n" +
+            "     \"name\" : \"DecisionTask\",\n" +
+            "     \"parameters\" : [\n" +
+            "       \"Language\" : new StringDataType(),\n" +
+            "       \"Namespace\" : new StringDataType(),\n" +
+            "       \"Model\" : new StringDataType(),\n" +
+            "       \"Decision\" : new StringDataType()\n" +
+            "     ],\n" +
+            "     \"displayName\" : \"Decision Task\",\n" +
+            "     \"icon\" : \"defaultdecisionicon.png\",\n" +
+            "     \"category\" : \"Decision tasks\"\n" +
+            "   ],\n" +
+            "\n" +
+            "   [\n" +
+            "    \"name\" : \"Milestone\",\n" +
+            "    \"parameters\" : [\n" +
+            "        \"Condition\" : new StringDataType()\n" +
+            "    ],\n" +
+            "    \"displayName\" : \"Milestone\",\n" +
+            "    \"icon\" : \"defaultmilestoneicon.png\",\n" +
+            "    \"category\" : \"Milestone\"\n" +
+            "    ]\n" +
+            "]";
+
+    static final String ANOTHER_DECLARATION = "[\n" +
+            "  [\n" +
+            "    \"name\" : \"AnotherLog\",\n" +
+            "    \"parameters\" : [\n" +
+            "      \"Message\" : new StringDataType()\n" +
+            "    ],\n" +
+            "    \"displayName\" : \"AnotherLog\",\n" +
+            "    \"icon\" : \"defaultlogicon.gif\"\n" +
+            "  ]\n" +
+            "]";
+
+    private static final String PATTERN_ALL_WID = "**/*.wid";
+    private static final Map<String, String> WID_ENTRIES =
+            new HashMap<String, String>() {{
+                put("default.wid", DEFAULT_DECLARATIONS);
+                put("another.wid", ANOTHER_DECLARATION);
+            }};
+    private static final Map<String, String> ICON_ENTRIES =
+            new HashMap<String, String>() {{
+                put("defaultemailicon.gif", EMAIL_SERVICE_TASK_DATA_URI);
+                put("defaultlogicon.gif", LOG_SERVICE_TASK_DATA_URI);
+            }};
+
+    private final Promises promises;
+
+    @Inject
+    public BPMNStaticResourceContentService(final Promises promises) {
+        this.promises = promises;
+    }
+
+    @Override
+    public Promise<String> get(final String uri) {
+        if (uri.endsWith(".wid")) {
+            return promises.resolve(WID_ENTRIES.getOrDefault(uri, ""));
+        }
+        return promises.resolve(ICON_ENTRIES.getOrDefault(uri, ""));
+    }
+
+    @Override
+    public Promise<String[]> list(final String pattern) {
+        final String[] allUris = PATTERN_ALL_WID.equalsIgnoreCase(pattern) ?
+                WID_ENTRIES.keySet().toArray(new String[0]) :
+                new String[0];
+        return promises.resolve(allUris);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientServiceTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.kogito.client.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.promise.Promise;
+import org.appformer.kogito.bridge.client.resource.ResourceContentService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
+import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinitionCacheRegistry;
+import org.kie.workbench.common.stunner.core.diagram.Metadata;
+import org.uberfire.client.promise.Promises;
+import org.uberfire.promise.SyncPromises;
+
+import static org.jgroups.util.Util.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientUtils.getDefaultIconData;
+import static org.mockito.Mockito.mock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class WorkItemDefinitionStandaloneClientServiceTest {
+
+    private WorkItemDefinitionStandaloneClientService tested;
+    private Promises promises;
+    private WorkItemDefinitionCacheRegistry registry;
+
+    @Before
+    public void setUp() {
+        promises = new SyncPromises();
+        registry = new WorkItemDefinitionCacheRegistry();
+        tested = new WorkItemDefinitionStandaloneClientService(promises,
+                                                               registry,
+                                                               new BPMNStaticResourceContentService(promises));
+    }
+
+    @Test
+    public void testGetRegistry() {
+        tested.init();
+        assertEquals(registry, tested.getRegistry());
+    }
+
+    @Test
+    public void testLoadAllWorkItems() {
+        call();
+
+        List<WorkItemDefinition> items = new ArrayList<>(registry.items());
+        assertEquals(6, items.size());
+
+        WorkItemDefinition email = items.get(0);
+        assertNotNull(email);
+        assertEquals("Email", email.getName());
+        assertEquals(BPMNStaticResourceContentService.EMAIL_SERVICE_TASK_DATA_URI, email.getIconDefinition().getIconData());
+
+        WorkItemDefinition log = items.get(1);
+        assertNotNull(log);
+        assertEquals("Log", log.getName());
+        assertEquals(BPMNStaticResourceContentService.LOG_SERVICE_TASK_DATA_URI, log.getIconDefinition().getIconData());
+
+        WorkItemDefinition decisionTask = items.get(2);
+        assertNotNull(decisionTask);
+        assertEquals("DecisionTask", decisionTask.getName());
+        assertEquals(getDefaultIconData(), decisionTask.getIconDefinition().getIconData());
+
+        WorkItemDefinition milestone = items.get(3);
+        assertNotNull(milestone);
+        assertEquals("Milestone", milestone.getName());
+        assertEquals(getDefaultIconData(), milestone.getIconDefinition().getIconData());
+
+        WorkItemDefinition brTask = items.get(4);
+        assertNotNull(brTask);
+        assertEquals("BusinessRuleTask", brTask.getName());
+        assertEquals(getDefaultIconData(), brTask.getIconDefinition().getIconData());
+
+        WorkItemDefinition anotherLog = items.get(5);
+        assertNotNull(anotherLog);
+        assertEquals("AnotherLog", anotherLog.getName());
+        assertEquals(BPMNStaticResourceContentService.LOG_SERVICE_TASK_DATA_URI, anotherLog.getIconDefinition().getIconData());
+    }
+
+    @Test
+    public void testLoadNoWorkItems() {
+        tested = new WorkItemDefinitionStandaloneClientService(promises,
+                                                               registry,
+                                                               new ResourceContentService() {
+                                                                   @Override
+                                                                   public Promise<String> get(String uri) {
+                                                                       return promises.resolve();
+                                                                   }
+
+                                                                   @Override
+                                                                   public Promise<String[]> list(String pattern) {
+                                                                       return promises.resolve(new String[0]);
+                                                                   }
+                                                               });
+        call();
+        assertTrue(registry.items().isEmpty());
+    }
+
+    @Test
+    public void testLoadEmptyWorkItems() {
+        tested = new WorkItemDefinitionStandaloneClientService(promises,
+                                                               registry,
+                                                               new ResourceContentService() {
+                                                                   @Override
+                                                                   public Promise<String> get(String uri) {
+                                                                       return promises.resolve();
+                                                                   }
+
+                                                                   @Override
+                                                                   public Promise<String[]> list(String pattern) {
+                                                                       return promises.resolve(new String[]{""});
+                                                                   }
+                                                               });
+        call();
+        assertTrue(registry.items().isEmpty());
+    }
+
+    @Test
+    public void testDestroy() {
+        call();
+        assertEquals(6, registry.items().size());
+        tested.destroy();
+        assertEquals(registry, tested.getRegistry());
+        assertTrue(registry.items().isEmpty());
+    }
+
+    private void call() {
+        tested.init();
+        tested.call(mock(Metadata.class));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
@@ -74,6 +74,11 @@
       <artifactId>kie-wb-common-stunner-bpmn-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.workbench.stunner</groupId>
+      <artifactId>kie-wb-common-stunner-bpmn-client</artifactId>
+    </dependency>
+
     <!-- GWT. -->
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientMarshalling.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientMarshalling.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.stunner.bpmn.client.marshall.service;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -28,6 +27,7 @@ import javax.inject.Inject;
 import org.eclipse.bpmn2.Definitions;
 import org.eclipse.bpmn2.DocumentRoot;
 import org.jboss.drools.DroolsPackage;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
 import org.kie.workbench.common.stunner.bpmn.client.emf.Bpmn2Marshalling;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.MarshallingRequest;
@@ -43,6 +43,7 @@ import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunne
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.GraphBuilder;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
+import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinitionRegistry;
 import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
@@ -65,18 +66,21 @@ public class BPMNClientMarshalling {
     private final TypedFactoryManager typedFactoryManager;
     private final GraphCommandFactory commandFactory;
     private final GraphCommandManager commandManager;
+    private final ManagedInstance<WorkItemDefinitionRegistry> widRegistries;
 
     @Inject
     public BPMNClientMarshalling(final DefinitionManager definitionManager,
                                  final RuleManager ruleManager,
                                  final FactoryManager factoryManager,
                                  final GraphCommandFactory commandFactory,
-                                 final GraphCommandManager commandManager) {
+                                 final GraphCommandManager commandManager,
+                                 final ManagedInstance<WorkItemDefinitionRegistry> widRegistries) {
         this.definitionManager = definitionManager;
         this.ruleManager = ruleManager;
         this.typedFactoryManager = new TypedFactoryManager(factoryManager);
         this.commandFactory = commandFactory;
         this.commandManager = commandManager;
+        this.widRegistries = widRegistries;
     }
 
     @PostConstruct
@@ -144,9 +148,8 @@ public class BPMNClientMarshalling {
         return graph;
     }
 
-    // TODO: Use the right WID registry.
-    private static Collection<WorkItemDefinition> getWorkItemDefinitions() {
-        return Collections.emptyList();
+    private Collection<WorkItemDefinition> getWorkItemDefinitions() {
+        return widRegistries.get().items();
     }
 
     public static Class<?> getDiagramClass() {


### PR DESCRIPTION
Hey guys,

This PR provides support service tasks in the kogito space. See [KOGITO-277](https://issues.redhat.com/browse/KOGITO-277)

This PR is a continuation of @jesuino 's work ([see PR](https://github.com/kiegroup/kie-wb-common/pull/3034)), and it also includes the fixes for the [missing points](https://issues.redhat.com/browse/KOGITO-277?focusedCommentId=13936693&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13936693) previously identified on top. So it's also using the "new resouce api" from kogito to fetch the declarations and icons for service tasks, if present.

I'll keep working on adding tests and completing the TODO's tomorrow, but the `bpmn-kogito-runtime` webapp it's already running fine (or should be :)), so can you please to the review on the meanwhile??

@ederign @jesuino please can you build the `bpmn-kogito-runtime` and test the generated plugin work properly in VSCode? I'm just testing the default work items that are provided in the BC, also same images, put all those in the same path (.wid & images) and it'll properly import all those.

Thanks in advance!
