### PR TITLE
[AF-2433] Fixed error when building the base kie template

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/maven/BuildProjectCommand.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/maven/BuildProjectCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.archetype.mgmt.backend.maven;
+
+import java.io.File;
+import java.nio.file.FileSystems;
+import java.util.Properties;
+
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenExecutionResult;
+import org.apache.maven.project.ProjectBuildingException;
+import org.appformer.maven.integration.embedder.MavenEmbedder;
+import org.appformer.maven.integration.embedder.MavenEmbedderException;
+import org.appformer.maven.integration.embedder.MavenRequest;
+import org.guvnor.common.services.project.backend.server.POMServiceImpl;
+
+public class BuildProjectCommand extends AbstractMavenCommand {
+
+    public BuildProjectCommand(final String baseDirectory) {
+        super(baseDirectory);
+    }
+
+    @Override
+    public MavenRequest buildMavenRequest() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Properties buildUserProperties() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MavenExecutionResult execute() throws MavenEmbedderException {
+        final MavenExecutionResult result = new DefaultMavenExecutionResult();
+        final MavenEmbedder mavenEmbedder = createMavenEmbedder();
+        final String pomPath = baseDirectory + FileSystems.getDefault().getSeparator() + POMServiceImpl.POM_XML;
+
+        try {
+            final File pomFile = new File(pomPath);
+            mavenEmbedder.buildProjects(pomFile, false);
+        } catch (ProjectBuildingException e) {
+            result.addException(e);
+        } finally {
+            mavenEmbedder.dispose();
+        }
+
+        return result;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImpl.java
@@ -63,7 +63,7 @@ import org.kie.workbench.common.screens.archetype.mgmt.backend.config.ArchetypeC
 import org.kie.workbench.common.screens.archetype.mgmt.backend.config.ArchetypeConfigStorageImpl;
 import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.AbstractMavenCommand;
 import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.ArchetypeGenerateCommand;
-import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.ExecuteGoalsCommand;
+import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.BuildProjectCommand;
 import org.kie.workbench.common.screens.archetype.mgmt.backend.preference.ArchetypePreferencesManager;
 import org.kie.workbench.common.screens.archetype.mgmt.backend.util.ArchetypeListingPredicates;
 import org.kie.workbench.common.screens.archetype.mgmt.shared.events.ArchetypeListUpdatedEvent;
@@ -492,7 +492,7 @@ public class ArchetypeServiceImpl implements ArchetypeService {
 
             final Path targetDirectoryPath = unpackArchetype(repository);
 
-            executeMaven(new ExecuteGoalsCommand(targetDirectoryPath.toString()));
+            executeMaven(new BuildProjectCommand(targetDirectoryPath.toString()));
 
             updateArchetypeStatus(repository.getAlias(),
                                   ArchetypeStatus.VALID,
@@ -666,7 +666,7 @@ public class ArchetypeServiceImpl implements ArchetypeService {
             throws GitAPIException, MavenEmbedderException {
         createTemporaryGitRepository(repositoryDirectory);
 
-        executeMaven(new ExecuteGoalsCommand(repositoryDirectory.getAbsolutePath()));
+        executeMaven(new BuildProjectCommand(repositoryDirectory.getAbsolutePath()));
 
         return createArchetypeRepository(templateGav,
                                          repositoryDirectory.toURI().toString());

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/maven/BuildProjectCommandTest.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/maven/BuildProjectCommandTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.archetype.mgmt.backend.maven;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.apache.maven.execution.MavenExecutionResult;
+import org.apache.maven.project.ProjectBuildingException;
+import org.appformer.maven.integration.embedder.MavenEmbedder;
+import org.appformer.maven.integration.embedder.MavenEmbedderException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BuildProjectCommandTest {
+
+    private static final String BASE_DIRECTORY = "baseDirectory";
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void buildMavenRequestTest() {
+        final BuildProjectCommand command = new BuildProjectCommand(BASE_DIRECTORY);
+
+        command.buildMavenRequest();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void buildUserPropertiesTest() {
+        final BuildProjectCommand command = new BuildProjectCommand(BASE_DIRECTORY);
+
+        command.buildUserProperties();
+    }
+
+    @Test
+    public void executeSuccessTest() throws MavenEmbedderException, ProjectBuildingException {
+        final BuildProjectCommand command = spy(new BuildProjectCommand(BASE_DIRECTORY));
+
+        final MavenEmbedder mavenEmbedder = mock(MavenEmbedder.class);
+        doReturn(Collections.emptyList()).when(mavenEmbedder).buildProjects(any(File.class), eq(false));
+        doReturn(mavenEmbedder).when(command).createMavenEmbedder();
+
+        final MavenExecutionResult executionResult = command.execute();
+
+        assertFalse(executionResult.hasExceptions());
+    }
+
+    @Test
+    public void executeFailedTest() throws MavenEmbedderException, ProjectBuildingException {
+        final BuildProjectCommand command = spy(new BuildProjectCommand(BASE_DIRECTORY));
+
+        final MavenEmbedder mavenEmbedder = mock(MavenEmbedder.class);
+        doThrow(ProjectBuildingException.class).when(mavenEmbedder).buildProjects(any(File.class), eq(false));
+        doReturn(mavenEmbedder).when(command).createMavenEmbedder();
+
+        final MavenExecutionResult executionResult = command.execute();
+
+        assertTrue(executionResult.hasExceptions());
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImplTest.java
@@ -47,7 +47,7 @@ import org.kie.workbench.common.screens.archetype.mgmt.backend.config.ArchetypeC
 import org.kie.workbench.common.screens.archetype.mgmt.backend.config.ArchetypeConfigStorageImpl;
 import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.AbstractMavenCommand;
 import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.ArchetypeGenerateCommand;
-import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.ExecuteGoalsCommand;
+import org.kie.workbench.common.screens.archetype.mgmt.backend.maven.BuildProjectCommand;
 import org.kie.workbench.common.screens.archetype.mgmt.backend.preference.ArchetypePreferencesManager;
 import org.kie.workbench.common.screens.archetype.mgmt.shared.events.ArchetypeListUpdatedEvent;
 import org.kie.workbench.common.screens.archetype.mgmt.shared.exceptions.ArchetypeAlreadyExistsException;
@@ -259,10 +259,10 @@ public class ArchetypeServiceImplTest {
     }
 
     @Test(expected = MavenExecutionException.class)
-    public void addWhenExecuteGoalsThrowsExceptionTest() throws MavenEmbedderException {
+    public void addWhenBuildProjectCommandThrowsExceptionTest() throws MavenEmbedderException {
         doReturn(mock(KieModule.class)).when(moduleService).resolveModule(any());
         doNothing().when(service).executeMaven(any(ArchetypeGenerateCommand.class));
-        doThrow(MavenExecutionException.class).when(service).executeMaven(any(ExecuteGoalsCommand.class));
+        doThrow(MavenExecutionException.class).when(service).executeMaven(any(BuildProjectCommand.class));
 
         service.add(createGav());
     }
@@ -464,7 +464,7 @@ public class ArchetypeServiceImplTest {
                 .when(repositoryService).getAllRepositories(any(Space.class));
         doReturn(mock(Path.class)).when(service).unpackArchetype(any(Repository.class));
 
-        doThrow(MavenEmbedderException.class).when(service).executeMaven(any(ExecuteGoalsCommand.class));
+        doThrow(MavenEmbedderException.class).when(service).executeMaven(any(BuildProjectCommand.class));
 
         final Archetype archetype = createArchetypeWithStatus(ArchetypeStatus.INVALID);
         doReturn(archetype).when(archetypeConfigStorage).loadArchetype(anyString());
@@ -486,7 +486,7 @@ public class ArchetypeServiceImplTest {
         doReturn(Collections.singletonList(mock(Repository.class)))
                 .when(repositoryService).getAllRepositories(any(Space.class));
         doReturn(mock(Path.class)).when(service).unpackArchetype(any(Repository.class));
-        doNothing().when(service).executeMaven(any(ExecuteGoalsCommand.class));
+        doNothing().when(service).executeMaven(any(BuildProjectCommand.class));
 
         final Archetype archetype = createArchetypeWithStatus(ArchetypeStatus.VALID);
         doReturn(archetype).when(archetypeConfigStorage).loadArchetype(anyString());
@@ -510,7 +510,7 @@ public class ArchetypeServiceImplTest {
         doReturn(Collections.nCopies(10, mock(Repository.class)))
                 .when(repositoryService).getAllRepositories(any(Space.class));
         doReturn(mock(Path.class)).when(service).unpackArchetype(any(Repository.class));
-        doNothing().when(service).executeMaven(any(ExecuteGoalsCommand.class));
+        doNothing().when(service).executeMaven(any(BuildProjectCommand.class));
 
         final Archetype archetype = createArchetypeWithStatus(ArchetypeStatus.VALID);
         doReturn(archetype).when(archetypeConfigStorage).loadArchetype(anyString());
@@ -562,7 +562,7 @@ public class ArchetypeServiceImplTest {
                                                                                         eq(COMMON_ARCHETYPE_ALIAS));
         doReturn(mock(Path.class)).when(service).unpackArchetype(any(Repository.class));
 
-        doThrow(MavenEmbedderException.class).when(service).executeMaven(any(ExecuteGoalsCommand.class));
+        doThrow(MavenEmbedderException.class).when(service).executeMaven(any(BuildProjectCommand.class));
 
         final Archetype archetype = createArchetypeWithStatus(ArchetypeStatus.INVALID);
         doReturn(archetype).when(archetypeConfigStorage).loadArchetype(anyString());
@@ -585,7 +585,7 @@ public class ArchetypeServiceImplTest {
         doReturn(mock(Repository.class)).when(repositoryService).getRepositoryFromSpace(any(Space.class),
                                                                                         eq(COMMON_ARCHETYPE_ALIAS));
         doReturn(mock(Path.class)).when(service).unpackArchetype(any(Repository.class));
-        doNothing().when(service).executeMaven(any(ExecuteGoalsCommand.class));
+        doNothing().when(service).executeMaven(any(BuildProjectCommand.class));
 
         final Archetype archetype = createArchetypeWithStatus(ArchetypeStatus.VALID);
         doReturn(archetype).when(archetypeConfigStorage).loadArchetype(anyString());


### PR DESCRIPTION
**Task**: [AF-2433](https://issues.redhat.com/browse/AF-2433)

**What's been done**: Building the template project for validation purposes using `MavenEmbedder#buildProjects` instead of executing the maven request from scratch.

**Expected behavior**: No related errors thrown during BC startup.