### PR TITLE
KOGITO-1436: Stunner - Remove double `setContent` call. 

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -50,6 +50,7 @@ import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.project.client.resources.i18n.DMNProjectClientConstants;
 import org.kie.workbench.common.dmn.project.client.type.DMNDiagramResourceType;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
 import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
@@ -346,12 +347,13 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
     }
 
     @Override
-    public void open(final ProjectDiagram diagram) {
+    public void open(final ProjectDiagram diagram,
+                     final Viewer.Callback callback) {
         this.layoutHelper.applyLayout(diagram, openDiagramLayoutExecutor);
 
         feelInitializer.initializeFEELEditor();
 
-        super.open(diagram);
+        super.open(diagram, callback);
     }
 
     @OnOpen

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 
 import javax.enterprise.event.Event;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
@@ -393,8 +392,8 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
 
     @Override
     @SetContent
-    public void setContent(final String path,
-                           final String value) {
+    public Promise setContent(final String path,
+                              final String value) {
         Promise promise =
                 promises.create((success, failure) -> {
                     superOnClose();
@@ -414,7 +413,6 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
                                                                                              @Override
                                                                                              public void onError(ClientRuntimeError error) {
                                                                                                  AbstractDMNDiagramEditor.this.getEditor().onLoadError(error);
-                                                                                                 // TODO: [TiagoBento] Are you also managing the error bus?
                                                                                                  failure.onInvoke(error);
                                                                                              }
                                                                                          });
@@ -423,17 +421,13 @@ public abstract class AbstractDMNDiagramEditor extends AbstractDiagramEditor {
                                                   @Override
                                                   public void onError(final ClientRuntimeError error) {
                                                       AbstractDMNDiagramEditor.this.getEditor().onLoadError(error);
-                                                      // TODO: [TiagoBento] Are you also managing the error bus?
                                                       failure.onInvoke(error);
+
                                                   }
                                               });
                 });
 
-        // TODO: [TiagoBento] Return the promise instance when API changed. Remove code below.
-        promise.then(nothing -> {
-            GWT.log("DMNDiagramEditor READY TO USE!");
-            return null;
-        });
+        return promise;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -462,30 +462,6 @@ public abstract class AbstractDMNDiagramEditorTest {
     }
 
     @Test
-    // This is a test for the kogito-tooling workaround in AbstractDMNDiagramEditor
-    public void testSetContentFailureWithConcurrentSuccess() {
-        final String path = "path";
-        editor.setContent(path, CONTENT);
-
-        verify(clientDiagramService).transform(eq(path), eq(CONTENT), serviceCallbackArgumentCaptor.capture());
-
-        final ServiceCallback<Diagram> serviceCallback = serviceCallbackArgumentCaptor.getValue();
-        assertThat(serviceCallback).isNotNull();
-        serviceCallback.onError(clientRuntimeError);
-
-        verify(feelInitializer, never()).initializeFEELEditor();
-        verify(diagramClientErrorHandler).handleError(eq(clientRuntimeError), any());
-
-        //Emulate completion of an asynchronous callback when a _valid_ diagram was first set
-        editor.open(diagram, mock(Viewer.Callback.class));
-
-        verify(decisionNavigatorDock, never()).setupCanvasHandler(canvasHandler);
-        verify(layoutHelper, never()).applyLayout(any(Diagram.class), any());
-        verify(feelInitializer, never()).initializeFEELEditor();
-        verify(dataTypesPage, never()).reload();
-    }
-
-    @Test
     public void testResetContentHash() {
         openDiagram();
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
 import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.webapp.common.client.docks.preview.PreviewDiagramDock;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
@@ -89,6 +90,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -475,7 +477,7 @@ public abstract class AbstractDMNDiagramEditorTest {
         verify(diagramClientErrorHandler).handleError(eq(clientRuntimeError), any());
 
         //Emulate completion of an asynchronous callback when a _valid_ diagram was first set
-        editor.open(diagram);
+        editor.open(diagram, mock(Viewer.Callback.class));
 
         verify(decisionNavigatorDock, never()).setupCanvasHandler(canvasHandler);
         verify(layoutHelper, never()).applyLayout(any(Diagram.class), any());
@@ -503,7 +505,7 @@ public abstract class AbstractDMNDiagramEditorTest {
         when(editorPresenter.getInstance()).thenReturn(session);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
 
-        editor.open(diagram);
+        editor.open(diagram, mock(Viewer.Callback.class));
 
         assertOnDiagramLoad();
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -65,6 +65,7 @@ import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.kie.workbench.common.widgets.client.search.component.SearchBarComponent;
 import org.uberfire.client.annotations.WorkbenchClientEditor;
 import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.promise.Promises;
 import org.uberfire.client.views.pfly.multipage.MultiPageEditorSelectedPageEvent;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
@@ -110,7 +111,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor implements Kogito
                             final DataTypesPage dataTypesPage,
                             final KogitoClientDiagramService diagramServices,
                             final MonacoFEELInitializer feelInitializer,
-                            final CanvasFileExport canvasFileExport) {
+                            final CanvasFileExport canvasFileExport,
+                            final Promises promises) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -139,7 +141,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor implements Kogito
               dataTypesPage,
               diagramServices,
               feelInitializer,
-              canvasFileExport);
+              canvasFileExport,
+              promises);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditor;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditorTest;
+import org.uberfire.promise.SyncPromises;
 import org.uberfire.workbench.model.menu.impl.DefaultMenus;
 
 import static org.mockito.Mockito.times;
@@ -70,7 +71,8 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
                                     dataTypesPage,
                                     clientDiagramService,
                                     feelInitializer,
-                                    canvasFileExport) {
+                                    canvasFileExport,
+                                    new SyncPromises()) {
             @Override
             protected ElementWrapperWidget<?> getWidget(final HTMLElement element) {
                 return searchBarComponentWidget;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -94,7 +94,6 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
 
     private final Event<NotificationEvent> notificationEvent;
     private final DMNVFSService vfsService;
-    private final Promises promises;
 
     @Inject
     public DMNDiagramEditor(final View view,
@@ -156,10 +155,10 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               dataTypesPage,
               diagramServices,
               feelInitializer,
-              canvasFileExport);
+              canvasFileExport,
+              promises);
         this.notificationEvent = notificationEvent;
         this.vfsService = vfsService;
-        this.promises = promises;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/test/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorTest.java
@@ -40,6 +40,7 @@ import org.uberfire.ext.editor.commons.client.menu.RestoreVersionCommandProvider
 import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.promise.SyncPromises;
 import org.uberfire.util.URIUtil;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
@@ -85,8 +86,7 @@ public class DMNDiagramEditorTest extends AbstractDMNDiagramEditorTest {
     @Mock
     private CanvasFileExport canvasFileExport;
 
-    @Mock
-    private Promises promises;
+    private Promises promises = new SyncPromises();
 
     @Captor
     private ArgumentCaptor<Command> commandArgumentCaptor;

--- a/kie-wb-common-kogito/kie-wb-common-kogito-client/src/main/java/org/kie/workbench/common/kogito/client/editor/BaseKogitoEditor.java
+++ b/kie-wb-common-kogito/kie-wb-common-kogito-client/src/main/java/org/kie/workbench/common/kogito/client/editor/BaseKogitoEditor.java
@@ -145,7 +145,7 @@ public abstract class BaseKogitoEditor<CONTENT> {
      * @param value
      * Editor's content
      */
-    public abstract void setContent(final String path, final String value);
+    public abstract Promise setContent(final String path, final String value);
 
     /**
      * Used by Kogito to get the XML content of the editor. This should return a {@link String}

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/.gitignore
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 target/
+yarn*.log

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/Viewer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/Viewer.java
@@ -40,8 +40,6 @@ public interface Viewer<T, H, V extends IsWidget, C extends Viewer.Callback> {
         default void onSuccess() {
         }
 
-        ;
-
         /**
          * Called in case of any error during loading or displaying operations.
          */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/Viewer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/presenters/Viewer.java
@@ -21,6 +21,7 @@ import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 
 /**
  * A generic viewer type for instances of type <code>T</code>.
+ *
  * @param <T> The instance type supported.
  * @param <H> The handler type.
  * @param <V> The view type.
@@ -36,7 +37,10 @@ public interface Viewer<T, H, V extends IsWidget, C extends Viewer.Callback> {
         /**
          * Called once the instance has been loaded an displayed.
          */
-        void onSuccess();
+        default void onSuccess() {
+        }
+
+        ;
 
         /**
          * Called in case of any error during loading or displaying operations.
@@ -46,7 +50,8 @@ public interface Viewer<T, H, V extends IsWidget, C extends Viewer.Callback> {
 
     /**
      * Opens the <code>item </code> instance and notifies the results to the <code>callback</code> instance.
-     * @param item The instance to open.
+     *
+     * @param item     The instance to open.
      * @param callback The operation's callback.
      */
     void open(final T item,
@@ -56,7 +61,8 @@ public interface Viewer<T, H, V extends IsWidget, C extends Viewer.Callback> {
      * Opens the <code>item </code> instance and notifies the results to the <code>callback</code> instance using
      * the constrained size values <code>width</code> and <code>height</code>.
      * It relies on the implementations to build the view uisng this size or scale views, etc.
-     * @param item The instance to open.
+     *
+     * @param item     The instance to open.
      * @param callback The operation's callback.
      */
     void open(final T item,
@@ -66,7 +72,8 @@ public interface Viewer<T, H, V extends IsWidget, C extends Viewer.Callback> {
 
     /**
      * Scales the current view to the given size.
-     * @param width The resulting width after scale.
+     *
+     * @param width  The resulting width after scale.
      * @param height The resulting height after scale.
      */
     void scale(final int width,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditor.java
@@ -31,6 +31,7 @@ import com.google.gwt.logging.client.LogConfiguration;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerPresenter;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
@@ -290,8 +291,9 @@ public abstract class AbstractDiagramEditor extends MultiPageEditorContainerPres
     }
 
     @Override
-    public void open(final Diagram diagram) {
-        editor.open(diagram);
+    public void open(final Diagram diagram,
+                     final Viewer.Callback callback) {
+        editor.open(diagram, callback);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/DiagramEditorCore.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/DiagramEditorCore.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.ProvidesResize;
 import com.google.gwt.user.client.ui.RequiresResize;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
@@ -45,7 +46,7 @@ public interface DiagramEditorCore<M extends Metadata, D extends Diagram> {
         void setWidget(final IsWidget widget);
     }
 
-    void open(final D diagram);
+    void open(final D diagram, Viewer.Callback callback);
 
     Annotation[] getDockQualifiers();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -34,6 +34,7 @@ import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
@@ -335,7 +336,8 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
                                          new ServiceCallback<ProjectDiagram>() {
                                              @Override
                                              public void onSuccess(final ProjectDiagram item) {
-                                                 AbstractProjectDiagramEditor.this.open(item);
+                                                 AbstractProjectDiagramEditor.this.open(item,
+                                                                                        AbstractProjectDiagramEditor.this.editor::onLoadError);
                                              }
 
                                              @Override
@@ -383,6 +385,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
     /**
      * Considering the diagram valid at this point ,
      * it delegates the save operation to the diagram services bean.
+     *
      * @param commitMessage The commit's message.
      */
     @Override
@@ -541,6 +544,7 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
     /**
      * Format the Diagram title to be displayed on the Editor.
      * This method can be override to customization and the default implementation just return the title from the diagram metadata.
+     *
      * @param title diagram metadata title
      * @return formatted title
      */
@@ -588,8 +592,9 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
     }
 
     @Override
-    public void open(final ProjectDiagram diagram) {
-        editor.open(diagram);
+    public void open(final ProjectDiagram diagram,
+                     final Viewer.Callback callback) {
+        editor.open(diagram, callback);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -39,6 +39,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
@@ -630,7 +631,7 @@ public class AbstractProjectDiagramEditorTest {
         final DefinitionSet definitionSet = mock(DefinitionSet.class);
         when(diagram.getGraph()).thenReturn(graph);
         when(graph.getContent()).thenReturn(definitionSet);
-        presenter.open(diagram);
+        presenter.open(diagram, mock(Viewer.Callback.class));
         return overview;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
@@ -29,6 +29,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
@@ -395,7 +396,7 @@ public class ProjectDiagramEditorTest {
     @Test
     public void testIsDirty() {
         presenter.init();
-        presenter.open(diagram);
+        presenter.open(diagram, mock(Viewer.Callback.class));
         assertFalse(presenter.isDirty(presenter.getCurrentDiagramHash()));
         presenter.setOriginalHash(~~(presenter.getCurrentDiagramHash() + 1));
         assertTrue(presenter.isDirty(presenter.getCurrentDiagramHash()));
@@ -404,7 +405,7 @@ public class ProjectDiagramEditorTest {
     @Test
     public void testHasChanges() {
         presenter.init();
-        presenter.open(diagram);
+        presenter.open(diagram, mock(Viewer.Callback.class));
         assertFalse(presenter.hasUnsavedChanges());
         presenter.setOriginalHash(~~(presenter.getCurrentDiagramHash() + 1));
         assertTrue(presenter.hasUnsavedChanges());
@@ -414,7 +415,7 @@ public class ProjectDiagramEditorTest {
 
     @Test
     public void testOnSaveWithoutChanges() {
-        presenter.open(diagram);
+        presenter.open(diagram, mock(Viewer.Callback.class));
         when(versionRecordManager.isCurrentLatest()).thenReturn(true);
 
         presenter.onSave();
@@ -425,7 +426,7 @@ public class ProjectDiagramEditorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testOnSaveWithChanges() {
-        presenter.open(diagram);
+        presenter.open(diagram, mock(Viewer.Callback.class));
         presenter.setOriginalHash(diagram.hashCode() + 1);
         doAnswer(i -> {
             ((ClientSessionCommand.Callback) i.getArguments()[0]).onSuccess();
@@ -440,7 +441,7 @@ public class ProjectDiagramEditorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testOnSaveRestore() {
-        presenter.open(diagram);
+        presenter.open(diagram, mock(Viewer.Callback.class));
         doAnswer(i -> {
             ((ClientSessionCommand.Callback) i.getArguments()[0]).onSuccess();
             return null;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -22,7 +22,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.promise.Promise;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -276,9 +275,8 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
     @SetContent
     @Override
     @SuppressWarnings("all")
-    public void setContent(final String path, final String value) {
-        // Create the promise that loads the content and the editor
-        Promise promise =
+    public Promise setContent(final String path, final String value) {
+        Promise<Void> promise =
                 promises.create((success, failure) -> {
                     superOnClose();
                     diagramServices.transform(value,
@@ -290,13 +288,12 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
                                                                        new Viewer.Callback() {
                                                                            @Override
                                                                            public void onSuccess() {
-                                                                               success.onInvoke((Object) null);
+                                                                               success.onInvoke((Void) null);
                                                                            }
 
                                                                            @Override
                                                                            public void onError(ClientRuntimeError error) {
                                                                                BPMNDiagramEditor.this.getEditor().onLoadError(error);
-                                                                               // TODO: [TiagoBento] Are you also managing the error bus?
                                                                                failure.onInvoke(error);
                                                                            }
                                                                        });
@@ -305,17 +302,11 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
                                                   @Override
                                                   public void onError(final ClientRuntimeError error) {
                                                       BPMNDiagramEditor.this.getEditor().onLoadError(error);
-                                                      // TODO: [TiagoBento] Are you also managing the error bus?
                                                       failure.onInvoke(error);
                                                   }
                                               });
                 });
-
-        // TODO: [TiagoBento] Return the promise instance when API changed. Remove code below.
-        promise.then(nothing -> {
-            GWT.log("BPMNDiagramEditor READY TO USE!");
-            return null;
-        });
+        return promise;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
@@ -42,10 +42,12 @@ import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.promise.Promises;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
 import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.promise.SyncPromises;
 import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.jgroups.util.Util.assertEquals;
@@ -118,9 +120,11 @@ public class BPMNDiagramEditorTest {
 
     @Mock
     private KogitoClientDiagramService diagramServices;
-    
+
     @Mock
     private CanvasFileExport canvasFileExport;
+
+    private Promises promises = new SyncPromises();
 
     @SuppressWarnings("unchecked")
     @Before
@@ -145,7 +149,8 @@ public class BPMNDiagramEditorTest {
                                        layoutHelper,
                                        openDiagramLayoutExecutor,
                                        diagramServices,
-                                       canvasFileExport);
+                                       canvasFileExport,
+                                       promises);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/main/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditor.java
@@ -255,7 +255,8 @@ public class CaseManagementDiagramEditor extends AbstractProjectDiagramEditor<Ca
         switchSessionHash = hasUnsavedChanges() ? OptionalInt.of(originalHash) : OptionalInt.empty();
         getMenuSessionItems().getCommands().getCommands().clearCommands();
         destroySession();
-        open(diagram);
+        open(diagram, error -> {
+        });
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/test/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-case-mgmt/kie-wb-common-stunner-case-mgmt-project-client/src/test/java/org/kie/workbench/common/stunner/cm/project/client/editor/CaseManagementDiagramEditorTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.cm.project.client.type.CaseManagementDiagramResourceType;
 import org.kie.workbench.common.stunner.cm.project.service.CaseManagementSwitchViewService;
@@ -165,7 +166,7 @@ public class CaseManagementDiagramEditorTest extends AbstractProjectDiagramEdito
             }
         });
 
-        tested.open(mock(ProjectDiagram.class));
+        tested.open(mock(ProjectDiagram.class), mock(Viewer.Callback.class));
         when(sessionEditorPresenters.get()).thenReturn(sessionEditorPresenter);
 
         return tested;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramEditor.java
@@ -26,6 +26,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.promise.Promise;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
+import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
 import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
@@ -169,9 +170,10 @@ public class BPMNStandaloneDiagramEditor extends AbstractDiagramEditor {
     }
 
     @Override
-    public void open(final Diagram diagram) {
+    public void open(final Diagram diagram,
+                     final Viewer.Callback callback) {
         this.layoutHelper.applyLayout(diagram, openDiagramLayoutExecutor);
-        super.open(diagram);
+        super.open(diagram, callback);
     }
 
     @OnOpen
@@ -303,10 +305,10 @@ public class BPMNStandaloneDiagramEditor extends AbstractDiagramEditor {
     public void setContent(final String path, final String value) {
         diagramServices.transform(value,
                                   new ServiceCallback<Diagram>() {
-
                                       @Override
                                       public void onSuccess(final Diagram diagram) {
-                                          getEditor().open(diagram);
+                                          getEditor().open(diagram,
+                                                           error -> BPMNStandaloneDiagramEditor.this.getEditor().onLoadError(error));
                                       }
 
                                       @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/java/org/kie/workbench/common/stunner/standalone/client/editor/BPMNStandaloneDiagramEditor.java
@@ -302,7 +302,7 @@ public class BPMNStandaloneDiagramEditor extends AbstractDiagramEditor {
 
     @Override
     // @SetContent
-    public void setContent(final String path, final String value) {
+    public Promise setContent(final String path, final String value) {
         diagramServices.transform(value,
                                   new ServiceCallback<Diagram>() {
                                       @Override
@@ -316,6 +316,7 @@ public class BPMNStandaloneDiagramEditor extends AbstractDiagramEditor {
                                           BPMNStandaloneDiagramEditor.this.getEditor().onLoadError(error);
                                       }
                                   });
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This PR changes the set content method to return a Promise instead of void.

The goal of this change is to be able to make the loading of editors predictable and remove the need for double set content call.

This PR also includes the changes by @manstis and @romartin  at https://github.com/kiegroup/kie-wb-common/pull/3236/

Merge together with:
kiegroup/kogito-tooling#95
https://github.com/kiegroup/appformer/pull/934

The new changes are here: https://github.com/kiegroup/kie-wb-common/pull/3246/commits/0d5c3a182f32482fa74a58097c72709a57e06171