### PR TITLE
KOGITO-1301: Adding support for binary icons

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientService.java
@@ -30,6 +30,8 @@ import javax.inject.Inject;
 
 import elemental2.promise.Promise;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
+import org.appformer.kogito.bridge.client.resource.interop.ResourceContentOptions;
+import org.jboss.errai.common.client.logging.util.Console;
 import org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientService;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinitionCacheRegistry;
@@ -45,6 +47,21 @@ import static org.kie.workbench.common.stunner.core.util.StringUtils.nonEmpty;
 
 @ApplicationScoped
 public class WorkItemDefinitionStandaloneClientService implements WorkItemDefinitionClientService {
+
+    private static final String DEFAULT_ICON_DATA = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAYAAAA7bUf6AAADVklEQVQ4EYVUbWhTVxg+UAR/" +
+                                                    "DP8oBX+4bsiYWpfOqggbosQfU1c3k9E6sTqVaFtxoKi0kwk1Rrkmy2rpjDVt0y/aZtckDTakTWckSW9tb9fsXvNxiSzWln" +
+                                                    "vBdgkiVdrR2jzjBFrmJvrC4Xy8z/vwfh5C3iIs2Jz1WmPhWyBvVp35IrRaHJnIx8upgit6zrluv0m+XM0F52cVdZgb2172" +
+                                                    "vXfDmy0JIQBWOMZ5w8l6R+zDPYxAvtKLZOdPM0RdjTW7zAtbSgzS2hJj/PBp1yO2PWwEsOq/ZMs6mkeZJlaYPq53YmtJG5" +
+                                                    "rtaQw/VFBvk1EnyrjpTGFrcQtKj7tgY4WXrrFh42skFd2ezbrzruShYy6UVvgy7N0YnqUFCJE+dHV6wUV7MTUSwZ1gFEd/" +
+                                                    "7s2UXnLihMXxqKz4X6Hxswn1llKjtO3HFth7JEzGOUixPNhrV+CuZzd8de9h0puP59Mx2INPUKhpxqZ9xjjHj21f8mb++b" +
+                                                    "i68EuDdEtIIf1XBEn7Rtxp3wEINgAhxMM2+IY+wFPPWUzyU/jF+RSflRgkzCrqJRKa/fc15oUaqwx/ax8iHgLM38ZsaBCY" +
+                                                    "+w0YHEJ8qBK+WgIu1odaUcaOXeYFXzUXzJKotDWFy/ebZFoFmsQu1oseaxH+5ngMBIN4FQhkFzgebmtRVk9xFE/tVLSPWJ" +
+                                                    "bNuXY/4Pz0hGmmpl6Bv8OHqJUAI5WYC4zg1UAACPCI/16JexaCgY5+1DUqUOlMM9SOLWZzst7MQSkge/XisJjGs1QE/raP" +
+                                                    "wVtWIjFUhcyNUSQeVOGeZSWCiVz8oYhoaEhj4wG9CGq3KAjJqg1FjHj4h1b86paQlAYxkciF5SZBtPprWG4TPG5fhzFpEI" +
+                                                    "3uOD7/tg25GkYQ70/kL3IQ/zl/3qnybukbxoFD13szLncciiKC7exHyOlFV6cPSEXQ75Zw5Hpv5juzA0fKXLGLZ0Krl0jo" +
+                                                    "ob0pfLW7R5i+YHZg04FWWBrSuNWo4AbtWKuMASGFg1UtOMg4YOsRpllb2PAaAb3Q2fmzKXyVKe+WiJYRacyf6EzZ2SnQmB" +
+                                                    "dIkUH6SGOUdOWuZIdtlKH4/5EsPmjP+fOiIVlFk0azvzTFL8bVfDCp1lV4NhNCli3i37nT8hNtzTv/k38Ask842m9tZx8A" +
+                                                    "AAAASUVORK5CYII=";
 
     private static Logger LOGGER = Logger.getLogger(BaseCanvasHandler.class.getName());
     private static final String RESOURCE_ALL_WID_PATTERN = "**/*.wid";
@@ -97,31 +114,31 @@ public class WorkItemDefinitionStandaloneClientService implements WorkItemDefini
             registry.clear();
             final List<WorkItemDefinition> loaded = new LinkedList<>();
             resourceContentService
-                    .list(RESOURCE_ALL_WID_PATTERN)
-                    .then(paths -> {
-                        if (paths.length > 0) {
-                            log("Work Items found at [" + paths + "]");
-                            promises.all(asList(paths),
-                                         path -> workItemsLoader(path, loaded))
-                                    .then(wids -> {
-                                        wids.forEach(registry::register);
-                                        success.onInvoke(wids);
-                                        return null;
-                                    })
-                                    .catch_(error -> {
-                                        failure.onInvoke(error);
-                                        return null;
-                                    });
-                        } else {
-                            log("NO Work Items found at [" + paths + "]");
-                            success.onInvoke(emptyList());
-                        }
-                        return promises.resolve();
-                    })
-                    .catch_(error -> {
-                        failure.onInvoke(error);
-                        return null;
-                    });
+                                  .list(RESOURCE_ALL_WID_PATTERN)
+                                  .then(paths -> {
+                                      if (paths.length > 0) {
+                                          log("Work Items found at [" + paths + "]");
+                                          promises.all(asList(paths),
+                                                       path -> workItemsLoader(path, loaded))
+                                                  .then(wids -> {
+                                                      wids.forEach(registry::register);
+                                                      success.onInvoke(wids);
+                                                      return null;
+                                                  })
+                                                  .catch_(error -> {
+                                                      failure.onInvoke(error);
+                                                      return null;
+                                                  });
+                                      } else {
+                                          log("NO Work Items found at [" + paths + "]");
+                                          success.onInvoke(emptyList());
+                                      }
+                                      return promises.resolve();
+                                  })
+                                  .catch_(error -> {
+                                      failure.onInvoke(error);
+                                      return null;
+                                  });
         });
     }
 
@@ -131,43 +148,57 @@ public class WorkItemDefinitionStandaloneClientService implements WorkItemDefini
         log("Processing [" + path + "]");
         if (nonEmpty(path)) {
             return resourceContentService
-                    .get(path)
-                    .then(value -> {
-                        log("Content for path = [" + value + "]");
-                        log("Loading Work Items for path [" + path + "]");
-                        final List<WorkItemDefinition> wids = parse(value);
-                        return promises.create((success, failure) -> {
-                            promises.all(wids, this::workItemIconLoader)
-                                    .then(wid -> {
-                                        loaded.addAll(wids);
-                                        success.onInvoke(loaded);
-                                        return promises.resolve();
-                                    })
-                                    .catch_(error -> {
-                                        failure.onInvoke(error);
-                                        return null;
-                                    });
-                        });
-                    });
+                                         .get(path)
+                                         .then(value -> {
+                                             log("Content for path = [" + value + "]");
+                                             log("Loading Work Items for path [" + path + "]");
+                                             final List<WorkItemDefinition> wids = parse(value);
+                                             return promises.create((success, failure) -> {
+                                                 promises.all(wids, this::workItemIconLoader)
+                                                         .then(wid -> {
+                                                             loaded.addAll(wids);
+                                                             success.onInvoke(loaded);
+                                                             return promises.resolve();
+                                                         })
+                                                         .catch_(error -> {
+                                                             failure.onInvoke(error);
+                                                             return null;
+                                                         });
+                                             });
+                                         });
         }
         return promises.resolve(emptyList());
     }
 
     private Promise workItemIconLoader(final WorkItemDefinition wid) {
+        Console.log("RUNING MY CODE MAN");
         final String iconUri = wid.getIconDefinition().getUri();
         log("Loading icon for URI [" + iconUri + "]");
         if (nonEmpty(iconUri)) {
             return resourceContentService
-                    .get(iconUri)
-                    .then(iconData -> {
-                        log("Content for icon = [" + iconData + "]");
-                        if (nonEmpty(iconData)) {
-                            wid.getIconDefinition().setIconData(iconData);
-                        }
-                        return promises.resolve();
-                    });
+                                         .get(iconUri, ResourceContentOptions.binary())
+                                         .then(iconData -> {
+                                             log("Content for icon = [" + iconData + "]");
+                                             if (nonEmpty(iconData)) {
+                                                 wid.getIconDefinition().setIconData(iconDataUri(iconUri, iconData));
+                                             }
+                                             return promises.resolve(DEFAULT_ICON_DATA);
+                                         }).catch_(error -> {
+                                             log("Not able to load icon for URI " + iconUri);
+                                             return Promise.resolve(DEFAULT_ICON_DATA);
+                                         });
         }
-        return promises.resolve();
+        return promises.resolve(DEFAULT_ICON_DATA);
+    }
+
+    private String iconDataUri(String iconUri, String iconData) {
+        String[] iconUriParts = iconUri.split("\\.");
+        if (iconUriParts.length > 0) {
+            int fileTypeIndex = iconUriParts.length - 1;
+            String fileType = iconUriParts[fileTypeIndex];
+            return "data:image/" + fileType + ";base64, " + iconData;
+        }
+        return DEFAULT_ICON_DATA;
     }
 
     private static void log(String s) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientService.java
@@ -48,21 +48,6 @@ import static org.kie.workbench.common.stunner.core.util.StringUtils.nonEmpty;
 @ApplicationScoped
 public class WorkItemDefinitionStandaloneClientService implements WorkItemDefinitionClientService {
 
-    private static final String DEFAULT_ICON_DATA = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAYAAAA7bUf6AAADVklEQVQ4EYVUbWhTVxg+UAR/" +
-                                                    "DP8oBX+4bsiYWpfOqggbosQfU1c3k9E6sTqVaFtxoKi0kwk1Rrkmy2rpjDVt0y/aZtckDTakTWckSW9tb9fsXvNxiSzWln" +
-                                                    "vBdgkiVdrR2jzjBFrmJvrC4Xy8z/vwfh5C3iIs2Jz1WmPhWyBvVp35IrRaHJnIx8upgit6zrluv0m+XM0F52cVdZgb2172" +
-                                                    "vXfDmy0JIQBWOMZ5w8l6R+zDPYxAvtKLZOdPM0RdjTW7zAtbSgzS2hJj/PBp1yO2PWwEsOq/ZMs6mkeZJlaYPq53YmtJG5" +
-                                                    "rtaQw/VFBvk1EnyrjpTGFrcQtKj7tgY4WXrrFh42skFd2ezbrzruShYy6UVvgy7N0YnqUFCJE+dHV6wUV7MTUSwZ1gFEd/" +
-                                                    "7s2UXnLihMXxqKz4X6Hxswn1llKjtO3HFth7JEzGOUixPNhrV+CuZzd8de9h0puP59Mx2INPUKhpxqZ9xjjHj21f8mb++b" +
-                                                    "i68EuDdEtIIf1XBEn7Rtxp3wEINgAhxMM2+IY+wFPPWUzyU/jF+RSflRgkzCrqJRKa/fc15oUaqwx/ax8iHgLM38ZsaBCY" +
-                                                    "+w0YHEJ8qBK+WgIu1odaUcaOXeYFXzUXzJKotDWFy/ebZFoFmsQu1oseaxH+5ngMBIN4FQhkFzgebmtRVk9xFE/tVLSPWJ" +
-                                                    "bNuXY/4Pz0hGmmpl6Bv8OHqJUAI5WYC4zg1UAACPCI/16JexaCgY5+1DUqUOlMM9SOLWZzst7MQSkge/XisJjGs1QE/raP" +
-                                                    "wVtWIjFUhcyNUSQeVOGeZSWCiVz8oYhoaEhj4wG9CGq3KAjJqg1FjHj4h1b86paQlAYxkciF5SZBtPprWG4TPG5fhzFpEI" +
-                                                    "3uOD7/tg25GkYQ70/kL3IQ/zl/3qnybukbxoFD13szLncciiKC7exHyOlFV6cPSEXQ75Zw5Hpv5juzA0fKXLGLZ0Krl0jo" +
-                                                    "ob0pfLW7R5i+YHZg04FWWBrSuNWo4AbtWKuMASGFg1UtOMg4YOsRpllb2PAaAb3Q2fmzKXyVKe+WiJYRacyf6EzZ2SnQmB" +
-                                                    "dIkUH6SGOUdOWuZIdtlKH4/5EsPmjP+fOiIVlFk0azvzTFL8bVfDCp1lV4NhNCli3i37nT8hNtzTv/k38Ask842m9tZx8A" +
-                                                    "AAAASUVORK5CYII=";
-
     private static Logger LOGGER = Logger.getLogger(BaseCanvasHandler.class.getName());
     private static final String RESOURCE_ALL_WID_PATTERN = "**/*.wid";
 
@@ -180,15 +165,16 @@ public class WorkItemDefinitionStandaloneClientService implements WorkItemDefini
                                          .then(iconData -> {
                                              log("Content for icon = [" + iconData + "]");
                                              if (nonEmpty(iconData)) {
-                                                 wid.getIconDefinition().setIconData(iconDataUri(iconUri, iconData));
+                                                 String iconDataUri = iconDataUri(iconUri, iconData);
+                                                wid.getIconDefinition().setIconData(iconDataUri);
                                              }
-                                             return promises.resolve(DEFAULT_ICON_DATA);
+                                             return promises.resolve();
                                          }).catch_(error -> {
                                              log("Not able to load icon for URI " + iconUri);
-                                             return Promise.resolve(DEFAULT_ICON_DATA);
+                                             return Promise.resolve("");
                                          });
         }
-        return promises.resolve(DEFAULT_ICON_DATA);
+        return promises.resolve();
     }
 
     private String iconDataUri(String iconUri, String iconData) {
@@ -198,7 +184,7 @@ public class WorkItemDefinitionStandaloneClientService implements WorkItemDefini
             String fileType = iconUriParts[fileTypeIndex];
             return "data:image/" + fileType + ";base64, " + iconData;
         }
-        return DEFAULT_ICON_DATA;
+        return "";
     }
 
     private static void log(String s) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/services/WorkItemDefinitionStandaloneClientServiceTest.java
@@ -33,6 +33,7 @@ import org.uberfire.client.promise.Promises;
 import org.uberfire.promise.SyncPromises;
 
 import static org.jgroups.util.Util.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientUtils.getDefaultIconData;
@@ -103,6 +104,7 @@ public class WorkItemDefinitionStandaloneClientServiceTest {
         tested = new WorkItemDefinitionStandaloneClientService(promises,
                                                                registry,
                                                                new ResourceContentService() {
+
                                                                    @Override
                                                                    public Promise<String> get(String uri) {
                                                                        return promises.resolve();
@@ -128,6 +130,7 @@ public class WorkItemDefinitionStandaloneClientServiceTest {
         tested = new WorkItemDefinitionStandaloneClientService(promises,
                                                                registry,
                                                                new ResourceContentService() {
+
                                                                    @Override
                                                                    public Promise<String> get(String uri) {
                                                                        return promises.resolve();
@@ -146,6 +149,23 @@ public class WorkItemDefinitionStandaloneClientServiceTest {
                                                                });
         call();
         assertTrue(registry.items().isEmpty());
+    }
+
+    @Test
+    public void testIconDataUri() {
+        final String testData = "testData";
+        final String iconDataUri = WorkItemDefinitionStandaloneClientService.iconDataUri("test.png", testData);
+        final String badUri = WorkItemDefinitionStandaloneClientService.iconDataUri("bad uri", testData);
+        assertEquals("data:image/png;base64, testData", iconDataUri);
+        assertEquals(testData, badUri);
+    }
+
+    @Test
+    public void testIsDataUri() {
+        boolean notDataUri = WorkItemDefinitionStandaloneClientService.isIconDataUri("test");
+        boolean dataUri = WorkItemDefinitionStandaloneClientService.isIconDataUri("data:test");
+        assertFalse(notDataUri);
+        assertTrue(dataUri);
     }
 
     @Test


### PR DESCRIPTION
KOGITO-1301: Adding support for icons in Work Items
--

In this change we are retrieving binary content, creating the URL for a base64 content and returning a default ICON if the icon could not be loaded. The result can be seen below:

![work_items_definitions_with_icons](https://user-images.githubusercontent.com/359820/75467431-64287580-596a-11ea-98f4-0dbcafcc653f.gif)


PART OF AN ENSEMBLE, Merge with:
https://github.com/kiegroup/kogito-tooling/pull/68