### PR TITLE
DROOLS-5080: [DMN Designer] Automatically create InputClause supporting Decisions

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/BaseDecisionTableEditorDefinitionTest.java
@@ -188,19 +188,19 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
         assertThat(output.get(0).getName()).isEqualTo(DecisionTableDefaultValueUtilities.OUTPUT_CLAUSE_PREFIX + "1");
     }
 
-    protected void assertStandardDecisionRuleEnrichment(final DecisionTable model,
-                                                        final int inputClauseCount,
-                                                        final int outputClauseCount) {
+    protected void assertStandardDecisionRuleEnrichment(final DecisionTable model) {
         final List<DecisionRule> rules = model.getRule();
         assertThat(rules.size()).isEqualTo(1);
 
         final DecisionRule rule = rules.get(0);
+        final int inputClauseCount = model.getInput().size();
         assertThat(rule.getInputEntry().size()).isEqualTo(inputClauseCount);
         rule.getInputEntry().forEach(inputEntry -> {
             assertThat(inputEntry).isInstanceOf(UnaryTests.class);
             assertThat(inputEntry.getText().getValue()).isEqualTo(DecisionTableDefaultValueUtilities.INPUT_CLAUSE_UNARY_TEST_TEXT);
         });
 
+        final int outputClauseCount = model.getOutput().size();
         assertThat(rule.getOutputEntry().size()).isEqualTo(outputClauseCount);
         rule.getOutputEntry().forEach(outputEntry -> {
             assertThat(outputEntry).isInstanceOf(LiteralExpression.class);
@@ -211,12 +211,11 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
         assertThat(rule.getDescription().getValue()).isEqualTo(DecisionTableDefaultValueUtilities.RULE_DESCRIPTION);
     }
 
-    protected void assertParentHierarchyEnrichment(final DecisionTable model,
-                                                   final int inputClauseCount,
-                                                   final int outputClauseCount) {
+    protected void assertParentHierarchyEnrichment(final DecisionTable model) {
         final List<DecisionRule> rules = model.getRule();
         final DecisionRule rule = rules.get(0);
 
+        final int inputClauseCount = model.getInput().size();
         final List<InputClause> inputClauses = model.getInput();
         assertThat(inputClauses.size()).isEqualTo(inputClauseCount);
         inputClauses.forEach(inputClause -> {
@@ -224,6 +223,7 @@ public abstract class BaseDecisionTableEditorDefinitionTest {
             assertThat(inputClause.getInputExpression().getParent()).isEqualTo(inputClause);
         });
 
+        final int outputClauseCount = model.getOutput().size();
         final List<OutputClause> outputClauses = model.getOutput();
         assertThat(outputClauses.size()).isEqualTo(outputClauseCount);
         outputClauses.forEach(outputClause -> assertThat(outputClause.getParent()).isEqualTo(model));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
@@ -27,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.model.Context;
 import org.kie.workbench.common.dmn.api.definition.model.ContextEntry;
 import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
+import org.kie.workbench.common.dmn.api.definition.model.Decision;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
 import org.kie.workbench.common.dmn.api.definition.model.InformationItem;
@@ -73,6 +75,10 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     private static final QName INPUT_DATA_QNAME_2 = NUMBER.asQName();
 
+    private static final String DECISION_NAME_1 = "b-decision1";
+
+    private static final QName DECISION_QNAME_1 = STRING.asQName();
+
     private static final QName OUTPUT_DATA_QNAME = BuiltInType.DATE.asQName();
 
     private DMNDiagram diagram;
@@ -81,6 +87,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     private InputData inputData2;
 
+    private Decision decision1;
+
     @Before
     public void setup() {
         super.setup();
@@ -88,12 +96,37 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         this.diagram = new DMNDiagram();
         this.inputData1 = new InputData();
         this.inputData2 = new InputData();
+        this.decision1 = new Decision();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testModelEnrichmentWhenTopLevelDecisionTableWithDecision() {
+        setupGraphWithDiagram();
+        setupGraphWithDecision();
+
+        final Optional<DecisionTable> oModel = definition.getModelClass();
+        definition.enrich(Optional.of(NODE_UUID), decision, oModel);
+
+        final DecisionTable model = oModel.get();
+        assertBasicEnrichment(model);
+
+        final List<InputClause> input = model.getInput();
+        assertThat(input.size()).isEqualTo(1);
+        assertThat(input.get(0).getInputExpression()).isInstanceOf(InputClauseLiteralExpression.class);
+        assertThat(input.get(0).getInputExpression().getText().getValue()).isEqualTo(DECISION_NAME_1);
+        assertThat(input.get(0).getInputExpression().getTypeRef()).isEqualTo(DECISION_QNAME_1);
+
+        assertStandardOutputClauseEnrichment(model);
+        assertStandardDecisionRuleEnrichment(model, 1, 1);
+        assertParentHierarchyEnrichment(model, 1, 1);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testModelEnrichmentWhenTopLevelDecisionTableWithInputData() {
-        setupGraph();
+        setupGraphWithDiagram();
+        setupGraphWithInputData();
 
         final Optional<DecisionTable> oModel = definition.getModelClass();
         definition.enrich(Optional.of(NODE_UUID), decision, oModel);
@@ -117,8 +150,39 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     @Test
     @SuppressWarnings("unchecked")
+    public void testModelEnrichmentWhenTopLevelDecisionTableWithDecisionAndInputData() {
+        setupGraphWithDiagram();
+        setupGraphWithDecision();
+        setupGraphWithInputData();
+
+        final Optional<DecisionTable> oModel = definition.getModelClass();
+        definition.enrich(Optional.of(NODE_UUID), decision, oModel);
+
+        final DecisionTable model = oModel.get();
+        assertBasicEnrichment(model);
+
+        final List<InputClause> input = model.getInput();
+        assertThat(input.size()).isEqualTo(3);
+        assertThat(input.get(0).getInputExpression()).isInstanceOf(InputClauseLiteralExpression.class);
+        assertThat(input.get(0).getInputExpression().getText().getValue()).isEqualTo(INPUT_DATA_NAME_2);
+        assertThat(input.get(0).getInputExpression().getTypeRef()).isEqualTo(INPUT_DATA_QNAME_2);
+        assertThat(input.get(1).getInputExpression()).isInstanceOf(InputClauseLiteralExpression.class);
+        assertThat(input.get(1).getInputExpression().getText().getValue()).isEqualTo(DECISION_NAME_1);
+        assertThat(input.get(1).getInputExpression().getTypeRef()).isEqualTo(DECISION_QNAME_1);
+        assertThat(input.get(2).getInputExpression()).isInstanceOf(InputClauseLiteralExpression.class);
+        assertThat(input.get(2).getInputExpression().getText().getValue()).isEqualTo(INPUT_DATA_NAME_1);
+        assertThat(input.get(2).getInputExpression().getTypeRef()).isEqualTo(INPUT_DATA_QNAME_1);
+
+        assertStandardOutputClauseEnrichment(model);
+        assertStandardDecisionRuleEnrichment(model, 3, 1);
+        assertParentHierarchyEnrichment(model, 3, 1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void testModelEnrichmentWhenTopLevelDecisionTableWithInputDataAndSimpleCustomType() {
-        setupGraph();
+        setupGraphWithDiagram();
+        setupGraphWithInputData();
 
         final Definitions definitions = diagram.getDefinitions();
 
@@ -155,7 +219,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
     @Test
     @SuppressWarnings("unchecked")
     public void testModelEnrichmentWhenTopLevelDecisionTableWithInputDataAndComplexCustomType() {
-        setupGraph();
+        setupGraphWithDiagram();
+        setupGraphWithInputData();
 
         final Definitions definitions = diagram.getDefinitions();
 
@@ -206,7 +271,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
     @Test
     @SuppressWarnings("unchecked")
     public void testModelEnrichmentWhenTopLevelDecisionTableWithInputDataAndRecursiveCustomType() {
-        setupGraph();
+        setupGraphWithDiagram();
+        setupGraphWithInputData();
 
         final Definitions definitions = diagram.getDefinitions();
 
@@ -266,7 +332,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
     @Test
     @SuppressWarnings("unchecked")
     public void testModelEnrichmentWhenTopLevelDecisionTableWithMultipleHierarchyCustomTypes() {
-        setupGraph();
+        setupGraphWithDiagram();
+        setupGraphWithInputData();
 
         final Definitions definitions = diagram.getDefinitions();
 
@@ -328,12 +395,51 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertParentHierarchyEnrichment(model, 4, 1);
     }
 
-    @SuppressWarnings("unchecked")
-    private void setupGraph() {
+    private Node<Definition, Edge> setupGraphWithDiagram() {
         final Node<Definition, Edge> diagramNode = new NodeImpl<>(UUID.uuid());
+        final Definition<DMNDiagram> diagramDefinition = new DefinitionImpl<>(diagram);
+        diagramNode.setContent(diagramDefinition);
+        graph.addNode(diagramNode);
+
+        return diagramNode;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupGraphWithDecision() {
+        Node<Definition, Edge> targetNode = graph.getNode(NODE_UUID);
+        if (Objects.isNull(targetNode)) {
+            targetNode = new NodeImpl<>(NODE_UUID);
+            graph.addNode(targetNode);
+        }
+
+        final Node<Definition, Edge> sourceNode1 = new NodeImpl<>(UUID.uuid());
+        decision1.getName().setValue(DECISION_NAME_1);
+        final QName decision1QName = new QName(QName.NULL_NS_URI, STRING.getName());
+        decision1.getVariable().setTypeRef(decision1QName);
+
+        final Definition<Decision> sourceNode1Definition = new DefinitionImpl<>(decision1);
+        sourceNode1.setContent(sourceNode1Definition);
+
+        final Edge edge1 = new EdgeImpl<>(UUID.uuid());
+        edge1.setTargetNode(targetNode);
+        edge1.setSourceNode(sourceNode1);
+
+        targetNode.getInEdges().add(edge1);
+        sourceNode1.getOutEdges().add(edge1);
+
+        graph.addNode(sourceNode1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupGraphWithInputData() {
+        Node<Definition, Edge> targetNode = graph.getNode(NODE_UUID);
+        if (Objects.isNull(targetNode)) {
+            targetNode = new NodeImpl<>(NODE_UUID);
+            graph.addNode(targetNode);
+        }
+
         final Node<Definition, Edge> sourceNode1 = new NodeImpl<>(UUID.uuid());
         final Node<Definition, Edge> sourceNode2 = new NodeImpl<>(UUID.uuid());
-        final Node<Definition, Edge> targetNode = new NodeImpl<>(NODE_UUID);
         inputData1.getName().setValue(INPUT_DATA_NAME_1);
         inputData2.getName().setValue(INPUT_DATA_NAME_2);
         final QName inputData1QName = new QName(QName.NULL_NS_URI, STRING.getName());
@@ -358,11 +464,6 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         sourceNode1.getOutEdges().add(edge1);
         sourceNode2.getOutEdges().add(edge2);
 
-        final Definition<DMNDiagram> diagramDefinition = new DefinitionImpl<>(diagram);
-        diagramNode.setContent(diagramDefinition);
-
-        graph.addNode(diagramNode);
-        graph.addNode(targetNode);
         graph.addNode(sourceNode1);
         graph.addNode(sourceNode2);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -118,8 +118,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(input.get(0).getInputExpression().getTypeRef()).isEqualTo(DECISION_QNAME_1);
 
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -144,8 +144,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(input.get(1).getInputExpression().getTypeRef()).isEqualTo(INPUT_DATA_QNAME_1);
 
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 2, 1);
-        assertParentHierarchyEnrichment(model, 2, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -174,8 +174,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(input.get(2).getInputExpression().getTypeRef()).isEqualTo(INPUT_DATA_QNAME_1);
 
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 3, 1);
-        assertParentHierarchyEnrichment(model, 3, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -212,8 +212,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(input.get(1).getInputExpression().getTypeRef()).isEqualTo(simpleItemDefinitionTypeRef);
 
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 2, 1);
-        assertParentHierarchyEnrichment(model, 2, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -264,8 +264,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(input.get(2).getInputExpression().getTypeRef()).isEqualTo(complexItemDefinitionPart2TypeRef);
 
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 3, 1);
-        assertParentHierarchyEnrichment(model, 3, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -325,8 +325,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(input.get(3).getInputExpression().getTypeRef()).isEqualTo(parentCustomType);
 
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 4, 1);
-        assertParentHierarchyEnrichment(model, 4, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -391,17 +391,15 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(input.get(3).getInputExpression().getTypeRef()).isEqualTo(dateBuiltInType);
 
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 4, 1);
-        assertParentHierarchyEnrichment(model, 4, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
-    private Node<Definition, Edge> setupGraphWithDiagram() {
+    private void setupGraphWithDiagram() {
         final Node<Definition, Edge> diagramNode = new NodeImpl<>(UUID.uuid());
         final Definition<DMNDiagram> diagramDefinition = new DefinitionImpl<>(diagram);
         diagramNode.setContent(diagramDefinition);
         graph.addNode(diagramNode);
-
-        return diagramNode;
     }
 
     @SuppressWarnings("unchecked")
@@ -481,8 +479,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertBasicEnrichment(model);
         assertStandardInputClauseEnrichment(model);
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -509,8 +507,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(output.get(0).getName()).isEqualTo(name);
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -540,8 +538,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(output.get(0).getName()).isEqualTo(name);
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -576,8 +574,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(output.get(0).getName()).isEqualTo(name);
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -597,8 +595,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(output.get(0).getName()).isEqualTo("output-1");
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test
@@ -616,8 +614,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertThat(output.get(0).getName()).isEqualTo("output-1");
         assertThat(output.get(0).getTypeRef()).isEqualTo(BuiltInType.UNDEFINED.asQName());
 
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionTest.java
@@ -60,8 +60,8 @@ public class DecisionTableEditorDefinitionTest extends BaseDecisionTableEditorDe
         assertBasicEnrichment(model);
         assertStandardInputClauseEnrichment(model);
         assertStandardOutputClauseEnrichment(model);
-        assertStandardDecisionRuleEnrichment(model, 1, 1);
-        assertParentHierarchyEnrichment(model, 1, 1);
+        assertStandardDecisionRuleEnrichment(model);
+        assertParentHierarchyEnrichment(model);
     }
 
     @Test


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-5080

The long and short of it is this:
- Create a new DMN model
- Add an `InputData`
- Add a `Decision`, called `A` 
- Add another `Decision`, called `B`
- Link the `InputData` to `A`
- Link the `B` to `A`
- Edit `A` and set its expression to `DecisionTable`
- It should have input columns for the `InputData` and `B`.
- You should be able to use _built in types_ and custom types (including structures). 