### PR TITLE
KOGITO-937: [DMN Designer] Decision Navigator dock position per channel

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
@@ -56,23 +56,27 @@ public class DecisionNavigatorPresenter {
 
     public static final String IDENTIFIER = "org.kie.dmn.decision.navigator";
 
-    private final View view;
+    private View view;
 
-    private final DecisionNavigatorTreePresenter treePresenter;
+    private DecisionNavigatorTreePresenter treePresenter;
 
-    private final DecisionComponents decisionComponents;
+    private DecisionComponents decisionComponents;
 
-    private final DecisionNavigatorObserver decisionNavigatorObserver;
+    private DecisionNavigatorObserver decisionNavigatorObserver;
 
-    private final DecisionNavigatorChildrenTraverse navigatorChildrenTraverse;
+    private DecisionNavigatorChildrenTraverse navigatorChildrenTraverse;
 
-    private final DecisionNavigatorItemFactory itemFactory;
+    private DecisionNavigatorItemFactory itemFactory;
 
-    private final TranslationService translationService;
+    private TranslationService translationService;
 
-    private final IsKogito isKogito;
+    private IsKogito isKogito;
 
     private CanvasHandler handler;
+
+    protected DecisionNavigatorPresenter() {
+        //CDI proxy
+    }
 
     @Inject
     public DecisionNavigatorPresenter(final View view,
@@ -232,6 +236,5 @@ public class DecisionNavigatorPresenter {
         void showDecisionComponentsContainer();
 
         void hideDecisionComponentsContainer();
-
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoDecisionNavigatorDock.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoDecisionNavigatorDock.java
@@ -19,6 +19,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Specializes;
 import javax.inject.Inject;
 
+import org.appformer.kogito.bridge.client.context.EditorContextProvider;
+import org.appformer.kogito.bridge.client.context.KogitoChannel;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorPresenter;
@@ -29,6 +31,8 @@ import org.uberfire.client.workbench.docks.UberfireDocks;
 @ApplicationScoped
 public class KogitoDecisionNavigatorDock extends DecisionNavigatorDock {
 
+    private EditorContextProvider context;
+
     public KogitoDecisionNavigatorDock() {
         // CDI proxy
     }
@@ -36,10 +40,12 @@ public class KogitoDecisionNavigatorDock extends DecisionNavigatorDock {
     @Inject
     public KogitoDecisionNavigatorDock(final UberfireDocks uberfireDocks,
                                        final DecisionNavigatorPresenter decisionNavigatorPresenter,
-                                       final TranslationService translationService) {
+                                       final TranslationService translationService,
+                                       final EditorContextProvider context) {
         super(uberfireDocks,
               decisionNavigatorPresenter,
               translationService);
+        this.context = context;
     }
 
     @Override
@@ -73,6 +79,17 @@ public class KogitoDecisionNavigatorDock extends DecisionNavigatorDock {
 
     @Override
     protected UberfireDockPosition position() {
-        return UberfireDockPosition.EAST;
+        return getUberfireDockPosition();
+    }
+
+    UberfireDockPosition getUberfireDockPosition() {
+        final KogitoChannel channel = context.getChannel();
+        switch (channel) {
+            case GITHUB:
+            case VSCODE:
+                return UberfireDockPosition.EAST;
+            default:
+                return UberfireDockPosition.WEST;
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/BaseKogitoDockTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/BaseKogitoDockTest.java
@@ -37,9 +37,9 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public abstract class BaseKogitoDockTest {
+public abstract class BaseKogitoDockTest<DOCK extends DiagramEditorDock> {
 
-    private static final String PERSPECTIVE_ID = "perspectiveId";
+    protected static final String PERSPECTIVE_ID = "perspectiveId";
 
     @Mock
     protected UberfireDocks uberfireDocks;
@@ -51,9 +51,9 @@ public abstract class BaseKogitoDockTest {
     protected TranslationService translationService;
 
     @Captor
-    private ArgumentCaptor<UberfireDock> dockArgumentCaptor;
+    protected ArgumentCaptor<UberfireDock> dockArgumentCaptor;
 
-    private DiagramEditorDock dock;
+    protected DOCK dock;
 
     @Before
     public void setup() {
@@ -62,7 +62,7 @@ public abstract class BaseKogitoDockTest {
         dock.init(PERSPECTIVE_ID);
     }
 
-    protected abstract DiagramEditorDock makeDock();
+    protected abstract DOCK makeDock();
 
     protected abstract UberfireDockPosition position();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoDecisionNavigatorDockTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoDecisionNavigatorDockTest.java
@@ -15,24 +15,73 @@
  */
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.docks;
 
+import org.appformer.kogito.bridge.client.context.EditorContextProvider;
+import org.appformer.kogito.bridge.client.context.KogitoChannel;
+import org.junit.Before;
+import org.junit.Test;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorPresenter;
-import org.kie.workbench.common.stunner.kogito.api.docks.DiagramEditorDock;
+import org.mockito.Mock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 
-public class KogitoDecisionNavigatorDockTest extends BaseKogitoDockTest {
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class KogitoDecisionNavigatorDockTest extends BaseKogitoDockTest<KogitoDecisionNavigatorDock> {
+
+    @Mock
+    private EditorContextProvider context;
+
+    @Before
+    @Override
+    public void setup() {
+        when(context.getChannel()).thenReturn(KogitoChannel.DEFAULT);
+
+        super.setup();
+    }
 
     @Override
-    protected DiagramEditorDock makeDock() {
+    protected KogitoDecisionNavigatorDock makeDock() {
         return new KogitoDecisionNavigatorDock(uberfireDocks,
                                                decisionNavigatorPresenter,
-                                               translationService);
+                                               translationService,
+                                               context);
     }
 
+    @Override
     protected UberfireDockPosition position() {
-        return UberfireDockPosition.EAST;
+        return UberfireDockPosition.WEST;
     }
 
+    @Override
     protected String screen() {
         return DecisionNavigatorPresenter.IDENTIFIER;
+    }
+
+    @Test
+    public void testDefaultChannelPosition() {
+        when(context.getChannel()).thenReturn(KogitoChannel.DEFAULT);
+
+        assertEquals(UberfireDockPosition.WEST, dock.position());
+    }
+
+    @Test
+    public void testOnlineChannelPosition() {
+        when(context.getChannel()).thenReturn(KogitoChannel.ONLINE);
+
+        assertEquals(UberfireDockPosition.WEST, dock.position());
+    }
+
+    @Test
+    public void testVSCodeChannelPosition() {
+        when(context.getChannel()).thenReturn(KogitoChannel.VSCODE);
+
+        assertEquals(UberfireDockPosition.EAST, dock.position());
+    }
+
+    @Test
+    public void testGitHubChannelPosition() {
+        when(context.getChannel()).thenReturn(KogitoChannel.GITHUB);
+
+        assertEquals(UberfireDockPosition.EAST, dock.position());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoPreviewDiagramDockTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoPreviewDiagramDockTest.java
@@ -16,13 +16,12 @@
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.docks;
 
 import org.kie.workbench.common.dmn.client.docks.preview.PreviewDiagramScreen;
-import org.kie.workbench.common.stunner.kogito.api.docks.DiagramEditorDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 
-public class KogitoPreviewDiagramDockTest extends BaseKogitoDockTest {
+public class KogitoPreviewDiagramDockTest extends BaseKogitoDockTest<KogitoPreviewDiagramDock> {
 
     @Override
-    protected DiagramEditorDock makeDock() {
+    protected KogitoPreviewDiagramDock makeDock() {
         return new KogitoPreviewDiagramDock(uberfireDocks,
                                             translationService);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoPropertiesDockTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/docks/KogitoPropertiesDockTest.java
@@ -15,14 +15,13 @@
  */
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.docks;
 
-import org.kie.workbench.common.stunner.kogito.api.docks.DiagramEditorDock;
 import org.kie.workbench.common.stunner.kogito.client.screens.DiagramEditorPropertiesScreen;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 
-public class KogitoPropertiesDockTest extends BaseKogitoDockTest {
+public class KogitoPropertiesDockTest extends BaseKogitoDockTest<KogitoPropertiesDock> {
 
     @Override
-    protected DiagramEditorDock makeDock() {
+    protected KogitoPropertiesDock makeDock() {
         return new KogitoPropertiesDock(uberfireDocks,
                                         translationService);
     }


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-937

**_How to test (for speed and simplicity)_**

1. `mvn clean install -DskipTests -Dgwt.compiler.skip=true` the `kie-wb-common-dmn` module.
2. `mvn clean install` the `kie-wb-common-dmn-webapp-kogito-runtime` module.
3. Fetch the latest `kogito-tooling` [repository](https://github.com/kiegroup/kogito-tooling.git).
4. Update the version of DMN used [in](https://github.com/kiegroup/kogito-tooling/blob/master/packages/kie-bc-editors-unpacked/pom.xml#L40) `packages/kie-bc-editors-unpacked/pom.xml`
5. `cd kogito-tooling`
6. `yarn run init`
7. `yarn run build:prod`
8. Follow the [README](https://github.com/kiegroup/kogito-tooling/blob/master/README.md) to test in VSCode and GitHub (Decision Navigator should be on the RIGHT).
9. Unzip `kie-wb-common-dmn-webapp-kogito-runtime`
10. Double click `index.html` (Decision Navigator should be on the LEFT).
11. Running `drools-wb-webapp` (or Business Central) Decision Navigator should be on the LEFT.