### PR TITLE
KOGITO-437: Revert of change made to DMN since editor does not open in VSCode with change

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -391,8 +391,8 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
 
     @Override
     @SetContent
-    public void setContent(final String path, final String value) {
-        superOnClose();
+    public void setContent(final String path,
+                           final String value) {
         diagramServices.transform(path,
                                   value,
                                   new ServiceCallback<Diagram>() {


### PR DESCRIPTION
Hi @handreyrc with your change for the captioned JIRA the DMN editor no longer opens (any file) in VSCode. Removal of the line in this PR allows the DMN editor to open again however whatever the issue was for KOGITO-437 possibly now exists again in DMN too.

You may need to reconsider your fix for KOGITO-437. Did you want the JIRA re-opened?

@romartin @ederign FYI.