### PR TITLE
RHDM-1145: [DMN Designer] Java Date field is not converted to DMN date type

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/DataObjectsServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/DataObjectsServiceImpl.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.jboss.errai.bus.server.annotations.Service;
 import org.kie.dmn.feel.lang.Type;
-import org.kie.dmn.feel.parser.feel11.ParserHelper;
+import org.kie.dmn.feel.lang.impl.JavaBackedType;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
 import org.kie.soup.project.datamodel.oracle.ModuleDataModelOracle;
@@ -148,7 +148,7 @@ public class DataObjectsServiceImpl implements DataObjectsService {
     }
 
     private BuiltInType determineBuiltInTypeFromClass(final Class<?> clazz) {
-        final Type type = ParserHelper.determineTypeFromClass(clazz);
+        final Type type = JavaBackedType.determineTypeFromClass(clazz);
         if (type instanceof org.kie.dmn.feel.lang.types.BuiltInType) {
             org.kie.dmn.feel.lang.types.BuiltInType builtIn = (org.kie.dmn.feel.lang.types.BuiltInType) type;
             switch (builtIn) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/DataObjectsServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/types/DataObjectsServiceImpl.java
@@ -15,12 +15,6 @@
  */
 package org.kie.workbench.common.dmn.backend.editors.types;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +26,8 @@ import javax.inject.Inject;
 
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.parser.feel11.ParserHelper;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
 import org.kie.soup.project.datamodel.oracle.ModuleDataModelOracle;
@@ -152,24 +148,32 @@ public class DataObjectsServiceImpl implements DataObjectsService {
     }
 
     private BuiltInType determineBuiltInTypeFromClass(final Class<?> clazz) {
-        if (Objects.isNull(clazz)) {
-            return BuiltInType.UNDEFINED;
-        } else if (Number.class.isAssignableFrom(clazz)) {
-            return BuiltInType.NUMBER;
-        } else if (String.class.isAssignableFrom(clazz)) {
-            return BuiltInType.STRING;
-        } else if (Character.class.isAssignableFrom(clazz)) {
-            return BuiltInType.STRING;
-        } else if (LocalDate.class.isAssignableFrom(clazz)) {
-            return BuiltInType.DATE;
-        } else if (LocalTime.class.isAssignableFrom(clazz) || OffsetTime.class.isAssignableFrom(clazz)) {
-            return BuiltInType.TIME;
-        } else if (ZonedDateTime.class.isAssignableFrom(clazz) || OffsetDateTime.class.isAssignableFrom(clazz) || LocalDateTime.class.isAssignableFrom(clazz)) {
-            return BuiltInType.DATE_TIME;
-        } else if (Boolean.class.isAssignableFrom(clazz)) {
-            return BuiltInType.BOOLEAN;
-        } else if (Map.class.isAssignableFrom(clazz)) {
-            return BuiltInType.CONTEXT;
+        final Type type = ParserHelper.determineTypeFromClass(clazz);
+        if (type instanceof org.kie.dmn.feel.lang.types.BuiltInType) {
+            org.kie.dmn.feel.lang.types.BuiltInType builtIn = (org.kie.dmn.feel.lang.types.BuiltInType) type;
+            switch (builtIn) {
+                case UNKNOWN:
+                case DURATION:
+                case RANGE:
+                case FUNCTION:
+                case LIST:
+                case UNARY_TEST:
+                    return BuiltInType.ANY;
+                case NUMBER:
+                    return BuiltInType.NUMBER;
+                case STRING:
+                    return BuiltInType.STRING;
+                case DATE:
+                    return BuiltInType.DATE;
+                case TIME:
+                    return BuiltInType.TIME;
+                case DATE_TIME:
+                    return BuiltInType.DATE_TIME;
+                case BOOLEAN:
+                    return BuiltInType.BOOLEAN;
+                case CONTEXT:
+                    return BuiltInType.CONTEXT;
+            }
         }
         return BuiltInType.ANY;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/editors/types/DataObjectsServiceImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/editors/types/DataObjectsServiceImplTest.java
@@ -24,6 +24,7 @@ import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoLocalDate;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -278,12 +279,14 @@ public class DataObjectsServiceImplTest {
                                                      DataType.TYPE_OBJECT),
                                        newModelField("listField",
                                                      List.class.getName(),
-                                                     List.class.getSimpleName())
+                                                     List.class.getSimpleName()),
+                                       newModelField("localDateField",
+                                                     Date.class.getName(),
+                                                     DataType.TYPE_LOCAL_DATE)
                                });
 
         final Map<String, ModelField[]> modelFields = modelFieldsBuilder.build();
         dataModelOracle.addModuleModelFields(modelFields);
-
 
         final Maps.Builder<String, String> modelFieldsParametersTypeBuilder = new Maps.Builder<>();
         modelFieldsParametersTypeBuilder.put(APerson.class.getName() + "#listField", String.class.getName());
@@ -296,7 +299,7 @@ public class DataObjectsServiceImplTest {
         assertThat(dataObjects).hasSize(1);
 
         assertThat(dataObjects.get(0).getClassType()).isEqualTo(APerson.class.getName());
-        assertThat(dataObjects.get(0).getProperties()).hasSize(11);
+        assertThat(dataObjects.get(0).getProperties()).hasSize(12);
         assertThat(dataObjects.get(0).getProperties().get(0).getProperty()).isEqualTo("stringField");
         assertThat(dataObjects.get(0).getProperties().get(0).getType()).isEqualTo(BuiltInType.STRING.getName());
         assertThat(dataObjects.get(0).getProperties().get(0).isList()).isFalse();
@@ -330,10 +333,13 @@ public class DataObjectsServiceImplTest {
         assertThat(dataObjects.get(0).getProperties().get(10).getProperty()).isEqualTo("listField");
         assertThat(dataObjects.get(0).getProperties().get(10).getType()).isEqualTo(BuiltInType.STRING.getName());
         assertThat(dataObjects.get(0).getProperties().get(10).isList()).isTrue();
+        assertThat(dataObjects.get(0).getProperties().get(11).getProperty()).isEqualTo("localDateField");
+        assertThat(dataObjects.get(0).getProperties().get(11).getType()).isEqualTo(BuiltInType.DATE_TIME.getName());
+        assertThat(dataObjects.get(0).getProperties().get(11).isList()).isFalse();
     }
 
     @Test
-    public void testLoadDataObjects_Lists(){
+    public void testLoadDataObjects_Lists() {
         final Maps.Builder<String, ModelField[]> modelFieldsBuilder = new Maps.Builder<>();
         modelFieldsBuilder.put(APerson.class.getName(),
                                new ModelField[]{


### PR DESCRIPTION
RHDM-1145: [DMN Designer] Java Date field is not converted to DMN date type
DROOLS-4977: [DMN Designer] Refactor DataObjectsServiceImpl to not duplicate logic from ParseHelper

EDIT: is not a part of an ensemble anymore. The changes in the Drools was superseded by https://github.com/kiegroup/drools/pull/2735