### PR TITLE
[RHPAM-2657] KieServer Scale-Up-From-Zero lifecycle hooks logic broken

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/src/main/java/org/kie/workbench/common/screens/server/management/utils/ControllerUtils.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/src/main/java/org/kie/workbench/common/screens/server/management/utils/ControllerUtils.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.screens.server.management.utils;
 
 import java.util.Properties;
 
+import org.kie.server.controller.api.KieServerControllerConstants;
+
 import static org.kie.server.common.KeyStoreHelperUtil.loadControllerPassword;
 
 public final class ControllerUtils {
@@ -29,7 +31,6 @@ public final class ControllerUtils {
     public static final String CFG_KIE_CONTROLLER_USER = "org.kie.workbench.controller.user";
     public static final String CFG_KIE_CONTROLLER_PASSWORD = "org.kie.workbench.controller.pwd";
     public static final String CFG_KIE_CONTROLLER_TOKEN = "org.kie.workbench.controller.token";
-    public static final String CFG_KIE_CONTROLLER_OCP_ENABLED = "org.kie.workbench.controller.openshift.enabled";
 
     private static ThreadLocal<Properties> configProps = new ThreadLocal<>().withInitial(System::getProperties);
 
@@ -60,6 +61,6 @@ public final class ControllerUtils {
     }
 
     public static boolean isOpenShiftSupported() {
-        return "true".equals(getConfigProps().getProperty(CFG_KIE_CONTROLLER_OCP_ENABLED, "false"));
+        return "true".equals(getConfigProps().getProperty(KieServerControllerConstants.KIE_CONTROLLER_OPENSHIFT_ENABLED, "false"));
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/utils/ControllerExtensionTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/utils/ControllerExtensionTest.java
@@ -22,12 +22,12 @@ import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.server.controller.api.KieServerControllerConstants;
 import org.kie.workbench.common.screens.server.management.backend.KieServerEmbeddedControllerProducer;
 import org.kie.workbench.common.screens.server.management.backend.KieServerStandaloneControllerProducer;
 import org.kie.workbench.common.screens.server.management.backend.storage.ServerTemplateOCPStorage;
 import org.kie.workbench.common.screens.server.management.utils.ControllerUtils;
 
-import static org.kie.workbench.common.screens.server.management.utils.ControllerUtils.CFG_KIE_CONTROLLER_OCP_ENABLED;
 import static org.kie.workbench.common.screens.server.management.utils.ControllerUtils.KIE_SERVER_CONTROLLER;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -42,7 +42,7 @@ public class ControllerExtensionTest {
     @After
     public void clear() {
         ControllerUtils.getConfigProps().remove(KIE_SERVER_CONTROLLER, "http://localhost:8080/controller");
-        ControllerUtils.getConfigProps().remove(CFG_KIE_CONTROLLER_OCP_ENABLED, "true");
+        ControllerUtils.getConfigProps().remove(KieServerControllerConstants.KIE_CONTROLLER_OPENSHIFT_ENABLED, "true");
     }
 
     @Test
@@ -67,7 +67,7 @@ public class ControllerExtensionTest {
 
     @Test
     public void testEmbeddedAnnotationWithServerTemplateOCPStorage() {
-        ControllerUtils.getConfigProps().put(CFG_KIE_CONTROLLER_OCP_ENABLED, "true");
+        ControllerUtils.getConfigProps().put(KieServerControllerConstants.KIE_CONTROLLER_OPENSHIFT_ENABLED, "true");
         final ProcessAnnotatedType annotatedType = createAnnotatedType(ServerTemplateOCPStorage.class);
 
         extension.processEmbeddedController(annotatedType);


### PR DESCRIPTION
Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Related JIRAs
https://issues.redhat.com/projects/RHPAM/issues/RHPAM-2657
https://issues.redhat.com/projects/RHPAM/issues/RHPAM-2008
https://issues.redhat.com/browse/JBPM-8585

Related PRs
https://github.com/kiegroup/droolsjbpm-integration/pull/1995

Followed-By PRs
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/414
https://github.com/jboss-container-images/rhdm-7-openshift-image/pull/329
https://github.com/jboss-container-images/jboss-kie-modules/pull/352
https://github.com/kiegroup/kie-cloud-operator/pull/353