### PR TITLE
KOGITO-862: Fixing compilation issues after ResourceContent API changed.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/BPMNStaticResourceContentService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/BPMNStaticResourceContentService.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import elemental2.promise.Promise;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
+import org.appformer.kogito.bridge.client.resource.interop.ResourceContentOptions;
 import org.uberfire.client.promise.Promises;
 
 public class BPMNStaticResourceContentService implements ResourceContentService {
@@ -124,6 +125,12 @@ public class BPMNStaticResourceContentService implements ResourceContentService 
             return promises.resolve(WID_ENTRIES.getOrDefault(uri, ""));
         }
         return promises.resolve(ICON_ENTRIES.getOrDefault(uri, ""));
+    }
+
+    @Override
+    public Promise<String> get(final String uri,
+                               final ResourceContentOptions options) {
+        return get(uri);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientServiceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.promise.Promise;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
+import org.appformer.kogito.bridge.client.resource.interop.ResourceContentOptions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -108,6 +109,12 @@ public class WorkItemDefinitionStandaloneClientServiceTest {
                                                                    }
 
                                                                    @Override
+                                                                   public Promise<String> get(String uri,
+                                                                                              ResourceContentOptions options) {
+                                                                       return get(uri);
+                                                                   }
+
+                                                                   @Override
                                                                    public Promise<String[]> list(String pattern) {
                                                                        return promises.resolve(new String[0]);
                                                                    }
@@ -124,6 +131,12 @@ public class WorkItemDefinitionStandaloneClientServiceTest {
                                                                    @Override
                                                                    public Promise<String> get(String uri) {
                                                                        return promises.resolve();
+                                                                   }
+
+                                                                   @Override
+                                                                   public Promise<String> get(String uri,
+                                                                                              ResourceContentOptions options) {
+                                                                       return get(uri);
                                                                    }
 
                                                                    @Override


### PR DESCRIPTION
Hey @jesuino @ederign @porcelli @manstis 

Actual master upstream is broken after merging https://github.com/kiegroup/appformer/pull/886. Here are the fixes to make this repo compile again.

Can you please quickly review and merge, if so? I think that's urgent because master doesn't compile, at least for me.

PS: Please guys next time check the downstream builds are green before merging. I don't see the downstream build green for https://github.com/kiegroup/appformer/pull/886, and it's expected it should be running into this compile issue as well, as it's a compilation error. Anyway, just for the records, lemme know if I can help on any other thing! :+1: 

Thanks in advance!