### PR TITLE
KOGITO-1157: [DMN Designer] New models must be named with the file name on VSCode

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -392,7 +392,8 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
     @Override
     @SetContent
     public void setContent(final String path, final String value) {
-        diagramServices.transform(value,
+        diagramServices.transform(path,
+                                  value,
                                   new ServiceCallback<Diagram>() {
 
                                       @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
@@ -95,17 +95,39 @@ public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
     //Kogito requirements
 
     @Override
-    public void transform(final String xml,
-                          final ServiceCallback<Diagram> callback) {
+    public void transform(final String fileName, final String xml, final ServiceCallback<Diagram> callback) {
         if (Objects.isNull(xml) || xml.isEmpty()) {
-            doNewDiagram(callback);
+            doNewDiagram(getDiagramTitle(fileName), callback);
         } else {
             doTransformation(xml, callback);
         }
     }
 
-    private void doNewDiagram(final ServiceCallback<Diagram> callback) {
-        final String title = UUID.uuid();
+    String getDiagramTitle(final String fileName) {
+        final String diagramTitle;
+        if (StringUtils.isEmpty(fileName)) {
+            diagramTitle = generateDiagramTitle();
+        } else {
+            if (fileName.contains(".")) {
+                diagramTitle = fileName.substring(0, fileName.lastIndexOf('.'));
+            } else {
+                diagramTitle = fileName;
+            }
+        }
+        return diagramTitle;
+    }
+
+    String generateDiagramTitle() {
+        return UUID.uuid();
+    }
+
+    @Override
+    public void transform(final String xml,
+                          final ServiceCallback<Diagram> callback) {
+        transform(UUID.uuid(), xml, callback);
+    }
+
+    void doNewDiagram(final String title, final ServiceCallback<Diagram> callback) {
         final Metadata metadata = buildMetadataInstance();
 
         try {
@@ -140,8 +162,8 @@ public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
     }
 
     @SuppressWarnings("unchecked")
-    private void doTransformation(final String xml,
-                                  final ServiceCallback<Diagram> callback) {
+    void doTransformation(final String xml,
+                          final ServiceCallback<Diagram> callback) {
         final Metadata metadata = buildMetadataInstance();
 
         try {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
@@ -61,6 +61,8 @@ import org.uberfire.commons.uuid.UUID;
 @ApplicationScoped
 public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
 
+    private static final char UNIX_SEPARATOR = '/';
+    private static final char WINDOWS_SEPARATOR = '\\';
     private static final String DIAGRAMS_PATH = "diagrams";
 
     //This path is needed by DiagramsNavigatorImpl's use of AbstractClientDiagramService.lookup(..) to retrieve a list of diagrams
@@ -105,11 +107,12 @@ public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
         }
     }
 
-    String getDiagramTitle(final String fileName) {
+    String getDiagramTitle(final String filePath) {
         final String diagramTitle;
-        if (StringUtils.isEmpty(fileName)) {
+        if (StringUtils.isEmpty(filePath)) {
             diagramTitle = generateDiagramTitle();
         } else {
+            final String fileName = getName(filePath);
             if (fileName.contains(".")) {
                 diagramTitle = fileName.substring(0, fileName.lastIndexOf('.'));
             } else {
@@ -117,6 +120,18 @@ public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
             }
         }
         return diagramTitle;
+    }
+
+    private String getName(final String filePath) {
+        final int index = indexOfLastSeparator(filePath);
+        return filePath.substring(index + 1);
+    }
+
+    public int indexOfLastSeparator(final String filename) {
+        final int lastUnixPos = filename.lastIndexOf(UNIX_SEPARATOR);
+        final int lastWindowsPos = filename.lastIndexOf(WINDOWS_SEPARATOR);
+        return Math.max(lastUnixPos,
+                        lastWindowsPos);
     }
 
     String generateDiagramTitle() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
@@ -95,7 +95,9 @@ public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
     //Kogito requirements
 
     @Override
-    public void transform(final String fileName, final String xml, final ServiceCallback<Diagram> callback) {
+    public void transform(final String fileName,
+                          final String xml,
+                          final ServiceCallback<Diagram> callback) {
         if (Objects.isNull(xml) || xml.isEmpty()) {
             doNewDiagram(getDiagramTitle(fileName), callback);
         } else {
@@ -127,7 +129,8 @@ public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
         transform(UUID.uuid(), xml, callback);
     }
 
-    void doNewDiagram(final String title, final ServiceCallback<Diagram> callback) {
+    void doNewDiagram(final String title,
+                      final ServiceCallback<Diagram> callback) {
         final Metadata metadata = buildMetadataInstance();
 
         try {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -428,9 +428,10 @@ public abstract class AbstractDMNDiagramEditorTest {
 
     @Test
     public void testSetContentSuccess() {
-        editor.setContent("", CONTENT);
+        final String path = "path";
+        editor.setContent(path, CONTENT);
 
-        verify(clientDiagramService).transform(eq(CONTENT), serviceCallbackArgumentCaptor.capture());
+        verify(clientDiagramService).transform(eq(path), eq(CONTENT), serviceCallbackArgumentCaptor.capture());
 
         final ServiceCallback<Diagram> serviceCallback = serviceCallbackArgumentCaptor.getValue();
         assertThat(serviceCallback).isNotNull();
@@ -441,9 +442,10 @@ public abstract class AbstractDMNDiagramEditorTest {
 
     @Test
     public void testSetContentFailure() {
-        editor.setContent("", CONTENT);
+        final String path = "path";
+        editor.setContent(path, CONTENT);
 
-        verify(clientDiagramService).transform(eq(CONTENT), serviceCallbackArgumentCaptor.capture());
+        verify(clientDiagramService).transform(eq(path), eq(CONTENT), serviceCallbackArgumentCaptor.capture());
 
         final ServiceCallback<Diagram> serviceCallback = serviceCallbackArgumentCaptor.getValue();
         assertThat(serviceCallback).isNotNull();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImplTest.java
@@ -90,6 +90,26 @@ public class DMNClientDiagramServiceImplTest {
     }
 
     @Test
+    public void testGetDiagramTitleWhenIsWindowsPath() {
+        final String fileName = "C:\\my path\\folder\\file.dmn";
+        final String expected = "file";
+
+        final String actual = service.getDiagramTitle(fileName);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetDiagramTitleWhenIsUnixPath() {
+        final String fileName = "/users/user/file.dmn";
+        final String expected = "file";
+
+        final String actual = service.getDiagramTitle(fileName);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testGetDiagramTitleWhenIsNotFileNameOrEmpty() {
         final String fileName = "Something";
         final String expected = "Something";

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImplTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.services;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNClientDiagramServiceImplTest {
+
+    private DMNClientDiagramServiceImpl service;
+
+    @Before
+    public void setup() {
+        service = spy(new DMNClientDiagramServiceImpl());
+    }
+
+    @Test
+    public void testTransformWhenFileIsNew() {
+        final String fileName = "file.dmn";
+        final String xml = "";
+        final ServiceCallback<Diagram> callback = mock(ServiceCallback.class);
+        final String title = "title";
+
+        doReturn(title).when(service).getDiagramTitle(fileName);
+        doNothing().when(service).doNewDiagram(title, callback);
+
+        service.transform(fileName, xml, callback);
+
+        verify(service).doNewDiagram(title, callback);
+    }
+
+    @Test
+    public void testTransformWhenFileIsNotNew() {
+        final String fileName = "file.dmn";
+        final String xml = "xml";
+        final ServiceCallback<Diagram> callback = mock(ServiceCallback.class);
+        final String title = "title";
+
+        doReturn(title).when(service).getDiagramTitle(fileName);
+        doNothing().when(service).doNewDiagram(title, callback);
+
+        service.transform(fileName, xml, callback);
+
+        verify(service, never()).doNewDiagram(title, callback);
+        verify(service).doTransformation(xml, callback);
+    }
+
+    @Test
+    public void testGetDiagramTitleWhenIsEmpty() {
+        final String expected = "some uuid";
+        doReturn(expected).when(service).generateDiagramTitle();
+        final String actual = service.getDiagramTitle("");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetDiagramTitleWhenIsFileName() {
+        final String fileName = "file.dmn";
+        final String expected = "file";
+
+        final String actual = service.getDiagramTitle(fileName);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetDiagramTitleWhenIsNotFileNameOrEmpty() {
+        final String fileName = "Something";
+        final String expected = "Something";
+
+        final String actual = service.getDiagramTitle(fileName);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImplTest.java
@@ -46,9 +46,8 @@ public class DMNClientDiagramServiceImplTest {
         final String fileName = "file.dmn";
         final String xml = "";
         final ServiceCallback<Diagram> callback = mock(ServiceCallback.class);
-        final String title = "title";
+        final String title = "file";
 
-        doReturn(title).when(service).getDiagramTitle(fileName);
         doNothing().when(service).doNewDiagram(title, callback);
 
         service.transform(fileName, xml, callback);
@@ -63,7 +62,6 @@ public class DMNClientDiagramServiceImplTest {
         final ServiceCallback<Diagram> callback = mock(ServiceCallback.class);
         final String title = "title";
 
-        doReturn(title).when(service).getDiagramTitle(fileName);
         doNothing().when(service).doNewDiagram(title, callback);
 
         service.transform(fileName, xml, callback);


### PR DESCRIPTION
See: [https://issues.redhat.com/browse/KOGITO-1157](https://issues.redhat.com/browse/KOGITO-1157)