### PR TITLE
[7.33.X] DROOLS-5125: [DMN Designer] Node data type is lost after drag and drop in data type editor

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidget.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.types;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -155,6 +156,10 @@ public class DataTypePickerWidget extends Composite implements HasValue<QName>,
         addItemDefinitions();
 
         typeSelector.refresh();
+
+        if (!Objects.isNull(getValue())) {
+            setValue(getValue(), false);
+        }
     }
 
     void addBuiltInTypes() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -394,21 +394,23 @@ public class DataTypeListItem {
 
     public void destroyWithDependentTypes() {
         final List<DataType> destroyedDataTypes = getDataType().destroy();
-        destroy(destroyedDataTypes);
+        destroy(destroyedDataTypes, true);
     }
 
     public void destroyWithoutDependentTypes() {
         final List<DataType> destroyedDataTypes = getDataType().destroyWithoutDependentTypes();
-        destroy(destroyedDataTypes);
+        destroy(destroyedDataTypes, false);
     }
 
-    void destroy(final List<DataType> destroyedDataTypes) {
+    void destroy(final List<DataType> destroyedDataTypes, final boolean fireDataChangedEvent) {
 
         final List<DataType> removedDataTypes = removeTopLevelDataTypes(destroyedDataTypes);
         destroyedDataTypes.removeAll(removedDataTypes);
         dataTypeList.refreshItemsByUpdatedDataTypes(destroyedDataTypes);
 
-        fireDataChangedEvent();
+        if (fireDataChangedEvent) {
+            fireDataChangedEvent();
+        }
         hideTooltips();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngine.java
@@ -112,7 +112,7 @@ public class ItemDefinitionRecordEngine implements DataTypeRecordEngine {
         final List<DataType> affectedDataTypes = new ArrayList<>();
         affectedDataTypes.add(dataType);
 
-        doDestroy(dataType);
+        doDestroy(dataType, false);
 
         return affectedDataTypes;
     }
@@ -148,8 +148,13 @@ public class ItemDefinitionRecordEngine implements DataTypeRecordEngine {
 
     public void doDestroy(final DataType dataType) {
 
+        doDestroy(dataType, true);
+    }
+
+    private void doDestroy(final DataType dataType, final boolean notifyPropertiesPanel) {
+
         dataTypeDestroyHandler.destroy(dataType);
-        itemDefinitionDestroyHandler.destroy(dataType);
+        itemDefinitionDestroyHandler.destroy(dataType, notifyPropertiesPanel);
     }
 
     private List<DataType> refreshDependentDataTypesFromUpdateOperation(final DataType dataType,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionDestroyHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionDestroyHandler.java
@@ -50,7 +50,7 @@ public class ItemDefinitionDestroyHandler {
         this.panelNotifier = panelNotifier;
     }
 
-    public void destroy(final DataType dataType) {
+    public void destroy(final DataType dataType, final boolean notifyPropertiesPanel) {
 
         final ItemDefinition itemDefinition = findItemDefinition(dataType);
         final String destroyedItemDefinition = itemDefinition.getName().getValue();
@@ -63,7 +63,9 @@ public class ItemDefinitionDestroyHandler {
         itemDefinitions().remove(itemDefinition);
         itemDefinitionStore.unIndex(dataType.getUUID());
 
-        notifyPropertiesPanel(destroyedItemDefinition);
+        if (notifyPropertiesPanel) {
+            notifyPropertiesPanel(destroyedItemDefinition);
+        }
     }
 
     void notifyPropertiesPanel(final String destroyedItemDefinition) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandler.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.types.persistence.handlers;
 import java.util.Objects;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.model.ItemDefinition;
@@ -28,6 +29,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.client.editors.types.DataTypeChangedEvent;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
 import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
@@ -44,13 +46,17 @@ public class ItemDefinitionUpdateHandler {
 
     private final PropertiesPanelNotifier panelNotifier;
 
+    private final Event<DataTypeChangedEvent> dataTypeChangedEvent;
+
     @Inject
     public ItemDefinitionUpdateHandler(final DataTypeManager dataTypeManager,
                                        final ItemDefinitionUtils itemDefinitionUtils,
-                                       final PropertiesPanelNotifier panelNotifier) {
+                                       final PropertiesPanelNotifier panelNotifier,
+                                       final Event<DataTypeChangedEvent> dataTypeChangedEvent) {
         this.dataTypeManager = dataTypeManager;
         this.itemDefinitionUtils = itemDefinitionUtils;
         this.panelNotifier = panelNotifier;
+        this.dataTypeChangedEvent = dataTypeChangedEvent;
     }
 
     public void update(final DataType dataType,
@@ -70,6 +76,11 @@ public class ItemDefinitionUpdateHandler {
         itemDefinition.setAllowedValues(makeAllowedValues(dataType, itemDefinition));
 
         notifyPropertiesPanel(itemDefinitionBeforeUpdate, itemDefinition);
+        fireDataChangedEvent();
+    }
+
+    void fireDataChangedEvent() {
+        dataTypeChangedEvent.fire(new DataTypeChangedEvent());
     }
 
     private void notifyPropertiesPanel(final String itemDefinitionBeforeUpdate,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypePickerWidgetTest.java
@@ -56,8 +56,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -382,7 +384,24 @@ public class DataTypePickerWidgetTest {
     }
 
     @Test
-    public void testPopulateTypeSelector() {
+    public void testPopulateTypeSelectorWhenValueIsNull() {
+        doReturn(null).when(picker).getValue();
+        picker.populateTypeSelector();
+
+        final InOrder inOrder = inOrder(typeSelector);
+        inOrder.verify(typeSelector).clear();
+        verify(picker).addBuiltInTypes();
+        verify(picker).addItemDefinitions();
+
+        inOrder.verify(typeSelector).refresh();
+        verify(picker, never()).setValue(any(), anyBoolean());
+    }
+
+    @Test
+    public void testPopulateTypeSelectorWhenValueIsNotNull() {
+        final QName value = mock(QName.class);
+        doReturn(value).when(picker).getValue();
+        doNothing().when(picker).setValue(value, false);
 
         picker.populateTypeSelector();
 
@@ -392,5 +411,6 @@ public class DataTypePickerWidgetTest {
         verify(picker).addItemDefinitions();
 
         inOrder.verify(typeSelector).refresh();
+        verify(picker).setValue(value, false);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemTest.java
@@ -61,6 +61,7 @@ import static org.kie.workbench.common.dmn.client.editors.types.persistence.Crea
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
@@ -769,11 +770,11 @@ public class DataTypeListItemTest {
 
         when(dataType.destroy()).thenReturn(removedDataTypes);
         doReturn(dataType).when(listItem).getDataType();
-        doNothing().when(listItem).destroy(any());
+        doNothing().when(listItem).destroy(any(), eq(true));
 
         listItem.destroyWithDependentTypes();
 
-        verify(listItem).destroy(removedDataTypes);
+        verify(listItem).destroy(removedDataTypes, true);
     }
 
     @Test
@@ -785,11 +786,11 @@ public class DataTypeListItemTest {
 
         when(dataType.destroyWithoutDependentTypes()).thenReturn(removedDataTypes);
         doReturn(dataType).when(listItem).getDataType();
-        doNothing().when(listItem).destroy(any());
+        doNothing().when(listItem).destroy(any(), eq(false));
 
         listItem.destroyWithoutDependentTypes();
 
-        verify(listItem).destroy(removedDataTypes);
+        verify(listItem).destroy(removedDataTypes, false);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/ItemDefinitionRecordEngineTest.java
@@ -162,7 +162,8 @@ public class ItemDefinitionRecordEngineTest {
         final List<DataType> actualDependentDataTypes = recordEngine.destroyWithoutDependentTypes(dataType);
         final List<DataType> expectedDependentDataTypes = singletonList(dataType);
 
-        verify(recordEngine).doDestroy(dataType);
+        verify(dataTypeDestroyHandler).destroy(dataType);
+        verify(itemDefinitionDestroyHandler).destroy(dataType, false);
         assertEquals(expectedDependentDataTypes, actualDependentDataTypes);
     }
 
@@ -242,6 +243,6 @@ public class ItemDefinitionRecordEngineTest {
         recordEngine.doDestroy(dataType);
 
         verify(dataTypeDestroyHandler).destroy(dataType);
-        verify(itemDefinitionDestroyHandler).destroy(dataType);
+        verify(itemDefinitionDestroyHandler).destroy(dataType, true);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionDestroyHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionDestroyHandlerTest.java
@@ -87,7 +87,7 @@ public class ItemDefinitionDestroyHandlerTest {
         doReturn(itemDefinitions).when(handler).itemDefinitions();
         doNothing().when(handler).notifyPropertiesPanel(anyString());
 
-        handler.destroy(dataType);
+        handler.destroy(dataType, true);
 
         assertEquals(emptyList(), itemDefinitionParent.getItemComponent());
         assertEquals(emptyList(), itemDefinitions);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandlerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/ItemDefinitionUpdateHandlerTest.java
@@ -29,17 +29,20 @@ import org.kie.workbench.common.dmn.api.definition.model.UnaryTests;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.client.editors.types.DataTypeChangedEvent;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.common.DataTypeManager;
 import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.editors.types.persistence.handlers.common.PropertiesPanelNotifier;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.mockito.Mock;
+import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -61,12 +64,15 @@ public class ItemDefinitionUpdateHandlerTest {
     @Mock
     private PropertiesPanelNotifier panelNotifier;
 
+    @Mock
+    private EventSourceMock<DataTypeChangedEvent> dataTypeChangedEvent;
+
     private ItemDefinitionUpdateHandler handler;
 
     @Before
     public void setup() {
         itemDefinitionUtils = spy(new ItemDefinitionUtils(dmnGraphUtils));
-        handler = spy(new ItemDefinitionUpdateHandler(dataTypeManager, itemDefinitionUtils, panelNotifier));
+        handler = spy(new ItemDefinitionUpdateHandler(dataTypeManager, itemDefinitionUtils, panelNotifier, dataTypeChangedEvent));
     }
 
     @Test
@@ -95,6 +101,7 @@ public class ItemDefinitionUpdateHandlerTest {
         verify(itemDefinition).setTypeRef(null);
         verify(itemDefinition).setName(name);
         verify(panelNotifier).notifyPanel();
+        verify(dataTypeChangedEvent).fire(any());
     }
 
     @Test
@@ -130,6 +137,7 @@ public class ItemDefinitionUpdateHandlerTest {
         verify(itemDefinition).setTypeRef(qName);
         verify(itemDefinition).setName(name);
         verify(panelNotifier).notifyPanel();
+        verify(dataTypeChangedEvent).fire(any());
         assertTrue(itemDefinitions.isEmpty());
     }
 


### PR DESCRIPTION
Cherry-pick from commit [b3f3a03406f8d489ac94864e073827a317565693](https://github.com/kiegroup/kie-wb-common/commit/b3f3a03406f8d489ac94864e073827a317565693)