### PR TITLE
KOGITO-652: Updating setContent method

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -391,7 +391,7 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
 
     @Override
     @SetContent
-    public void setContent(final String value) {
+    public void setContent(final String path, final String value) {
         diagramServices.transform(value,
                                   new ServiceCallback<Diagram>() {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -428,7 +428,7 @@ public abstract class AbstractDMNDiagramEditorTest {
 
     @Test
     public void testSetContentSuccess() {
-        editor.setContent(CONTENT);
+        editor.setContent("", CONTENT);
 
         verify(clientDiagramService).transform(eq(CONTENT), serviceCallbackArgumentCaptor.capture());
 
@@ -441,7 +441,7 @@ public abstract class AbstractDMNDiagramEditorTest {
 
     @Test
     public void testSetContentFailure() {
-        editor.setContent(CONTENT);
+        editor.setContent("", CONTENT);
 
         verify(clientDiagramService).transform(eq(CONTENT), serviceCallbackArgumentCaptor.capture());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -166,7 +166,7 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
     public void onStartup(final PlaceRequest place) {
         super.onStartup(place);
 
-        setContent(place.getParameter(CONTENT_PARAMETER_NAME, ""));
+        setContent("", place.getParameter(CONTENT_PARAMETER_NAME, ""));
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -168,7 +168,7 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
     public void testOnStartup() {
         super.testOnStartup();
 
-        verify(editor).setContent(eq(""));
+        verify(editor).setContent(eq(""), eq(""));
     }
 
     @Test

--- a/kie-wb-common-kogito/kie-wb-common-kogito-client/src/main/java/org/kie/workbench/common/kogito/client/editor/BaseKogitoEditor.java
+++ b/kie-wb-common-kogito/kie-wb-common-kogito-client/src/main/java/org/kie/workbench/common/kogito/client/editor/BaseKogitoEditor.java
@@ -141,7 +141,7 @@ public abstract class BaseKogitoEditor<CONTENT> {
     /**
      * Used by Kogito to set the XML content of the editor.
      */
-    public abstract void setContent(final String value);
+    public abstract void setContent(final String path, final String value);
 
     /**
      * Used by Kogito to get the XML content of the editor. This should return a {@link String}

--- a/kie-wb-common-kogito/kie-wb-common-kogito-client/src/main/java/org/kie/workbench/common/kogito/client/editor/BaseKogitoEditor.java
+++ b/kie-wb-common-kogito/kie-wb-common-kogito-client/src/main/java/org/kie/workbench/common/kogito/client/editor/BaseKogitoEditor.java
@@ -140,6 +140,10 @@ public abstract class BaseKogitoEditor<CONTENT> {
 
     /**
      * Used by Kogito to set the XML content of the editor.
+     * @param path
+     * Relative path to the content resource
+     * @param value
+     * Editor's content
      */
     public abstract void setContent(final String path, final String value);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
@@ -10,7 +10,7 @@ the [Stunner directory README documentation](../../../).
   * `mvn -T 8C clean install -DskipTests=true`
 * Start GWT super dev mode by: `mvn gwt:run`
 * To create new diagram copy/paste this command into the browser console:
-  * `gwtEditorBeans.get("BPMNDiagramEditor").get().setContent("")` 
+  * `gwtEditorBeans.get("BPMNDiagramEditor").get().setContent("", "")` 
 * To get content of the diagram copy/paste this command into the browser console:
   * `gwtEditorBeans.get("BPMNDiagramEditor").get().getContent()`
 * Alternatively you can load file from the disk, change url to `http://127.0.0.1:8888/test.html` and select file from the disk.

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -265,7 +265,7 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
 
     @SetContent
     @Override
-    public void setContent(final String value) {
+    public void setContent(final String path, final String value) {
         diagramServices.transform(value,
                                   new ServiceCallback<Diagram>() {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramEditor.java
@@ -301,7 +301,7 @@ public class BPMNStandaloneDiagramEditor extends AbstractDiagramEditor {
 
     @Override
     // @SetContent
-    public void setContent(final String value) {
+    public void setContent(final String path, final String value) {
         diagramServices.transform(value,
                                   new ServiceCallback<Diagram>() {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramWrapper.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramWrapper.java
@@ -50,7 +50,7 @@ public class BPMNStandaloneDiagramWrapper {
     public void newFile() {
         placeManager.registerOnOpenCallback(BPMNDiagramsNavigatorScreen.DIAGRAM_EDITOR,
                                             () -> {
-                                                diagramEditor.setContent("");
+                                                diagramEditor.setContent("", "");
                                                 placeManager.unregisterOnOpenCallbacks(BPMNDiagramsNavigatorScreen.DIAGRAM_EDITOR);
                                             });
 
@@ -64,7 +64,7 @@ public class BPMNStandaloneDiagramWrapper {
                                                                                new ServiceCallback<String>() {
                                                                                    @Override
                                                                                    public void onSuccess(final String xml) {
-                                                                                       diagramEditor.setContent(xml);
+                                                                                       diagramEditor.setContent("", xml);
                                                                                        placeManager.unregisterOnOpenCallbacks(BPMNDiagramsNavigatorScreen.DIAGRAM_EDITOR);
                                                                                    }
 


### PR DESCRIPTION
Update Kogito editors so they can accept the path parameter in `setContent` method.

Also pass the content path when calling `setContent`.

Part of an ensemble:

https://github.com/kiegroup/kogito-tooling/pull/47
https://github.com/kiegroup/kie-wb-common/pull/3099