### PR TITLE
KOGITO-1458: Run gwt compilation of kie-wb-common-dmn-webapp-kogito-runtime

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -535,22 +535,6 @@
 
   <profiles>
 
-    <!-- Profile to disable GWT compilation of showcase (useful in full downstream builds) -->
-    <profile>
-      <id>no-showcase</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- Profile to build GWT code and package WAR for Community builds -->
     <profile>
       <id>kogito</id>


### PR DESCRIPTION
The gwt compilation of the kie-wb-common-dmn-webapp-kogito-runtime is necessary for the selenium tests in this module.
The selenium tests open and html page generated byt the gwt compilation.

The no-showcase module is activated during full downstream build on jenkins. We keep this profile in the rest of dmn showcase webapps