### PR TITLE
KOGITO-1458: take screenshot in case of selenium test fail

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -525,6 +525,7 @@
           </excludes>
           <systemPropertyVariables>
             <org.kie.dmn.kogito.browser.headless>${org.kie.dmn.kogito.browser.headless}</org.kie.dmn.kogito.browser.headless>
+            <org.kie.dmn.kogito.screenshots.dir>${project.build.directory}/screenshots</org.kie.dmn.kogito.screenshots.dir>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR creates 'png' screenshot in 'target' folder of the 'kie-wb-common-dmn-webapp-kogito-runtime' module in case of selenium test fail.

This should facilitate investigation of failures like reported in https://issues.redhat.com/browse/KOGITO-1458