### PR TITLE
KOGITO-1521: Avoid to publish kogito-testing artifacts

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
@@ -533,6 +533,19 @@
           </excludes>
         </configuration>
       </plugin>
+
+      <!-- The kogito-testing is used just for development/testing, we don't want to publish it into remote repos. -->
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-deploy</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Currently we are uploading DMN Editor testing artifacts in the public repo.
This shouldn't happen, because testing artifacts are used for testing and development. Moreover, the war size is 77mb.
--> https://repository.jboss.org/org/kie/workbench/kie-wb-common-dmn-webapp-kogito-testing/

https://issues.redhat.com/browse/KOGITO-1521
