### PR TITLE
Stunner - Update maven profiles for bpmn kogito webapp

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -860,32 +860,6 @@
 
   <profiles>
 
-    <!-- Development profile - Not optimized. -->
-    <profile>
-      <id>dev</id>
-      <activation>
-        <property>
-          <name>dev</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <module>org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor</module>
-              <saveSource>false</saveSource>
-              <logLevel>INFO</logLevel>
-              <optimizationLevel>0</optimizationLevel>
-              <draftCompile>true</draftCompile>
-              <style>PRETTY</style>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- As Dev Profile but also including Source Maps in the assembled webapp. -->
     <profile>
       <id>sources</id>
@@ -902,6 +876,10 @@
             <configuration>
               <module>org.kie.workbench.common.stunner.kogito.KogitoBPMNEditorWithSourceMap</module>
               <saveSource>true</saveSource>
+              <logLevel>INFO</logLevel>
+              <optimizationLevel>0</optimizationLevel>
+              <draftCompile>true</draftCompile>
+              <style>PRETTY</style>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
Hey @hasys 

Just a quick fix on the maven profiles for the BPMN kogito runtime webapp:
* Removed the `dev` profile 
* Fixed the `sources` profile

So let's keep it easy - there only exists a couple of profiles: `default` and `sources`:
* `default` - optimized / not source code
* `sources` - not optimized, prettyfied, source code (& sourcemaps) included

Thanks! 