### PR TITLE
DROOLS-4901 / DROOLS-4803: [DMN Designer] Data Types - Drag and Drop - Error when a single structure data type is dragged twice / User is unable to reorder structure items

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentView.java
@@ -41,6 +41,7 @@ import static org.kie.workbench.common.dmn.client.editors.types.listview.dragand
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asDragging;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asHover;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonDragging;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSPaddingLeft;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSTop;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSWidth;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isGrip;
@@ -247,7 +248,7 @@ public class DNDListComponentView implements DNDListComponent.View {
     }
 
     private int getCurrentXPosition(final HTMLElement element) {
-        final int margin = getCSSWidth(element) / getLevelSize();
+        final int margin = getCSSPaddingLeft(element) / getLevelSize();
         return margin > 0 ? margin : 0;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelper.java
@@ -153,6 +153,10 @@ class DNDListDOMHelper {
         return parseInt(element.style.getPropertyValue("top"));
     }
 
+    static int getCSSPaddingLeft(final HTMLElement element) {
+        return parseInt(element.style.getPropertyValue("padding-left"));
+    }
+
     static int getCSSWidth(final HTMLElement element) {
         final String width = element.style.getPropertyValue("width");
         return parseInt(width.replace("calc(100% - ", "").replace("px)", ""));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListComponentViewTest.java
@@ -542,10 +542,10 @@ public class DNDListComponentViewTest {
         doReturn(true).when(view).hasChildren(previousElement);
 
         when(presenter.getIndentationSize()).thenReturn(50);
-        when(draggingElement.style.getPropertyValue("width")).thenReturn("calc(100% - 100px)");
-        when(getDependentElement0.style.getPropertyValue("width")).thenReturn("calc(100% - 150px)");
-        when(getDependentElement1.style.getPropertyValue("width")).thenReturn("calc(100% - 200px)");
-        when(getDependentElement2.style.getPropertyValue("width")).thenReturn("calc(100% - 250px)");
+        when(draggingElement.style.getPropertyValue("padding-left")).thenReturn("100px");
+        when(getDependentElement0.style.getPropertyValue("padding-left")).thenReturn("150px");
+        when(getDependentElement1.style.getPropertyValue("padding-left")).thenReturn("200px");
+        when(getDependentElement2.style.getPropertyValue("padding-left")).thenReturn("250px");
 
         view.updateDraggingElementsPosition();
 
@@ -576,10 +576,10 @@ public class DNDListComponentViewTest {
         doReturn(false).when(view).hasChildren(previousElement);
 
         when(presenter.getIndentationSize()).thenReturn(50);
-        when(draggingElement.style.getPropertyValue("width")).thenReturn("calc(100% - 100px)");
-        when(dependentElement0.style.getPropertyValue("width")).thenReturn("calc(100% - 150px)");
-        when(dependentElement1.style.getPropertyValue("width")).thenReturn("calc(100% - 200px)");
-        when(dependentElement2.style.getPropertyValue("width")).thenReturn("calc(100% - 250px)");
+        when(draggingElement.style.getPropertyValue("padding-left")).thenReturn("100px");
+        when(dependentElement0.style.getPropertyValue("padding-left")).thenReturn("150px");
+        when(dependentElement1.style.getPropertyValue("padding-left")).thenReturn("200px");
+        when(dependentElement2.style.getPropertyValue("padding-left")).thenReturn("250px");
 
         view.updateDraggingElementsPosition();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/draganddrop/DNDListDOMHelperTest.java
@@ -49,6 +49,7 @@ import static org.kie.workbench.common.dmn.client.editors.types.listview.dragand
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asHover;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonDragging;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.asNonHover;
+import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSPaddingLeft;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSTop;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.getCSSWidth;
 import static org.kie.workbench.common.dmn.client.editors.types.listview.draganddrop.DNDListDOMHelper.isDraggingElement;
@@ -301,6 +302,18 @@ public class DNDListDOMHelperTest {
         final int expectedWidth = 321;
 
         assertEquals(expectedWidth, actualWidth);
+    }
+
+    @Test
+    public void testGetCSSPaddingLeft() {
+
+        element.style = mock(CSSStyleDeclaration.class);
+        when(element.style.getPropertyValue("padding-left")).thenReturn("321");
+
+        final int actualPadding = getCSSPaddingLeft(element);
+        final int expectedPadding = 321;
+
+        assertEquals(expectedPadding, actualPadding);
     }
 
     // -- Class handlers


### PR DESCRIPTION
See:
- https://issues.redhat.com/browse/DROOLS-4803
- https://issues.redhat.com/browse/DROOLS-4901

Before:
![2020-01-10 16 45 42](https://user-images.githubusercontent.com/1079279/72182120-96394480-33c9-11ea-92bf-4c4de49e52d1.gif)
![2020-01-10 16 46 10](https://user-images.githubusercontent.com/1079279/72182130-9a656200-33c9-11ea-9271-974dabf730bf.gif)

After:
![2020-01-10 16 48 17](https://user-images.githubusercontent.com/1079279/72182140-a0f3d980-33c9-11ea-9d21-47a0fa1cb300.gif)
![2020-01-10 16 49 32](https://user-images.githubusercontent.com/1079279/72182149-a5b88d80-33c9-11ea-93f6-a4b07c6acad9.gif)

