### PR TITLE
KOGITO-987 - VsCode editor - process id not saved/updated

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsFlushManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsFlushManager.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.forms.client.widgets;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.forms.client.widgets.container.FormsContainer;
+
+@Singleton
+public class FormsFlushManager {
+
+    protected FormsContainer container;
+
+    void setCurrentContainer(FormsContainer container) {
+        this.container = container;
+    }
+
+    public void flush(ClientSession session,
+                      String elementUUID) {
+        if (container != null) {
+            container.flush(session.getCanvasHandler().getDiagram().getGraph().getUUID(), elementUUID);
+        }
+    }
+
+    @PreDestroy
+    public void destroy() {
+        this.container = null;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainer.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import org.jboss.errai.common.client.api.IsElement;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.forms.dynamic.client.DynamicFormRenderer;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandler;
 import org.kie.workbench.common.stunner.forms.client.event.FormFieldChanged;
@@ -43,8 +44,8 @@ public class FormsContainer implements IsElement {
     private static Logger LOGGER = Logger.getLogger(FormsContainer.class.getName());
 
     private final FormsContainerView view;
-    private final ManagedInstance<FormDisplayer> displayersInstance;
-    private final Map<FormDisplayerKey, FormDisplayer> formDisplayers;
+    protected final ManagedInstance<FormDisplayer> displayersInstance;
+    protected final Map<FormDisplayerKey, FormDisplayer> formDisplayers;
     private final Event<FormFieldChanged> formFieldChangedEvent;
 
     private FormDisplayer currentDisplayer;
@@ -81,8 +82,8 @@ public class FormsContainer implements IsElement {
         });
     }
 
-    private FormDisplayer getDisplayer(final String graphUuid,
-                                       final String elementUuid) {
+    protected FormDisplayer getDisplayer(final String graphUuid,
+                                         final String elementUuid) {
         FormDisplayerKey key = new FormDisplayerKey(graphUuid, elementUuid);
         FormDisplayer displayer = formDisplayers.get(key);
 
@@ -120,6 +121,12 @@ public class FormsContainer implements IsElement {
                 .filter(key -> key.getGraphUuid().equals(graphUuid) && key.getElementUid().equals(elementUid))
                 .findAny()
                 .ifPresent(this::clearDisplayer);
+    }
+
+    public void flush(String graphUUID, String elementUUID) {
+        FormDisplayer displayer = getDisplayer(graphUUID, elementUUID);
+        DynamicFormRenderer renderer = displayer.getRenderer();
+        renderer.flush();
     }
 
     private void clearDisplayer(final FormDisplayerKey key) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormPropertiesWidgetTest.java
@@ -90,6 +90,8 @@ public class FormPropertiesWidgetTest {
     @Mock
     private FormsContainer formsContainer;
     @Mock
+    private FormsFlushManager formsFlushManager;
+    @Mock
     private TranslationService translationService;
     @Mock
     private EditorSession session;
@@ -164,6 +166,7 @@ public class FormPropertiesWidgetTest {
                                                formsCanvasSessionHandler,
                                                propertiesOpenedEvent,
                                                formsContainer,
+                                               formsFlushManager,
                                                translationService) {
             @Override
             protected void log(final Level level, final String message) {
@@ -172,6 +175,12 @@ public class FormPropertiesWidgetTest {
         };
 
         doAnswer((i) -> i.getArguments()[0]).when(translationService).getTranslation(anyString());
+    }
+
+    @Test
+    public void testInit() {
+        tested.init();
+        verify(formsFlushManager, times(1)).setCurrentContainer(formsContainer);
     }
 
     @Test
@@ -184,6 +193,7 @@ public class FormPropertiesWidgetTest {
         verify(formsCanvasSessionHandler).show(callback);
 
         verify(formsContainer, never()).render(anyString(), any(), any(), any(), any(), any());
+        verify(propertiesOpenedEvent, never()).fire(formPropertiesOpenedArgumentCaptor.capture());
     }
 
     /**
@@ -258,6 +268,7 @@ public class FormPropertiesWidgetTest {
                                                                             eq(fieldValue));
 
         verify(propertiesOpenedEvent).fire(formPropertiesOpenedArgumentCaptor.capture());
+
         final FormPropertiesOpened formPropertiesOpened = formPropertiesOpenedArgumentCaptor.getValue();
         assertThat(formPropertiesOpened.getUuid()).isEqualTo(DOMAIN_OBJECT_UUID);
         assertThat(formPropertiesOpened.getName()).isEqualTo(DOMAIN_OBJECT_TRANSLATION_KEY);
@@ -277,6 +288,7 @@ public class FormPropertiesWidgetTest {
         formRenderer.render(GRAPH_UUID, (Element) null, command);
 
         verify(formsContainer, never()).render(any(), any(), any(), any(), any(), any());
+        verify(propertiesOpenedEvent, never()).fire(formPropertiesOpenedArgumentCaptor.capture());
         verify(command, never()).execute();
     }
 
@@ -296,6 +308,12 @@ public class FormPropertiesWidgetTest {
         verify(formsCanvasSessionHandler, never()).executeUpdateProperty(any(), any(), any());
         // Verify it is only rendered once, since the same item was already rendered
         verify(formsContainer, atMost(1)).render(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testFireFormsPropertiesOpenedEvent() {
+        tested.fireFormsPropertiesOpenedEvent("", "");
+        verify(propertiesOpenedEvent, times(1)).fire(formPropertiesOpenedArgumentCaptor.capture());
     }
 
     @Test
@@ -359,5 +377,4 @@ public class FormPropertiesWidgetTest {
         formRenderer.render(GRAPH_UUID, edge, command);
         assertEquals("Value is not the same ", tested.areLastPositionsForSameElementSame(node), false);
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsFlushManagerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsFlushManagerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.forms.client.widgets;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.forms.client.widgets.container.FormsContainer;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FormsFlushManagerTest {
+
+    private static final String GRAPH_UUID = "GraphUUID";
+    private static final String ELEMENT_UUID = "ElementUUID";
+
+    @Mock
+    private FormsContainer formsContainer;
+
+    @Mock
+    private ClientSession clientSession;
+
+    @Mock
+    private CanvasHandler canvasHandler;
+
+    @Mock
+    private Diagram diagram;
+
+    @Mock
+    private Graph graph;
+
+    private FormsFlushManager tested;
+
+    @Before
+    public void setUp() throws Exception {
+        tested = new FormsFlushManager();
+        when(clientSession.getCanvasHandler()).thenReturn(canvasHandler);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getGraph()).thenReturn(graph);
+        when(graph.getUUID()).thenReturn(GRAPH_UUID);
+    }
+
+    @Test
+    public void setCurrentContainer() {
+        tested.container = formsContainer;
+        tested.setCurrentContainer(formsContainer);
+        assertEquals(formsContainer, tested.container);
+    }
+
+    @Test
+    public void flush() {
+        tested.container = null;
+        tested.flush(clientSession, ELEMENT_UUID);
+
+        tested.container = formsContainer;
+        tested.flush(clientSession, ELEMENT_UUID);
+
+        verify(formsContainer, times(1)).flush(GRAPH_UUID, ELEMENT_UUID);
+    }
+
+    @Test
+    public void destroy() {
+        FormsContainer formsContainer = mock(FormsContainer.class);
+        tested.container = formsContainer;
+        tested.destroy();
+        assertEquals(null, tested.container);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/widgets/container/FormsContainerTest.java
@@ -38,6 +38,8 @@ import org.uberfire.backend.vfs.Path;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -48,10 +50,10 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class FormsContainerTest {
 
-    private static final String GRAPH_UID = "graphUid";
+    private static final String GRAPH_UUID = "graphUid";
 
-    private static final String FIRST_ELEMENT_UID = "first_uid";
-    private static final String SECOND_ELEMENT_UID = "second_uid";
+    private static final String FIRST_ELEMENT_UUID = "first_uid";
+    private static final String SECOND_ELEMENT_UUID = "second_uid";
 
     @Mock
     private Path path;
@@ -90,31 +92,31 @@ public class FormsContainerTest {
     public void testFirstRender() {
         //arbitrary render mode
         RenderMode renderMode = RenderMode.EDIT_MODE;
-        testRender(getNode(FIRST_ELEMENT_UID), 1, 1, renderMode);
+        testRender(getNode(FIRST_ELEMENT_UUID), 1, 1, renderMode);
     }
 
     @Test
     public void testSecondRender() {
         //arbitrary render mode
         RenderMode renderMode = RenderMode.EDIT_MODE;
-        testRender(getNode(FIRST_ELEMENT_UID), 1, 1, renderMode);
+        testRender(getNode(FIRST_ELEMENT_UUID), 1, 1, renderMode);
 
-        testRender(getNode(SECOND_ELEMENT_UID), 2, 1, renderMode);
+        testRender(getNode(SECOND_ELEMENT_UUID), 2, 1, renderMode);
     }
 
     @Test
     public void testRenderExistingNode() {
         //arbitrary render mode
         RenderMode renderMode = RenderMode.EDIT_MODE;
-        NodeImpl<Definition<?>> firstNode = getNode(FIRST_ELEMENT_UID);
+        NodeImpl<Definition<?>> firstNode = getNode(FIRST_ELEMENT_UUID);
 
         FormDisplayer firstDisplayer = testRender(firstNode, 1, 1, renderMode);
 
-        NodeImpl secondNode = getNode(SECOND_ELEMENT_UID);
+        NodeImpl secondNode = getNode(SECOND_ELEMENT_UUID);
 
         FormDisplayer secondDisplayer = testRender(secondNode, 2, 1, renderMode);
 
-        formsContainer.render(GRAPH_UID, firstNode.getUUID(), firstNode.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
+        formsContainer.render(GRAPH_UUID, firstNode.getUUID(), firstNode.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
 
         verify(displayersInstance, times(2)).get();
 
@@ -128,11 +130,11 @@ public class FormsContainerTest {
     public void testDestroyDiagramDisplayers() {
         //arbitrary render mode
         RenderMode renderMode = RenderMode.EDIT_MODE;
-        FormDisplayer firstDisplayer = testRender(getNode(FIRST_ELEMENT_UID), 1, 1, renderMode);
+        FormDisplayer firstDisplayer = testRender(getNode(FIRST_ELEMENT_UUID), 1, 1, renderMode);
 
-        FormDisplayer secondDisplayer = testRender(getNode(SECOND_ELEMENT_UID), 2, 1, renderMode);
+        FormDisplayer secondDisplayer = testRender(getNode(SECOND_ELEMENT_UUID), 2, 1, renderMode);
 
-        formsContainer.clearDiagramDisplayers(GRAPH_UID);
+        formsContainer.clearDiagramDisplayers(GRAPH_UUID);
 
         verify(firstDisplayer, times(3)).hide();
         verify(view, times(1)).removeDisplayer(firstDisplayer);
@@ -147,15 +149,15 @@ public class FormsContainerTest {
     public void testDestroyOneDisplayer() {
         //arbitrary render mode
         RenderMode renderMode = RenderMode.EDIT_MODE;
-        NodeImpl firstNode = getNode(FIRST_ELEMENT_UID);
+        NodeImpl firstNode = getNode(FIRST_ELEMENT_UUID);
 
         FormDisplayer firstDisplayer = testRender(firstNode, 1, 1, renderMode);
 
-        NodeImpl secondNode = getNode(SECOND_ELEMENT_UID);
+        NodeImpl secondNode = getNode(SECOND_ELEMENT_UUID);
 
         FormDisplayer secondDisplayer = testRender(secondNode, 2, 1, renderMode);
 
-        formsContainer.clearFormDisplayer(GRAPH_UID, FIRST_ELEMENT_UID);
+        formsContainer.clearFormDisplayer(GRAPH_UUID, FIRST_ELEMENT_UUID);
 
         verify(firstDisplayer, times(3)).hide();
         verify(view, times(1)).removeDisplayer(firstDisplayer);
@@ -165,7 +167,7 @@ public class FormsContainerTest {
         verify(view, never()).removeDisplayer(secondDisplayer);
         verify(displayersInstance, never()).destroy(secondDisplayer);
 
-        formsContainer.clearFormDisplayer(GRAPH_UID, SECOND_ELEMENT_UID);
+        formsContainer.clearFormDisplayer(GRAPH_UUID, SECOND_ELEMENT_UUID);
 
         verify(secondDisplayer, times(2)).hide();
         verify(view, times(1)).removeDisplayer(secondDisplayer);
@@ -176,9 +178,9 @@ public class FormsContainerTest {
     public void testDestroyAllDisplayers() {
         //arbitrary render mode
         RenderMode renderMode = RenderMode.EDIT_MODE;
-        testRender(getNode(FIRST_ELEMENT_UID), 1, 1, renderMode);
+        testRender(getNode(FIRST_ELEMENT_UUID), 1, 1, renderMode);
 
-        testRender(getNode(SECOND_ELEMENT_UID), 2, 1, renderMode);
+        testRender(getNode(SECOND_ELEMENT_UUID), 2, 1, renderMode);
 
         formsContainer.destroyAll();
 
@@ -186,12 +188,48 @@ public class FormsContainerTest {
         verify(displayersInstance, times(1)).destroyAll();
     }
 
+    @Test
+    public void testflush() {
+        DynamicFormRenderer dynamicFormRenderer = mock(DynamicFormRenderer.class);
+
+        FormDisplayer formDisplayer = mock(FormDisplayer.class);
+        when(formDisplayer.getRenderer()).thenReturn(dynamicFormRenderer);
+
+        FormsContainer formsContainer = mock(FormsContainer.class);
+
+        when(formsContainer.getDisplayer(GRAPH_UUID, FIRST_ELEMENT_UUID)).thenReturn(formDisplayer);
+        doCallRealMethod().when(formsContainer).flush(GRAPH_UUID, FIRST_ELEMENT_UUID);
+
+        formsContainer.flush(GRAPH_UUID, FIRST_ELEMENT_UUID);
+        verify(dynamicFormRenderer, times(1)).flush();
+    }
+
+    @Test
+    public void testGetDisplayer() {
+        FormDisplayer formDisplayer1 = mock(FormDisplayer.class);
+        FormDisplayer formDisplayer2 = mock(FormDisplayer.class);
+
+        ManagedInstance managedInstance = mock(ManagedInstance.class);
+        when(managedInstance.get()).thenReturn(formDisplayer2);
+
+        FormsContainerView formsContainerView = mock(FormsContainerView.class);
+
+        FormsContainer formsContainer = new FormsContainer(formsContainerView, managedInstance, null);
+        formsContainer.formDisplayers.put(new FormDisplayerKey(GRAPH_UUID, FIRST_ELEMENT_UUID), formDisplayer1);
+
+        FormDisplayer result1 = formsContainer.getDisplayer(GRAPH_UUID, FIRST_ELEMENT_UUID);
+        FormDisplayer result2 = formsContainer.getDisplayer(GRAPH_UUID, SECOND_ELEMENT_UUID);
+
+        assertEquals(formDisplayer1, result1);
+        assertEquals(formDisplayer2, result2);
+    }
+
     private FormDisplayer testRender(NodeImpl<Definition<?>> node, int expectedDisplayers, int currentDisplayerRender, RenderMode renderMode) {
         //clear mocks
         reset(renderer);
         reset(formFieldChangedEvent);
 
-        formsContainer.render(GRAPH_UID, node.getUUID(), node.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
+        formsContainer.render(GRAPH_UUID, node.getUUID(), node.getContent().getDefinition(), path, fieldChangeHandler, renderMode);
 
         verify(displayersInstance, times(expectedDisplayers)).get();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-987

This fix uses the recent added capability of "flushing" added in this JIRA:
[KOGITO-1219](https://issues.redhat.com/browse/KOGITO-1219). The flush method is called each time the document content is requested.
Providing updated content each time.