### PR TITLE
DROOLS-4970: DMN FunctionDefinition parameter not trimmed by editor

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/AddParameterCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/expressions/types/function/AddParameterCommand.java
@@ -39,6 +39,7 @@ public class AddParameterCommand extends AbstractCanvasGraphCommand implements V
     private final FunctionDefinition function;
     private final InformationItem parameter;
     private final org.uberfire.mvp.Command canvasOperation;
+    private final String name;
 
     public AddParameterCommand(final FunctionDefinition function,
                                final InformationItem parameter,
@@ -46,6 +47,7 @@ public class AddParameterCommand extends AbstractCanvasGraphCommand implements V
         this.function = function;
         this.parameter = parameter;
         this.canvasOperation = canvasOperation;
+        this.name = FunctionDefaultValueUtilities.getNewParameterName(function);
     }
 
     @Override
@@ -59,7 +61,7 @@ public class AddParameterCommand extends AbstractCanvasGraphCommand implements V
             @Override
             public CommandResult<RuleViolation> execute(final GraphCommandExecutionContext gce) {
                 function.getFormalParameter().add(parameter);
-                parameter.getName().setValue(FunctionDefaultValueUtilities.getNewParameterName(function));
+                parameter.getName().setValue(name);
 
                 parameter.setParent(function);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGrid.java
@@ -253,14 +253,13 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
     public void addParameter(final Command onSuccess) {
         getExpression().get().ifPresent(e -> {
             final InformationItem parameter = new InformationItem();
-            parameter.setName(new Name("p" + e.getFormalParameter().size()));
+            parameter.setName(new Name());
 
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new AddParameterCommand(e,
                                                                   parameter,
                                                                   () -> {
                                                                       gridLayer.batch();
-                                                                      gridPanel.setFocus(true);
                                                                       onSuccess.execute();
                                                                   }));
         });
@@ -275,7 +274,6 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
                                                                      parameter,
                                                                      () -> {
                                                                          gridLayer.batch();
-                                                                         gridPanel.setFocus(true);
                                                                          onSuccess.execute();
                                                                      }));
         });
@@ -283,12 +281,16 @@ public class FunctionGrid extends BaseExpressionGrid<FunctionDefinition, DMNGrid
 
     @Override
     public void updateParameterName(final InformationItem parameter,
-                                    final String name) {
+                                    final String name,
+                                    final Command onSuccess) {
         getExpression().get().ifPresent(e -> {
             sessionCommandManager.execute((AbstractCanvasHandler) sessionManager.getCurrentSession().getCanvasHandler(),
                                           new UpdateParameterNameCommand(parameter,
                                                                          name,
-                                                                         gridLayer::batch));
+                                                                         () -> {
+                                                                             gridLayer.batch();
+                                                                             onSuccess.execute();
+                                                                         }));
         });
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/HasParametersControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/HasParametersControl.java
@@ -32,7 +32,8 @@ public interface HasParametersControl {
                          final Command onSuccess);
 
     void updateParameterName(final InformationItem parameter,
-                             final String name);
+                             final String name,
+                             final Command onSuccess);
 
     void updateParameterTypeRef(final InformationItem parameter,
                                 final QName typeRef);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverImpl.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.function.parameters;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -98,8 +99,24 @@ public class ParametersPopoverImpl implements ParametersPopoverView.Presenter {
     @Override
     public void updateParameterName(final InformationItem parameter,
                                     final String name) {
-        binding.ifPresent(b -> b.updateParameterName(parameter,
-                                                     name));
+        binding.ifPresent(b -> {
+            // See https://issues.redhat.com/browse/DROOLS-4907
+            final String trimmedName = Objects.nonNull(name) ? name.trim() : "";
+            if (!Objects.equals(parameter.getName().getValue(), trimmedName)) {
+                b.updateParameterName(parameter,
+                                      trimmedName,
+                                      () -> updateViewParameterName(b, parameter, trimmedName));
+            } else if (!Objects.equals(name, trimmedName)) {
+                updateViewParameterName(b, parameter, trimmedName);
+            }
+        });
+    }
+
+    private void updateViewParameterName(final HasParametersControl binding,
+                                         final InformationItem parameter,
+                                         final String name) {
+        final int index = binding.getParameters().indexOf(parameter);
+        view.updateParameterName(index, name);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverView.java
@@ -42,5 +42,8 @@ public interface ParametersPopoverView extends PopoverView,
 
     void setParameters(final List<InformationItem> parameters);
 
+    void updateParameterName(final int index,
+                             final String name);
+
     void focusParameter(final int index);
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImpl.java
@@ -99,6 +99,15 @@ public class ParametersPopoverViewImpl extends AbstractPopoverViewImpl implement
     }
 
     @Override
+    public void updateParameterName(final int index,
+                                    final String name) {
+        if (index < 0 || index >= parameterViewInstances.size()) {
+            return;
+        }
+        parameterViewInstances.get(index).setName(name);
+    }
+
+    @Override
     public void focusParameter(final int index) {
         if (index < 0 || index >= parameterViewInstances.size()) {
             return;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/FunctionGridTest.java
@@ -84,6 +84,7 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
@@ -122,7 +123,9 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class FunctionGridTest {
 
-    private static final String PARAMETER_NAME = "name";
+    private static final String PARAMETER_NAME = "parameter-name";
+
+    private static final String PARAMETER_NAME_NEW = "parameter-name-new";
 
     private static final String NODE_UUID = "uuid";
 
@@ -158,6 +161,9 @@ public class FunctionGridTest {
 
     @Mock
     private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private GraphCommandExecutionContext graphCommandExecutionContext;
 
     @Mock
     private Diagram diagram;
@@ -379,6 +385,7 @@ public class FunctionGridTest {
         when(canvasCommandFactory.updatePropertyValue(any(Element.class),
                                                       anyString(),
                                                       any())).thenReturn(mock(UpdateElementPropertyCommand.class));
+        when(canvasHandler.getGraphExecutionContext()).thenReturn(graphCommandExecutionContext);
 
         doAnswer((i) -> i.getArguments()[0].toString()).when(translationService).format(anyString());
         doAnswer((i) -> i.getArguments()[0].toString()).when(translationService).getTranslation(anyString());
@@ -573,7 +580,6 @@ public class FunctionGridTest {
 
         verify(gridLayer).batch();
         verify(onSuccess).execute();
-        verify(gridPanel).setFocus(true);
     }
 
     @Test
@@ -591,15 +597,17 @@ public class FunctionGridTest {
 
         verify(gridLayer).batch();
         verify(onSuccess).execute();
-        verify(gridPanel).setFocus(true);
     }
 
     @Test
     public void testUpdateParameterName() {
         setupGrid(0);
 
+        final Command command = mock(Command.class);
+
         grid.updateParameterName(parameter,
-                                 "name");
+                                 PARAMETER_NAME_NEW,
+                                 command);
 
         verify(sessionCommandManager).execute(eq(canvasHandler),
                                               updateParameterNameCommandCaptor.capture());
@@ -607,7 +615,9 @@ public class FunctionGridTest {
         final UpdateParameterNameCommand updateParameterNameCommand = updateParameterNameCommandCaptor.getValue();
         updateParameterNameCommand.execute(canvasHandler);
 
+        assertEquals(PARAMETER_NAME_NEW, parameter.getName().getValue());
         verify(gridLayer).batch();
+        verify(command).execute();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImplTest.java
@@ -38,6 +38,7 @@ import org.uberfire.client.views.pfly.widgets.Popover;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -172,6 +173,33 @@ public class ParametersPopoverViewImplTest {
         commandArgumentCaptor.getValue().execute(PARAMETER_TYPE_REF_NEW);
 
         verify(presenter).updateParameterTypeRef(parameter, PARAMETER_TYPE_REF_NEW);
+    }
+
+    @Test
+    public void testUpdateParameterName() {
+        final InformationItem parameter1 = new InformationItem();
+        final InformationItem parameter2 = new InformationItem();
+
+        view.setParameters(Arrays.asList(parameter1, parameter2));
+
+        view.updateParameterName(0, PARAMETER1_NAME);
+
+        verify(parameterView1).setName(PARAMETER1_NAME);
+
+        view.updateParameterName(1, PARAMETER2_NAME);
+
+        verify(parameterView2).setName(PARAMETER2_NAME);
+
+        reset(parameterView1, parameterView2);
+        view.updateParameterName(-1, "cheese");
+
+        verify(parameterView1, never()).setName(anyString());
+        verify(parameterView2, never()).setName(anyString());
+
+        view.updateParameterName(2, "cheese");
+
+        verify(parameterView1, never()).setName(anyString());
+        verify(parameterView2, never()).setName(anyString());
     }
 
     @Test


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-4907

This PR also fixes another issue I found when adding a parameter, then undoing the addition and redoing it.. on `master` the redo gives the parameter a new name and not the original.