### PR TITLE
DROOLS-5137: [DMN Designer] Decision Navigator shows Name.toString() value for diagram

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/factory/AbstractDMNDiagramFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/factory/AbstractDMNDiagramFactory.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.definition.DefinitionSet;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.StringUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
 
@@ -71,7 +72,7 @@ public abstract class AbstractDMNDiagramFactory<M extends Metadata, D extends Di
     }
 
     private void updateDefaultNameSpaces(final Node<Definition<DMNDiagram>, ?> diagramNode) {
-        final DMNDiagram dmnDiagram = diagramNode.getContent().getDefinition();
+        final DMNDiagram dmnDiagram = (DMNDiagram) DefinitionUtils.getElementDefinition(diagramNode);
         final Definitions dmnDefinitions = dmnDiagram.getDefinitions();
 
         Stream.of(DMNModelInstrumentedBase.Namespace.values())
@@ -93,7 +94,7 @@ public abstract class AbstractDMNDiagramFactory<M extends Metadata, D extends Di
 
     private void updateName(final Node<Definition<DMNDiagram>, ?> diagramNode,
                             final String name) {
-        final DMNDiagram dmnDiagram = diagramNode.getContent().getDefinition();
+        final DMNDiagram dmnDiagram = (DMNDiagram) DefinitionUtils.getElementDefinition(diagramNode);
         final Definitions dmnDefinitions = dmnDiagram.getDefinitions();
         final Name dmnName = dmnDefinitions.getName();
         if (StringUtils.isEmpty(dmnName.getValue())) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/rules/AcyclicDirectedGraphRule.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/rules/AcyclicDirectedGraphRule.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
 import org.kie.workbench.common.stunner.core.rule.ext.RuleExtensionHandler;
 import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
 import org.kie.workbench.common.stunner.core.rule.violations.RuleViolationImpl;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
 public class AcyclicDirectedGraphRule extends RuleExtensionHandler<AcyclicDirectedGraphRule, GraphConnectionContext> {
@@ -53,7 +54,7 @@ public class AcyclicDirectedGraphRule extends RuleExtensionHandler<AcyclicDirect
     @Override
     public boolean accepts(final RuleExtension rule,
                            final GraphConnectionContext context) {
-        final Object o = context.getConnector().getContent().getDefinition();
+        final Object o = DefinitionUtils.getElementDefinition(context.getConnector());
         final Class<?> type = rule.getTypeArguments()[0];
         return o.getClass().equals(type);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/rules/SingleConnectorPerTypeGraphRule.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/rules/SingleConnectorPerTypeGraphRule.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.stunner.core.rule.ext.RuleExtension;
 import org.kie.workbench.common.stunner.core.rule.ext.RuleExtensionHandler;
 import org.kie.workbench.common.stunner.core.rule.violations.DefaultRuleViolations;
 import org.kie.workbench.common.stunner.core.rule.violations.RuleViolationImpl;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @ApplicationScoped
 public class SingleConnectorPerTypeGraphRule extends RuleExtensionHandler<SingleConnectorPerTypeGraphRule, GraphConnectionContext> {
@@ -50,7 +51,7 @@ public class SingleConnectorPerTypeGraphRule extends RuleExtensionHandler<Single
     @Override
     public boolean accepts(final RuleExtension rule,
                            final GraphConnectionContext context) {
-        final Object o = context.getConnector().getContent().getDefinition();
+        final Object o = DefinitionUtils.getElementDefinition(context.getConnector());
         final Class<?> type = rule.getTypeArguments()[0];
         return o.getClass().equals(type);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/factory/DMNDiagramFactoryImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/factory/DMNDiagramFactoryImplTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.kie.workbench.common.stunner.core.graph.impl.GraphImpl;
 import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
 import org.kie.workbench.common.stunner.core.graph.store.GraphNodeStoreImpl;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -80,7 +81,7 @@ public class DMNDiagramFactoryImplTest {
 
         //We can safely get the first object on the iterator as we know the graph only contains one node
         final Node<View, Edge> root = (Node<View, Edge>) diagram.getGraph().nodes().iterator().next();
-        final DMNDiagram dmnDiagram = (DMNDiagram) root.getContent().getDefinition();
+        final DMNDiagram dmnDiagram = (DMNDiagram) DefinitionUtils.getElementDefinition(root);
 
         final Definitions dmnDefinitions = dmnDiagram.getDefinitions();
         final Map<String, String> dmnDefaultNameSpaces = dmnDefinitions.getNsContext();
@@ -121,7 +122,7 @@ public class DMNDiagramFactoryImplTest {
 
         //We can safely get the first object on the iterator as we know the graph only contains one node
         final Node<View, Edge> root = (Node<View, Edge>) diagram.getGraph().nodes().iterator().next();
-        final DMNDiagram dmnDiagram = (DMNDiagram) root.getContent().getDefinition();
+        final DMNDiagram dmnDiagram = (DMNDiagram) DefinitionUtils.getElementDefinition(root);
 
         final Definitions dmnDefinitions = dmnDiagram.getDefinitions();
 
@@ -132,13 +133,13 @@ public class DMNDiagramFactoryImplTest {
     @SuppressWarnings("unchecked")
     public void testModelNameWithNonEmptyExistingName() {
         final Node<View, Edge> existingRoot = (Node<View, Edge>) graph.nodes().iterator().next();
-        final DMNDiagram existingDMNDiagram = (DMNDiagram) existingRoot.getContent().getDefinition();
+        final DMNDiagram existingDMNDiagram = (DMNDiagram) DefinitionUtils.getElementDefinition(existingRoot);
         final Definitions existingDMNDefinitions = existingDMNDiagram.getDefinitions();
         existingDMNDefinitions.getName().setValue(EXISTING_NAME);
 
         final Diagram newDiagram = factory.build(NAME, metadata, graph);
         final Node<View, Edge> newRoot = (Node<View, Edge>) newDiagram.getGraph().nodes().iterator().next();
-        final DMNDiagram newDMNDiagram = (DMNDiagram) newRoot.getContent().getDefinition();
+        final DMNDiagram newDMNDiagram = (DMNDiagram) DefinitionUtils.getElementDefinition(newRoot);
         final Definitions newDMNDefinitions = newDMNDiagram.getDefinitions();
 
         assertEquals(EXISTING_NAME, newDMNDefinitions.getName().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandalone.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandalone.java
@@ -551,7 +551,7 @@ public class DMNMarshallerStandalone implements DiagramMarshaller<Graph, Metadat
 
     public static Node<?, ?> findDMNDiagramRoot(final Graph<?, Node<View, ?>> graph) {
         return StreamSupport.stream(graph.nodes().spliterator(),
-                                    false).filter(n -> n.getContent().getDefinition() instanceof DMNDiagram).findFirst().orElseThrow(() -> new UnsupportedOperationException("TODO"));
+                                    false).filter(n -> DefinitionUtils.getElementDefinition(n) instanceof DMNDiagram).findFirst().orElseThrow(() -> new UnsupportedOperationException("TODO"));
     }
 
     private String getId(final org.kie.dmn.model.api.DMNElementReference er) {
@@ -773,7 +773,7 @@ public class DMNMarshallerStandalone implements DiagramMarshaller<Graph, Metadat
         final Map<String, org.kie.dmn.model.api.TextAnnotation> textAnnotations = new HashMap<>();
 
         final Node<View<DMNDiagram>, ?> dmnDiagramRoot = (Node<View<DMNDiagram>, ?>) findDMNDiagramRoot(g);
-        final Definitions definitionsStunnerPojo = dmnDiagramRoot.getContent().getDefinition().getDefinitions();
+        final Definitions definitionsStunnerPojo = ((DMNDiagram) DefinitionUtils.getElementDefinition(dmnDiagramRoot)).getDefinitions();
         cleanImportedItemDefinitions(definitionsStunnerPojo);
         final org.kie.dmn.model.api.Definitions definitions = DefinitionsConverter.dmnFromWB(definitionsStunnerPojo);
         if (definitions.getExtensionElements() == null) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/AssociationConverter.java
@@ -25,13 +25,14 @@ import org.kie.workbench.common.dmn.api.definition.model.TextAnnotation;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.backend.definition.v1_1.HrefBuilder.getHref;
 
 public class AssociationConverter {
 
     public static List<org.kie.dmn.model.api.Association> dmnFromWB(final Node<View<TextAnnotation>, ?> node) {
-        final TextAnnotation ta = node.getContent().getDefinition();
+        final TextAnnotation ta = (TextAnnotation) DefinitionUtils.getElementDefinition(node);
         final org.kie.dmn.model.api.DMNElementReference ta_elementReference = new org.kie.dmn.model.v1_2.TDMNElementReference();
         ta_elementReference.setHref(new StringBuilder("#").append(ta.getId().getValue()).toString());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverter.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.backend.definition.v1_1.HrefBuilder.getHref;
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
@@ -99,7 +100,7 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<org.kie.dm
     @Override
     public org.kie.dmn.model.api.BusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node,
                                                                     final Consumer<ComponentWidths> componentWidthsConsumer) {
-        final BusinessKnowledgeModel source = node.getContent().getDefinition();
+        final BusinessKnowledgeModel source = (BusinessKnowledgeModel) DefinitionUtils.getElementDefinition(node);
         final org.kie.dmn.model.api.BusinessKnowledgeModel result = new org.kie.dmn.model.v1_2.TBusinessKnowledgeModel();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverter.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.backend.definition.v1_1.HrefBuilder.getHref;
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
@@ -97,7 +98,7 @@ public class DecisionConverter implements NodeConverter<org.kie.dmn.model.api.De
     @Override
     public org.kie.dmn.model.api.Decision dmnFromNode(final Node<View<Decision>, ?> node,
                                                       final Consumer<ComponentWidths> componentWidthsConsumer) {
-        final Decision source = node.getContent().getDefinition();
+        final Decision source = (Decision) DefinitionUtils.getElementDefinition(node);
         final org.kie.dmn.model.api.Decision d = new org.kie.dmn.model.v1_2.TDecision();
         d.setId(source.getId().getValue());
         d.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionServiceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionServiceConverter.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
 
@@ -97,7 +98,7 @@ public class DecisionServiceConverter implements NodeConverter<org.kie.dmn.model
     @SuppressWarnings("unchecked")
     public org.kie.dmn.model.api.DecisionService dmnFromNode(final Node<View<DecisionService>, ?> node,
                                                              final Consumer<ComponentWidths> componentWidthsConsumer) {
-        final DecisionService source = node.getContent().getDefinition();
+        final DecisionService source = (DecisionService) DefinitionUtils.getElementDefinition(node);
         final org.kie.dmn.model.api.DecisionService ds = new org.kie.dmn.model.v1_2.TDecisionService();
         ds.setId(source.getId().getValue());
         ds.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverter.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
 
@@ -75,7 +76,7 @@ public class InputDataConverter implements NodeConverter<org.kie.dmn.model.api.I
     @Override
     public org.kie.dmn.model.api.InputData dmnFromNode(final Node<View<InputData>, ?> node,
                                                        final Consumer<ComponentWidths> componentWidthsConsumer) {
-        final InputData source = node.getContent().getDefinition();
+        final InputData source = (InputData) DefinitionUtils.getElementDefinition(node);
         final org.kie.dmn.model.api.InputData result = new org.kie.dmn.model.v1_2.TInputData();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/KnowledgeSourceConverter.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.backend.definition.v1_1.HrefBuilder.getHref;
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
@@ -80,7 +81,7 @@ public class KnowledgeSourceConverter implements NodeConverter<org.kie.dmn.model
     @Override
     public org.kie.dmn.model.api.KnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node,
                                                              final Consumer<ComponentWidths> componentWidthsConsumer) {
-        final KnowledgeSource source = node.getContent().getDefinition();
+        final KnowledgeSource source = (KnowledgeSource) DefinitionUtils.getElementDefinition(node);
         final org.kie.dmn.model.api.KnowledgeSource result = new org.kie.dmn.model.v1_2.TKnowledgeSource();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/TextAnnotationConverter.java
@@ -32,6 +32,7 @@ import org.kie.workbench.common.dmn.backend.definition.v1_1.dd.ComponentWidths;
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
 
@@ -68,7 +69,7 @@ public class TextAnnotationConverter implements NodeConverter<org.kie.dmn.model.
     @Override
     public org.kie.dmn.model.api.TextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node,
                                                             final Consumer<ComponentWidths> componentWidthsConsumer) {
-        final TextAnnotation source = node.getContent().getDefinition();
+        final TextAnnotation source = (TextAnnotation) DefinitionUtils.getElementDefinition(node);
         final org.kie.dmn.model.api.TextAnnotation result = new org.kie.dmn.model.v1_2.TTextAnnotation();
         result.setId(source.getId().getValue());
         result.setDescription(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
@@ -146,6 +146,7 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.kie.workbench.common.stunner.core.graph.impl.EdgeImpl;
 import org.kie.workbench.common.stunner.core.graph.processing.index.map.MapIndexBuilder;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
@@ -2347,7 +2348,7 @@ public class DMNMarshallerStandaloneTest {
     private static void checkDecisionExpression(final Graph<?, Node<View, ?>> unmarshalledGraph,
                                                 final Expression expression) {
         final Node<View, ?> decisionNode = nodeOfDefinition(unmarshalledGraph.nodes().iterator(), Decision.class);
-        final Expression decisionNodeExpression = ((Decision) decisionNode.getContent().getDefinition()).getExpression();
+        final Expression decisionNodeExpression = ((Decision) DefinitionUtils.getElementDefinition(decisionNode)).getExpression();
 
         // The process of marshalling an Expression that has been programmatically instantiated (vs created in the UI)
         // leads to the _source_ Expression ComponentWidths being initialised. Therefore to ensure a like-for-like equality
@@ -2359,7 +2360,7 @@ public class DMNMarshallerStandaloneTest {
 
     private static Node<View, ?> nodeOfDefinition(final Iterator<Node<View, ?>> nodesIterator, final Class aClass) {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(nodesIterator, Spliterator.NONNULL), false)
-                .filter(node -> aClass.isInstance(node.getContent().getDefinition()))
+                .filter(node -> aClass.isInstance(DefinitionUtils.getElementDefinition(node)))
                 .findFirst().get();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BusinessKnowledgeModelConverterTest.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -116,7 +117,7 @@ public class BusinessKnowledgeModelConverterTest {
         dmn.setEncapsulatedLogic(functionDefinition);
 
         final Node<View<BusinessKnowledgeModel>, ?> node = converter.nodeFromDMN(dmn, hasComponentWidthsConsumer);
-        final BusinessKnowledgeModel wb = node.getContent().getDefinition();
+        final BusinessKnowledgeModel wb = (BusinessKnowledgeModel) DefinitionUtils.getElementDefinition(node);
 
         assertThat(wb).isNotNull();
         assertThat(wb.getId()).isNotNull();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionConverterTest.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -107,7 +108,7 @@ public class DecisionConverterTest {
         dmn.setExpression(literalExpression);
 
         final Node<View<Decision>, ?> node = converter.nodeFromDMN(dmn, hasComponentWidthsConsumer);
-        final Decision wb = node.getContent().getDefinition();
+        final Decision wb = (Decision) DefinitionUtils.getElementDefinition(node);
 
         assertThat(wb).isNotNull();
         assertThat(wb.getId()).isNotNull();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionServiceConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/DecisionServiceConverterTest.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -92,7 +93,7 @@ public class DecisionServiceConverterTest {
         dmn.setVariable(informationItem);
 
         final Node<View<DecisionService>, ?> node = converter.nodeFromDMN(dmn, hasComponentWidthsConsumer);
-        final DecisionService wb = node.getContent().getDefinition();
+        final DecisionService wb = (DecisionService) DefinitionUtils.getElementDefinition(node);
 
         assertThat(wb).isNotNull();
         assertThat(wb.getId()).isNotNull();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/InputDataConverterTest.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.UUID;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -92,7 +93,7 @@ public class InputDataConverterTest {
         dmn.setVariable(informationItem);
 
         final Node<View<InputData>, ?> node = converter.nodeFromDMN(dmn, hasComponentWidthsConsumer);
-        final InputData wb = node.getContent().getDefinition();
+        final InputData wb = (InputData) DefinitionUtils.getElementDefinition(node);
 
         assertThat(wb).isNotNull();
         assertThat(wb.getId()).isNotNull();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DMNDiagramTextPropertyProviderImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DMNDiagramTextPropertyProviderImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.canvas.controls.actions;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.dmn.client.editors.expressions.util.NameUtils;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProvider;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+
+@ApplicationScoped
+public class DMNDiagramTextPropertyProviderImpl implements TextPropertyProvider {
+
+    private DefaultCanvasCommandFactory canvasCommandFactory;
+    private DefinitionUtils definitionUtils;
+
+    public DMNDiagramTextPropertyProviderImpl() {
+        //CDI proxy
+    }
+
+    @Inject
+    public DMNDiagramTextPropertyProviderImpl(final @DMNEditor DefaultCanvasCommandFactory canvasCommandFactory,
+                                              final DefinitionUtils definitionUtils) {
+        this.canvasCommandFactory = canvasCommandFactory;
+        this.definitionUtils = definitionUtils;
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+
+    @Override
+    public boolean supports(final Element<? extends Definition> element) {
+        return element.getContent().getDefinition() instanceof DMNDiagram;
+    }
+
+    @Override
+    public String getText(final Element<? extends Definition> element) {
+        final DMNDiagram dmnDiagram = (DMNDiagram) element.getContent().getDefinition();
+        return dmnDiagram.getDefinitions().getNameHolder().getValue().getValue();
+    }
+
+    @Override
+    public void setText(final AbstractCanvasHandler canvasHandler,
+                        final CanvasCommandManager<AbstractCanvasHandler> commandManager,
+                        final Element<? extends Definition> element,
+                        final String text) {
+        final Object definition = ((DMNDiagram) element.getContent().getDefinition()).getDefinitions();
+        final CanvasCommand<AbstractCanvasHandler> command =
+                canvasCommandFactory.updatePropertyValue(element,
+                                                         definitionUtils.getNameIdentifier(definition),
+                                                         new Name(NameUtils.normaliseName(text)));
+        commandManager.execute(canvasHandler,
+                               command);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DMNDiagramTextPropertyProviderImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DMNDiagramTextPropertyProviderImpl.java
@@ -56,12 +56,12 @@ public class DMNDiagramTextPropertyProviderImpl implements TextPropertyProvider 
 
     @Override
     public boolean supports(final Element<? extends Definition> element) {
-        return element.getContent().getDefinition() instanceof DMNDiagram;
+        return DefinitionUtils.getElementDefinition(element) instanceof DMNDiagram;
     }
 
     @Override
     public String getText(final Element<? extends Definition> element) {
-        final DMNDiagram dmnDiagram = (DMNDiagram) element.getContent().getDefinition();
+        final DMNDiagram dmnDiagram = (DMNDiagram) DefinitionUtils.getElementDefinition(element);
         return dmnDiagram.getDefinitions().getNameHolder().getValue().getValue();
     }
 
@@ -70,7 +70,7 @@ public class DMNDiagramTextPropertyProviderImpl implements TextPropertyProvider 
                         final CanvasCommandManager<AbstractCanvasHandler> commandManager,
                         final Element<? extends Definition> element,
                         final String text) {
-        final Object definition = ((DMNDiagram) element.getContent().getDefinition()).getDefinitions();
+        final Object definition = ((DMNDiagram) DefinitionUtils.getElementDefinition(element)).getDefinitions();
         final CanvasCommand<AbstractCanvasHandler> command =
                 canvasCommandFactory.updatePropertyValue(element,
                                                          definitionUtils.getNameIdentifier(definition),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DRGElementTextPropertyProviderImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DRGElementTextPropertyProviderImpl.java
@@ -56,12 +56,12 @@ public class DRGElementTextPropertyProviderImpl implements TextPropertyProvider 
 
     @Override
     public boolean supports(final Element<? extends Definition> element) {
-        return element.getContent().getDefinition() instanceof DRGElement;
+        return DefinitionUtils.getElementDefinition(element) instanceof DRGElement;
     }
 
     @Override
     public String getText(final Element<? extends Definition> element) {
-        final DRGElement drgElement = (DRGElement) element.getContent().getDefinition();
+        final DRGElement drgElement = (DRGElement) DefinitionUtils.getElementDefinition(element);
         return drgElement.getNameHolder().getValue().getValue();
     }
 
@@ -70,7 +70,7 @@ public class DRGElementTextPropertyProviderImpl implements TextPropertyProvider 
                         final CanvasCommandManager<AbstractCanvasHandler> commandManager,
                         final Element<? extends Definition> element,
                         final String text) {
-        final Object definition = element.getContent().getDefinition();
+        final Object definition = DefinitionUtils.getElementDefinition(element);
         final CanvasCommand<AbstractCanvasHandler> command =
                 canvasCommandFactory.updatePropertyValue(element,
                                                          definitionUtils.getNameIdentifier(definition),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
@@ -54,7 +54,7 @@ public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvi
 
     @Override
     public boolean supports(final Element<? extends Definition> element) {
-        return element.getContent().getDefinition() instanceof TextAnnotation;
+        return DefinitionUtils.getElementDefinition(element) instanceof TextAnnotation;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvi
                         final CanvasCommandManager<AbstractCanvasHandler> commandManager,
                         final Element<? extends Definition> element,
                         final String text) {
-        final Object definition = element.getContent().getDefinition();
+        final Object definition = DefinitionUtils.getElementDefinition(element);
         final CanvasCommand<AbstractCanvasHandler> command =
                 canvasCommandFactory.updatePropertyValue(element,
                                                          definitionUtils.getNameIdentifier(definition),
@@ -73,7 +73,7 @@ public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvi
 
     @Override
     public String getText(final Element<? extends Definition> element) {
-        final TextAnnotation ta = (TextAnnotation) element.getContent().getDefinition();
+        final TextAnnotation ta = (TextAnnotation) DefinitionUtils.getElementDefinition(element);
         final String text = ta.getText().getValue();
         return text;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditBusinessKnowledgeModelToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditBusinessKnowledgeModelToolboxAction.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
 public class DMNEditBusinessKnowledgeModelToolboxAction implements ToolboxAction<AbstractCanvasHandler> {
@@ -80,7 +81,7 @@ public class DMNEditBusinessKnowledgeModelToolboxAction implements ToolboxAction
                 = (Node<View<? extends BusinessKnowledgeModel>, Edge>) CanvasLayoutUtils.getElement(canvasHandler,
                                                                                                     uuid)
                 .asNode();
-        final BusinessKnowledgeModel bkm = bkmNode.getContent().getDefinition();
+        final BusinessKnowledgeModel bkm = (BusinessKnowledgeModel) DefinitionUtils.getElementDefinition(bkmNode);
         final boolean isOnlyVisualChangeAllowed = bkm.isAllowOnlyVisualChange();
         editExpressionEvent.fire(new EditExpressionEvent(sessionManager.getCurrentSession(),
                                                          uuid,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDecisionToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDecisionToolboxAction.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.i18n.CoreTranslationMessages;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 @Dependent
 public class DMNEditDecisionToolboxAction implements ToolboxAction<AbstractCanvasHandler> {
@@ -80,7 +81,7 @@ public class DMNEditDecisionToolboxAction implements ToolboxAction<AbstractCanva
                 = (Node<View<? extends Decision>, Edge>) CanvasLayoutUtils.getElement(canvasHandler,
                                                                                       uuid)
                 .asNode();
-        final Decision decision = decisionNode.getContent().getDefinition();
+        final Decision decision = (Decision) DefinitionUtils.getElementDefinition(decisionNode);
         final boolean isOnlyVisualChangeAllowed = decision.isAllowOnlyVisualChange();
         editExpressionEvent.fire(new EditExpressionEvent(sessionManager.getCurrentSession(),
                                                          uuid,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNSafeDeleteNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNSafeDeleteNodeCommand.java
@@ -21,6 +21,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.impl.SafeDeleteNodeCommand;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 public class DMNSafeDeleteNodeCommand extends SafeDeleteNodeCommand {
 
@@ -32,6 +33,6 @@ public class DMNSafeDeleteNodeCommand extends SafeDeleteNodeCommand {
 
     @Override
     public boolean shouldKeepChildren(final Node<Definition<?>, Edge> candidate) {
-        return candidate.getContent().getDefinition() instanceof DecisionService;
+        return DefinitionUtils.getElementDefinition(candidate) instanceof DecisionService;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/common/BoxedExpressionHelper.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/common/BoxedExpressionHelper.java
@@ -25,12 +25,13 @@ import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 public class BoxedExpressionHelper {
 
     public Optional<HasExpression> getOptionalHasExpression(final Node<View, Edge> node) {
 
-        final Object definition = getDefinition(node);
+        final Object definition = DefinitionUtils.getElementDefinition(node);
         final HasExpression expression;
 
         if (definition instanceof BusinessKnowledgeModel) {
@@ -54,9 +55,5 @@ public class BoxedExpressionHelper {
 
     public HasExpression getHasExpression(final Node<View, Edge> node) {
         return getOptionalHasExpression(node).orElseThrow(UnsupportedOperationException::new);
-    }
-
-    public Object getDefinition(final Node<View, Edge> node) {
-        return node.getContent().getDefinition();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorBaseItemFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorBaseItemFactory.java
@@ -148,7 +148,7 @@ public class DecisionNavigatorBaseItemFactory {
         final AdapterManager adapters = definitionUtils.getDefinitionManager().adapters();
         final DefinitionAdapter<Object> objectDefinitionAdapter = adapters.forDefinition();
 
-        return objectDefinitionAdapter.getTitle(element.getContent().getDefinition());
+        return objectDefinitionAdapter.getTitle(DefinitionUtils.getElementDefinition(element));
     }
 
     List<DecisionNavigatorItem> makeNestedItems(final Node<View, Edge> node) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactory.java
@@ -49,6 +49,7 @@ import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.uberfire.mvp.Command;
 
 import static org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem.Type.CONTEXT;
@@ -135,7 +136,7 @@ public class DecisionNavigatorNestedItemFactory {
     EditExpressionEvent makeEditExpressionEvent(final Node<View, Edge> node) {
 
         final ClientSession currentSession = sessionManager.getCurrentSession();
-        final Object definition = helper.getDefinition(node);
+        final Object definition = DefinitionUtils.getElementDefinition(node);
         final HasExpression hasExpression = helper.getHasExpression(node);
         final Optional<HasName> hasName = Optional.of((HasName) definition);
         final boolean isOnlyVisualChangeAllowed = isOnlyVisualChangeAllowed(definition);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationDRDsFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationDRDsFactory.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 public class DMNDocumentationDRDsFactory {
 
@@ -101,7 +102,7 @@ public class DMNDocumentationDRDsFactory {
                                     final String uuid) {
 
         final Node<View, Edge> node = getNode(diagram, uuid);
-        final Object definition = expressionHelper.getDefinition(node);
+        final Object definition = DefinitionUtils.getElementDefinition(node);
         final HasExpression hasExpression = expressionHelper.getHasExpression(node);
         final Optional<HasName> hasName = Optional.of((HasName) definition);
         final ExpressionContainerGrid grid = getExpressionContainerGrid();
@@ -115,7 +116,7 @@ public class DMNDocumentationDRDsFactory {
         final List<DMNDocumentationDRD> dmnDocumentationDRDS = new ArrayList<>();
 
         getNodeStream(diagram).forEach(node -> {
-            final Object definition = expressionHelper.getDefinition(node);
+            final Object definition = DefinitionUtils.getElementDefinition(node);
             if (definition instanceof DRGElement) {
                 final DRGElement drgElement = (DRGElement) definition;
                 dmnDocumentationDRDS.add(createDMNDocumentationDRD(diagram, node, drgElement));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DMNDiagramTextPropertyProviderImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DMNDiagramTextPropertyProviderImplTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.canvas.controls.actions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
+import org.kie.workbench.common.dmn.api.definition.model.Definitions;
+import org.kie.workbench.common.dmn.api.definition.model.TextAnnotation;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.NameHolder;
+import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProvider;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.actions.TextPropertyProviderFactory;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNDiagramTextPropertyProviderImplTest {
+
+    private static final String NAME_FIELD = "name";
+
+    private static final String NAME_VALUE = "text";
+
+    private static final String NAME_VALUE_WITH_WHITESPACE = "   " + NAME_VALUE + "   ";
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private DefaultCanvasCommandFactory canvasCommandFactory;
+
+    @Mock
+    private Element<Definition> element;
+
+    @Mock
+    private Definition content;
+
+    @Mock
+    private DMNDiagram definition;
+
+    @Mock
+    private Definitions definitions;
+
+    @Mock
+    private Name name;
+
+    @Mock
+    private NameHolder nameHolder;
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private CanvasCommandManager<AbstractCanvasHandler> commandManager;
+
+    @Mock
+    private CanvasCommand<AbstractCanvasHandler> command;
+
+    @Captor
+    private ArgumentCaptor<Name> nameArgumentCaptor;
+
+    private TextPropertyProvider provider;
+
+    @Before
+    public void setup() {
+        this.provider = new DMNDiagramTextPropertyProviderImpl(canvasCommandFactory, definitionUtils);
+        when(element.getContent()).thenReturn(content);
+        when(content.getDefinition()).thenReturn(definition);
+        when(definition.getDefinitions()).thenReturn(definitions);
+        when(definitions.getName()).thenReturn(name);
+        when(definitions.getNameHolder()).thenReturn(nameHolder);
+        when(nameHolder.getValue()).thenReturn(name);
+        when(definitionUtils.getNameIdentifier(eq(definitions))).thenReturn(NAME_FIELD);
+        when(canvasCommandFactory.updatePropertyValue(eq(element),
+                                                      anyString(),
+                                                      anyString())).thenReturn(command);
+    }
+
+    @Test
+    public void checkPriorityLessThanCatchAll() {
+        assertTrue(provider.getPriority() < TextPropertyProviderFactory.CATCH_ALL_PRIORITY);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkSupportsDMNDiagram() {
+        assertTrue(provider.supports(element));
+
+        final Element other = mock(Element.class);
+        final Definition otherContent = mock(Definition.class);
+        final TextAnnotation otherDefinition = mock(TextAnnotation.class);
+        when(other.getContent()).thenReturn(otherContent);
+        when(otherContent.getDefinition()).thenReturn(otherDefinition);
+
+        assertFalse(provider.supports(other));
+    }
+
+    @Test
+    public void checkReadGetsTextFromNameProperty() {
+        provider.getText(element);
+
+        verify(definitions).getNameHolder();
+        verify(nameHolder).getValue();
+    }
+
+    @Test
+    public void checkWriteUsesCommandToUpdateTextProperty() {
+        provider.setText(canvasHandler, commandManager, element, NAME_VALUE);
+
+        verify(canvasCommandFactory).updatePropertyValue(eq(element), eq(NAME_FIELD), nameArgumentCaptor.capture());
+        assertEquals(NAME_VALUE, nameArgumentCaptor.getValue().getValue());
+        verify(commandManager).execute(eq(canvasHandler), eq(command));
+    }
+
+    @Test
+    public void checkWriteUsesCommandToUpdateTextPropertyWithWhitespace() {
+        provider.setText(canvasHandler, commandManager, element, NAME_VALUE_WITH_WHITESPACE);
+
+        verify(canvasCommandFactory).updatePropertyValue(eq(element), eq(NAME_FIELD), nameArgumentCaptor.capture());
+        assertEquals(NAME_VALUE, nameArgumentCaptor.getValue().getValue());
+        verify(commandManager).execute(eq(canvasHandler), eq(command));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/common/BoxedExpressionHelperTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/common/BoxedExpressionHelperTest.java
@@ -171,18 +171,4 @@ public class BoxedExpressionHelperTest {
 
         helper.getHasExpression(node);
     }
-
-    @Test
-    public void testGetDefinition() {
-
-        final View content = mock(View.class);
-        final Decision expected = mock(Decision.class);
-
-        when(node.getContent()).thenReturn(content);
-        when(content.getDefinition()).thenReturn(expected);
-
-        final Object actual = helper.getDefinition(node);
-
-        assertEquals(expected, actual);
-    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactoryTest.java
@@ -164,11 +164,13 @@ public class DecisionNavigatorNestedItemFactoryTest {
         final ClientSession currentSession = mock(ClientSession.class);
         final HasName hasName = mock(HasName.class);
         final HasExpression hasExpression = mock(HasExpression.class);
+        final View view = mock(View.class);
         final String uuid = "uuid";
 
         when(node.getUUID()).thenReturn(uuid);
         when(sessionManager.getCurrentSession()).thenReturn(currentSession);
-        when(boxedExpressionHelper.getDefinition(node)).thenReturn(hasName);
+        when(node.getContent()).thenReturn(view);
+        when(view.getDefinition()).thenReturn(hasName);
         when(boxedExpressionHelper.getHasExpression(node)).thenReturn(hasExpression);
 
         final EditExpressionEvent expressionEvent = factory.makeEditExpressionEvent(node);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationDRDsFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/common/DMNDocumentationDRDsFactoryTest.java
@@ -129,6 +129,8 @@ public class DMNDocumentationDRDsFactoryTest {
         final String nodeUUID2 = "2222-2222-2222-2222";
         final Node<View, Edge> node1 = new NodeImpl<>(nodeUUID1);
         final Node<View, Edge> node2 = new NodeImpl<>(nodeUUID2);
+        final View view1 = mock(View.class);
+        final View view2 = mock(View.class);
         final HasExpression hasExpression1 = mock(HasExpression.class);
         final List<Node<View, Edge>> nodes = asList(node1, node2);
         final Decision drgElement1 = new Decision();
@@ -144,8 +146,10 @@ public class DMNDocumentationDRDsFactoryTest {
         linksHolder.getValue().addLink(externalLink);
         drgElement2.setLinksHolder(linksHolder);
 
-        when(expressionHelper.getDefinition(node1)).thenReturn(drgElement1);
-        when(expressionHelper.getDefinition(node2)).thenReturn(drgElement2);
+        node1.setContent(view1);
+        node2.setContent(view2);
+        when(view1.getDefinition()).thenReturn(drgElement1);
+        when(view2.getDefinition()).thenReturn(drgElement2);
         when(expressionHelper.getOptionalHasExpression(node1)).thenReturn(Optional.ofNullable(hasExpression1));
         when(expressionHelper.getOptionalHasExpression(node2)).thenReturn(Optional.empty());
         when(expressionContainerGrid.getNodeUUID()).thenReturn(Optional.of(nodeUUID2));
@@ -213,10 +217,12 @@ public class DMNDocumentationDRDsFactoryTest {
         final Node<View, Edge> node = new NodeImpl<>(uuid);
         final Decision drgElement = new Decision();
         final HasExpression hasExpression = mock(HasExpression.class);
+        final View view = mock(View.class);
 
+        node.setContent(view);
         drgElement.setName(new Name(name));
         when(graph.nodes()).thenReturn(singletonList(node));
-        when(expressionHelper.getDefinition(node)).thenReturn(drgElement);
+        when(view.getDefinition()).thenReturn(drgElement);
         when(expressionHelper.getHasExpression(node)).thenReturn(hasExpression);
 
         factory.setExpressionContainerGrid(diagram, uuid);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/DMNMarshallerKogitoMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/DMNMarshallerKogitoMarshaller.java
@@ -79,6 +79,7 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.dd.PointUtils.upperLeftBound;
 import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.dd.PointUtils.xOfBound;
@@ -144,7 +145,7 @@ public class DMNMarshallerKogitoMarshaller {
         final Map<String, JSITDRGElement> nodes = new HashMap<>();
         final Map<String, JSITTextAnnotation> textAnnotations = new HashMap<>();
         final Node<View<DMNDiagram>, ?> dmnDiagramRoot = (Node<View<DMNDiagram>, ?>) DMNMarshallerUtils.findDMNDiagramRoot(graph);
-        final Definitions definitionsStunnerPojo = dmnDiagramRoot.getContent().getDefinition().getDefinitions();
+        final Definitions definitionsStunnerPojo = ((DMNDiagram) DefinitionUtils.getElementDefinition(dmnDiagramRoot)).getDefinitions();
         final List<JSIDMNEdge> dmnEdges = new ArrayList<>();
 
         cleanImportedItemDefinitions(definitionsStunnerPojo);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/AssociationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/AssociationConverter.java
@@ -30,6 +30,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSIT
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.HrefBuilder.getHref;
 
@@ -37,7 +38,7 @@ public class AssociationConverter {
 
     @SuppressWarnings("unchecked")
     public static List<JSITAssociation> dmnFromWB(final Node<View<TextAnnotation>, ?> node) {
-        final TextAnnotation ta = node.getContent().getDefinition();
+        final TextAnnotation ta = (TextAnnotation) DefinitionUtils.getElementDefinition(node);
         final JSITDMNElementReference ta_elementReference = new JSITDMNElementReference();
         ta_elementReference.setHref(new StringBuilder("#").append(ta.getId().getValue()).toString());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/BusinessKnowledgeModelConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/BusinessKnowledgeModelConverter.java
@@ -48,6 +48,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.HrefBuilder.getHref;
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
@@ -105,7 +106,7 @@ public class BusinessKnowledgeModelConverter implements NodeConverter<JSITBusine
     @SuppressWarnings("unchecked")
     public JSITBusinessKnowledgeModel dmnFromNode(final Node<View<BusinessKnowledgeModel>, ?> node,
                                                   final Consumer<JSITComponentWidths> componentWidthsConsumer) {
-        final BusinessKnowledgeModel source = node.getContent().getDefinition();
+        final BusinessKnowledgeModel source = (BusinessKnowledgeModel) DefinitionUtils.getElementDefinition(node);
         final JSITBusinessKnowledgeModel result = new JSITBusinessKnowledgeModel();
         result.setId(source.getId().getValue());
         final Optional<String> description = Optional.ofNullable(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DecisionConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DecisionConverter.java
@@ -56,6 +56,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.StringUtils;
 
 import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.HrefBuilder.getHref;
@@ -119,7 +120,7 @@ public class DecisionConverter implements NodeConverter<JSITDecision, org.kie.wo
     @SuppressWarnings("unchecked")
     public JSITDecision dmnFromNode(final Node<View<Decision>, ?> node,
                                     final Consumer<JSITComponentWidths> componentWidthsConsumer) {
-        final Decision source = node.getContent().getDefinition();
+        final Decision source = (Decision) DefinitionUtils.getElementDefinition(node);
         final JSITDecision d = new JSITDecision();
         d.setId(source.getId().getValue());
         final Optional<String> description = Optional.ofNullable(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DecisionServiceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/DecisionServiceConverter.java
@@ -50,6 +50,7 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
 
@@ -148,7 +149,7 @@ public class DecisionServiceConverter implements NodeConverter<JSITDecisionServi
     @SuppressWarnings("unchecked")
     public JSITDecisionService dmnFromNode(final Node<View<DecisionService>, ?> node,
                                            final Consumer<JSITComponentWidths> componentWidthsConsumer) {
-        final DecisionService source = node.getContent().getDefinition();
+        final DecisionService source = (DecisionService) DefinitionUtils.getElementDefinition(node);
         final JSITDecisionService ds = new JSITDecisionService();
         ds.setId(source.getId().getValue());
         final Optional<String> description = Optional.ofNullable(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/InputDataConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/InputDataConverter.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.kie.JSITCo
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
 
@@ -80,7 +81,7 @@ public class InputDataConverter implements NodeConverter<JSITInputData, InputDat
     @Override
     public JSITInputData dmnFromNode(final Node<View<InputData>, ?> node,
                                      final Consumer<JSITComponentWidths> componentWidthsConsumer) {
-        final InputData source = node.getContent().getDefinition();
+        final InputData source = (InputData) DefinitionUtils.getElementDefinition(node);
         final JSITInputData result = new JSITInputData();
         result.setId(source.getId().getValue());
         final Optional<String> description = Optional.ofNullable(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/KnowledgeSourceConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/KnowledgeSourceConverter.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.HrefBuilder.getHref;
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
@@ -86,7 +87,7 @@ public class KnowledgeSourceConverter implements NodeConverter<JSITKnowledgeSour
     @SuppressWarnings("unchecked")
     public JSITKnowledgeSource dmnFromNode(final Node<View<KnowledgeSource>, ?> node,
                                            final Consumer<JSITComponentWidths> componentWidthsConsumer) {
-        final KnowledgeSource source = node.getContent().getDefinition();
+        final KnowledgeSource source = (KnowledgeSource) DefinitionUtils.getElementDefinition(node);
         final JSITKnowledgeSource result = new JSITKnowledgeSource();
         result.setId(source.getId().getValue());
         final Optional<String> description = Optional.ofNullable(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/TextAnnotationConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/TextAnnotationConverter.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.kie.JSITCo
 import org.kie.workbench.common.stunner.core.api.FactoryManager;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
 
@@ -70,7 +71,7 @@ public class TextAnnotationConverter implements NodeConverter<JSITTextAnnotation
     @Override
     public JSITTextAnnotation dmnFromNode(final Node<View<TextAnnotation>, ?> node,
                                           final Consumer<JSITComponentWidths> componentWidthsConsumer) {
-        final TextAnnotation source = node.getContent().getDefinition();
+        final TextAnnotation source = (TextAnnotation) DefinitionUtils.getElementDefinition(node);
         final JSITTextAnnotation result = new JSITTextAnnotation();
         result.setId(source.getId().getValue());
         final Optional<String> description = Optional.ofNullable(DescriptionPropertyConverter.dmnFromWB(source.getDescription()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/DMNMarshallerUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/DMNMarshallerUtils.java
@@ -21,6 +21,7 @@ import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 public class DMNMarshallerUtils {
 
@@ -30,7 +31,7 @@ public class DMNMarshallerUtils {
 
     public static Node<?, ?> findDMNDiagramRoot(final Graph<?, Node<View, ?>> graph) {
         return StreamSupport.stream(graph.nodes().spliterator(), false)
-                .filter(n -> n.getContent().getDefinition() instanceof DMNDiagram)
+                .filter(n -> DefinitionUtils.getElementDefinition(n) instanceof DMNDiagram)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("DMNDiagram root not found."));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientDiagramServiceImpl.java
@@ -50,6 +50,7 @@ import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.kie.workbench.common.stunner.core.util.StringUtils;
 import org.kie.workbench.common.stunner.kogito.api.editor.DiagramType;
 import org.kie.workbench.common.stunner.kogito.api.editor.impl.KogitoDiagramResourceImpl;
@@ -190,7 +191,7 @@ public class DMNClientDiagramServiceImpl implements KogitoClientDiagramService {
                 final JSITDefinitions definitions = Js.uncheckedCast(JsUtils.getUnwrappedElement(dmn12));
                 final Graph graph = dmnMarshallerKogitoUnmarshaller.unmarshall(metadata, definitions);
                 final Node<Definition<DMNDiagram>, ?> diagramNode = GraphUtils.getFirstNode((Graph<?, Node>) graph, DMNDiagram.class);
-                final String title = diagramNode.getContent().getDefinition().getDefinitions().getName().getValue();
+                final String title = ((DMNDiagram) DefinitionUtils.getElementDefinition(diagramNode)).getDefinitions().getName().getValue();
                 final Diagram diagram = dmnDiagramFactory.build(title, metadata, graph);
                 updateClientShapeSetId(diagram);
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-5137

This PR/JIRA fixes the regression caused by [DROOSL-5060](https://issues.redhat.com/browse/DROOLS-5060).

It does not fix a pre-existing issue recorded in [DROOLS-5139](https://issues.redhat.com/browse/DROOLS-5139).