### PR TITLE
KOGITO-1337: [DMN Designer] Author and filename are always non defined

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationView.java
@@ -108,7 +108,7 @@ public class DMNDocumentationView extends DefaultDiagramDocumentationView {
     @EventHandler("download-html-file")
     public void onDownloadHtmlFile(final ClickEvent e) {
         final String html = getCurrentDocumentationHTML();
-        downloadHelper.download(getCurrentDocumentationFilename(), html);
+        downloadHelper.download(getCurrentDocumentationModelName(), html);
     }
 
     String getCurrentDocumentationHTML() {
@@ -122,10 +122,10 @@ public class DMNDocumentationView extends DefaultDiagramDocumentationView {
                 .orElse(EMPTY.getValue());
     }
 
-    String getCurrentDocumentationFilename() {
+    String getCurrentDocumentationModelName() {
         return getDiagram()
                 .map(diagram -> documentationService.processDocumentation(diagram))
-                .map(dmnDocumentation -> DOCUMENTATION_FILENAME + "-" + dmnDocumentation.getFileName())
+                .map(dmnDocumentation -> DOCUMENTATION_FILENAME + "-" + dmnDocumentation.getDiagramName())
                 .orElse(DOCUMENTATION_FILENAME);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentation.java
@@ -43,8 +43,6 @@ public class DMNDocumentation implements DiagramDocumentation {
 
     private String diagramImage;
 
-    private String fileName;
-
     private String currentDate;
 
     private String currentUser;
@@ -67,7 +65,6 @@ public class DMNDocumentation implements DiagramDocumentation {
 
     @JsOverlay
     public static DMNDocumentation create(final String namespace,
-                                          final String fileName,
                                           final String diagramName,
                                           final String diagramDescription,
                                           final boolean hasGraphNodes,
@@ -85,7 +82,6 @@ public class DMNDocumentation implements DiagramDocumentation {
         dmn.namespace = namespace;
         dmn.diagramName = diagramName;
         dmn.diagramDescription = diagramDescription;
-        dmn.fileName = fileName;
         dmn.currentUser = currentUser;
         dmn.currentDate = currentDate;
         dmn.diagramImage = diagramImage;
@@ -117,11 +113,6 @@ public class DMNDocumentation implements DiagramDocumentation {
     @JsOverlay
     public final String getDiagramImage() {
         return diagramImage;
-    }
-
-    @JsOverlay
-    public final String getFileName() {
-        return fileName;
     }
 
     @JsOverlay

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationFactory.java
@@ -29,14 +29,11 @@ import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.Metadata;
-import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.views.pfly.widgets.Moment;
 import org.uberfire.rpc.SessionInfo;
 
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_Constraints;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_ListYes;
-import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_NoFileName;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_Structure;
 import static org.kie.workbench.common.stunner.core.util.StringUtils.isEmpty;
 
@@ -69,7 +66,6 @@ public class DMNDocumentationFactory {
 
     public DMNDocumentation create(final Diagram diagram) {
         return DMNDocumentation.create(getNamespace(diagram),
-                                       getFileName(diagram),
                                        getDiagramName(diagram),
                                        getDiagramDescription(diagram),
                                        hasGraphNodes(diagram),
@@ -81,31 +77,25 @@ public class DMNDocumentationFactory {
                                        getDocumentationI18n());
     }
 
-    private List<DMNDocumentationDRD> getDrds(final Diagram diagram) {
+    protected List<DMNDocumentationDRD> getDrds(final Diagram diagram) {
         return drdsFactory.create(diagram);
     }
 
-    private String getNamespace(final Diagram diagram) {
+    protected String getNamespace(final Diagram diagram) {
         return graphUtils.getDefinitions(diagram).getNamespace().getValue();
     }
 
-    String getFileName(final Diagram diagram) {
-        final Metadata metadata = diagram.getMetadata();
-        final Optional<Path> path = Optional.ofNullable(metadata.getPath());
-        return path.map(Path::getFileName).orElse(translationService.format(DMNDocumentationFactory_NoFileName));
-    }
-
-    boolean hasGraphNodes(final Diagram diagram) {
+    protected boolean hasGraphNodes(final Diagram diagram) {
         return !graphUtils.getDRGElements(diagram).isEmpty();
     }
 
-    String getDiagramImage() {
+    protected String getDiagramImage() {
         return getCanvasHandler()
                 .map(canvasFileExport::exportToPng)
                 .orElse(EMPTY);
     }
 
-    private List<DMNDocumentationDataType> getDataTypes(final Diagram diagram) {
+    protected List<DMNDocumentationDataType> getDataTypes(final Diagram diagram) {
 
         final List<ItemDefinition> itemDefinitions = graphUtils.getDefinitions(diagram).getItemDefinition();
         final List<DMNDocumentationDataType> dataTypes = new ArrayList<>();
@@ -161,25 +151,25 @@ public class DMNDocumentationFactory {
         return translationService.format(DMNDocumentationFactory_Structure);
     }
 
-    private String getCurrentDate() {
+    protected String getCurrentDate() {
         return moment().format("D MMMM YYYY");
     }
 
-    private String getDiagramName(final Diagram diagram) {
+    protected String getDiagramName(final Diagram diagram) {
         return graphUtils
                 .getDefinitions(diagram)
                 .getName()
                 .getValue();
     }
 
-    private String getDiagramDescription(final Diagram diagram) {
+    protected String getDiagramDescription(final Diagram diagram) {
         return graphUtils
                 .getDefinitions(diagram)
                 .getDescription()
                 .getValue();
     }
 
-    private String getCurrentUserName() {
+    protected String getCurrentUserName() {
         return sessionInfo.getIdentity().getIdentifier();
     }
 
@@ -190,7 +180,7 @@ public class DMNDocumentationFactory {
                 .map(c -> (AbstractCanvasHandler) c);
     }
 
-    DMNDocumentationI18n getDocumentationI18n() {
+    protected DMNDocumentationI18n getDocumentationI18n() {
         return DMNDocumentationI18n.create(translationService);
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/template/dmn-documentation-template.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/template/dmn-documentation-template.html
@@ -282,13 +282,15 @@
                 <b>{{i18n.generatedOn}}</b>
                 {{currentDate}}
             </li>
+            {{#currentUser}}
             <li>
                 <b>{{i18n.generatedBy}}</b>
                 {{currentUser}}
             </li>
+            {{/currentUser}}
             <li>
                 <b>{{i18n.generatedFrom}}</b>
-                {{fileName}}
+                {{diagramName}}
             </li>
         </ul>
     </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/resources/i18n/DMNEditorConstants.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/resources/i18n/DMNEditorConstants.java
@@ -452,9 +452,6 @@ public class DMNEditorConstants {
     public static final String DMNDocumentationI18n_URLPlaceholder = "DMNDocumentationI18n.URLPlaceholder";
 
     @TranslationKey(defaultValue = "")
-    public static final String DMNDocumentationFactory_NoFileName = "DMNDocumentationFactory.NoFileName";
-
-    @TranslationKey(defaultValue = "")
     public static final String DMNDocumentationFactory_Constraints = "DMNDocumentationFactory.Constraints";
 
     @TranslationKey(defaultValue = "")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants.properties
@@ -261,7 +261,6 @@ DMNDocumentationI18n.URLPlaceholder=https://
 DMNDocumentationI18n.Ok=OK
 DMNDocumentationI18n.Cancel=Cancel
 DMNDocumentationI18n.AttachmentTip=.pdf, .doc, .jpeg, .xls
-DMNDocumentationFactory.NoFileName=No file name
 DMNDocumentationFactory.Constraints=Constraints:
 DMNDocumentationFactory.ListYes=List: Yes
 DMNDocumentationFactory.Structure=Structure

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants_es.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants_es.properties
@@ -264,7 +264,6 @@ DMNDocumentationI18n.URLPlaceholder=https://
 DMNDocumentationI18n.Ok=Aceptar
 DMNDocumentationI18n.Cancel=Cancelar
 DMNDocumentationI18n.AttachmentTip=.pdf, .doc, .jpeg, .xls
-DMNDocumentationFactory.NoFileName=No hay nombre de archivo
 DMNDocumentationFactory.Constraints=Restricciones:
 DMNDocumentationFactory.ListYes=Lista: Sí
 DMNDocumentationFactory.Structure=Estructura

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants_fr.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants_fr.properties
@@ -264,7 +264,6 @@ DMNDocumentationI18n.URLPlaceholder=https://
 DMNDocumentationI18n.Ok=OK
 DMNDocumentationI18n.Cancel=Annuler
 DMNDocumentationI18n.AttachmentTip=.pdf, .doc, .jpeg, .xls
-DMNDocumentationFactory.NoFileName=Aucun nom de fichier
 DMNDocumentationFactory.Constraints=Contraintes :
 DMNDocumentationFactory.ListYes=Liste : Oui
 DMNDocumentationFactory.Structure=Structure

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants_ja.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/org/kie/workbench/common/dmn/client/resources/i18n/DMNClientConstants_ja.properties
@@ -264,7 +264,6 @@ DMNDocumentationI18n.URLPlaceholder=https://
 DMNDocumentationI18n.Ok=OK
 DMNDocumentationI18n.Cancel=キャンセル
 DMNDocumentationI18n.AttachmentTip=.pdf。.doc、.jpeg、.xls
-DMNDocumentationFactory.NoFileName=ファイル名がありません
 DMNDocumentationFactory.Constraints=制約:
 DMNDocumentationFactory.ListYes=リスト:はい
 DMNDocumentationFactory.Structure=Structure

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/DMNDocumentationViewTest.java
@@ -191,13 +191,13 @@ public class DMNDocumentationViewTest {
     @Test
     public void testOnDownloadHtmlFile() {
         final String html = "<html><body>Hi</body></html>";
-        final String fileName = "file name";
-        doReturn(fileName).when(view).getCurrentDocumentationFilename();
+        final String modelName = "model name";
+        doReturn(modelName).when(view).getCurrentDocumentationModelName();
         doReturn(html).when(view).getCurrentDocumentationHTML();
 
         view.onDownloadHtmlFile(mock(ClickEvent.class));
 
         verify(view).getCurrentDocumentationHTML();
-        verify(downloadHelper).download(fileName, html);
+        verify(downloadHelper).download(modelName, html);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationFactoryTest.java
@@ -36,7 +36,6 @@ import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.mockito.Mock;
@@ -54,7 +53,6 @@ import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.documentation.common.DMNDocumentationFactory.EMPTY;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_Constraints;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_ListYes;
-import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_NoFileName;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DMNDocumentationFactory_Structure;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -110,13 +108,10 @@ public class DMNDocumentationFactoryTest {
         when(translationService.format(DMNDocumentationFactory_Constraints)).thenReturn("Constraints:");
         when(translationService.format(DMNDocumentationFactory_ListYes)).thenReturn("List: Yes");
         when(translationService.format(DMNDocumentationFactory_Structure)).thenReturn("Structure");
-        when(translationService.format(DMNDocumentationFactory_NoFileName)).thenReturn("No file name");
     }
 
     @Test
     public void testCreate() {
-
-        final String fileName = "filename.dmn";
         final String diagramName = "Diagram name";
         final String diagramDescription = "Diagram description";
         final String image = "<image>";
@@ -137,7 +132,6 @@ public class DMNDocumentationFactoryTest {
         id.setAllowedValues(unaryTests);
         id.setIsCollection(true);
 
-        doReturn(fileName).when(documentationFactory).getFileName(diagram);
         doReturn(image).when(documentationFactory).getDiagramImage();
         doReturn(i18n).when(documentationFactory).getDocumentationI18n();
         doReturn(moment).when(documentationFactory).moment();
@@ -155,7 +149,6 @@ public class DMNDocumentationFactoryTest {
         final DMNDocumentation documentation = documentationFactory.create(diagram);
 
         assertEquals(namespace, documentation.getNamespace());
-        assertEquals(fileName, documentation.getFileName());
         assertEquals(diagramName, documentation.getDiagramName());
         assertEquals(diagramDescription, documentation.getDiagramDescription());
         assertEquals(image, documentation.getDiagramImage());
@@ -203,8 +196,6 @@ public class DMNDocumentationFactoryTest {
 
     @Test
     public void testGetDiagramImageWhenCanvasHandlerIsPresent() {
-
-        final ClientSession clientSession = mock(ClientSession.class);
         final AbstractCanvasHandler canvasHandler = mock(AbstractCanvasHandler.class);
         final String image = "<image>";
 
@@ -230,33 +221,6 @@ public class DMNDocumentationFactoryTest {
     public void testGetHasGraphNodesWhenIsReturnsTrue() {
         when(graphUtils.getDRGElements(diagram)).thenReturn(singletonList(mock(DRGElement.class)));
         assertTrue(documentationFactory.hasGraphNodes(diagram));
-    }
-
-    @Test
-    public void testGetFileNameWhenPathIsPresent() {
-
-        final String expectedFileName = "filename.dmn";
-
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getPath()).thenReturn(path);
-        when(path.getFileName()).thenReturn(expectedFileName);
-
-        final String actualFileName = documentationFactory.getFileName(diagram);
-
-        assertEquals(expectedFileName, actualFileName);
-    }
-
-    @Test
-    public void testGetFileNameWhenPathIsNotPresent() {
-
-        final String expectedFileName = "No file name";
-
-        when(diagram.getMetadata()).thenReturn(metadata);
-        when(metadata.getPath()).thenReturn(null);
-
-        final String actualFileName = documentationFactory.getFileName(diagram);
-
-        assertEquals(expectedFileName, actualFileName);
     }
 
     private ItemDefinition makeItemDefinition(final String name,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/DMNDocumentationViewButtonsVisibilitySupplier.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/DMNDocumentationViewButtonsVisibilitySupplier.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.webapp.kogito.common.client.editor;
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.editors.documentation;
 
 import java.util.Objects;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/common/DMNDocumentationFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/common/DMNDocumentationFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.editors.documentation.common;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.dmn.client.editors.documentation.common.DMNDocumentationDRDsFactory;
+import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
+import org.uberfire.rpc.SessionInfo;
+
+@Dependent
+@Alternative
+@ApplicationScoped
+public class DMNDocumentationFactory extends org.kie.workbench.common.dmn.client.editors.documentation.common.DMNDocumentationFactory {
+
+    @Inject
+    public DMNDocumentationFactory(final CanvasFileExport canvasFileExport,
+                                   final TranslationService translationService,
+                                   final DMNDocumentationDRDsFactory drdsFactory,
+                                   final SessionInfo sessionInfo,
+                                   final DMNGraphUtils graphUtils) {
+        super(canvasFileExport,
+              translationService,
+              drdsFactory,
+              sessionInfo,
+              graphUtils);
+    }
+
+    @Override
+    protected String getCurrentUserName() {
+        return null;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/resources/META-INF/ErraiApp.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/resources/META-INF/ErraiApp.properties
@@ -30,4 +30,5 @@
 # for details.
 errai.ioc.enabled.alternatives=org.kie.workbench.common.dmn.webapp.kogito.common.client.workarounds.IsKogito \
                                org.uberfire.preferences.client.store.PreferenceBeanStoreClientImpl \
-                               org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.DMNDocumentationViewButtonsVisibilitySupplier
+                               org.kie.workbench.common.dmn.webapp.kogito.common.client.editors.documentation.DMNDocumentationViewButtonsVisibilitySupplier \
+                               org.kie.workbench.common.dmn.webapp.kogito.common.client.editors.documentation.common.DMNDocumentationFactory

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/DMNDocumentationViewButtonsVisibilitySupplierTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/DMNDocumentationViewButtonsVisibilitySupplierTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.webapp.kogito.common.client.editor;
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.editors.documentation;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.appformer.kogito.bridge.client.context.EditorContextProvider;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/common/DMNDocumentationFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editors/documentation/common/DMNDocumentationFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.editors.documentation.common;
+
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.dmn.client.editors.documentation.common.DMNDocumentationDRDsFactory;
+import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
+import org.mockito.Mock;
+import org.uberfire.rpc.SessionInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DMNDocumentationFactoryTest {
+
+    @Mock
+    private CanvasFileExport canvasFileExport;
+
+    @Mock
+    private TranslationService translationService;
+
+    @Mock
+    private DMNDocumentationDRDsFactory drdsFactory;
+
+    @Mock
+    private SessionInfo sessionInfo;
+
+    @Mock
+    private DMNGraphUtils graphUtils;
+
+    private DMNDocumentationFactory factory;
+
+    @Before
+    public void setup() {
+        this.factory = new DMNDocumentationFactory(canvasFileExport,
+                                                   translationService,
+                                                   drdsFactory,
+                                                   sessionInfo,
+                                                   graphUtils);
+    }
+
+    @Test
+    public void testGetCurrentUserName() {
+        assertThat(factory.getCurrentUserName()).isNull();
+    }
+}


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-1337

The DMN _model name_ was already in the `DMNDocumentation` class, so I just removed `fileName`.

I've also [moved](https://github.com/kiegroup/kie-wb-common/pull/3208/files#diff-2beebe31108b6489cb3b435185072878) the existing _kogito_ version of `DMNDocumentationViewButtonsVisibilitySupplier` (and test) to the same sub-package path as the one it replaces for kogito for consistency. So there are a couple of other (sort of) related changes in this PR.

**TO TEST**

- Compile `kie-wb-common-dmn`
- Run `kie-wb-common-dmn-webapp-standalone`
- The "Documentation" tab will show both model name (Generated from) and user name (Generated by). The user name will be ANONYMOUS. If you run `drools-wb-webapp` you'll see a _real_ user name.
- Run `kie-wb-common-dmn-webapp-kogito-testing`
- The "Documentation" tab will show only model name (Generated from).