### PR TITLE
DROOLS-5170: [DMN Designer] Properties panel can not be expanded

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
@@ -249,6 +249,9 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
     @Override
     public void setValue(final QName value,
                          final boolean fireEvents) {
+        if (Objects.equals(value, type)) {
+            return;
+        }
         final QName oldValue = type;
         type = value;
         typeSelector.setValue(qNameConverter.toWidgetValue(type), false);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
@@ -306,6 +306,21 @@ public class DataTypePickerWidgetTest {
     }
 
     @Test
+    //See https://issues.redhat.com/browse/DROOLS-5170
+    public void testSetValueMultipleTimes() {
+        picker.setValue(VALUE);
+
+        verify(typeSelector).setValue(eq(WIDGET_VALUE), eq(false));
+        verify(picker, never()).fireValueChangeEvent(any());
+
+        //Check successive calls to setValue(..) with the same value do not trigger more updates.
+        reset(typeSelector, picker);
+        picker.setValue(VALUE);
+        verify(typeSelector, never()).setValue(anyString(), anyBoolean());
+        verify(picker, never()).fireValueChangeEvent(any());
+    }
+
+    @Test
     public void testSetValueFireEvent() {
         picker.setValue(VALUE, true);
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-5170

This is a patch for the regression added by https://issues.redhat.com/browse/RHPAM-1954

If the powers that be don't want to revert RHPAM-1954 this PR fixes the reported DMN problem.

There may be other, undiscovered, issues... but for now this is the only one I could find (in DMN).