### PR TITLE
RHPAM-2727 - Stunner - it is not possible to open process without simulation extensions

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/DefinitionResolver.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/DefinitionResolver.java
@@ -186,6 +186,10 @@ public class DefinitionResolver {
                 value.get(BpsimPackage.Literals.DOCUMENT_ROOT__BP_SIM_DATA, true);
         List<BPSimDataType> bpsimExtensions = (List<BPSimDataType>) simData;
 
+        if (bpsimExtensions.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
         Scenario scenario = bpsimExtensions.get(0).getScenario().get(0);
 
         for (ElementParameters parameters : scenario.getElementParameters()) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/DefinitionResolver.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/DefinitionResolver.java
@@ -182,6 +182,10 @@ public class DefinitionResolver {
                 value.get(BpsimPackage.Literals.DOCUMENT_ROOT__BP_SIM_DATA, true);
         List<BPSimDataType> bpsimExtensions = (List<BPSimDataType>) simData;
 
+        if (bpsimExtensions.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
         Scenario scenario = bpsimExtensions.get(0).getScenario().get(0);
 
         for (ElementParameters parameters : scenario.getElementParameters()) {


### PR DESCRIPTION
Hi @romartin, @LuboTerifaj with this fix I was able to load 3 from 4 diagrams provided to me in RHPAM-2686. One of attached to jira issue diagram can be used to test this change (see comment in jira issue). 

This is first part of the RHPAM-2686, small fix for missing SimData. Now marshallers doesn't fail with NullPointer exception but just ignore missing SimData.