### PR TITLE
AF-2410: Added switch to remove BC features in Monitoring

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/service/impl/FormEditorServiceImplTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/service/impl/FormEditorServiceImplTest.java
@@ -172,7 +172,7 @@ public class FormEditorServiceImplTest {
                                                           renameService,
                                                           copyService));
 
-        when(path.toURI()).thenReturn("default:///src/main/resources/test.frm");
+        when(path.toURI()).thenReturn("file:///src/main/resources/test.frm");
         when(moduleService.resolveModule(any())).thenReturn(module);
     }
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/service/impl/helpers/AbstractFormDefinitionHelperTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/java/org/kie/workbench/common/forms/editor/backend/service/impl/helpers/AbstractFormDefinitionHelperTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractFormDefinitionHelperTest<HELPER extends AbstractFo
 
     private static final String DESTINATION_FORM_NAME = "PersonShort2";
     private static final String DESTINATION_FORM_ASSET_NAME = DESTINATION_FORM_NAME + "." + FormResourceTypeDefinition.EXTENSION;
-    private static final String DESTINATION_FORM_PATH = "default:///src/main" + FORM_PATH + DESTINATION_FORM_ASSET_NAME;
+    private static final String DESTINATION_FORM_PATH = "file:///src/main" + FORM_PATH + DESTINATION_FORM_ASSET_NAME;
 
     @Mock
     protected IOService ioService;

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
+org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
 org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImpl.java
@@ -83,6 +83,7 @@ import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.Files;
 import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
 import org.uberfire.java.nio.fs.jgit.FileSystemLock;
 import org.uberfire.java.nio.fs.jgit.FileSystemLockManager;
 import org.uberfire.java.nio.fs.jgit.JGitPathImpl;
@@ -160,15 +161,21 @@ public class ArchetypeServiceImpl implements ArchetypeService {
 
     @PostConstruct
     void postConstruct() {
-        maybeCreateArchetypesOU();
+        if (this.isGitDefaultFileSystem()) {
+            maybeCreateArchetypesOU();
 
-        if (isArchetypesOUAvailable()) {
-            archetypePreferencesManager.initializeCustomPreferences();
+            if (isArchetypesOUAvailable()) {
+                archetypePreferencesManager.initializeCustomPreferences();
 
-            checkKieTemplates();
+                checkKieTemplates();
 
-            validateAll();
+                validateAll();
+            }
         }
+    }
+
+    protected boolean isGitDefaultFileSystem() {
+        return FileSystemUtils.isGitDefaultFileSystem();
     }
 
     public void onNewOrganizationalUnitEvent(final @Observes NewOrganizationalUnitEvent newOrganizationalUnitEvent) {

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImplTest.java
@@ -63,6 +63,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
 import org.uberfire.java.nio.fs.jgit.FileSystemLock;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 import org.uberfire.spaces.Space;
@@ -125,6 +126,7 @@ public class ArchetypeServiceImplTest {
 
         doReturn(mock(FileSystemLock.class)).when(service).createLock(any(File.class));
         doReturn(mock(Path.class)).when(service).createTempDirectory(anyString());
+        doReturn(true).when(service).isGitDefaultFileSystem();
     }
 
     @Test
@@ -548,7 +550,6 @@ public class ArchetypeServiceImplTest {
         doReturn(ArchetypeStatus.VALID).when(archetype).getStatus();
         doReturn(archetype).when(archetypeConfigStorage).loadArchetype(anyString());
 
-
         doReturn(null).when(repositoryService).getRepositoryFromSpace(any(Space.class),
                                                                       anyString());
 
@@ -897,7 +898,7 @@ public class ArchetypeServiceImplTest {
         final Repository repository = mock(Repository.class);
 
         doReturn(repository).when(repositoryService).getRepositoryFromSpace(any(Space.class),
-                                                                                        anyString());
+                                                                            anyString());
 
         final Git git = mock(Git.class);
         final org.eclipse.jgit.lib.Repository gitRepository = mock(org.eclipse.jgit.lib.Repository.class);
@@ -997,6 +998,14 @@ public class ArchetypeServiceImplTest {
 
         verify(archetypeConfigStorage).loadArchetype(repositoryAlias);
         assertFalse(archetype.isPresent());
+    }
+
+    @Test
+    public void testIsMonitoringEnabled() {
+        System.setProperty(FileSystemUtils.SIMPLIFIED_MONITORING_ENABLED, "true");
+        System.setProperty(FileSystemUtils.CFG_KIE_CONTROLLER_OCP_ENABLED, "true");
+        service.postConstruct();
+        verify(service, never()).validateAll();
     }
 
     private GAV createGav() {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/AbstractDataModelerServiceWeldTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/AbstractDataModelerServiceWeldTest.java
@@ -48,8 +48,6 @@ public abstract class AbstractDataModelerServiceWeldTest {
         dataModelService = weldContainer.select(DataModelerService.class).get();
         moduleService = weldContainer.select(KieModuleService.class).get();
 
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
     }
 
     @After

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerEventObserverTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerEventObserverTest.java
@@ -57,7 +57,7 @@ public class DataModelerEventObserverTest {
     @Mock
     private Path descriptorPath;
 
-    private static final String DESCRIPTOR_PATH = "default://dummy-repo/dummy-project/src/main/resources/META-INF/persistence.xml";
+    private static final String DESCRIPTOR_PATH = "file://dummy-repo/dummy-project/src/main/resources/META-INF/persistence.xml";
 
     private DataModelerEventObserver eventObserver;
     private PersistenceDescriptorModel descriptorModel;

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceHelperTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceHelperTest.java
@@ -93,7 +93,6 @@ public class DataModelerServiceHelperTest {
     @Before
     public void setUp() throws Exception {
         SimpleFileSystemProvider fileSystemProvider = new SimpleFileSystemProvider();
-        fileSystemProvider.forceAsDefault();
 
         serviceHelper = new DataModelerServiceHelper(moduleService,
                                                      ioService,

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
+org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
 org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/BaseLibraryIndexingTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/BaseLibraryIndexingTest.java
@@ -51,13 +51,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import org.kie.workbench.common.services.refactoring.backend.server.query.standard.LibraryFileNameIndexTerm;
-import org.kie.workbench.common.services.refactoring.backend.server.query.standard.LibraryRepositoryRootIndexTerm;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.ImpactAnalysisAnalyzerWrapperFactory;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.LowerCaseOnlyAnalyzer;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQueries;
 import org.kie.workbench.common.services.refactoring.backend.server.query.NamedQuery;
 import org.kie.workbench.common.services.refactoring.backend.server.query.RefactoringQueryServiceImpl;
+import org.kie.workbench.common.services.refactoring.backend.server.query.standard.LibraryFileNameIndexTerm;
+import org.kie.workbench.common.services.refactoring.backend.server.query.standard.LibraryRepositoryRootIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.ModuleRootPathIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
 import org.kie.workbench.common.services.shared.project.KieModule;
@@ -79,6 +79,7 @@ import org.uberfire.ext.metadata.io.IndexersFactory;
 import org.uberfire.ext.metadata.io.MetadataConfigBuilder;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
 import org.uberfire.workbench.type.AnyResourceTypeDefinition;
 
 import static org.mockito.Matchers.any;
@@ -157,6 +158,8 @@ public abstract class BaseLibraryIndexingTest {
                                "false");
             System.setProperty("org.uberfire.sys.repo.monitor.disabled",
                                "true");
+            System.setProperty(FileSystemUtils.SIMPLIFIED_MONITORING_ENABLED,
+                               "false");
             System.out.println(".niogit: " + path);
 
             final URI newRepo = URI.create("git://" + repositoryName);

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryAssetUpdateNotifierTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryAssetUpdateNotifierTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.impl;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.metadata.event.BatchIndexEvent;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LibraryAssetUpdateNotifierTest {
+
+    @Spy
+    private LibraryAssetUpdateNotifier notifier = new LibraryAssetUpdateNotifier();
+
+    @Mock
+    private BatchIndexEvent event;
+
+    @Before
+    public void setUp() {
+        doReturn(new ArrayList<>()).when(event).getIndexEvents();
+        doReturn(true).when(notifier).isUpdateNotifierEnabled();
+    }
+
+    @Test
+    public void testMonitoringEnabled() {
+        doReturn(false).when(notifier).isUpdateNotifierEnabled();
+        notifier.notifyOnUpdatedAssets(event);
+        verify(event, never()).getIndexEvents();
+    }
+
+    @Test
+    public void testMonitoringDisabled() {
+        {
+            notifier.notifyOnUpdatedAssets(event);
+            verify(event, times(1)).getIndexEvents();
+        }
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/java/org/kie/workbench/common/screens/impl/LibraryServiceImplTest.java
@@ -248,7 +248,7 @@ public class LibraryServiceImplTest {
     @Test
     public void queryingUnindexedProjectGivesUnindexedResult() throws Exception {
         Branch branch = new Branch("fake-branch",
-                                   mockPath("default:///a/b/c"));
+                                   mockPath("file:///a/b/c"));
         final WorkspaceProject project = new WorkspaceProject(ou1,
                                                               repo1,
                                                               branch,

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider


### PR DESCRIPTION
## Intention

* Disable JGit specific features when JGit is not the default FS
* Add a switch to choose between Monitoring and Simplified Monitoring

## Simplified Monitoring 
Simplified monitoring is the K8S FS based solution. This can't use JGit specific parts so they are disabled (Like _Pages_)

Possible values:
* -Dorg.appformer.server.simplified.monitoring.enabled=true/false

## Related PRs:
* https://github.com/kiegroup/appformer/pull/882
* https://github.com/kiegroup/kie-wb-common/pull/3128
* https://github.com/kiegroup/drools-wb/pull/1363
* https://github.com/kiegroup/jbpm-designer/pull/881