### PR TITLE
KOGITO-1236: Preview Support in Editors

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -43,6 +43,8 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.S
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
@@ -72,6 +74,7 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.editor.commons.client.menu.MenuItems;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
 import org.uberfire.lifecycle.GetContent;
+import org.uberfire.lifecycle.GetPreview;
 import org.uberfire.lifecycle.IsDirty;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnFocus;
@@ -114,6 +117,7 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
     protected final KogitoClientDiagramService diagramServices;
     protected final MonacoFEELInitializer feelInitializer;
 
+<<<<<<< HEAD
     // --- Workaround : Start ---
     // This is a workaround for kogito-tooling that calls setContent(..) twice; once with a _valid_ DMN model (a new one) and
     // then again with whatever content is in the file being opened. If the content is _invalid_ we open an XML Text Editor.
@@ -146,6 +150,9 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
 
     private Consumer<Diagram> openDiagramMethodProxy = VALID_DIAGRAM_PROXY;
     // --- Workaround : End ---
+=======
+    private CanvasFileExport canvasFileExport;
+>>>>>>> KOGITO-1236: Preview Support in Editors
 
     public AbstractDMNDiagramEditor(final View view,
                                     final FileMenuBuilder fileMenuBuilder,
@@ -174,7 +181,8 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
                                     final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                                     final DataTypesPage dataTypesPage,
                                     final KogitoClientDiagramService diagramServices,
-                                    final MonacoFEELInitializer feelInitializer) {
+                                    final MonacoFEELInitializer feelInitializer,
+                                    final CanvasFileExport canvasFileExport) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -208,6 +216,7 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
 
         this.diagramServices = diagramServices;
         this.feelInitializer = feelInitializer;
+        this.canvasFileExport = canvasFileExport;
     }
 
     @OnStartup
@@ -447,5 +456,15 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
     @Override
     public void resetContentHash() {
         setOriginalContentHash(getCurrentDiagramHash());
+    }
+    
+    @GetPreview
+    public Promise getPreview() {
+        CanvasHandler canvasHandler = getCanvasHandler();
+        if (canvasHandler != null) {
+            return Promise.resolve(canvasFileExport.exportToSvg((AbstractCanvasHandler) canvasHandler));
+        } else {
+            return Promise.resolve("");
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -117,7 +117,8 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
     protected final KogitoClientDiagramService diagramServices;
     protected final MonacoFEELInitializer feelInitializer;
 
-<<<<<<< HEAD
+    private CanvasFileExport canvasFileExport;
+
     // --- Workaround : Start ---
     // This is a workaround for kogito-tooling that calls setContent(..) twice; once with a _valid_ DMN model (a new one) and
     // then again with whatever content is in the file being opened. If the content is _invalid_ we open an XML Text Editor.
@@ -150,9 +151,6 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
 
     private Consumer<Diagram> openDiagramMethodProxy = VALID_DIAGRAM_PROXY;
     // --- Workaround : End ---
-=======
-    private CanvasFileExport canvasFileExport;
->>>>>>> KOGITO-1236: Preview Support in Editors
 
     public AbstractDMNDiagramEditor(final View view,
                                     final FileMenuBuilder fileMenuBuilder,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -41,6 +41,7 @@ import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.S
 import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
@@ -231,6 +232,9 @@ public abstract class AbstractDMNDiagramEditorTest {
 
     @Mock
     protected MonacoFEELInitializer feelInitializer;
+    
+    @Mock
+    protected CanvasFileExport canvasFileExport;
 
     @Captor
     protected ArgumentCaptor<KogitoDiagramResourceImpl> kogitoDiagramResourceArgumentCaptor;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -47,6 +47,7 @@ import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
@@ -109,7 +110,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor implements Kogito
                             final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                             final DataTypesPage dataTypesPage,
                             final KogitoClientDiagramService diagramServices,
-                            final MonacoFEELInitializer feelInitializer) {
+                            final MonacoFEELInitializer feelInitializer,
+                            final CanvasFileExport canvasFileExport) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -137,7 +139,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor implements Kogito
               openDiagramLayoutExecutor,
               dataTypesPage,
               diagramServices,
-              feelInitializer);
+              feelInitializer,
+              canvasFileExport);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -69,7 +69,8 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                                     layoutExecutor,
                                     dataTypesPage,
                                     clientDiagramService,
-                                    feelInitializer) {
+                                    feelInitializer,
+                                    canvasFileExport) {
             @Override
             protected ElementWrapperWidget<?> getWidget(final HTMLElement element) {
                 return searchBarComponentWidget;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -47,6 +47,7 @@ import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
@@ -125,7 +126,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final KogitoClientDiagramService diagramServices,
                             final DMNVFSService vfsService,
                             final Promises promises,
-                            final MonacoFEELInitializer feelInitializer) {
+                            final MonacoFEELInitializer feelInitializer,
+                            final CanvasFileExport canvasFileExport) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -153,7 +155,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               openDiagramLayoutExecutor,
               dataTypesPage,
               diagramServices,
-              feelInitializer);
+              feelInitializer,
+              canvasFileExport);
         this.notificationEvent = notificationEvent;
         this.vfsService = vfsService;
         this.promises = promises;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -24,6 +24,7 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTyp
 import org.kie.workbench.common.dmn.showcase.client.navigator.DMNVFSService;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditor;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditorTest;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.kogito.client.PromiseMock;
 import org.mockito.ArgumentCaptor;
@@ -80,6 +81,9 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
 
     @Mock
     private DMNVFSService vfsService;
+    
+    @Mock
+    CanvasFileExport canvasFileExport;
 
     @Mock
     private Promises promises;
@@ -92,7 +96,7 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
 
     @Captor
     private ArgumentCaptor<Path> pathArgumentCaptor;
-
+    
     @Override
     public void setup() {
         super.setup();
@@ -143,7 +147,8 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                                     clientDiagramService,
                                     vfsService,
                                     promises,
-                                    feelInitializer) {
+                                    feelInitializer,
+                                    canvasFileExport) {
 
             @Override
             protected PlaceRequest getPlaceRequest() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -58,7 +58,6 @@ import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.mvp.PlaceManager;
-import org.uberfire.client.promise.Promises;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -29,7 +29,9 @@ import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerVie
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
 import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
@@ -56,10 +58,12 @@ import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.promise.Promises;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
 import org.uberfire.lifecycle.GetContent;
+import org.uberfire.lifecycle.GetPreview;
 import org.uberfire.lifecycle.IsDirty;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnFocus;
@@ -87,6 +91,8 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
 
     private final KogitoClientDiagramService diagramServices;
 
+    private final CanvasFileExport canvasFileExport;
+
     @Inject
     public BPMNDiagramEditor(final View view,
                              final FileMenuBuilder fileMenuBuilder,
@@ -107,7 +113,8 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
                              final DiagramEditorPropertiesDock diagramPropertiesDock,
                              final LayoutHelper layoutHelper,
                              final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
-                             final KogitoClientDiagramService diagramServices) {
+                             final KogitoClientDiagramService diagramServices,
+                             final CanvasFileExport canvasFileExport) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -130,6 +137,7 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
         this.openDiagramLayoutExecutor = openDiagramLayoutExecutor;
 
         this.diagramServices = diagramServices;
+        this.canvasFileExport = canvasFileExport;
     }
 
     @OnStartup
@@ -251,6 +259,16 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
     @Override
     public Promise getContent() {
         return diagramServices.transform(getEditor().getEditorProxy().getContentSupplier().get());
+    }
+
+    @GetPreview
+    public Promise getPreview() {
+        CanvasHandler canvasHandler = getCanvasHandler();
+        if (canvasHandler != null) {
+            return Promise.resolve(canvasFileExport.exportToSvg((AbstractCanvasHandler) canvasHandler));
+        } else {
+            return Promise.resolve("");
+        }
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.error.DiagramClientErrorHandler;
@@ -113,6 +114,9 @@ public class BPMNDiagramEditorTest {
 
     @Mock
     private KogitoClientDiagramService diagramServices;
+    
+    @Mock
+    private CanvasFileExport canvasFileExport;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -136,7 +140,8 @@ public class BPMNDiagramEditorTest {
                                        diagramPropertiesDock,
                                        layoutHelper,
                                        openDiagramLayoutExecutor,
-                                       diagramServices);
+                                       diagramServices,
+                                       canvasFileExport);
     }
 
     @Test


### PR DESCRIPTION
Supporting the new Preview API in DMN and BPMN Editors.

This is done by using canvasFileExport class inside the new client editor `GetPreview` method. GetPreview method will be called by Kogito tooling according to the user action on the channel where the tooling is running:

* On VSCode a new command was added;
* On Online Editor a new button allow users to download the SVG;
* It will be used by Desktop to generate preview of files recently opened by the user.

The getPreview method is any method form the editor that returns a string and have the GetPreview annotation. It works just like GetContent annotation, but it is not required, which means that if you don't provide it then by default it will return null. By default it returns null, no preview, if you want to export SVG from processes you just have to implement getPreview and return the SVG string.

You can see it in action in the following GIFs:

![actual_SVG_online_editor](https://user-images.githubusercontent.com/359820/75390329-dba4c900-58c6-11ea-9710-1c1452a9adbf.gif)
![editor_preview](https://user-images.githubusercontent.com/359820/75390333-de072300-58c6-11ea-9cf8-38865cae70ad.gif)


Part of an ensemble, merge with:

kiegroup/kogito-tooling#67
https://github.com/kiegroup/appformer/pull/906
