### PR TITLE
RHPAM-2699 - Stunner - Imports dialog not opening

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/ImportsFieldEditorWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/ImportsFieldEditorWidget.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.client.ui.HasValue;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerFormsClientFieldsConstants;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.importsEditor.popup.ImportsEditor;
@@ -39,15 +40,18 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.imports
 @Templated
 public class ImportsFieldEditorWidget extends Composite implements HasValue<ImportsValue> {
 
+    private ImportsValue importsValue;
+
     @Inject
     protected ImportsEditor importsEditor;
+
     @Inject
     @DataField
-    private Button importsButton;
+    protected Button importsButton;
+
     @Inject
     @DataField
-    private TextBox importsTextBox;
-    private ImportsValue importsValue;
+    protected TextBox importsTextBox;
 
     public ImportsFieldEditorWidget() {
     }
@@ -159,10 +163,12 @@ public class ImportsFieldEditorWidget extends Composite implements HasValue<Impo
         return copy;
     }
 
+    @EventHandler("importsButton")
     public void onClickImportsButton(final ClickEvent clickEvent) {
         showImportsEditor();
     }
 
+    @EventHandler("importsTextBox")
     public void onClickImportsTextBox(final ClickEvent clickEvent) {
         showImportsEditor();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/popup/editor/ImportsEditorWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/popup/editor/ImportsEditorWidget.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.Widget;
@@ -28,7 +27,6 @@ import com.google.gwt.user.client.ui.Widget;
 import static com.google.gwt.dom.client.Style.Display.NONE;
 import static com.google.gwt.dom.client.Style.Display.TABLE;
 
-@Dependent
 public abstract class ImportsEditorWidget<T> implements ImportsEditorWidgetView.Presenter<T> {
 
     @Inject


### PR DESCRIPTION
https://issues.redhat.com/browse/RHPAM-2699

The @EventHandler tags for the field and the button were removed, preventing the call for
the method that opens the dialog. 

This changes were introduced by this commit:
https://github.com/kiegroup/kie-wb-common/commit/445d3d307a92f741969979567ed22d99e902afe6

This fixes the problem.