### PR TITLE
KOGITO-528: [DMN Designer] Zoom control should be hidden in grid view

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/general/BaseNavigateCommand.java
@@ -119,6 +119,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
     protected void addExpressionEditorToCanvasWidget() {
         final ResizeFlowPanel container = wrapElementForErrai1090();
         presenter.getView().setCanvasWidget(container);
+        presenter.lostFocus();
         editor.getView().setFocus();
 
         Scheduler.get().scheduleDeferred(container::onResize);
@@ -149,6 +150,7 @@ public abstract class BaseNavigateCommand extends AbstractCanvasGraphCommand {
 
     protected void addDRGEditorToCanvasWidget() {
         presenter.getView().setCanvasWidget(((AbstractSessionPresenter) presenter).getDisplayer().getView());
+        presenter.focus();
     }
 
     protected void hidePaletteWidget(final boolean hidden) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToDRGEditorCommandTest.java
@@ -61,6 +61,7 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
         verify(command).hidePaletteWidget(eq(false));
         verify(command).addDRGEditorToCanvasWidget();
         verify(sessionPresenterView).setCanvasWidget(view);
+        verify(sessionPresenter).focus();
 
         verify(refreshFormPropertiesEvent).fire(refreshFormPropertiesEventCaptor.capture());
 
@@ -96,6 +97,7 @@ public class NavigateToDRGEditorCommandTest extends BaseNavigationCommandTest {
                                      eq(Optional.of(hasName)),
                                      eq(isOnlyVisualChangeAllowed));
         verify(expressionEditorView).setFocus();
+        verify(sessionPresenter).lostFocus();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/general/NavigateToExpressionEditorCommandTest.java
@@ -76,6 +76,7 @@ public class NavigateToExpressionEditorCommandTest extends BaseNavigationCommand
                                      eq(Optional.of(hasName)),
                                      eq(isOnlyVisualChangeAllowed));
         verify(expressionEditorView).setFocus();
+        verify(sessionPresenter).lostFocus();
     }
 
     @Test
@@ -92,6 +93,7 @@ public class NavigateToExpressionEditorCommandTest extends BaseNavigationCommand
         verify(sessionPresenterView).setCanvasWidget(view);
 
         verify(canvasHandler).notifyCanvasClear();
+        verify(sessionPresenter).focus();
     }
 
     @Test


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-528

@romartin @jomarko At the moment there is a slight delay (250ms) before the zoom control hides (due to use of a timer in `ZoomLevelSelectorPresenter`). @romartin Was this timer requested or did you use it to make the zoom control _prettier_? I wonder whether it might be worth me removing the delay in this PR (we don't have a delay _showing_ the control). @romartin @jomarko WDYT?