### PR TITLE
KOGITO-1208 - VSCode modified BPMN doesn't work in runtime

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriter.java
@@ -17,6 +17,8 @@
 package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.properties;
 
 import org.eclipse.bpmn2.Interface;
+import org.eclipse.bpmn2.ItemDefinition;
+import org.eclipse.bpmn2.Message;
 import org.eclipse.bpmn2.Operation;
 import org.eclipse.bpmn2.ServiceTask;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.CustomAttribute;
@@ -51,8 +53,29 @@ public class GenericServiceTaskPropertyWriter extends MultipleInstanceActivityPr
         //2 Interface
         String serviceInterface = value.getServiceInterface();
 
-        //https://issues.jboss.org/browse/KOGITO-418
-        // In/Out Messages should not be written now
+        //in message
+        final Message inMessage;
+        ItemDefinition itemDefinitionInMsg = bpmn2.createItemDefinition();
+        itemDefinitionInMsg.setId(task.getId() + "_InMessageType");
+        itemDefinitionInMsg.setStructureRef(value.getInMessageStructure());
+        addItemDefinition(itemDefinitionInMsg);
+
+        inMessage = bpmn2.createMessage();
+        inMessage.setId(task.getId() + "_InMessage");
+        inMessage.setItemRef(itemDefinitionInMsg);
+        addRootElement(inMessage);
+
+        //out message
+        final Message outMessage;
+        ItemDefinition itemDefinitionOutMsg = bpmn2.createItemDefinition();
+        itemDefinitionOutMsg.setId(task.getId() + "_OutMessageType");
+        itemDefinitionOutMsg.setStructureRef(value.getOutMessagetructure());
+        addItemDefinition(itemDefinitionOutMsg);
+
+        outMessage = bpmn2.createMessage();
+        outMessage.setId(task.getId() + "_OutMessage");
+        outMessage.setItemRef(itemDefinitionOutMsg);
+        addRootElement(outMessage);
 
         //custom attribute
         CustomAttribute.serviceInterface.of(task).set(serviceInterface);
@@ -74,6 +97,8 @@ public class GenericServiceTaskPropertyWriter extends MultipleInstanceActivityPr
         iface.getOperations().add(operation);
         task.setOperationRef(operation);
         addInterfaceDefinition(iface);
+        operation.setInMessageRef(inMessage);
+        operation.setOutMessageRef(outMessage);
     }
 
     public void setAdHocAutostart(boolean autoStart) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriterTest.java
@@ -71,8 +71,8 @@ public class GenericServiceTaskPropertyWriterTest {
         assertEquals("serviceOperation", CustomAttribute.serviceOperation.of(serviceTask).get());
         assertEquals("serviceInterface", CustomAttribute.serviceInterface.of(serviceTask).get());
         assertEquals("serviceOperation", serviceTask.getOperationRef().getName());
-        //https://issues.jboss.org/browse/KOGITO-418
-        // In/Out Messages should not be written now
+        assertEquals("inMessageStructure", serviceTask.getOperationRef().getInMessageRef().getItemRef().getStructureRef());
+        assertEquals("outMessagetructure", serviceTask.getOperationRef().getOutMessageRef().getItemRef().getStructureRef());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/GenericServiceTaskPropertyReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/GenericServiceTaskPropertyReaderTest.java
@@ -85,8 +85,8 @@ public class GenericServiceTaskPropertyReaderTest {
         assertEquals("Java", task.getServiceImplementation());
         assertEquals("serviceOperation", task.getServiceOperation());
         assertEquals("serviceInterface", task.getServiceInterface());
-        //https://issues.jboss.org/browse/KOGITO-418
-        // In/Out Messages should not be written now
+        assertEquals("inMessageStructure", task.getInMessageStructure());
+        assertEquals("outMessageStructure", task.getOutMessagetructure());
         assertEquals(SLA_DUE_DATE_CDATA, reader.getSLADueDate());
         assertEquals(false, reader.isAsync());
         assertEquals(true, reader.isAdHocAutostart());


### PR DESCRIPTION
revert of KOGITO-418 - Missing structureref type for service task in VSCode BPMN editor

Hi @romartin, @domhanak, I tested this revert on Kogito Showcase, unfortunately I can't run latest Stunner changes under the VS Code and this is an urgent issue, so I created PR already.

Will try to find out why VS Code plugin doesn't use Stunner from local SNAPSHOT in parallel.

Thank you!