### PR TITLE
DROOLS-4989: [DMN Designer] Tab content background colour consistency

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.less
@@ -15,7 +15,8 @@
  */
 
 [data-i18n-prefix="DMNDocumentationView."] {
-  background-color: #DDD;
+  //See PF Empty State: https://www.patternfly.org/v3/pattern-library/communication/empty-state/
+  background-color: #f5f5f5;
   padding: 30px;
 
   .documentation-panel {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.less
@@ -92,7 +92,8 @@
   }
 
   .kie-data-types-placeholder {
-    background-color: #f2f2f2;
+    //See PF Empty State: https://www.patternfly.org/v3/pattern-library/communication/empty-state/
+    background-color: #f5f5f5;
     text-align: center;
     height: ~"calc(100% - 120px)";
     width: ~"calc(100%)";
@@ -103,7 +104,8 @@
     flex: 1 1 auto;
 
     i {
-      color: #999999;
+      //See PF Empty State: https://www.patternfly.org/v3/pattern-library/communication/empty-state/
+      color: #9c9c9c;
       font-size: 5em;
     }
   }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/EmptyStateLayer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/EmptyStateLayer.java
@@ -21,7 +21,7 @@ import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.SVGPath;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.types.BoundingBox;
-import com.ait.lienzo.shared.core.types.ColorName;
+import com.ait.lienzo.shared.core.types.Color;
 
 class EmptyStateLayer extends Layer {
 
@@ -57,7 +57,7 @@ class EmptyStateLayer extends Layer {
                                      "3.5-17.5-0.5-21-8.5l-47.75-113-78 78c-3 3-7 4.75-11.25 4.75-2 " +
                                      "0-4.25-0.5-6-1.25-6-2.5-10-8.25-10-14.75v-376c0-6.5 4-12.25 " +
                                      "10-14.75 1.75-0.75 4-1.25 6-1.25 4.25 0 8.25 1.5 11.25 4.75z");
-        cursor.setFillColor(ColorName.DARKGRAY.toString());
+        cursor.setFillColor(Color.fromColorString(EmptyStateView.CURSOR_FILL_COLOR));
         add(cursor);
     }
 
@@ -85,8 +85,7 @@ class EmptyStateLayer extends Layer {
 
     private void drawBackground(final Context2D context) {
         context.save();
-        context.setGlobalAlpha(.5);
-        context.setFillColor(ColorName.LIGHTGREY.toString());
+        context.setFillColor(Color.fromColorString(EmptyStateView.BACKGROUND_FILL_COLOR));
 
         context.fillRect(0, 0, getWidth(), this.getHeight());
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/EmptyStateView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/views/session/EmptyStateView.java
@@ -30,10 +30,14 @@ public class EmptyStateView {
     public static final String TEXT_FONT_FAMILY = "Open Sans,Helvetica,Arial,sans-serif";
 
     public static final int TEXT_ALPHA = 1;
-    public static final String TEXT_FILL_COLOR = "#363636";
 
     public static final String TEXT_STROKE_COLOR = ColorName.TRANSPARENT.toString();
     public static final int TEXT_STROKE_WIDTH = 0;
+
+    //See PF Empty State: https://www.patternfly.org/v3/pattern-library/communication/empty-state/
+    public static final String BACKGROUND_FILL_COLOR = "#f5f5f5";
+    public static final String CURSOR_FILL_COLOR = "#9c9c9c";
+    public static final String TEXT_FILL_COLOR = "#363636";
 
     private LienzoLayer lienzoLayer;
     private String captionText;


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-4989

The background, font and icon colours have been made consistent with https://www.patternfly.org/v3/pattern-library/communication/empty-state/#code