### PR TITLE
KOGITO-1529: BPMN Editor - Cannot save a process once a service tasks' attributes are not properly set

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/DeclarationList.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/DeclarationList.java
@@ -36,6 +36,9 @@ public class DeclarationList {
     }
 
     public static DeclarationList fromString(String encoded) {
+        if (null == encoded) {
+            return new DeclarationList();
+        }
         return new DeclarationList(
                 Arrays.stream(encoded.split(","))
                         .filter(s -> !s.isEmpty()) // "" makes no sense

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/ParsedAssignmentsInfo.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/ParsedAssignmentsInfo.java
@@ -114,14 +114,10 @@ public class ParsedAssignmentsInfo {
             );
         }
 
-        if (split.length < 5) {
-            throw new IllegalArgumentException(encoded);
-        }
-
         boolean alternativeEncoding = false;
         String in = split[0];
         String out = split[2];
-        String assoc = split[4];
+        String assoc = split.length < 5 ? null : split[4];
 
         if (in.isEmpty() && out.isEmpty()) {
             if (!split[1].isEmpty() || !split[3].isEmpty()) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/DeclarationListTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/DeclarationListTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class DeclarationListTest {
+
+    @Test
+    public void testNullSafeBuilderMethod() {
+        DeclarationList result = DeclarationList.fromString("");
+        assertNotNull(result);
+        assertTrue(result.getDeclarations().isEmpty());
+        result = DeclarationList.fromString(null);
+        assertNotNull(result);
+        assertTrue(result.getDeclarations().isEmpty());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ParsedAssignmentsInfoTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ParsedAssignmentsInfoTest.java
@@ -18,12 +18,8 @@ package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunn
 
 import java.util.List;
 
-import org.eclipse.bpmn2.Assignment;
-import org.eclipse.bpmn2.DataInput;
-import org.eclipse.bpmn2.DataInputAssociation;
 import org.eclipse.bpmn2.DataOutput;
 import org.eclipse.bpmn2.DataOutputAssociation;
-import org.eclipse.bpmn2.FormalExpression;
 import org.eclipse.bpmn2.ItemAwareElement;
 import org.eclipse.bpmn2.impl.PropertyImpl;
 import org.junit.Before;
@@ -38,6 +34,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParsedAssignmentsInfoTest {
@@ -58,48 +55,6 @@ public class ParsedAssignmentsInfoTest {
         tested = ParsedAssignmentsInfo.of(assignmentsInfos);
         testedDuplicates = ParsedAssignmentsInfo.of(assignmentsInfosDuplicates);
         testedNoAssociation = ParsedAssignmentsInfo.of(assignmentNoAssociation);
-    }
-
-    // TODO: Kogito - @Test
-    public void testCreateInitializedInputVariables() {
-        final String DATA_INPUT_ID = "_Years-of-ServiceInputX";
-        final String DATA_INPUT_NAME = "Years of Service";
-        final String DATA_INPUT_ASSOCIATION_ID = "Years of Service";
-        final String DATA_INPUT_ASSOCIATION_VALUE = "<![CDATA[35]]>";
-        final String INIT_INPUT_VAR_ID = "Years-of-Service";
-        final String INIT_INPUT_VAR_TYPE = "Integer";
-
-        VariableScope variableScope = new FlatVariableScope();
-        List<InitializedVariable.InitializedInputVariable> initializedInputVariables =
-                tested.createInitializedInputVariables("", variableScope);
-
-        assertEquals(initializedInputVariables.size(), 1);
-
-        InitializedVariable.InitializedInputVariable initializedInputVariable =
-                initializedInputVariables.get(0);
-
-        DataInput dataInput = initializedInputVariable.getDataInput();
-
-        DataInputAssociation dataInputAssociation = initializedInputVariable.getDataInputAssociation();
-        DataInput target = (DataInput) dataInputAssociation.getTargetRef();
-
-        List<Assignment> assignments = dataInputAssociation.getAssignment();
-        Assignment assignment = assignments.get(0);
-        FormalExpression from = (FormalExpression) assignment.getFrom();
-
-        String dataInputID = dataInput.getId();
-        String dataInputName = dataInput.getName();
-        String dataInputAssociationID = target.getName();
-        String dataInputAssociationValue = from.getBody();
-        String initVarID = initializedInputVariable.getIdentifier();
-        String initVarType = initializedInputVariable.getType();
-
-        assertEquals(dataInputID, DATA_INPUT_ID);
-        assertEquals(dataInputName, DATA_INPUT_NAME);
-        assertEquals(dataInputAssociationID, DATA_INPUT_ASSOCIATION_ID);
-        assertEquals(dataInputAssociationValue, DATA_INPUT_ASSOCIATION_VALUE);
-        assertEquals(initVarID, INIT_INPUT_VAR_ID);
-        assertEquals(initVarType, INIT_INPUT_VAR_TYPE);
     }
 
     @Test
@@ -238,6 +193,15 @@ public class ParsedAssignmentsInfoTest {
         assertEquals(dataOutputAssocationValue2, DATA_OUTPUT_ASSOCIATION_VALUE_2);
         assertEquals(initVarID2, INIT_OUTPUT_VAR_ID);
         assertEquals(initVarType2, INIT_OUTPUT_VAR_TYPE);
+    }
+
+    @Test
+    public void fromStringWithNoDataOutput() {
+        ParsedAssignmentsInfo assignmentsInfo =
+                ParsedAssignmentsInfo.fromString("|IntermediateMessageEventCatchingOutputVar1:String||");
+        assertTrue(assignmentsInfo.getOutputs().getDeclarations().isEmpty());
+        assertTrue(assignmentsInfo.getAssociations().getInputs().isEmpty());
+        assertTrue(assignmentsInfo.getAssociations().getOutputs().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Hey @domhanak @LuboTerifaj 

This PR fixes the issue [KOGITO-1529](https://issues.redhat.com/browse/KOGITO-1529)

**[Not Urgent]** It cannot yet be tested until having [KOGITO-1426](https://issues.redhat.com/browse/KOGITO-1426) done, so no worries for now, but I could reproduce and fix it locally so creating the PR with the fix for further re-integration.

Thanks!