### PR TITLE
KOGITO-437: Stunner - Zoom widget duplicated after `setContent` calls

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -392,6 +392,7 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
     @Override
     @SetContent
     public void setContent(final String path, final String value) {
+        superOnClose();
         diagramServices.transform(path,
                                   value,
                                   new ServiceCallback<Diagram>() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -91,6 +91,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -374,7 +375,7 @@ public abstract class AbstractDMNDiagramEditorTest {
 
         editor.onClose();
 
-        verify(dmnEditorMenuSessionItems).destroy();
+        verify(dmnEditorMenuSessionItems, times(2)).destroy();
         verify(editorPresenter).destroy();
 
         verify(decisionNavigatorDock).destroy();
@@ -483,5 +484,16 @@ public abstract class AbstractDMNDiagramEditorTest {
         verify(decisionNavigatorDock).setupCanvasHandler(canvasHandler);
         verify(layoutHelper).applyLayout(eq(diagram), eq(layoutExecutor));
         verify(dataTypesPage).reload();
+    }
+
+    @Test
+    public void testSuperOnCloseDMNOnSetContent() {
+        //First setContent call context
+        editor.setContent("", "");
+        verify(dmnEditorMenuSessionItems, times(1)).destroy();
+
+        //Second setContent call context
+        editor.setContent("", "");
+        verify(dmnEditorMenuSessionItems, times(2)).destroy();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -26,6 +26,8 @@ import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractD
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditorTest;
 import org.uberfire.workbench.model.menu.impl.DefaultMenus;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
@@ -79,5 +81,23 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                 getOnDataTypeEditModeToggleCallback(event).onInvoke(event);
             }
         };
+    }
+
+    @Override
+    public void testOnClose() {
+        openDiagram();
+
+        editor.onClose();
+
+        verify(dmnEditorMenuSessionItems, times(1)).destroy();
+        verify(editorPresenter).destroy();
+
+        verify(decisionNavigatorDock).destroy();
+        verify(decisionNavigatorDock).resetContent();
+
+        verify(diagramPropertiesDock).destroy();
+        verify(diagramPreviewDock).destroy();
+
+        verify(dataTypesPage).disableShortcuts();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -262,6 +262,7 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
     @SetContent
     @Override
     public void setContent(final String path, final String value) {
+        superOnClose();
         diagramServices.transform(value,
                                   new ServiceCallback<Diagram>() {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
@@ -46,6 +46,8 @@ import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.jgroups.util.Util.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class BPMNDiagramEditorTest {
@@ -146,5 +148,16 @@ public class BPMNDiagramEditorTest {
         editor.menuBarInitialized = true;
         editor.makeMenuBar();
         assertEquals(editor.menuBarInitialized, true);
+    }
+
+    @Test
+    public void testSuperOnCloseOnSetContent() {
+        //First setContent call context
+        editor.setContent("", "");
+        verify(menuSessionItems, times(1)).destroy();
+
+        //Second setContent call context
+        editor.setContent("", "");
+        verify(menuSessionItems, times(2)).destroy();
     }
 }


### PR DESCRIPTION
Jenkins execute full downstream build