### PR TITLE
Kogito 1020 : VSCode - BPMN modeler support variables tagging

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/variables/ProcessVariableSerializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/variables/ProcessVariableSerializer.java
@@ -38,17 +38,17 @@ public class ProcessVariableSerializer {
             throw new IllegalArgumentException("Variable identifier cannot be empty. Given: '" + encoded + "'");
         }
 
-        String kpi = split[2];
-        return new AbstractMap.SimpleEntry<>(identifier, new ProcessVariableSerializer.VariableInfo(type, kpi));
+        String tags = split[2];
+        return new AbstractMap.SimpleEntry<>(identifier, new ProcessVariableSerializer.VariableInfo(type, tags));
     }
 
     static public class VariableInfo {
         public String type;
-        public String kpi;
+        public String tags;
 
-        VariableInfo(String type, String kpi) {
+        VariableInfo(String type, String tags) {
             this.type = type;
-            this.kpi = kpi;
+            this.tags = tags;
         }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/documentation/model/general/ProcessVariablesTotal.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/documentation/model/general/ProcessVariablesTotal.java
@@ -64,7 +64,7 @@ public class ProcessVariablesTotal {
             final ProcessVariableSerializer.VariableInfo info = (ProcessVariableSerializer.VariableInfo) variables[i].getValue();
             triplets[i] = VariableTriplets.create(variables[i].getKey(),
                                                info.type,
-                                               info.kpi == null || info.kpi.isEmpty() ? "false" : info.kpi);
+                                               info.tags == null || info.tags.isEmpty() ? "false" : info.tags);
         }
         return triplets;
     }
@@ -73,17 +73,17 @@ public class ProcessVariablesTotal {
     public static class VariableTriplets {
         public Object name;
         public Object type;
-        public Object kpi;
+        public Object tags;
 
         private VariableTriplets() {
         }
 
         @JsOverlay
-        public static final VariableTriplets create(final Object name, final Object type, final Object kpi) {
+        public static final VariableTriplets create(final Object name, final Object type, final Object tags) {
             final VariableTriplets instance = new VariableTriplets();
             instance.name = name;
             instance.type = type;
-            instance.kpi = kpi;
+            instance.tags = tags;
             return instance;
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/variables/ProcessVariableSerializerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/variables/ProcessVariableSerializerTest.java
@@ -24,17 +24,17 @@ import static org.junit.Assert.assertEquals;
 
 public class ProcessVariableSerializerTest {
 
-    private static final String VARIABLE = "PV1:java.lang.String:false,PV2:java.lang.Boolean:false";
+    private static final String VARIABLE = "PV1:java.lang.String:[internal;output],PV2:java.lang.Boolean:[internal;readonly;customTag]";
 
     @Test
     public void deserialize() {
         final Map<String, ProcessVariableSerializer.VariableInfo> deserialized = ProcessVariableSerializer.deserialize(VARIABLE);
         assertEquals(deserialized.size(), 2);
         assertEquals(deserialized.get("PV1").type, "java.lang.String");
-        assertEquals(deserialized.get("PV1").kpi, "false");
+        assertEquals(deserialized.get("PV1").tags, "[internal;output]");
 
         assertEquals(deserialized.get("PV2").type, "java.lang.Boolean");
-        assertEquals(deserialized.get("PV2").kpi, "false");
+        assertEquals(deserialized.get("PV2").tags, "[internal;readonly;customTag]");
 
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/CustomElement.java
@@ -31,7 +31,7 @@ public class CustomElement<T> {
     public static final MetadataTypeDefinition<Boolean> autoStart = new BooleanElement("customAutoStart", false);
     public static final MetadataTypeDefinition<Boolean> autoConnectionSource = new BooleanElement("isAutoConnection.source", false);
     public static final MetadataTypeDefinition<Boolean> autoConnectionTarget = new BooleanElement("isAutoConnection.target", false);
-    public static final MetadataTypeDefinition<Boolean> customKPI = new BooleanElement("customKPI", false);
+    public static final MetadataTypeDefinition<String> customTags = new StringElement("customTags", "[]");
     public static final MetadataTypeDefinition<String> description = new StringElement("customDescription", "");
     public static final MetadataTypeDefinition<String> scope = new StringElement("customScope", "");
     public static final MetadataTypeDefinition<String> name = new StringElement("elementname", "") {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/VariableDeclaration.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/VariableDeclaration.java
@@ -30,13 +30,13 @@ public class VariableDeclaration {
     private final Property typedIdentifier;
     private String identifier;
     private String type;
-    private String kpi;
+    private String tags;
 
     public VariableDeclaration(String identifier, String type) {
         this(identifier, type, "");
     }
 
-    public VariableDeclaration(String identifier, String type, String kpi) {
+    public VariableDeclaration(String identifier, String type, String tags) {
         this.setIdentifier(identifier);
         this.type = type;
 
@@ -48,7 +48,7 @@ public class VariableDeclaration {
         this.typedIdentifier.setId(Ids.typedIdentifier("GLOBAL", this.getIdentifier()));
         this.typedIdentifier.setName(identifier);
         this.typedIdentifier.setItemSubjectRef(typeDeclaration);
-        this.kpi = kpi;
+        this.tags = tags;
     }
 
     public static VariableDeclaration fromString(String encoded) {
@@ -58,18 +58,18 @@ public class VariableDeclaration {
         if (identifier.isEmpty()) {
             throw new IllegalArgumentException("Variable identifier cannot be empty. Given: '" + encoded + "'");
         }
-        String kpi = "";
+        String tags = "";
 
         if (split.length == 3) {
-            kpi = split[2];
+            tags = split[2];
         }
 
-        return new VariableDeclaration(identifier, type, kpi);
+        return new VariableDeclaration(identifier, type, tags);
     }
 
-    public String getKpi() { return kpi; }
+    public String getTags() { return tags; }
 
-    public void setKpi(String kpi) { this.kpi = kpi; }
+    public void setTags(String tags) { this.tags = tags; }
 
     public String getIdentifier() {
         return identifier;
@@ -98,14 +98,14 @@ public class VariableDeclaration {
 
     @Override
     public String toString() {
-        String kpiString = "";
-        if (kpi != null && !kpi.isEmpty()) {
-            kpiString = ":" + kpi;
+        String tagsString = "";
+        if (tags != null && !tags.isEmpty()) {
+            tagsString = ":" + tags;
         }
         if (type == null || type.isEmpty()) {
-            return typedIdentifier.getName() + kpiString;
+            return typedIdentifier.getName() + tagsString;
         } else {
-            return typedIdentifier.getName() + ":" + type + kpiString;
+            return typedIdentifier.getName() + ":" + type + tagsString;
         }
     }
 
@@ -120,12 +120,12 @@ public class VariableDeclaration {
         VariableDeclaration that = (VariableDeclaration) o;
         return Objects.equals(identifier, that.identifier) &&
                 Objects.equals(type, that.type) &&
-                Objects.equals(kpi, that.kpi);
+                Objects.equals(tags, that.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier, type, kpi);
+        return Objects.hash(identifier, type, tags);
     }
 }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/FlatVariableScope.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/FlatVariableScope.java
@@ -63,8 +63,8 @@ public class FlatVariableScope implements VariableScope {
         return variable;
     }
 
-    public Variable declare(String scopeId, String identifier, String type, String kpi) {
-        Variable variable = new Variable(scopeId, identifier, type, kpi);
+    public Variable declare(String scopeId, String identifier, String type, String tags) {
+        Variable variable = new Variable(scopeId, identifier, type, tags);
         variables.put(identifier, variable);
         return variable;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -193,10 +193,18 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
                     variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType(), decl.getTags());
-            if (decl.getTags() != null) {
+
+            final String tags = decl.getTags();
+
+            if (tags != null) {
+                if (tags.charAt(0) == '[' && tags.charAt(tags.length() - 1) == ']') {
+                    decl.setTags(tags.substring(1, tags.length() - 1));
+                }
                 CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
+
             }
-            properties.add(variable.getTypedIdentifier());
+
+                properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());
         });
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -197,7 +197,7 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
             final String tags = decl.getTags();
 
             if (tags != null) {
-                if (tags.charAt(0) == '[' && tags.charAt(tags.length() - 1) == ']') {
+                if (!tags.isEmpty() && tags.charAt(0) == '[' && tags.charAt(tags.length() - 1) == ']') {
                     decl.setTags(tags.substring(1, tags.length() - 1));
                 }
                 CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -192,9 +192,9 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
         List<Property> properties = process.getProperties();
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
-                    variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType(), decl.getKpi());
-            if (Boolean.parseBoolean(decl.getKpi())) {
-                CustomElement.customKPI.of(variable.getTypedIdentifier()).set(true);
+                    variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType(), decl.getTags());
+            if (decl.getTags() != null) {
+                CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
             }
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/SubProcessPropertyWriter.java
@@ -100,8 +100,8 @@ public class SubProcessPropertyWriter extends MultipleInstanceActivityPropertyWr
             VariableScope.Variable variable =
                     variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType());
 
-            if (Boolean.parseBoolean(decl.getKpi())) {
-                CustomElement.customKPI.of(variable.getTypedIdentifier()).set(true);
+            if (decl.getTags() != null) {
+                CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
             }
 
             properties.add(variable.getTypedIdentifier());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/VariableScope.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/VariableScope.java
@@ -32,7 +32,7 @@ public interface VariableScope {
 
     Optional<Variable> lookup(String identifier);
 
-    Variable declare(String scopeId, String identifier, String type, String kpi);
+    Variable declare(String scopeId, String identifier, String type, String tags);
 
     Collection<Variable> getVariables(String scopeId);
 
@@ -42,7 +42,7 @@ public interface VariableScope {
         VariableDeclaration declaration;
         ItemDefinition typeDeclaration;
         Property typedIdentifier;
-        String kpi;
+        String tags;
 
         Variable(String parentScopeId, String identifier, String type) {
             this.parentScopeId = parentScopeId;
@@ -58,9 +58,9 @@ public interface VariableScope {
             this.typedIdentifier.setItemSubjectRef(typeDeclaration);
         }
 
-        Variable(String parentScopeId, String identifier, String type, String kpi) {
+        Variable(String parentScopeId, String identifier, String type, String tags) {
             this(parentScopeId, identifier, type);
-            this.kpi = kpi;
+            this.tags = tags;
         }
 
         public ItemDefinition getTypeDeclaration() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessVariableReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ProcessVariableReader.java
@@ -36,11 +36,11 @@ class ProcessVariableReader {
 
     private static String toProcessVariableString(Property p) {
         String processVariableName = getProcessVariableName(p);
-        boolean kpi = CustomElement.customKPI.of(p).get();
+        String tags = CustomElement.customTags.of(p).get();
 
         return Optional.ofNullable(p.getItemSubjectRef())
                 .map(ItemDefinition::getStructureRef)
-                .map(type -> processVariableName + ":" + type + ":" + kpi)
+                .map(type -> processVariableName + ":" + type + ":" + tags)
                 .orElse(processVariableName);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/VariableDeclarationTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/VariableDeclarationTest.java
@@ -28,17 +28,17 @@ public class VariableDeclarationTest {
 
     private static final String CONSTRUCTOR_IDENTIFIER = "Variable Declaration Test";
     private static final String CONSTRUCTOR_TYPE = "Integer";
-    private static final String CONSTRUCTOR_KPI = "false";
+    private static final String CONSTRUCTOR_TAGS = "[input;customTag]";
 
     private static final String VAR_IDENTIFIER = "Variable-Declaration-Test";
     private static final String VAR_NAME = "Variable Declaration Test";
-    private static final String VAR_KPI = "false";
+    private static final String VAR_TAGS = "[internal;input;customTag]";
 
     private VariableDeclaration tested;
 
     @Before
     public void setup() {
-        tested = new VariableDeclaration(CONSTRUCTOR_IDENTIFIER, CONSTRUCTOR_TYPE, CONSTRUCTOR_KPI);
+        tested = new VariableDeclaration(CONSTRUCTOR_IDENTIFIER, CONSTRUCTOR_TYPE, CONSTRUCTOR_TAGS);
     }
 
     @Test
@@ -54,9 +54,9 @@ public class VariableDeclarationTest {
     }
 
     @Test
-    public void testKPI() {
-        String kpi = tested.getKpi();
-        assertEquals(kpi, VAR_KPI);
+    public void testTags() {
+        String tags = tested.getTags();
+        assertEquals(tags, CONSTRUCTOR_TAGS);
     }
 
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -150,13 +150,13 @@ public class ProcessPropertyWriterTest {
 
     @Test
     public void processVariables() {
-        ProcessVariables processVariables = new ProcessVariables("GV1:Boolean:true,GV2:Boolean:true,GV3:Integer:false");
+        ProcessVariables processVariables = new ProcessVariables("GV1:Boolean:[input],GV2:Boolean:[output;required],GV3:Integer:[customTag;required]");
         p.setProcessVariables(processVariables);
 
         final ProcessPropertyReader pp = new ProcessPropertyReader(
                 p.getProcess(), p.getBpmnDiagram(), p.getShape(), 1.0);
         String processVariablesString = pp.getProcessVariables();
-        assertThat(processVariablesString).isEqualTo("GV1:Boolean:true,GV2:Boolean:true,GV3:Integer:false");
+        assertThat(processVariablesString).isEqualTo("GV1:Boolean:<![CDATA[input]]>,GV2:Boolean:<![CDATA[output;required]]>,GV3:Integer:<![CDATA[customTag;required]]>");
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -520,7 +520,7 @@ public class BPMNDirectDiagramMarshallerTest {
         BPMNDiagramImpl bpmnDiagram = getBpmnDiagram(diagram);
         ProcessVariables variables = bpmnDiagram.getProcessData().getProcessVariables();
         assertEquals(variables.getValue(),
-                     "employee:java.lang.String:false,reason:java.lang.String:false,performance:java.lang.String:false");
+                     "employee:java.lang.String:[],reason:java.lang.String:[],performance:java.lang.String:[]");
 
         Node<? extends Definition, ?> diagramNode = diagram.getGraph().getNode("_luRBMdEjEeWXpsZ1tNStKQ");
         assertTrue(diagramNode.getContent().getDefinition() instanceof BPMNDiagram);
@@ -530,7 +530,7 @@ public class BPMNDirectDiagramMarshallerTest {
 
         variables = bpmnDiagram.getProcessData().getProcessVariables();
         assertEquals(variables.getValue(),
-                     "employee:java.lang.String:false,reason:java.lang.String:false,performance:java.lang.String:false");
+                     "employee:java.lang.String:[],reason:java.lang.String:[],performance:java.lang.String:[]");
     }
 
     @Test
@@ -1953,7 +1953,7 @@ public class BPMNDirectDiagramMarshallerTest {
         assertEquals("java",
                      executionSet.getOnExitAction().getValue().getValues().get(0).getLanguage());
 
-        assertEquals("subProcessVar1:String:false,subProcessVar2:String:false",
+        assertEquals("subProcessVar1:String:[],subProcessVar2:String:[]",
                      processData.getProcessVariables().getValue());
 
         assertTrue(executionSet.getIsAsync().getValue());
@@ -3588,7 +3588,7 @@ public class BPMNDirectDiagramMarshallerTest {
         assertEquals("java",
                      multipleInstanceSubprocess.getExecutionSet().getOnExitAction().getValue().getValues().get(0).getLanguage());
         assertTrue(multipleInstanceSubprocess.getExecutionSet().getIsAsync().getValue());
-        assertEquals("mi-var1:String:false", multipleInstanceSubprocess.getProcessData().getProcessVariables().getValue());
+        assertEquals("mi-var1:String:[]", multipleInstanceSubprocess.getProcessData().getProcessVariables().getValue());
         assertEquals(Boolean.TRUE, multipleInstanceSubprocess.getExecutionSet().getIsAsync().getValue());
 
         final String SLA_DUE_DATE = "12/25/1983";
@@ -3607,7 +3607,7 @@ public class BPMNDirectDiagramMarshallerTest {
         EventSubprocess eventSubprocess = (EventSubprocess) eventSubprocessNode.getContent().getDefinition();
         assertTrue(eventSubprocess.getExecutionSet().getIsAsync().getValue());
         assertEquals(eventSubprocess.getProcessData().getProcessVariables().getValue(),
-                     "Var1:String:false");
+                     "Var1:String:[]");
 
         final String SLA_DUE_DATE = "12/25/1983";
         assertEquals(SLA_DUE_DATE, eventSubprocess.getExecutionSet().getSlaDueDate().getValue());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -3044,8 +3044,9 @@ public class BPMNDirectDiagramMarshallerTest {
                       1,
                       0);
 
+        // 2 from the file plus 2 from tags
         assertEquals("Unexpected number of extensionElements sections.",
-                     2, countOccurrences(result, "<bpmn2:extensionElements>"));
+                     4, countOccurrences(result, "<bpmn2:extensionElements>"));
         assertTrue(result.contains("<bpmn2:subProcess id=\"_2316CEC1-C1F7-41B1-8C91-3CE73ADE5571\""));
         assertTrue(result.contains("name=\"MultipleInstanceSubprocess\""));
         assertTrue(result.contains("<drools:onEntry-script scriptFormat=\"http://www.java.com/java\">"));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/AdHocSubProcessTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/AdHocSubProcessTest.java
@@ -118,9 +118,9 @@ public class AdHocSubProcessTest extends SubProcessTest<AdHocSubprocess> {
         final String SUB_PROCESS_NAME_MVEL = "Ad-hoc sub-process03 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION_MVEL = "Ad-hoc sub-process03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
 
-        final String SUB_PROCESS_VARIABLES_JAVA = "subVar01:String:false";
-        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar02:String:false";
-        final String SUB_PROCESS_VARIABLES_MVEL = "subVarString:String:false,subVarCustom:CustomType:false,subVarBoolean:Boolean:false,subVarFloat:Float:false,subVarInteger:Integer:false,subVarObject:Object:false";
+        final String SUB_PROCESS_VARIABLES_JAVA = "subVar01:String:[]";
+        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar02:String:[]";
+        final String SUB_PROCESS_VARIABLES_MVEL = "subVarString:String:[],subVarCustom:CustomType:[],subVarBoolean:Boolean:[],subVarFloat:Float:[],subVarInteger:Integer:[],subVarObject:Object:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
@@ -242,9 +242,9 @@ public class AdHocSubProcessTest extends SubProcessTest<AdHocSubprocess> {
         final String SUB_PROCESS_NAME_MVEL = "Ad-hoc sub-process06 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION_MVEL = "Ad-hoc sub-process06 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
 
-        final String SUB_PROCESS_VARIABLES_JAVA = "subVar04:String:false";
-        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar05:String:false";
-        final String SUB_PROCESS_VARIABLES_MVEL = "subVarString:String:false,subVarCustom:CustomType:false,subVarBoolean:Boolean:false,subVarFloat:Float:false,subVarInteger:Integer:false,subVarObject:Object:false";
+        final String SUB_PROCESS_VARIABLES_JAVA = "subVar04:String:[]";
+        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar05:String:[]";
+        final String SUB_PROCESS_VARIABLES_MVEL = "subVarString:String:[],subVarCustom:CustomType:[],subVarBoolean:Boolean:[],subVarFloat:Float:[],subVarInteger:Integer:[],subVarObject:Object:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/EmbeddedSubProcessTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/EmbeddedSubProcessTest.java
@@ -112,9 +112,9 @@ public class EmbeddedSubProcessTest extends SubProcessTest<EmbeddedSubprocess> {
         final String SUB_PROCESS_NAME_MVEL = "Embedded process03 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION_MVEL = "Embedded process03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
 
-        final String SUB_PROCESS_VARIABLES_JAVA = "subVar01:String:false";
-        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar02:String:false";
-        final String SUB_PROCESS_VARIABLES_MVEL = "subVar03:String:false";
+        final String SUB_PROCESS_VARIABLES_JAVA = "subVar01:String:[]";
+        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar02:String:[]";
+        final String SUB_PROCESS_VARIABLES_MVEL = "subVar03:String:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
@@ -221,9 +221,9 @@ public class EmbeddedSubProcessTest extends SubProcessTest<EmbeddedSubprocess> {
         final String SUB_PROCESS_NAME_MVEL = "Embedded process06 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION_MVEL = "Embedded process06 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
 
-        final String SUB_PROCESS_VARIABLES_JAVA = "subVar04:String:false";
-        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar05:String:false";
-        final String SUB_PROCESS_VARIABLES_MVEL = "subVar06:String:false";
+        final String SUB_PROCESS_VARIABLES_JAVA = "subVar04:String:[]";
+        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar05:String:[]";
+        final String SUB_PROCESS_VARIABLES_MVEL = "subVar06:String:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/EventSubProcessTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/EventSubProcessTest.java
@@ -82,7 +82,7 @@ public class EventSubProcessTest extends SubProcessTest<EventSubprocess> {
     public void testUnmarshallTopLevelFilledPropertiesSubProcess() {
         final String SUB_PROCESS_NAME = "Event process01 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION = "Event process01 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
-        final String SUB_PROCESS_VARIABLES = "subVarString:String:false,subVarCustom:Custom:false,subVarBoolean:Boolean:false,subVarFloat:Float:false,subVarInteger:Integer:false,subVarObject:Object:false";
+        final String SUB_PROCESS_VARIABLES = "subVarString:String:[],subVarCustom:Custom:[],subVarBoolean:Boolean:[],subVarFloat:Float:[],subVarInteger:Integer:[],subVarObject:Object:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
@@ -142,7 +142,7 @@ public class EventSubProcessTest extends SubProcessTest<EventSubprocess> {
     public void testUnmarshallSubProcessLevelFilledPropertiesSubProcess() {
         final String SUB_PROCESS_NAME = "Event process02 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION = "Event process02 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
-        final String SUB_PROCESS_VARIABLES = "subVarString:String:false,subVarCustom:Custom:false,subVarBoolean:Boolean:false,subVarFloat:Float:false,subVarInteger:Integer:false,subVarObject:Object:false";
+        final String SUB_PROCESS_VARIABLES = "subVarString:String:[],subVarCustom:Custom:[],subVarBoolean:Boolean:[],subVarFloat:Float:[],subVarInteger:Integer:[],subVarObject:Object:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/MultipleInstanceSubProcessTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/subprocesses/MultipleInstanceSubProcessTest.java
@@ -120,9 +120,9 @@ public class MultipleInstanceSubProcessTest extends SubProcessTest<MultipleInsta
         final String SUB_PROCESS_NAME_MVEL = "Multiple Instance sub-process03 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION_MVEL = "Multiple Instance sub-process03 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
 
-        final String SUB_PROCESS_VARIABLES_JAVA = "subVar01:String:false";
-        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar02:String:false";
-        final String SUB_PROCESS_VARIABLES_MVEL = "subVarCustom:any.Custom:false,subVarBoolean:Boolean:false,subVarFloat:Float:false,subVarInteger:Integer:false,subVarObject:Object:false,subVarString:String:false";
+        final String SUB_PROCESS_VARIABLES_JAVA = "subVar01:String:[]";
+        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar02:String:[]";
+        final String SUB_PROCESS_VARIABLES_MVEL = "subVarCustom:any.Custom:[],subVarBoolean:Boolean:[],subVarFloat:Float:[],subVarInteger:Integer:[],subVarObject:Object:[],subVarString:String:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);
@@ -254,9 +254,9 @@ public class MultipleInstanceSubProcessTest extends SubProcessTest<MultipleInsta
         final String SUB_PROCESS_NAME_MVEL = "Multiple Instance sub-process06 name ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
         final String SUB_PROCESS_DOCUMENTATION_MVEL = "Multiple Instance sub-process06 doc\n ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,./";
 
-        final String SUB_PROCESS_VARIABLES_JAVA = "subVar04:String:false";
-        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar05:String:false";
-        final String SUB_PROCESS_VARIABLES_MVEL = "subVarCustom:any.Custom:false,subVarBoolean:Boolean:false,subVarFloat:Float:false,subVarInteger:Integer:false,subVarObject:Object:false,subVarString:String:false";
+        final String SUB_PROCESS_VARIABLES_JAVA = "subVar04:String:[]";
+        final String SUB_PROCESS_VARIABLES_JAVASCRIPT = "subVar05:String:[]";
+        final String SUB_PROCESS_VARIABLES_MVEL = "subVarCustom:any.Custom:[],subVarBoolean:Boolean:[],subVarFloat:Float:[],subVarInteger:Integer:[],subVarObject:Object:[],subVarString:String:[]";
 
         Diagram<Graph, Metadata> diagram = getDiagram();
         assertDiagram(diagram, AMOUNT_OF_NODES_IN_DIAGRAM);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
@@ -164,6 +164,7 @@ public class Variable {
                             var.setCustomDataType(dataType);
                         }
                     }
+                    //kṕi, this is where it needs to be saved
                     if (varParts.length == 3) {
                         var.kpi = Boolean.parseBoolean(varParts[2]);
                     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.model;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ public class Variable {
 
     private String customDataType;
 
-    private boolean kpi;
+    private List<String> tags;
 
     public Variable(VariableType variableType) {
         this.variableType = variableType;
@@ -62,12 +63,12 @@ public class Variable {
                     final VariableType variableType,
                     final String dataType,
                     final String customDataType,
-                    final boolean kpi) {
+                    final List<String> tags) {
         this.name = name;
         this.variableType = variableType;
         this.dataType = dataType;
         this.customDataType = customDataType;
-        this.kpi = kpi;
+        this.tags = tags;
     }
 
     public Variable(final VariableRow row,
@@ -80,7 +81,15 @@ public class Variable {
             this.dataType = row.getDataTypeDisplayName();
         }
         this.customDataType = row.getCustomDataType();
-        this.kpi = row.getKpi();
+        this.tags = row.getTags();
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
     }
 
     public VariableType getVariableType() {
@@ -107,13 +116,6 @@ public class Variable {
         this.dataType = dataType;
     }
 
-    public boolean getKpi() {
-        return kpi;
-    }
-
-    public void setKpi(boolean kpi) {
-        this.kpi = kpi;
-    }
 
     public String getCustomDataType() {
         return customDataType;
@@ -131,9 +133,10 @@ public class Variable {
             } else if (dataType != null && !dataType.isEmpty()) {
                 sb.append(':').append(dataType);
             }
-            if (this.getVariableType() == Variable.VariableType.PROCESS && (customDataType != null || dataType != null)) {
-                sb.append(":").append(kpi);
+            if (tags != null && this.getVariableType() == Variable.VariableType.PROCESS && (customDataType != null || dataType != null)) {
+                sb.append(":").append("[").append(String.join(";", tags)).append("]");
             }
+
             return sb.toString();
         }
         return null;
@@ -164,9 +167,10 @@ public class Variable {
                             var.setCustomDataType(dataType);
                         }
                     }
-                    //kṕi, this is where it needs to be saved
+                    //tags, this is where it needs to be saved
                     if (varParts.length == 3) {
-                        var.kpi = Boolean.parseBoolean(varParts[2]);
+                        String[] elements = varParts[2].replace("[", "").replace("]", "").split(";");
+                        var.tags = Arrays.asList(elements);
                     }
                 }
             }
@@ -205,7 +209,7 @@ public class Variable {
         if (getDataType() != null ? !getDataType().equals(variable.getDataType()) : variable.getDataType() != null) {
             return false;
         }
-        if (kpi != variable.kpi) {
+        if (!tags.equals(variable.tags)) {
             return false;
         }
         return getCustomDataType() != null ? getCustomDataType().equals(variable.getCustomDataType()) : variable.getCustomDataType() == null;
@@ -217,7 +221,8 @@ public class Variable {
         result = 31 * result + (getName() != null ? getName().hashCode() : 0);
         result = 31 * result + (getDataType() != null ? getDataType().hashCode() : 0);
         result = 31 * result + (getCustomDataType() != null ? getCustomDataType().hashCode() : 0);
-        result = 31 * result +  Boolean.hashCode(kpi);
+        result = 31 * result +  (tags != null ? tags.hashCode() : 0);
+
         return result;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
@@ -134,7 +134,7 @@ public class Variable {
                 sb.append(':').append(dataType);
             }
             if (tags != null && this.getVariableType() == Variable.VariableType.PROCESS && (customDataType != null || dataType != null)) {
-                sb.append(":").append("[").append(String.join(";", tags)).append("]");
+                sb.append(":").append(String.join(";", tags));
             }
 
             return sb.toString();
@@ -169,7 +169,7 @@ public class Variable {
                     }
                     //tags, this is where it needs to be saved
                     if (varParts.length == 3) {
-                        String[] elements = varParts[2].replace("[", "").replace("]", "").split(";");
+                        String[] elements = varParts[2].split(";");
                         var.tags = Arrays.asList(elements);
                     }
                 }
@@ -209,7 +209,7 @@ public class Variable {
         if (getDataType() != null ? !getDataType().equals(variable.getDataType()) : variable.getDataType() != null) {
             return false;
         }
-        if (!tags.equals(variable.tags)) {
+        if (tags != null ? !tags.equals(variable.tags) : variable.getTags() != null) {
             return false;
         }
         return getCustomDataType() != null ? getCustomDataType().equals(variable.getCustomDataType()) : variable.getCustomDataType() == null;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRow.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.jboss.errai.databinding.client.api.Bindable;
@@ -33,22 +35,14 @@ public class VariableRow {
 
     private String customDataType;
 
-    public boolean getKpi() {
-        return kpi;
-    }
-
-    public void setKpi(boolean kpi) {
-        this.kpi = kpi;
-    }
-
-    private boolean kpi;
+    private List<String> tags;;
 
     // Field which is incremented for each row.
     // Required to implement equals function which needs a unique field
     private static long lastId = 0;
 
     public VariableRow() {
-        this(Variable.VariableType.PROCESS, null, null, null, false);
+        this(Variable.VariableType.PROCESS, null, null, null, new ArrayList<>());
         this.id = lastId++;
     }
 
@@ -68,13 +62,13 @@ public class VariableRow {
                        final String name,
                        final String dataTypeDisplayName,
                        final String customDataType,
-                       final boolean isKPI) {
+                       final List<String> tags) {
         this.id = lastId++;
         this.variableType = variableType;
         this.name = name;
         this.dataTypeDisplayName = dataTypeDisplayName;
         this.customDataType = customDataType;
-        this.kpi = isKPI;
+        this.tags = tags;
     }
 
     public VariableRow(final Variable variable,
@@ -88,9 +82,16 @@ public class VariableRow {
             this.dataTypeDisplayName = variable.getDataType();
         }
         this.customDataType = variable.getCustomDataType();
-        this.kpi = variable.getKpi();
+        this.tags = variable.getTags();
     }
 
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
 
     public long getId() {
         return id;
@@ -154,6 +155,6 @@ public class VariableRow {
 
     @Override
     public String toString() {
-        return "VariableRow [variableType=" + variableType.toString() + ", name=" + name + ", dataTypeDisplayName=" + dataTypeDisplayName + ", customDataType=" + customDataType + ", kpi=" + kpi + "]";
+        return "VariableRow [variableType=" + variableType.toString() + ", name=" + name + ", dataTypeDisplayName=" + dataTypeDisplayName + ", customDataType=" + customDataType + ", tags=" + String.join(",", tags) + "]";
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRow.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gwt.core.client.GWT;
 import org.jboss.errai.databinding.client.api.Bindable;
 
 @Bindable
@@ -83,6 +84,7 @@ public class VariableRow {
         }
         this.customDataType = variable.getCustomDataType();
         this.tags = variable.getTags();
+        GWT.log("Value of Tags on Variable Row Constructor: " + this.tags);
     }
 
     public List<String> getTags() {
@@ -126,10 +128,12 @@ public class VariableRow {
     }
 
     public String getCustomDataType() {
+        GWT.log("Get Custom Data Type from Variable Row: " + customDataType);
         return customDataType;
     }
 
     public void setCustomDataType(final String customDataType) {
+        GWT.log("Set Custom Data Type from Variable Row: " + customDataType);
         this.customDataType = customDataType;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.variablesEditor;
 
+import java.util.List;
+
 import org.jboss.errai.ui.client.widget.HasModel;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable.VariableType;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.VariableRow;
@@ -44,6 +46,10 @@ public interface VariableListItemWidgetView extends HasModel<VariableRow> {
     String getCustomDataType();
 
     void setCustomDataType(final String customDataType);
+
+    void setCustomTags(final List<String> tags);
+
+    List<String> getCustomTags();
 
     void setReadOnly(final boolean readOnly);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
@@ -46,5 +46,5 @@ public interface VariableListItemWidgetView extends HasModel<VariableRow> {
 
     void setReadOnly(final boolean readOnly);
 
-    void setKPINotEnabled();
+    void setTagsNotEnabled();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
@@ -25,6 +25,7 @@ public interface VariableListItemWidgetView extends HasModel<VariableRow> {
 
     String CUSTOM_PROMPT = "Custom" + ListBoxValues.EDIT_SUFFIX;
     String ENTER_TYPE_PROMPT = "Enter type" + ListBoxValues.EDIT_SUFFIX;
+    String ENTER_TAG_PROMPT = "Enter tag" + ListBoxValues.EDIT_SUFFIX;
 
     void init();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetView.java
@@ -37,6 +37,8 @@ public interface VariableListItemWidgetView extends HasModel<VariableRow> {
 
     void setDataTypes(final ListBoxValues dataTypeListBoxValues);
 
+    void setTagTypes(List<String> tagTypes);
+
     VariableType getVariableType();
 
     String getDataTypeDisplayName();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -24,18 +24,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.TableCellElement;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.FocusEvent;
-import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.text.shared.Renderer;
 import elemental2.dom.CSSProperties;
@@ -152,7 +150,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     private String overlayTopPosition = null;
 
-    final String [] defaultTags = {"internal", "required", "readonly", "input", "output", "business_relevant"};
+    final String[] defaultTags = {"internal", "required", "readonly", "input", "output", "business_relevant"};
 
     final Set<String> defaultTagsSet = new HashSet<>(Arrays.asList(defaultTags));
 
@@ -215,22 +213,46 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     @Override
     public void setTextBoxModelValue(final TextBox textBox,
                                      final String value) {
-        setCustomDataType(value);
+        GWT.log("Setting Textbox Model Value Textbox: " + textBox);
+
+        GWT.log("Setting Textbox Model Value: " + value);
+        if (textBox == customDataType) {
+            setCustomDataType(value);
+            GWT.log("It is custom Data Type");
+        } else {
+            GWT.log("Not Custom Data Type");
+        }
     }
 
     @Override
     public void setListBoxModelValue(final ValueListBox<String> listBox,
                                      final String value) {
-        setDataTypeDisplayName(value);
+        GWT.log("Setting Listbox Model Value Listbox: " + listBox);
+
+        GWT.log("Setting Listbox Model Value: " + value);
+
+        if (listBox == dataType) {
+            GWT.log("Is Data Type Listbox");
+            setDataTypeDisplayName(value);
+        } else {
+            GWT.log("Is not Data Type Listbox");
+        }
     }
 
     @Override
     public String getModelValue(final ValueListBox<String> listBox) {
-        String value = getCustomDataType();
-        if (value == null || value.isEmpty()) {
-            value = getDataTypeDisplayName();
+
+        if (true || listBox == dataType) {
+            GWT.log("Not setting Model Value");
+            String value = getCustomDataType();
+            if (value == null || value.isEmpty()) {
+                value = getDataTypeDisplayName();
+            }
+            return value;
+        } else {
+            GWT.log("Not setting Model Value");
+            return "";
         }
-        return value;
     }
 
     @PostConstruct
@@ -253,6 +275,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
             }
             notifyModelChanged();
         });
+        GWT.log("Value of Data Types: " + dataType);
         dataTypeComboBox.init(this,
                               true,
                               dataType,
@@ -271,81 +294,81 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
             }
         });
 
+        GWT.log("On Init value of Model Tags: " + getModel().getTags());
         PopOver.$(variableTagsSettings).popovers();
 
         setTagTittle("Tags: ");
 
-                variableTagsSettings.onclick = e -> {
-                // This is needed when opened
+        variableTagsSettings.onclick = e -> {
+            // This is needed when opened
 
-                    if (isOpen) {
-                        isOpen = false;
-                        GWT.log("Pop Over is Open Must be closed");
-                        lastOverlayOpened = null;
-                        return null;
-                    } else {
-                        isOpen = true;
-                        GWT.log("Pop Over is Closed Must be Opened");
-                    }
+            if (isOpen) {
+                isOpen = false;
+                GWT.log("Pop Over is Open Must be closed");
+                lastOverlayOpened = null;
+                return null;
+            } else {
+                isOpen = true;
+                GWT.log("Pop Over is Closed Must be Opened");
+            }
 
-                GWT.log("Item has been clicked");
-                GWT.log("Last Overlay: " + lastOverlayOpened);
+            GWT.log("Item has been clicked");
+            GWT.log("Last Overlay: " + lastOverlayOpened);
 
-                final HTMLDivElement overlayDiv =  ((HTMLDivElement) variableTagsSettings.nextElementSibling);
-                GWT.log("Opening");
-                GWT.log("Next Sibling: " + overlayDiv.innerHTML);
+            final HTMLDivElement overlayDiv = ((HTMLDivElement) variableTagsSettings.nextElementSibling);
+            GWT.log("Opening");
+            GWT.log("Next Sibling: " + overlayDiv.innerHTML);
 
-                if (lastOverlayOpened != null && lastOverlayOpened != this.closeButton) {
-                    GWT.log("Closing Anchor Overlay");
-                    GWT.log("Closing");
-                    GWT.log("Performing Click");
-                    lastOverlayOpened.click();
-                 }
+            if (lastOverlayOpened != null && lastOverlayOpened != this.closeButton) {
+                GWT.log("Closing Anchor Overlay");
+                GWT.log("Closing");
+                GWT.log("Performing Click");
+                lastOverlayOpened.click();
+            }
 
-                overlayDiv.style.display = "block";
+            overlayDiv.style.display = "block";
 
-                GWT.log("Should Have opened: " + tagNamesComboBox.getValue());
-                overlayDiv.style.left = "130px";
-                GWT.log("Next Sibling Child Count: " + overlayDiv.childElementCount);
-                final Element lastNode = overlayDiv.lastElementChild;
-                GWT.log("Last Sibling Child Count: " + lastNode);
-                lastNode.innerHTML = "";
-                lastNode.appendChild(tagsDiv);
+            GWT.log("Should Have opened: " + tagNamesComboBox.getValue());
+            overlayDiv.style.left = "130px";
+            GWT.log("Next Sibling Child Count: " + overlayDiv.childElementCount);
+            final Element lastNode = overlayDiv.lastElementChild;
+            GWT.log("Last Sibling Child Count: " + lastNode);
+            lastNode.innerHTML = "";
+            lastNode.appendChild(tagsDiv);
 
-                GWT.log("Variable Tag Settings Left: " + variableTagsSettings.style.left);
-                GWT.log("Variable Tag Settings Top: " + variableTagsSettings.style.left);
+            GWT.log("Variable Tag Settings Left: " + variableTagsSettings.style.left);
+            GWT.log("Variable Tag Settings Top: " + variableTagsSettings.style.left);
 
-                GWT.log("Variable Tag Settings Client Left: " + variableTagsSettings.clientLeft);
-                GWT.log("Variable Tag Settings Client Top: " + variableTagsSettings.clientTop);
+            GWT.log("Variable Tag Settings Client Left: " + variableTagsSettings.clientLeft);
+            GWT.log("Variable Tag Settings Client Top: " + variableTagsSettings.clientTop);
 
-                GWT.log("Variable Tag Settings Bounding Rect Left: " + variableTagsSettings.getBoundingClientRect().left);
-                GWT.log("Variable Tag Settings Bounding Rect Top: " + variableTagsSettings.getBoundingClientRect().top);
+            GWT.log("Variable Tag Settings Bounding Rect Left: " + variableTagsSettings.getBoundingClientRect().left);
+            GWT.log("Variable Tag Settings Bounding Rect Top: " + variableTagsSettings.getBoundingClientRect().top);
 
-                GWT.log("Overlay Left: " + overlayDiv.style.left);
-                GWT.log("Overlay Top: " + overlayDiv.style.top);
+            GWT.log("Overlay Left: " + overlayDiv.style.left);
+            GWT.log("Overlay Top: " + overlayDiv.style.top);
 
-                if (overlayTopPosition == null) {
-                    overlayTopPosition = overlayDiv.style.top;
-                }
+            if (overlayTopPosition == null) {
+                overlayTopPosition = overlayDiv.style.top;
+            }
 
-                overlayDiv.style.top = overlayTopPosition;
+            overlayDiv.style.top = overlayTopPosition;
 
-                GWT.log("Inner Html: " + overlayDiv.lastElementChild.innerHTML);
-                GWT.log("Style: " + overlayDiv.lastElementChild.getAttribute("style"));
-                GWT.log("Style: " + overlayDiv.lastElementChild.getAttribute("class"));
+            GWT.log("Inner Html: " + overlayDiv.lastElementChild.innerHTML);
+            GWT.log("Style: " + overlayDiv.lastElementChild.getAttribute("style"));
+            GWT.log("Style: " + overlayDiv.lastElementChild.getAttribute("class"));
 
-                overlayDiv.style.maxWidth = CSSProperties.MaxWidthUnionType.of("280px");
-                overlayDiv.style.minHeight = CSSProperties.MinHeightUnionType.of("280px");
+            overlayDiv.style.maxWidth = CSSProperties.MaxWidthUnionType.of("280px");
+            overlayDiv.style.minHeight = CSSProperties.MinHeightUnionType.of("280px");
 
-                tagsDiv.style.display = "block";
-                overlayDiv.style.display = "block";
+            tagsDiv.style.display = "block";
+            overlayDiv.style.display = "block";
 
-                lastOverlayOpened = this.closeButton;
-                GWT.log("This Close Button: " + lastOverlayOpened);
+            lastOverlayOpened = this.closeButton;
+            GWT.log("This Close Button: " + lastOverlayOpened);
 
-                 return null;
-            };
-
+            return null;
+        };
 
         customTagName.addFocusHandler(focusEvent -> {
             previousCustomValue = customTagName.getValue();
@@ -372,7 +395,6 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     }
 
     private void setTagsListItems() {
-
         ListBoxValues classNameListBoxValues = new ListBoxValues(VariableListItemWidgetView.CUSTOM_PROMPT,
                                                                  "Edit" + " ",
                                                                  null);
@@ -384,7 +406,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         defaultTagNames.setValue("");
 
         tagNamesComboBox.init(this,
-                              true,
+                              false,
                               defaultTagNames,
                               customTagName,
                               false,
@@ -405,11 +427,11 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Override
     public void setModel(final VariableRow model) {
+        GWT.log("Setting Model: " + model);
         variableRow.setModel(model);
         initVariableControls();
         currentValue = getModel().toString();
         currentName = getModel().getName();
-
     }
 
     @Override
@@ -424,6 +446,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Override
     public void setDataTypeDisplayName(final String dataTypeDisplayName) {
+        GWT.log("Setting Data Display Name: " + dataTypeDisplayName);
         getModel().setDataTypeDisplayName(dataTypeDisplayName);
     }
 
@@ -434,14 +457,17 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Override
     public void setCustomDataType(final String customDataType) {
+        GWT.log("Setting Custom Data Type: " + customDataType);
         getModel().setCustomDataType(customDataType);
     }
 
     @Override
     public void setCustomTags(final List<String> tags) {
+        GWT.log("Setting Custom Tags: " + tags);
         getModel().setTags(tags);
         tagNamesList = tags;
-        setTagsListItems();
+        GWT.log("Value of TagNamesList: " + tagNamesList);
+        GWT.log("Value of Default tag List: " + defaultTagsSet);
     }
 
     @Override
@@ -451,6 +477,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Override
     public void setDataTypes(final ListBoxValues dataTypeListBoxValues) {
+        GWT.log("Setting Data Types: " + dataTypeListBoxValues);
         dataTypeComboBox.setCurrentTextValue("");
         dataTypeComboBox.setListBoxValues(dataTypeListBoxValues);
         dataTypeComboBox.setShowCustomValues(true);
@@ -459,6 +486,25 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
             dataTypeComboBox.addCustomValueToListBoxValues(cdt,
                                                            "");
         }
+    }
+
+    @Override
+    public void setTagTypes(final List<String> tagTypes) {
+        GWT.log("Setting Tag Types: " + tagTypes);
+        tagNamesComboBox.setCurrentTextValue("");
+        tagNamesComboBox.setShowCustomValues(true);
+
+       for (final String tag : tagTypes) {
+           if (!defaultTagsSet.contains(tag)) {
+               GWT.log("Adding Custom Type: " + tag);
+               tagNamesComboBox.addCustomValueToListBoxValues(tag, "");
+           }
+       }
+       tagSet.clear();
+       tagSet.addAll(tagTypes);
+
+        renderTagElementsBadges(true);
+
     }
 
     @Override
@@ -488,6 +534,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @EventHandler("acceptButton")
     public void handleAcceptButton(final ClickEvent e) {
+
         final String tagX = tagNamesComboBox.getValue();
 
         GWT.log("Custom Value: " + customTagName.getValue());
@@ -497,13 +544,16 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
             for (final HTMLAnchorElement anchor : removeButtons.values()) {
                 anchor.click();
             }
-
             removeButtons.clear();
 
             GWT.log("Adding Message: " + tagX);
             GWT.log("Adding Buttons");
 
             tagSet.add(tagX);
+            GWT.log("Value of Tags before notifying: " + tagSet);
+            // Update Model
+            setCustomTags(new ArrayList<>(tagSet));
+            notifyModelChanged();
 
             GWT.log("Adding Tags : " + tagSet);
             GWT.log("Custom Value: " + customTagName.getValue());
@@ -514,37 +564,49 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                 tagSet.remove(previousCustomValue);
             }
 
-            for (final String tag : tagSet) {
+            renderTagElementsBadges(false);
+        }
+    }
 
-                final HTMLLabelElement tagLabel = (HTMLLabelElement) document.createElement("label");
-                tagLabel.textContent = tag;
-                tagLabel.className = "badge tagBadge  tagBadges";
-                tagLabel.htmlFor = "closeButton";
+    private void renderTagElementsBadges(final boolean updateSet) {
+        for (final String tag : tagSet) {
 
-                final HTMLAnchorElement closeButton = (HTMLAnchorElement) document.createElement("a");
-                closeButton.id = "closeButton";
-                closeButton.textContent = "x";
-                closeButton.className = "close tagCloseButton tagBadges";
+            final HTMLLabelElement tagLabel = (HTMLLabelElement) document.createElement("label");
+            tagLabel.textContent = tag;
+            tagLabel.className = "badge tagBadge  tagBadges";
+            tagLabel.htmlFor = "closeButton";
 
-                closeButton.onclick = ex -> {
-                    GWT.log("Item has been clicked 2");
-                    tagLabel.remove();
-                    closeButton.remove();
-                    ex.preventDefault();
-                    tagCount.setTextContent(tagSet.size() != 0 ? String.valueOf(tagSet.size()) : "");
-                    setTagTittle("Tags: " + tagSet.toString());
-                    return null;
-                };
+            final HTMLAnchorElement closeButton = (HTMLAnchorElement) document.createElement("a");
+            closeButton.id = "closeButton";
+            closeButton.textContent = "x";
+            closeButton.className = "close tagCloseButton tagBadges";
 
-                tagLabel.appendChild(closeButton);
-                tagsContainer.appendChild(tagLabel);
+            closeButton.onclick = ex -> {
+                GWT.log("Item has been clicked 2");
+                tagLabel.remove();
+                closeButton.remove();
+                ex.preventDefault();
+
+                if (updateSet) {
+                    tagSet.remove(tag);
+                    setCustomTags(new ArrayList<>(tagSet));
+                    notifyModelChanged();
+                }
 
                 tagCount.setTextContent(tagSet.size() != 0 ? String.valueOf(tagSet.size()) : "");
                 setTagTittle("Tags: " + tagSet.toString());
+                setCustomTags(new ArrayList<>(tagSet));
+                return null;
+            };
 
-                removeButtons.put(tag, closeButton);
-            }
-        }
+            tagLabel.appendChild(closeButton);
+            tagsContainer.appendChild(tagLabel);
+
+            tagCount.setTextContent(tagSet.size() != 0 ? String.valueOf(tagSet.size()) : "");
+            setTagTittle("Tags: " + tagSet.toString());
+
+            removeButtons.put(tag, closeButton);
+        } //
     }
 
     /**
@@ -552,18 +614,24 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
      * corresponding {@link VariableRow}.
      */
     private void initVariableControls() {
+        GWT.log("Initializing Variable Controls");
         deleteButton.setIcon(IconType.TRASH);
         String cdt = getCustomDataType();
         if (cdt != null && !cdt.isEmpty()) {
             customDataType.setValue(cdt);
+            GWT.log("Initializing Custom Data Type: " + cdt);
             dataType.setValue(cdt);
         } else if (getDataTypeDisplayName() != null) {
+            GWT.log("Initializing Data Type: " + getDataTypeDisplayName());
             dataType.setValue(getDataTypeDisplayName());
         }
     }
 
     @Override
     public void notifyModelChanged() {
+        GWT.log("Model Changed");
+        GWT.log("Model Changed Tags: " + tagSet);
+
         String oldValue = currentValue;
         currentValue = getModel().toString();
         currentName = getModel().getName();
@@ -572,6 +640,12 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                 parentWidget.notifyModelChanged();
             }
         } else if (!oldValue.equals(currentValue)) {
+            parentWidget.notifyModelChanged();
+        }
+
+        if (tagSet.size() != 0) {
+            GWT.log("There are some tags, notifying model changed");
+            GWT.log("Values of tags: " + getModel().getTags());
             parentWidget.notifyModelChanged();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -18,27 +18,30 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.fields.variablesEdito
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.AnchorElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.text.shared.Renderer;
-import com.google.gwt.user.client.Timer;
 import elemental2.dom.CSSProperties;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
+import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLInputElement;
+import elemental2.dom.HTMLLabelElement;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
-import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.ValueListBox;
@@ -60,12 +63,10 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.ComboBoxView;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.CustomDataTypeTextBox;
 import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTextBox;
-import org.kie.workbench.common.stunner.lienzo.primitive.PrimitiveTooltip;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.workbench.events.NotificationEvent;
 
 import static jsinterop.annotations.JsPackage.GLOBAL;
-import static org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils.createDataTypeDisplayName;
 
 /**
  * A templated widget that will be used to display a row in a table of
@@ -102,6 +103,11 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     private String currentValue;
     private String currentName;
 
+    protected Set<String> tagSet = new HashSet<>();
+
+    @Inject
+    private org.jboss.errai.common.client.dom.Document document;
+
     @Inject
     @DataField("variable-tags-settings")
     private HTMLAnchorElement variableTagsSettings;
@@ -109,6 +115,10 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     @Inject
     @DataField("tags-div")
     HTMLDivElement tagsDiv;
+
+    @Inject
+    @DataField
+    HTMLDivElement tagsContainer;
 
     @Inject
     @DataField("some-check")
@@ -120,19 +130,20 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Inject
     @DataField
+    private Span acceptButton;
+
+    @Inject
+    @DataField
     protected Span tagCount;
 
     @Inject
     @DataField
-    protected CustomDataTypeTextBox customClassName;
+    protected CustomDataTypeTextBox customTagName;
 
     @Inject
-    protected ComboBox classNamesComboBox;
+    protected ComboBox tagNamesComboBox;
 
-    protected Map<String, String> dataTypes = new TreeMap<>();
-
-    // @Inject
-   // private JQueryProducer.JQuery<Popover> durationTimerHelpPopover;
+    protected List<String> tagNamesList = new ArrayList<>();
 
     @DataField
     protected ValueListBox<String> dataType = new ValueListBox<>(new Renderer<String>() {
@@ -170,7 +181,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     protected HTMLDivElement tagsTD;
 
     @DataField
-    protected ValueListBox<String> defaultClassNames = new ValueListBox<>(new Renderer<String>() {
+    protected ValueListBox<String> defaultTagNames = new ValueListBox<>(new Renderer<String>() {
         public String render(final String object) {
             return object != null ? object : "";
         }
@@ -250,7 +261,6 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
             }
         });
 
-
         PopOver.$(variableTagsSettings).popovers();
 
         setTagTittle("This is a new title");
@@ -258,7 +268,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
             variableTagsSettings.onclick = e -> {
                 GWT.log("Item has been clicked");
                 GWT.log("Next Sibling: " + variableTagsSettings.nextElementSibling.innerHTML);
-                ((HTMLDivElement) variableTagsSettings.nextElementSibling).style.left = "200px";
+                ((HTMLDivElement) variableTagsSettings.nextElementSibling).style.left = "130px";
 
                 GWT.log("Next Sibling Child Count: " + variableTagsSettings.nextElementSibling.childElementCount);
                 Element lastNode = variableTagsSettings.nextElementSibling.lastElementChild;
@@ -266,92 +276,63 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                 GWT.log("some check value is: " + somecheck.checked);
                 lastNode.innerHTML = "";
                 lastNode.appendChild(tagsDiv);
-               // ((HTMLDivElement) variableTagsSettings.nextElementSibling.lastElementChild).style.maxWidth = CSSProperties.MaxWidthUnionType.of("320px");
+                // ((HTMLDivElement) variableTagsSettings.nextElementSibling.lastElementChild).style.maxWidth = CSSProperties.MaxWidthUnionType.of("320px");
 
-                new Timer() {
-                    @Override
-                    public void run() {
+                GWT.log("Inner Html: " + variableTagsSettings.nextElementSibling.lastElementChild.innerHTML);
+                GWT.log("Style: " + variableTagsSettings.nextElementSibling.lastElementChild.getAttribute("style"));
+                GWT.log("Style: " + variableTagsSettings.nextElementSibling.lastElementChild.getAttribute("class"));
 
-                        GWT.log("Inner Html: " +variableTagsSettings.nextElementSibling.lastElementChild.innerHTML);
-                        GWT.log("Style: " +variableTagsSettings.nextElementSibling.lastElementChild.getAttribute("style"));
-                        GWT.log("Style: " +variableTagsSettings.nextElementSibling.lastElementChild.getAttribute("class"));
-
-                        //variableTagsSettings.nextElementSibling.lastElementChild.setAttribute("style", "max-width: 300px;");
-
-                    //    variableTagsSettings.nextElementSibling.setAttribute("style", "max-width: 300px;");
-
-                        ((HTMLDivElement) variableTagsSettings.nextElementSibling).style.maxWidth = CSSProperties.MaxWidthUnionType.of("300px");
-                    }
-                }.schedule(100);
-
+                ((HTMLDivElement) variableTagsSettings.nextElementSibling).style.maxWidth = CSSProperties.MaxWidthUnionType.of("280px");
 
                 tagsDiv.style.display = "block";
                 return null;
             };
         }
 
-        customClassName.addKeyDownHandler(event -> {
+        customTagName.addKeyDownHandler(event -> {
             int iChar = event.getNativeKeyCode();
             if (iChar == ' ') {
                 event.preventDefault();
             }
         });
 
-        loadDefaultDataTypes();
-        setListItems();
+        loadDefaultTagNames();
+        setTagsListItems();
     }
 
-
-    protected void loadDefaultDataTypes() {
-        List<String> dataTypes = new ArrayList<>();
-        dataTypes.add("internal");
-        dataTypes.add("required");
-        dataTypes.add("readonly");
-        dataTypes.add("input");
-        dataTypes.add("output");
-        dataTypes.add("business relevant");
-
-        addDataTypes(dataTypes);
+    protected void loadDefaultTagNames() {
+        List<String> tagNames = new ArrayList<>();
+        tagNames.add("internal");
+        tagNames.add("required");
+        tagNames.add("readonly");
+        tagNames.add("input");
+        tagNames.add("output");
+        tagNames.add("business relevant");
+        tagNamesList.addAll(tagNames);
     }
 
-    protected void addDataTypes(List<String> dataTypesList) {
-        for (String dataType : dataTypesList) {
-            String displayName = dataType;
-            dataTypes.put(dataType, displayName);
-        }
-    }
-
-    private void setListItems() {
-        Map<String, String> dataTypes = this.dataTypes;
+    private void setTagsListItems() {
 
         ListBoxValues classNameListBoxValues = new ListBoxValues(VariableListItemWidgetView.CUSTOM_PROMPT,
                                                                  "Edit" + " ",
                                                                  null);
 
-        List<String> displayNames = new ArrayList<>(dataTypes.values());
-        classNameListBoxValues.addValues(displayNames);
-        classNamesComboBox.setShowCustomValues(true);
-        classNamesComboBox.setListBoxValues(classNameListBoxValues);
+        classNameListBoxValues.addValues(tagNamesList);
+        tagNamesComboBox.setShowCustomValues(true);
+        tagNamesComboBox.setListBoxValues(classNameListBoxValues);
 
-        String className = "MyClass";
-        if (className == null) {
-            className = "";
-        }
+        defaultTagNames.setValue("");
 
-        String displayName = dataTypes.getOrDefault(className, "");
-        defaultClassNames.setValue(displayName);
-
-        classNamesComboBox.init(this,
-                                true,
-                                defaultClassNames,
-                                customClassName,
-                                false,
-                                true,
-                                CUSTOM_PROMPT,
-                                ENTER_TYPE_PROMPT);
-
-
+        tagNamesComboBox.init(this,
+                              true,
+                              defaultTagNames,
+                              customTagName,
+                              false,
+                              true,
+                              CUSTOM_PROMPT,
+                              ENTER_TYPE_PROMPT);
     }
+
     private void setTagTittle(final String title) {
         variableTagsSettings.setAttribute("title", title);
         tagCount.setAttribute("title", title);
@@ -432,6 +413,57 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         variableTagsSettings.click();
     }
 
+    @EventHandler("acceptButton")
+    public void handleAcceptButton(final ClickEvent e) {
+        final String tag = tagNamesComboBox.getValue();
+        if (tag != null && !tag.isEmpty() && !tagSet.contains(tag)) {
+            GWT.log("Adding Message: " + tag);
+
+            final Span tagSpan = (Span) document.createElement("Span");
+            tagSpan.setTextContent(tag);
+            tagSpan.setClassName("badge tagBadge  tagBadges");
+
+            final Span closeSpan = (Span) document.createElement("Span");
+            closeSpan.setTextContent("x");
+            closeSpan.setClassName("close tagCloseButton tagBadges");
+
+            final org.jboss.errai.common.client.dom.Button closeSpan2 = (org.jboss.errai.common.client.dom.Button) document.createElement("button");
+            closeSpan2.setTextContent("x");
+            closeSpan2.setClassName("close tagCloseButton tagBadges");
+
+            tagSpan.appendChild(closeSpan);
+            tagSpan.appendChild(closeSpan2);
+
+
+            closeSpan2.setOnclick(ex ->     {
+                GWT.log("Item has been clicked");
+                ex.preventDefault();
+                //tagSet.remove(tag);
+                //tagSpan.getParentElement().removeChild(tagSpan);
+            });
+
+            HTMLAnchorElement someButton = (HTMLAnchorElement) document.createElement("a");
+
+            someButton.textContent = "XXX";
+
+            someButton.onclick = ex -> {
+                GWT.log("Item has been clicked 2");
+                ex.preventDefault();
+                tagSet.remove(tag);
+          //      tagSpan.getParentElement().removeChild(tagSpan);
+                tagsContainer.innerHTML = "";
+                return null;
+            };
+
+            tagsContainer.innerHTML += tagSpan.getOuterHTML();
+            tagsContainer.appendChild(someButton);
+
+
+
+            tagSet.add(tag);
+
+        }
+    }
 
     /**
      * Updates the display of this row according to the state of the
@@ -475,5 +507,4 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
         public native void popovers();
     }
-
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -22,11 +22,18 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.text.shared.Renderer;
+import elemental2.dom.CSSProperties;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLInputElement;
+import elemental2.dom.Node;
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsType;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.ValueListBox;
@@ -50,6 +57,8 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTe
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.workbench.events.NotificationEvent;
 
+import static jsinterop.annotations.JsPackage.GLOBAL;
+
 /**
  * A templated widget that will be used to display a row in a table of
  * {@link VariableRow}s.
@@ -58,7 +67,7 @@ import org.uberfire.workbench.events.NotificationEvent;
  * they use a combination of ListBox and TextBox to implement a drop-down combo
  * to hold the values.
  */
-@Templated("VariablesEditorWidget.html#variableRow")
+@Templated(value = "VariablesEditorWidget.html#variableRow", stylesheet = "VariablesEditorWidget.css")
 public class VariableListItemWidgetViewImpl implements VariableListItemWidgetView,
                                                        ComboBoxView.ModelPresenter {
 
@@ -84,6 +93,26 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     private String currentValue;
     private String currentName;
+
+    @Inject
+    @DataField("variable-tags-settings")
+    private HTMLAnchorElement variableTagsSettings;
+
+    @Inject
+    @DataField("tags-div")
+    HTMLDivElement tagsDiv;
+
+    @Inject
+    @DataField("some-check")
+    protected HTMLInputElement somecheck;
+
+    @Inject
+    @DataField
+    protected Button closeButton;
+
+
+    // @Inject
+   // private JQueryProducer.JQuery<Popover> durationTimerHelpPopover;
 
     @DataField
     protected ValueListBox<String> dataType = new ValueListBox<>(new Renderer<String>() {
@@ -195,8 +224,24 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
         kpi.addEventListener("change", (evt) -> notifyModelChanged());
 
+        PopOver.$(variableTagsSettings).popovers();
+
+        variableTagsSettings.onclick = e -> {
+            GWT.log("Item has been clicked");
+            GWT.log("Next Sibling: " + variableTagsSettings.nextElementSibling.innerHTML);
+            GWT.log("Next Sibling Child Count: " + variableTagsSettings.nextElementSibling.childElementCount);
+            Element lastNode = variableTagsSettings.nextElementSibling.lastElementChild;
+            GWT.log("Last Sibling Child Count: " + lastNode);
+            GWT.log("some check value is: " + somecheck.checked);
+            lastNode.innerHTML= "";
+            lastNode.appendChild(tagsDiv);
+            tagsDiv.style.display = "block";
+            return null;
+        };
+
     }
 
+    private static boolean initialized = false;
     @Override
     public VariableRow getModel() {
         return variableRow.getModel();
@@ -268,6 +313,12 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         parentWidget.removeVariable(getModel());
     }
 
+    @EventHandler("closeButton")
+    public void handleCloseButton(final ClickEvent e) {
+        variableTagsSettings.click();
+    }
+
+
     /**
      * Updates the display of this row according to the state of the
      * corresponding {@link VariableRow}.
@@ -303,4 +354,16 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         this.kpi.remove();
         this.kpiTD.remove();
     }
+
+
+
+    @JsType(isNative = true)
+    private static abstract class PopOver {
+
+        @JsMethod(namespace = GLOBAL, name = "jQuery")
+        public native static PopOver $(final elemental2.dom.Node selector);
+
+        public native void popovers();
+    }
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -26,12 +26,10 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.text.shared.Renderer;
-import elemental2.dom.CSSProperties;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLInputElement;
-import elemental2.dom.Node;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
 import org.gwtbootstrap3.client.ui.Button;
@@ -147,12 +145,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Inject
     @DataField
-    @Bound
-    protected HTMLInputElement kpi;
-
-    @Inject
-    @DataField
-    protected HTMLDivElement kpiTD;
+    protected HTMLDivElement tagsTD;
 
     /**
      * Required for implementation of Delete button.
@@ -222,22 +215,23 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
             }
         });
 
-        kpi.addEventListener("change", (evt) -> notifyModelChanged());
 
         PopOver.$(variableTagsSettings).popovers();
 
-        variableTagsSettings.onclick = e -> {
-            GWT.log("Item has been clicked");
-            GWT.log("Next Sibling: " + variableTagsSettings.nextElementSibling.innerHTML);
-            GWT.log("Next Sibling Child Count: " + variableTagsSettings.nextElementSibling.childElementCount);
-            Element lastNode = variableTagsSettings.nextElementSibling.lastElementChild;
-            GWT.log("Last Sibling Child Count: " + lastNode);
-            GWT.log("some check value is: " + somecheck.checked);
-            lastNode.innerHTML= "";
-            lastNode.appendChild(tagsDiv);
-            tagsDiv.style.display = "block";
-            return null;
-        };
+        if (variableTagsSettings != null) {
+            variableTagsSettings.onclick = e -> {
+                GWT.log("Item has been clicked");
+                GWT.log("Next Sibling: " + variableTagsSettings.nextElementSibling.innerHTML);
+                GWT.log("Next Sibling Child Count: " + variableTagsSettings.nextElementSibling.childElementCount);
+                Element lastNode = variableTagsSettings.nextElementSibling.lastElementChild;
+                GWT.log("Last Sibling Child Count: " + lastNode);
+                GWT.log("some check value is: " + somecheck.checked);
+                lastNode.innerHTML = "";
+                lastNode.appendChild(tagsDiv);
+                tagsDiv.style.display = "block";
+                return null;
+            };
+        }
 
     }
 
@@ -297,7 +291,6 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         deleteButton.setEnabled(!readOnly);
         dataTypeComboBox.setReadOnly(readOnly);
         name.setEnabled(!readOnly);
-        kpi.disabled = readOnly;
     }
 
     private boolean isDuplicateName(final String name) {
@@ -349,13 +342,9 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     }
 
     @Override
-    public void setKPINotEnabled() {
-        this.kpi.disabled = true;
-        this.kpi.remove();
-        this.kpiTD.remove();
+    public void setTagsNotEnabled() {
+        this.tagsTD.remove();
     }
-
-
 
     @JsType(isNative = true)
     private static abstract class PopOver {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -27,18 +27,13 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.AnchorElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.text.shared.Renderer;
 import elemental2.dom.CSSProperties;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
-import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
-import elemental2.dom.HTMLInputElement;
 import elemental2.dom.HTMLLabelElement;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
@@ -119,10 +114,6 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     @Inject
     @DataField
     HTMLDivElement tagsContainer;
-
-    @Inject
-    @DataField("some-check")
-    protected HTMLInputElement somecheck;
 
     @Inject
     @DataField
@@ -273,7 +264,6 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                 GWT.log("Next Sibling Child Count: " + variableTagsSettings.nextElementSibling.childElementCount);
                 Element lastNode = variableTagsSettings.nextElementSibling.lastElementChild;
                 GWT.log("Last Sibling Child Count: " + lastNode);
-                GWT.log("some check value is: " + somecheck.checked);
                 lastNode.innerHTML = "";
                 lastNode.appendChild(tagsDiv);
                 // ((HTMLDivElement) variableTagsSettings.nextElementSibling.lastElementChild).style.maxWidth = CSSProperties.MaxWidthUnionType.of("320px");
@@ -283,6 +273,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
                 GWT.log("Style: " + variableTagsSettings.nextElementSibling.lastElementChild.getAttribute("class"));
 
                 ((HTMLDivElement) variableTagsSettings.nextElementSibling).style.maxWidth = CSSProperties.MaxWidthUnionType.of("280px");
+                ((HTMLDivElement) variableTagsSettings.nextElementSibling).style.minHeight = CSSProperties.MinHeightUnionType.of("280px");
 
                 tagsDiv.style.display = "block";
                 return null;
@@ -419,49 +410,32 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         if (tag != null && !tag.isEmpty() && !tagSet.contains(tag)) {
             GWT.log("Adding Message: " + tag);
 
-            final Span tagSpan = (Span) document.createElement("Span");
-            tagSpan.setTextContent(tag);
-            tagSpan.setClassName("badge tagBadge  tagBadges");
+            final HTMLLabelElement tagLabel = (HTMLLabelElement) document.createElement("label");
+            tagLabel.textContent = tag;
+            tagLabel.className = "badge tagBadge  tagBadges";
+            tagLabel.htmlFor = "closeButton";
 
-            final Span closeSpan = (Span) document.createElement("Span");
-            closeSpan.setTextContent("x");
-            closeSpan.setClassName("close tagCloseButton tagBadges");
+            final HTMLAnchorElement closeButton = (HTMLAnchorElement) document.createElement("a");
+            closeButton.id = "closeButton";
+            closeButton.textContent = "x";
+            closeButton.className = "close tagCloseButton tagBadges";
 
-            final org.jboss.errai.common.client.dom.Button closeSpan2 = (org.jboss.errai.common.client.dom.Button) document.createElement("button");
-            closeSpan2.setTextContent("x");
-            closeSpan2.setClassName("close tagCloseButton tagBadges");
-
-            tagSpan.appendChild(closeSpan);
-            tagSpan.appendChild(closeSpan2);
-
-
-            closeSpan2.setOnclick(ex ->     {
-                GWT.log("Item has been clicked");
-                ex.preventDefault();
-                //tagSet.remove(tag);
-                //tagSpan.getParentElement().removeChild(tagSpan);
-            });
-
-            HTMLAnchorElement someButton = (HTMLAnchorElement) document.createElement("a");
-
-            someButton.textContent = "XXX";
-
-            someButton.onclick = ex -> {
+            closeButton.onclick = ex -> {
                 GWT.log("Item has been clicked 2");
-                ex.preventDefault();
                 tagSet.remove(tag);
-          //      tagSpan.getParentElement().removeChild(tagSpan);
-                tagsContainer.innerHTML = "";
+                tagLabel.remove();
+                closeButton.remove();
+                ex.preventDefault();
+                tagCount.setTextContent(tagSet.size() != 0 ? String.valueOf(tagSet.size()) : "");
+                setTagTittle("Tags: " + tagSet.toString());
                 return null;
             };
 
-            tagsContainer.innerHTML += tagSpan.getOuterHTML();
-            tagsContainer.appendChild(someButton);
-
-
-
+            tagLabel.appendChild(closeButton);
+            tagsContainer.appendChild(tagLabel);
             tagSet.add(tag);
-
+            tagCount.setTextContent(tagSet.size() != 0 ? String.valueOf(tagSet.size()) : "");
+            setTagTittle("Tags: " + tagSet.toString());
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
@@ -116,7 +117,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
     @Inject
     @DataField("variable-tags-settings")
-    private HTMLAnchorElement variableTagsSettings;
+    protected HTMLAnchorElement variableTagsSettings;
 
     @Inject
     @DataField("tags-div")
@@ -273,7 +274,6 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         PopOver.$(variableTagsSettings).popovers();
 
         setTagTittle("Tags: ");
-        if (variableTagsSettings != null) {
 
                 variableTagsSettings.onclick = e -> {
                 // This is needed when opened
@@ -345,7 +345,7 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
                  return null;
             };
-        }
+
 
         customTagName.addFocusHandler(focusEvent -> {
             previousCustomValue = customTagName.getValue();
@@ -435,6 +435,18 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
     @Override
     public void setCustomDataType(final String customDataType) {
         getModel().setCustomDataType(customDataType);
+    }
+
+    @Override
+    public void setCustomTags(final List<String> tags) {
+        getModel().setTags(tags);
+        tagNamesList = tags;
+        setTagsListItems();
+    }
+
+    @Override
+    public List<String> getCustomTags() {
+        return new ArrayList<>(tagSet);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
 import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
 import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.FormGroup;
@@ -57,6 +58,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
     Map<String, String> mapDataTypeNamesToDisplayNames = null;
     Map<String, String> mapDataTypeDisplayNamesToNames = null;
     ListBoxValues dataTypeListBoxValues;
+
     private VariablesEditorWidgetView view;
     private Variable.VariableType variableType = Variable.VariableType.PROCESS;
     private List<String> dataTypes = new ArrayList<>();
@@ -115,6 +117,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
 
     @Override
     public void addVariable() {
+        GWT.log("Adding Variable");
         List<VariableRow> as = view.getVariableRows();
         if (as.isEmpty()) {
             view.setTableDisplayStyle();
@@ -123,6 +126,8 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
         newVariable.setVariableType(variableType);
         as.add(newVariable);
         VariableListItemWidgetView widget = view.getVariableWidget(view.getVariableRowsCount() - 1);
+        GWT.log("Adding Variable Data Types: " + dataTypeListBoxValues);
+
         widget.setDataTypes(dataTypeListBoxValues);
         widget.setParentWidget(this);
         checkTagsNotEnabled();
@@ -131,6 +136,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
     @Override
     public void setDataTypes(final List<String> dataTypes,
                              final List<String> dataTypeDisplayNames) {
+        GWT.log("Rendering Data Types :" + dataTypes);
         this.dataTypes = dataTypes;
         this.mapDataTypeNamesToDisplayNames = createMapDataTypeNamesToDisplayNames(dataTypes,
                                                                                    dataTypeDisplayNames);
@@ -170,6 +176,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
 
     @Override
     public List<VariableRow> deserializeVariables(final String s) {
+        GWT.log("Deserializing Variables: " + s);
         List<VariableRow> variableRows = new ArrayList<>();
         if (s != null && !s.isEmpty()) {
             String[] vs = s.split(",");
@@ -178,6 +185,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
                     Variable var = Variable.deserialize(v,
                                                         Variable.VariableType.PROCESS,
                                                         dataTypes);
+                    GWT.log("variable After Deserialize: " + var);
                     if (var != null && var.getName() != null && !var.getName().isEmpty()) {
                         variableRows.add(new VariableRow(var,
                                                          mapDataTypeNamesToDisplayNames));
@@ -197,6 +205,10 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
                                            mapDataTypeDisplayNamesToNames));
             }
         }
+
+        GWT.log("Serializing Variables: " + variables);
+        GWT.log("String Serializing Variables: " + StringUtils.getStringForList(variables));
+
         return StringUtils.getStringForList(variables);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
@@ -94,7 +94,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
 
         formGroup.render(view.asWidget(), field);
 
-        checkKPINotEnabled();
+        checkTagsNotEnabled();
 
         if (field != null && field.isCaseFileVariable()) {
             findVariableUsagesFlags = EnumSet.of(CASE_FILE_VARIABLE);
@@ -125,7 +125,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
         VariableListItemWidgetView widget = view.getVariableWidget(view.getVariableRowsCount() - 1);
         widget.setDataTypes(dataTypeListBoxValues);
         widget.setParentWidget(this);
-        checkKPINotEnabled();
+        checkTagsNotEnabled();
     }
 
     @Override
@@ -259,9 +259,9 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
         return path;
     }
 
-    private void checkKPINotEnabled() {
+    private void checkTagsNotEnabled() {
         if (this.field != null && !this.field.getId().equals("processVariables")) {
-            this.view.setKPINotEnabled();
+            this.view.setTagsNotEnabled();
         }
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
@@ -34,6 +34,8 @@
 
 .acceptButton {
     color: #00659c;
+    padding-left: 10px;
+    cursor: pointer;
 }
 
 .tagBadges {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
@@ -1,0 +1,27 @@
+.containerDiv {
+    width: 40px;
+    height: 26px;
+}
+
+.tagAnchor {
+    width: 26px;
+    height: 26px;
+    font-size:18px;
+    font-weight: bold;
+    cursor: pointer;
+    color: #0060B6;
+    text-decoration: none;"
+}
+
+.tagSpan {
+    margin-left: 25px;
+    color: black;
+}
+
+.tagsSVG {
+    display: inline-block;
+    content: "";
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjAgMjAiIGRhdGEtdG9nZ2xlPSJ0b29sdGlwIiBjbGFzcz0iYmkgYmktdGFnLWZpbGwiIHdpZHRoPSIyNnB4IiBoZWlnaHQ9IjI2cHgiICBmaWxsPSJjdXJyZW50Q29sb3IiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDNhMSAxIDAgMDAtMSAxdjQuNTg2YTEgMSAwIDAwLjI5My43MDdsNyA3YTEgMSAwIDAwMS40MTQgMGw0LjU4Ni00LjU4NmExIDEgMCAwMDAtMS40MTRsLTctN0ExIDEgMCAwMDguNTg2IDNINHptNCAzLjVhMS41IDEuNSAwIDExLTMgMCAxLjUgMS41IDAgMDEzIDB6IiBjbGlwLXJ1bGU9ImV2ZW5vZGQiPjwvcGF0aD4KICAgIDwvc3ZnPgo=");
+    background-repeat: no-repeat;
+}
+

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
@@ -1,5 +1,5 @@
 .containerDiv {
-    width: 40px;
+    width: 30px;
     height: 26px;
 }
 
@@ -23,7 +23,7 @@
     content: "";
     background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjAgMjAiIGRhdGEtdG9nZ2xlPSJ0b29sdGlwIiBjbGFzcz0iYmkgYmktdGFnLWZpbGwiIHdpZHRoPSIyNnB4IiBoZWlnaHQ9IjI2cHgiICBmaWxsPSJjdXJyZW50Q29sb3IiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDNhMSAxIDAgMDAtMSAxdjQuNTg2YTEgMSAwIDAwLjI5My43MDdsNyA3YTEgMSAwIDAwMS40MTQgMGw0LjU4Ni00LjU4NmExIDEgMCAwMDAtMS40MTRsLTctN0ExIDEgMCAwMDguNTg2IDNINHptNCAzLjVhMS41IDEuNSAwIDExLTMgMCAxLjUgMS41IDAgMDEzIDB6IiBjbGlwLXJ1bGU9ImV2ZW5vZGQiPjwvcGF0aD4KICAgIDwvc3ZnPgo=");
     background-repeat: no-repeat;
-    margin-left: 10px;
+    margin-left: 0px;
 
 }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
@@ -27,7 +27,34 @@
 
 }
 
-.popov {
-    max-width: 320px;
+.tagsDiv {
+    width: 200px;
+    display: none;
 }
 
+.acceptButton {
+    color: #00659c;
+}
+
+.tagBadges {
+    adding-right: .6em;
+    padding-left: .6em;
+    border-radius: 10rem;
+}
+
+.tagCloseButton {
+    font-size:13px;
+    cursor: pointer;
+    color: #0060B6;
+}
+
+
+.tagBadge {
+    font-size:15px;
+    padding-right: 10px;
+    color: #0060B6;
+    background-color: #F5F5F5;
+    font-family: "Open Sans",Helvetica,Arial,sans-serif;
+    font-style: normal;
+    font-weight: 400;
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.css
@@ -23,5 +23,11 @@
     content: "";
     background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjAgMjAiIGRhdGEtdG9nZ2xlPSJ0b29sdGlwIiBjbGFzcz0iYmkgYmktdGFnLWZpbGwiIHdpZHRoPSIyNnB4IiBoZWlnaHQ9IjI2cHgiICBmaWxsPSJjdXJyZW50Q29sb3IiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDNhMSAxIDAgMDAtMSAxdjQuNTg2YTEgMSAwIDAwLjI5My43MDdsNyA3YTEgMSAwIDAwMS40MTQgMGw0LjU4Ni00LjU4NmExIDEgMCAwMDAtMS40MTRsLTctN0ExIDEgMCAwMDguNTg2IDNINHptNCAzLjVhMS41IDEuNSAwIDExLTMgMCAxLjUgMS41IDAgMDEzIDB6IiBjbGlwLXJ1bGU9ImV2ZW5vZGQiPjwvcGF0aD4KICAgIDwvc3ZnPgo=");
     background-repeat: no-repeat;
+    margin-left: 10px;
+
+}
+
+.popov {
+    max-width: 320px;
 }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
@@ -62,14 +62,14 @@
                                 <input type="text" class="form-control" data-field="customDataType"/>
                             </td>
 
-                            <td style="width:22%" data-field="tagsTD" title = "These are the tags included 2" >
-                                <div class = "containerDiv" title = "These are the tags included 3">
-                                    <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-placement="bottom" data-toggle="popover" data-html="true" data-content="S">
+                            <td style="width:22%" data-field="tagsTD">
+                                <div class = "containerDiv" title = "Tags">
+                                    <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-dismiss="onblur" data-placement="bottom" data-toggle="popover" data-html="true" data-content="OverlayContent">
                                         <span data-field ="tagCount"  title = "These are the tags included " class = "tagSpan"></span>
                                     </a>
                                 </div>
 
-                                <div data-field = "tags-div" class = "tagsDiv">
+                                <div style="display:none;"   data-field = "tags-div" class = "tagsDiv">
 
                                     <button type="button" class ="close" data-field="closeButton">x</button>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
@@ -39,11 +39,7 @@
                                 Data Type
                             </th>
 
-                            <th data-field="kpith" style="width:4%">
-                                KPI
-                            </th>
-
-                            <th style="width:20%">
+                            <th style="width:24%" data-field="tagsth">
                                 Tags
                                 <i class="fa fa-info-circle" title = "Variable Tags Info Go Here"/>
                             </th>
@@ -66,11 +62,7 @@
                                 <input type="text" class="form-control" data-field="customDataType"/>
                             </td>
 
-                            <td style="width:4%" data-field="kpiTD">
-                                <input type="checkbox" style="margin-left:15px; margin-top:10px" data-field="kpi"/>
-                            </td>
-
-                            <td style="width:20%">
+                            <td style="width:24%" data-field="tagsTD">
                                 <div class = "containerDiv">
                                     <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-placement="bottom" data-toggle="popover" data-html="true" data-content="Something Before <button>Sample Pop Over Text</button> Something After">
                                         <span id = "tagCount" class = "tagSpan">4</span>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
@@ -35,16 +35,16 @@
                             <th data-field="nameth" style="width:32%">
                                 Name
                             </th>
-                            <th data-field="datatypeth" style="width:40%">
+                            <th data-field="datatypeth" style="width:43%">
                                 Data Type
                             </th>
 
-                            <th style="width:24%" data-field="tagsth">
+                            <th style="width:22%" data-field="tagsth">
                                 Tags
                                 <i class="fa fa-info-circle" title = "Variable Tags Info Go Here"/>
                             </th>
 
-                            <td style="width:4%">
+                            <td style="width:3%">
                                 <button type="button" class="center-block" data-field="addVarButton"></button>
                             </td>
                         </tr>
@@ -54,7 +54,7 @@
                             <td style="width:32%">
                                 <input type="text" class="form-control" data-field="name"/>
                             </td>
-                            <td style="width:40%">
+                            <td style="width:43%">
                                 <select data-field="dataType" class="form-control">
                                     <option value="Integer">Integer</option>
                                     <option value="String">String</option>
@@ -62,18 +62,22 @@
                                 <input type="text" class="form-control" data-field="customDataType"/>
                             </td>
 
-                            <td style="width:24%" data-field="tagsTD">
-                                <div class = "containerDiv">
-                                    <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-placement="bottom" data-toggle="popover" data-html="true" data-content="Something Before <button>Sample Pop Over Text</button> Something After">
-                                        <span id = "tagCount" class = "tagSpan">4</span>
+                            <td style="width:22%" data-field="tagsTD" title = "These are the tags included 2" >
+                                <div class = "containerDiv" title = "These are the tags included 3">
+                                    <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-placement="bottom" data-toggle="popover" data-html="true" data-content="S">
+                                        <span data-field ="tagCount"  title = "These are the tags included " class = "tagSpan">4</span>
                                     </a>
                                 </div>
 
-                                <div data-field = "tags-div" style = "display: none; ">
+                                <div data-field = "tags-div" style = "width: 250px; display: none; ">
 
                                     <button type="button" class ="close" data-field="closeButton">x</button>
 
-                                    Variable tags                                      .
+                                    Variable tags     Information                                 .
+
+                                    <select data-field="defaultClassNames" class="form-control"/>
+                                    <input class="form-control" data-field="customClassName" type="text"/>
+
 
                                     <input type="checkbox" class="center-block" data-field="some-check"/>
 
@@ -84,7 +88,7 @@
                                 </div>
                             </td>
 
-                            <td style="width:4%">
+                            <td style="width:3%">
                                 <button type="button" class="center-block" data-field="deleteButton"></button>
                             </td>
                         </tr>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
@@ -41,7 +41,7 @@
 
                             <th style="width:22%" data-field="tagsth">
                                 Tags
-                                <i class="fa fa-info-circle" title = "Variable Tags Info Go Here"/>
+                                <i class="fa fa-info-circle" title = "Add Predefined or Custom Tags to Variables"/>
                             </th>
 
                             <td style="width:3%">

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
@@ -16,7 +16,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+
 </head>
+
 
 <body>
 
@@ -30,15 +32,20 @@
                     <table class="table table-striped table-bordered" data-field="table">
                         <thead>
                         <tr>
-                            <th data-field="nameth" style="width:46%">
+                            <th data-field="nameth" style="width:32%">
                                 Name
                             </th>
-                            <th data-field="datatypeth" style="width:46%">
+                            <th data-field="datatypeth" style="width:40%">
                                 Data Type
                             </th>
 
                             <th data-field="kpith" style="width:4%">
                                 KPI
+                            </th>
+
+                            <th style="width:20%">
+                                Tags
+                                <i class="fa fa-info-circle" title = "Variable Tags Info Go Here"/>
                             </th>
 
                             <td style="width:4%">
@@ -48,10 +55,10 @@
                         </thead>
                         <tbody id="variableRows">
                         <tr id="variableRow">
-                            <td style="width:46%">
+                            <td style="width:32%">
                                 <input type="text" class="form-control" data-field="name"/>
                             </td>
-                            <td style="width:46%">
+                            <td style="width:40%">
                                 <select data-field="dataType" class="form-control">
                                     <option value="Integer">Integer</option>
                                     <option value="String">String</option>
@@ -59,11 +66,33 @@
                                 <input type="text" class="form-control" data-field="customDataType"/>
                             </td>
 
-                            <td style="width:4%">
-                                <input type="checkbox" class="center-block" data-field="kpi"/>
+                            <td style="width:4%" data-field="kpiTD">
+                                <input type="checkbox" style="margin-left:15px; margin-top:10px" data-field="kpi"/>
                             </td>
 
-                            <td style="width:4%" data-field="kpiTD">
+                            <td style="width:20%">
+                                <div class = "containerDiv">
+                                    <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-placement="bottom" data-toggle="popover" data-html="true" data-content="Something Before <button>Sample Pop Over Text</button> Something After">
+                                        <span id = "tagCount" class = "tagSpan">4</span>
+                                    </a>
+                                </div>
+
+                                <div data-field = "tags-div" style = "display: none; ">
+
+                                    <button type="button" class ="close" data-field="closeButton">x</button>
+
+                                    Variable tags                                      .
+
+                                    <input type="checkbox" class="center-block" data-field="some-check"/>
+
+                                    <input type="checkbox" class="center-block" />
+
+                                    <input type="checkbox" class="center-block" />
+
+                                </div>
+                            </td>
+
+                            <td style="width:4%">
                                 <button type="button" class="center-block" data-field="deleteButton"></button>
                             </td>
                         </tr>
@@ -76,4 +105,5 @@
 
 </div>
 </body>
+
 </html>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
@@ -65,8 +65,7 @@
                             <td style="width:22%" data-field="tagsTD" title = "These are the tags included 2" >
                                 <div class = "containerDiv" title = "These are the tags included 3">
                                     <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-placement="bottom" data-toggle="popover" data-html="true" data-content="S">
-                                        <span data-field ="tagCount"  title = "These are the tags included " class = "tagSpan">4</span>
-
+                                        <span data-field ="tagCount"  title = "These are the tags included " class = "tagSpan"></span>
                                     </a>
                                 </div>
 
@@ -79,20 +78,9 @@
                                     <select data-field="defaultTagNames" class="form-control selectionWidget" style = "width: 150px;"/>
                                     <input class="form-control selectionWidget" data-field="customTagName" style = "width: 150px;" type="text"/>
 
-                                    &nbsp;
-                                    &nbsp;
-
                                     <span class="glyphicon glyphicon-ok check-mark acceptButton" title = "Add Tag" data-field="acceptButton" ></span>
-
-                                    <br>
-                                    <br>
-                                    <input type="checkbox" class="center-block" data-field="some-check"/>
-
-                                    <input type="checkbox" class="center-block" />
-
-                                    <input type="checkbox" class="center-block" />
+                                    <br><br><br>
                                     <div data-field="tagsContainer">
-
                                     </div>
 
                                 </div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidget.html
@@ -66,24 +66,34 @@
                                 <div class = "containerDiv" title = "These are the tags included 3">
                                     <a class = "tagAnchor tagsSVG" data-field="variable-tags-settings" data-placement="bottom" data-toggle="popover" data-html="true" data-content="S">
                                         <span data-field ="tagCount"  title = "These are the tags included " class = "tagSpan">4</span>
+
                                     </a>
                                 </div>
 
-                                <div data-field = "tags-div" style = "width: 250px; display: none; ">
+                                <div data-field = "tags-div" class = "tagsDiv">
 
                                     <button type="button" class ="close" data-field="closeButton">x</button>
 
-                                    Variable tags     Information                                 .
+                                    <h3>Variable tags</h3>
 
-                                    <select data-field="defaultClassNames" class="form-control"/>
-                                    <input class="form-control" data-field="customClassName" type="text"/>
+                                    <select data-field="defaultTagNames" class="form-control selectionWidget" style = "width: 150px;"/>
+                                    <input class="form-control selectionWidget" data-field="customTagName" style = "width: 150px;" type="text"/>
 
+                                    &nbsp;
+                                    &nbsp;
 
+                                    <span class="glyphicon glyphicon-ok check-mark acceptButton" title = "Add Tag" data-field="acceptButton" ></span>
+
+                                    <br>
+                                    <br>
                                     <input type="checkbox" class="center-block" data-field="some-check"/>
 
                                     <input type="checkbox" class="center-block" />
 
                                     <input type="checkbox" class="center-block" />
+                                    <div data-field="tagsContainer">
+
+                                    </div>
 
                                 </div>
                             </td>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetView.java
@@ -77,5 +77,5 @@ public interface VariablesEditorWidgetView extends IsWidget {
 
     void setReadOnly(final boolean readOnly);
 
-    void setKPINotEnabled();
+    void setTagsNotEnabled();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImpl.java
@@ -78,13 +78,13 @@ public class VariablesEditorWidgetViewImpl extends Composite implements Variable
     private DataTypeNamesService clientDataTypesService;
 
     @DataField
-    protected TableCellElement kpith = Document.get().createTHElement();
+    protected TableCellElement tagsth = Document.get().createTHElement();
 
     List<String> dataTypes;
     List<String> dataTypeDisplayNames;
     boolean readOnly = false;
 
-    private boolean kpiDisabled = false;
+    private boolean tagsDisabled = false;
 
     /**
      * The list of variableRows that currently exist.
@@ -244,7 +244,6 @@ public class VariablesEditorWidgetViewImpl extends Composite implements Variable
         addVarButton.setIcon(IconType.PLUS);
         nameth.setInnerText("Name");
         datatypeth.setInnerText("Data Type");
-        kpith.setInnerText("KPI");
     }
 
     @Override
@@ -254,7 +253,7 @@ public class VariablesEditorWidgetViewImpl extends Composite implements Variable
         for (int i = 0; i < getVariableRowsCount(); i++) {
             getVariableWidget(i).setReadOnly(readOnly);
         }
-        checkKPINotEnabled();
+        checkTagsNotEnabled();
     }
 
     @Override
@@ -312,16 +311,16 @@ public class VariablesEditorWidgetViewImpl extends Composite implements Variable
     }
 
     @Override
-    public void setKPINotEnabled() {
-        kpiDisabled = true;
-        checkKPINotEnabled();
+    public void setTagsNotEnabled() {
+        tagsDisabled = true;
+        checkTagsNotEnabled();
     }
 
-    private void checkKPINotEnabled() {
-        if (kpiDisabled) {
-            kpith.removeFromParent();
+    private void checkTagsNotEnabled() {
+        if (tagsDisabled) {
+            tagsth.removeFromParent();
             for (int i = 0; i < getVariableRowsCount(); i++) {
-                getVariableWidget(i).setKPINotEnabled();
+                getVariableWidget(i).setTagsNotEnabled();
             }
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImpl.java
@@ -26,6 +26,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.TableCellElement;
@@ -139,11 +140,13 @@ public class VariablesEditorWidgetViewImpl extends Composite implements Variable
 
     protected void setDataTypes(final List<String> dataTypes,
                                 final List<String> dataTypeDisplayNames) {
+        GWT.log("- Set Data Types: " + dataTypes);
         this.dataTypes = dataTypes;
         this.dataTypeDisplayNames = dataTypeDisplayNames;
         presenter.setDataTypes(dataTypes,
                                dataTypeDisplayNames);
     }
+
 
     protected void getDataTypes(final String value,
                                 final boolean fireEvents) {
@@ -273,10 +276,13 @@ public class VariablesEditorWidgetViewImpl extends Composite implements Variable
 
     @Override
     public void setVariableRows(final List<VariableRow> rows) {
+        GWT.log("Setting Variable Rows: " + rows);
         variableRows.setValue(rows);
         for (int i = 0; i < getVariableRowsCount(); i++) {
             VariableListItemWidgetView widget = getVariableWidget(i);
             widget.setDataTypes(dataTypeListBoxValues);
+            GWT.log("Setting Tags: " + rows.get(i).getTags());
+            widget.setTagTypes(rows.get(i).getTags());
             widget.setParentWidget(presenter);
         }
     }
@@ -291,6 +297,7 @@ public class VariablesEditorWidgetViewImpl extends Composite implements Variable
         return variableRows.getComponent(index);
     }
 
+    @Override
     public void setVariablesDataTypes(final ListBoxValues dataTypeListBoxValues) {
         this.dataTypeListBoxValues = dataTypeListBoxValues;
         for (int i = 0; i < getVariableRowsCount(); i++) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/documentation/ClientBPMNDocumentationServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/documentation/ClientBPMNDocumentationServiceTest.java
@@ -167,9 +167,9 @@ public class ClientBPMNDocumentationServiceTest {
     public static final String ON_ENTRY_CAPTION = "ONENTRY_CAPTION";
     public static final String TEMPLATE = "documentationTemplate";
     public static final String ASSIGNEMNTS = "assignemnts";
-    private static final String VARIABLES = "PV1:java.lang.String:false,PV2:java.lang.Boolean:false";
-    private static final String GLOBAL_VARIABLES = "GL1:java.lang.String:false,GL2:java.lang.Boolean:false";
-    private static final String SUB_PROCESS_VARIABLES = "SUBPV1:java.lang.String:false,SUBPV2:java.lang.Boolean:false";
+    private static final String VARIABLES = "PV1:java.lang.String:[internal;input],PV2:java.lang.Boolean:[customTag;output]";
+    private static final String GLOBAL_VARIABLES = "GL1:java.lang.String:[],GL2:java.lang.Boolean:[]";
+    private static final String SUB_PROCESS_VARIABLES = "SUBPV1:java.lang.String:[internal],SUBPV2:java.lang.Boolean:[readonly;customTag]";
     private static final String ISASYNC_CAPTION = "ISASYNC_CAPTION";
     private static final String ON_EXIT_CAPTION = "ONEXIT_CAPTION";
     private static final String ICON_HTML = "icon image";
@@ -543,27 +543,27 @@ public class ClientBPMNDocumentationServiceTest {
         final ProcessVariablesTotal.VariableTriplets[] variables = dataTotal.getVariablesAsTriplets();
         assertEquals(variables[0].name, "GL1");
         assertEquals(variables[0].type, String.class.getName());
-        assertEquals(variables[0].kpi, "false");
+        assertEquals(variables[0].tags, "[]");
 
         assertEquals(variables[1].name, "GL2");
         assertEquals(variables[1].type, Boolean.class.getName());
-        assertEquals(variables[1].kpi, "false");
+        assertEquals(variables[1].tags, "[]");
 
         assertEquals(variables[2].name, "PV1");
         assertEquals(variables[2].type, String.class.getName());
-        assertEquals(variables[2].kpi, "false");
+        assertEquals(variables[2].tags, "[internal;input]");
 
         assertEquals(variables[3].name, "PV2");
         assertEquals(variables[3].type, Boolean.class.getName());
-        assertEquals(variables[3].kpi, "false");
+        assertEquals(variables[3].tags, "[customTag;output]");
 
         assertEquals(variables[4].name, "SUBPV1");
         assertEquals(variables[4].type, String.class.getName());
-        assertEquals(variables[4].kpi, "false");
+        assertEquals(variables[4].tags, "[internal]");
 
         assertEquals(variables[5].name, "SUBPV2");
         assertEquals(variables[5].type, Boolean.class.getName());
-        assertEquals(variables[5].kpi, "false");
+        assertEquals(variables[5].tags, "[readonly;customTag]");
 
         final ElementTotal[] totals = bpmnDocumentation.getElementsDetails().getTotals();
         assertEquals(totals.length, 2);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
@@ -16,17 +16,23 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.variablesEditor;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockito;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLInputElement;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.ValueListBox;
 import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.common.client.dom.Span;
 import org.jboss.errai.databinding.client.api.DataBinder;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +48,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -52,7 +59,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests the data get/set methods of VariableListItemWidget
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class VariableListItemWidgetTest {
 
     ValueListBox<String> dataType;
@@ -62,6 +69,18 @@ public class VariableListItemWidgetTest {
     ComboBox dataTypeComboBox;
 
     ComboBox tagNamesComboBox;
+
+    @GwtMock
+    ValueListBox<String> defaultTagNames;
+
+    @GwtMock
+    CustomDataTypeTextBox customTagName;
+
+    @GwtMock
+    Span tagCount;
+
+    @GwtMock
+    HTMLAnchorElement variableTagsSettings;
 
     @GwtMock
     VariableNameTextBox name;
@@ -83,6 +102,10 @@ public class VariableListItemWidgetTest {
         customDataType = mock(CustomDataTypeTextBox.class);
         dataTypeComboBox = mock(ComboBox.class);
         tagNamesComboBox = mock(ComboBox.class);
+        customTagName = mock(CustomDataTypeTextBox.class);
+        variableTagsSettings = mock(HTMLAnchorElement.class);
+        defaultTagNames = mock(ValueListBox.class);
+        tagCount = mock(Span.class);
         widget = GWT.create(VariableListItemWidgetViewImpl.class);
         VariableRow variableRow = new VariableRow();
         widget.dataType = dataType;
@@ -91,6 +114,11 @@ public class VariableListItemWidgetTest {
         widget.name = name;
         widget.deleteButton = deleteButton;
         widget.variableRow = variable;
+        widget.variableTagsSettings = variableTagsSettings;
+        widget.tagCount = tagCount;
+        widget.customTagName = customTagName;
+        widget.tagNamesComboBox = tagNamesComboBox;
+        widget.defaultTagNames = defaultTagNames;
         Mockito.doCallRealMethod().when(widget).setTextBoxModelValue(any(TextBox.class),
                                                                      anyString());
         Mockito.doCallRealMethod().when(widget).setListBoxModelValue(any(ValueListBox.class),
@@ -103,6 +131,13 @@ public class VariableListItemWidgetTest {
         Mockito.doCallRealMethod().when(widget).setDataTypes(any(ListBoxValues.class));
         Mockito.doCallRealMethod().when(widget).init();
         Mockito.doCallRealMethod().when(widget).setModel(any(VariableRow.class));
+        Mockito.doCallRealMethod().when(widget).setCustomTags(any(List.class));
+        Mockito.doCallRealMethod().when(widget).getCustomTags();
+
+        Mockito.doCallRealMethod().when(tagNamesComboBox).setListBoxValues(any());
+        Mockito.doCallRealMethod().when(tagNamesComboBox).getListBoxValues();
+
+
         when(widget.getModel()).thenReturn(variableRow);
     }
 
@@ -213,20 +248,10 @@ public class VariableListItemWidgetTest {
     }
 
     @Test
-    public void testSetKPI() {
-        String sDataType = "Boolean";
-        widget.setListBoxModelValue(widget.dataType,
-                                    sDataType);
-        tagNamesComboBox.setTextBoxValue("output");
-        String returnedDataType1 = widget.getDataTypeDisplayName();
-        assertEquals(sDataType,
-                     returnedDataType1);
-        String returnedDataType2 = widget.getModelValue(widget.dataType);
-        assertEquals(sDataType,
-                     returnedDataType2);
-        String returnedTag = widget.tagNamesComboBox.getValue();
-        assertEquals("output",
-                     returnedTag);
-
+    public void testSetTags() {
+        List<String> tags = Arrays.asList("internal", "input", "customTag");
+        widget.setCustomTags(tags);
+        assertEquals(tags, tagNamesComboBox.getListBoxValues().getAcceptableValuesWithoutCustomValues());
+        verify(tagNamesComboBox, times(1)).setListBoxValues(any());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
@@ -91,7 +91,6 @@ public class VariableListItemWidgetTest {
         widget.name = name;
         widget.deleteButton = deleteButton;
         widget.variableRow = variable;
-        widget.kpi = kpi;
         Mockito.doCallRealMethod().when(widget).setTextBoxModelValue(any(TextBox.class),
                                                                      anyString());
         Mockito.doCallRealMethod().when(widget).setListBoxModelValue(any(ValueListBox.class),
@@ -225,9 +224,9 @@ public class VariableListItemWidgetTest {
         String returnedDataType2 = widget.getModelValue(widget.dataType);
         assertEquals(sDataType,
                      returnedDataType2);
-        boolean returnedDataType3 = widget.kpi.checked;
-        assertEquals(true,
-                     returnedDataType3);
+   //     boolean returnedDataType3 = widget.kpi.checked;
+   //     assertEquals(true,
+  //                   returnedDataType3);
 
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetTest.java
@@ -61,7 +61,7 @@ public class VariableListItemWidgetTest {
 
     ComboBox dataTypeComboBox;
 
-    HTMLInputElement kpi;
+    ComboBox tagNamesComboBox;
 
     @GwtMock
     VariableNameTextBox name;
@@ -82,7 +82,7 @@ public class VariableListItemWidgetTest {
         dataType = mock(ValueListBox.class);
         customDataType = mock(CustomDataTypeTextBox.class);
         dataTypeComboBox = mock(ComboBox.class);
-        kpi = mock(HTMLInputElement.class);
+        tagNamesComboBox = mock(ComboBox.class);
         widget = GWT.create(VariableListItemWidgetViewImpl.class);
         VariableRow variableRow = new VariableRow();
         widget.dataType = dataType;
@@ -217,16 +217,16 @@ public class VariableListItemWidgetTest {
         String sDataType = "Boolean";
         widget.setListBoxModelValue(widget.dataType,
                                     sDataType);
-        kpi.checked = true;
+        tagNamesComboBox.setTextBoxValue("output");
         String returnedDataType1 = widget.getDataTypeDisplayName();
         assertEquals(sDataType,
                      returnedDataType1);
         String returnedDataType2 = widget.getModelValue(widget.dataType);
         assertEquals(sDataType,
                      returnedDataType2);
-   //     boolean returnedDataType3 = widget.kpi.checked;
-   //     assertEquals(true,
-  //                   returnedDataType3);
+        String returnedTag = widget.tagNamesComboBox.getValue();
+        assertEquals("output",
+                     returnedTag);
 
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
@@ -28,11 +28,13 @@ import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockito;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLInputElement;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.ValueListBox;
 import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.common.client.dom.Span;
 import org.jboss.errai.databinding.client.api.DataBinder;
 import org.junit.Before;
 import org.junit.Test;
@@ -93,6 +95,14 @@ public class VariableListItemWidgetViewImplTest {
 
     private ComboBox processVarComboBox;
 
+    private HTMLAnchorElement variableTagsSettings;
+
+    private Span tagCount;
+
+    private CustomDataTypeTextBox customTagName;
+
+    private ValueListBox<String> defaultTagNames;
+
     @GwtMock
     private KeyDownEvent keyDownEvent;
 
@@ -119,6 +129,10 @@ public class VariableListItemWidgetViewImplTest {
         dataType = mock(ValueListBox.class);
         dataTypeComboBox = mock(ComboBox.class);
         processVarComboBox = mock(ComboBox.class);
+        variableTagsSettings = mock(HTMLAnchorElement.class);
+        tagCount = mock(Span.class);
+        customTagName = mock(CustomDataTypeTextBox.class);
+        defaultTagNames = mock(ValueListBox.class);
         view = mock(VariableListItemWidgetViewImpl.class);
         view.variableRow = variableRow;
         view.name = name;
@@ -130,6 +144,10 @@ public class VariableListItemWidgetViewImplTest {
         view.dataTypeComboBox = dataTypeComboBox;
         view.notification = notification;
         view.errorPopupPresenter = errorPopupPresenter;
+        view.variableTagsSettings = variableTagsSettings;
+        view.tagCount = tagCount;
+        view.customTagName = customTagName;
+        view.defaultTagNames = defaultTagNames;
         doCallRealMethod().when(view).init();
         doCallRealMethod().when(view).getCustomDataType();
         doCallRealMethod().when(view).setCustomDataType(anyString());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.variablesEditor;
 
+import java.util.Arrays;
+
 import javax.enterprise.event.Event;
 
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -81,7 +83,7 @@ public class VariableListItemWidgetViewImplTest {
     private Button deleteButton;
 
     @Mock
-    private HTMLInputElement kpi;
+    private ComboBox tagNamesComboBox;
 
     private CustomDataTypeTextBox customDataType;
 
@@ -121,8 +123,8 @@ public class VariableListItemWidgetViewImplTest {
         view.variableRow = variableRow;
         view.name = name;
         view.deleteButton = deleteButton;
-        kpi = mock(HTMLInputElement.class);
-       // view.kpi = kpi;
+        tagNamesComboBox = mock(ComboBox.class);
+        view.tagNamesComboBox = tagNamesComboBox;
         view.customDataType = customDataType;
         view.dataType = dataType;
         view.dataTypeComboBox = dataTypeComboBox;
@@ -177,8 +179,8 @@ public class VariableListItemWidgetViewImplTest {
         row.setCustomDataType(null);
         row.setDataTypeDisplayName(DATA_TYPE_NAME);
         row.setVariableType(Variable.VariableType.PROCESS);
-        row.setKpi(true);
-        kpi.click();
+        row.setTags(Arrays.asList("internal"));
+        tagNamesComboBox.setTextBoxValue("internal");
         doReturn(row).when(variableRow).getModel();
         view.setModel(row);
         verify(variableRow,
@@ -189,8 +191,8 @@ public class VariableListItemWidgetViewImplTest {
                never()).setValue(DATA_TYPE_NAME);
         verify(dataType,
                times(1)).setValue(DATA_TYPE_NAME);
-        verify(kpi,
-               times(1)).click();
+        verify(tagNamesComboBox,
+               times(1)).setTextBoxValue("internal");
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
@@ -25,6 +25,7 @@ import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockito;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLInputElement;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
@@ -43,7 +44,6 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTe
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class VariableListItemWidgetViewImplTest {
 
     private static final String VARIABLE_NAME = "variableName";
@@ -122,7 +122,7 @@ public class VariableListItemWidgetViewImplTest {
         view.name = name;
         view.deleteButton = deleteButton;
         kpi = mock(HTMLInputElement.class);
-        view.kpi = kpi;
+       // view.kpi = kpi;
         view.customDataType = customDataType;
         view.dataType = dataType;
         view.dataTypeComboBox = dataTypeComboBox;
@@ -145,7 +145,7 @@ public class VariableListItemWidgetViewImplTest {
         doCallRealMethod().when(view).handleDeleteButton(any(ClickEvent.class));
         doCallRealMethod().when(view).setReadOnly(anyBoolean());
         doCallRealMethod().when(view).notifyModelChanged();
-        doCallRealMethod().when(view).setKPINotEnabled();
+        doCallRealMethod().when(view).setTagsNotEnabled();
 
         VariableRow row = new VariableRow();
         doReturn(row).when(variableRow).getModel();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
@@ -222,7 +222,7 @@ public class VariablesEditorFieldRendererTest {
 
         variablesEditor.setDataTypes(dataTypes,
                                      dataTypeDisplayNames);
-        List<VariableRow> variableRows = variablesEditor.deserializeVariables("var1:String:[internal;input],var2:Integer:[output],var3:org.stuff.Potato");
+        List<VariableRow> variableRows = variablesEditor.deserializeVariables("var1:String:internal;input,var2:Integer:output,var3:org.stuff.Potato");
         assertEquals(3,
                      variableRows.size());
         VariableRow var = variableRows.get(0);
@@ -317,7 +317,7 @@ public class VariablesEditorFieldRendererTest {
                                          null,
                                          Arrays.asList("input", "output")));
         String s = variablesEditor.serializeVariables(variableRows);
-        assertEquals("var1:String:[internal],var2:Integer:[input],var3:org.veg.Potato:[input;output]",
+        assertEquals("var1:String:internal,var2:Integer:input,var3:org.veg.Potato:input;output",
                      s);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
@@ -222,7 +222,7 @@ public class VariablesEditorFieldRendererTest {
 
         variablesEditor.setDataTypes(dataTypes,
                                      dataTypeDisplayNames);
-        List<VariableRow> variableRows = variablesEditor.deserializeVariables("var1:String,var2:Integer,var3:org.stuff.Potato");
+        List<VariableRow> variableRows = variablesEditor.deserializeVariables("var1:String:[internal;input],var2:Integer:[output],var3:org.stuff.Potato");
         assertEquals(3,
                      variableRows.size());
         VariableRow var = variableRows.get(0);
@@ -232,6 +232,10 @@ public class VariablesEditorFieldRendererTest {
                      var.getDataTypeDisplayName());
         assertEquals(Variable.VariableType.PROCESS,
                      var.getVariableType());
+        assertEquals(2, var.getTags().size());
+        assertEquals("internal", var.getTags().get(0));
+        assertEquals("input", var.getTags().get(1));
+
         var = variableRows.get(1);
         assertEquals("var2",
                      var.getName());
@@ -239,6 +243,10 @@ public class VariablesEditorFieldRendererTest {
                      var.getDataTypeDisplayName());
         assertEquals(Variable.VariableType.PROCESS,
                      var.getVariableType());
+
+        assertEquals(1, var.getTags().size());
+        assertEquals("output", var.getTags().get(0));
+
         var = variableRows.get(2);
         assertEquals("var3",
                      var.getName());
@@ -246,6 +254,9 @@ public class VariablesEditorFieldRendererTest {
                      var.getCustomDataType());
         assertEquals(Variable.VariableType.PROCESS,
                      var.getVariableType());
+
+        assertEquals(null, var.getTags());
+
     }
 
     @Test
@@ -273,12 +284,12 @@ public class VariablesEditorFieldRendererTest {
                                          "org.veg.Potato",
                                          null));
         String s = variablesEditor.serializeVariables(variableRows);
-        assertEquals("var1:String:false,var2:Integer:false,var3:org.veg.Potato:false",
+        assertEquals("var1:String,var2:Integer,var3:org.veg.Potato",
                      s);
     }
 
     @Test
-    public void testSerializeVariablesWithKPI() {
+    public void testSerializeVariablesWithTags() {
         Map<String, String> mapDataTypeDisplayNamesToNames = new HashMap<String, String>();
         mapDataTypeDisplayNamesToNames.put("String",
                                            "String");
@@ -293,20 +304,20 @@ public class VariablesEditorFieldRendererTest {
                                          "var1",
                                          "String",
                                          null,
-                                         true));
+                                         Arrays.asList("internal")));
         variableRows.add(new VariableRow(Variable.VariableType.PROCESS,
                                          "var2",
                                          "Integer",
                                          null,
-                                         true
-        ));
+                                         Arrays.asList("input"
+        )));
         variableRows.add(new VariableRow(Variable.VariableType.PROCESS,
                                          "var3",
                                          "org.veg.Potato",
                                          null,
-                                         true));
+                                         Arrays.asList("input", "output")));
         String s = variablesEditor.serializeVariables(variableRows);
-        assertEquals("var1:String:true,var2:Integer:true,var3:org.veg.Potato:true",
+        assertEquals("var1:String:[internal],var2:Integer:[input],var3:org.veg.Potato:[input;output]",
                      s);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImplTest.java
@@ -114,7 +114,7 @@ public class VariablesEditorWidgetViewImplTest {
         view.nameth = nameth;
         view.datatypeth = datatypeth;
         view.notification = notification;
-        view.kpith = kpith;
+        view.tagsth = kpith;
         doCallRealMethod().when(view).setVariableRows(any(List.class));
         doCallRealMethod().when(view).init(any(VariablesEditorWidgetView.Presenter.class));
         doCallRealMethod().when(view).handleAddVarButton(any(ClickEvent.class));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetViewImplTest.java
@@ -91,7 +91,7 @@ public class VariablesEditorWidgetViewImplTest {
     private ListWidget<VariableRow, VariableListItemWidgetViewImpl> variableRows;
 
     @GwtMock
-    private TableCellElement kpith;
+    private TableCellElement tagsth;
 
     private VariablesEditorWidgetViewImpl view;
 
@@ -114,7 +114,7 @@ public class VariablesEditorWidgetViewImplTest {
         view.nameth = nameth;
         view.datatypeth = datatypeth;
         view.notification = notification;
-        view.tagsth = kpith;
+        view.tagsth = tagsth;
         doCallRealMethod().when(view).setVariableRows(any(List.class));
         doCallRealMethod().when(view).init(any(VariablesEditorWidgetView.Presenter.class));
         doCallRealMethod().when(view).handleAddVarButton(any(ClickEvent.class));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/CustomElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/CustomElement.java
@@ -30,7 +30,7 @@ public class CustomElement<T> {
     public static final MetadataTypeDefinition<Boolean> autoStart = new BooleanElement("customAutoStart", false);
     public static final MetadataTypeDefinition<Boolean> autoConnectionSource = new BooleanElement("isAutoConnection.source", false);
     public static final MetadataTypeDefinition<Boolean> autoConnectionTarget = new BooleanElement("isAutoConnection.target", false);
-    public static final MetadataTypeDefinition<Boolean> customKPI = new BooleanElement("customKPI", false);
+    public static final MetadataTypeDefinition<String> customTags = new StringElement("customTags", "[]");
     public static final MetadataTypeDefinition<String> description = new StringElement("customDescription", "");
     public static final MetadataTypeDefinition<String> scope = new StringElement("customScope", "");
     public static final MetadataTypeDefinition<String> name = new StringElement("elementname", "") {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/VariableDeclaration.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/VariableDeclaration.java
@@ -30,13 +30,13 @@ public class VariableDeclaration {
     private final Property typedIdentifier;
     private String identifier;
     private String type;
-    private String kpi;
+    private String tags;
 
     public VariableDeclaration(String identifier, String type) {
         this(identifier, type, "");
     }
 
-    public VariableDeclaration(String identifier, String type, String kpi) {
+    public VariableDeclaration(String identifier, String type, String tags) {
         this.setIdentifier(identifier);
         this.type = type;
 
@@ -48,7 +48,7 @@ public class VariableDeclaration {
         this.typedIdentifier.setId(Ids.typedIdentifier("GLOBAL", this.getIdentifier()));
         this.typedIdentifier.setName(identifier);
         this.typedIdentifier.setItemSubjectRef(typeDeclaration);
-        this.kpi = kpi;
+        this.tags = tags;
     }
 
     public static VariableDeclaration fromString(String encoded) {
@@ -58,21 +58,21 @@ public class VariableDeclaration {
         if (identifier.isEmpty()) {
             throw new IllegalArgumentException("Variable identifier cannot be empty. Given: '" + encoded + "'");
         }
-        String kpi = "";
+        String tags = "";
 
         if (split.length == 3) {
-            kpi = split[2];
+            tags = split[2];
         }
 
-        return new VariableDeclaration(identifier, type, kpi);
+        return new VariableDeclaration(identifier, type, tags);
     }
 
-    public String getKpi() {
-        return kpi;
+    public String getTags() {
+        return tags;
     }
 
-    public void setKpi(String kpi) {
-        this.kpi = kpi;
+    public void setTags(String tags) {
+        this.tags = tags;
     }
 
     public String getIdentifier() {
@@ -102,14 +102,14 @@ public class VariableDeclaration {
 
     @Override
     public String toString() {
-        String kpiString = "";
-        if (kpi != null && !kpi.isEmpty()) {
-            kpiString = ":" + kpi;
+        String tagString = "";
+        if (tags != null && !tags.isEmpty()) {
+            tagString = ":" + tags;
         }
         if (type == null || type.isEmpty()) {
-            return typedIdentifier.getName() + kpiString;
+            return typedIdentifier.getName() + tagString;
         } else {
-            return typedIdentifier.getName() + ":" + type + kpiString;
+            return typedIdentifier.getName() + ":" + type + tagString;
         }
     }
 
@@ -124,12 +124,12 @@ public class VariableDeclaration {
         VariableDeclaration that = (VariableDeclaration) o;
         return Objects.equals(identifier, that.identifier) &&
                 Objects.equals(type, that.type) &&
-                Objects.equals(kpi, that.kpi);
+                Objects.equals(tags, that.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier, type, kpi);
+        return Objects.hash(identifier, type, tags);
     }
 }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/FlatVariableScope.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/FlatVariableScope.java
@@ -63,8 +63,8 @@ public class FlatVariableScope implements VariableScope {
         return variable;
     }
 
-    public Variable declare(String scopeId, String identifier, String type, String kpi) {
-        Variable variable = new Variable(scopeId, identifier, type, kpi);
+    public Variable declare(String scopeId, String identifier, String type, String tags) {
+        Variable variable = new Variable(scopeId, identifier, type, tags);
         variables.put(identifier, variable);
         return variable;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -28,6 +28,7 @@ import bpsim.BpsimPackage;
 import bpsim.ElementParameters;
 import bpsim.Scenario;
 import bpsim.ScenarioParameters;
+import com.google.gwt.core.client.GWT;
 import org.eclipse.bpmn2.ExtensionAttributeValue;
 import org.eclipse.bpmn2.LaneSet;
 import org.eclipse.bpmn2.Process;
@@ -195,11 +196,13 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
 
             final String tags = decl.getTags();
 
+            GWT.log("Value of Tags: " + tags);
             if (tags != null) {
-                if (tags.charAt(0) == '[' && tags.charAt(tags.length() - 1) == ']') {
+                if (!tags.isEmpty() && tags.charAt(0) == '[' && tags.charAt(tags.length() - 1) == ']') {
                     decl.setTags(tags.substring(1, tags.length() - 1));
                 }
             CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
+                GWT.log("Value of Tags After: " + CustomElement.customTags.of(variable.getTypedIdentifier()).get());
             }
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -192,8 +192,14 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
                     variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType(), decl.getTags());
-            if (decl.getTags() != null) {
-                CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
+
+            final String tags = decl.getTags();
+
+            if (tags != null) {
+                if (tags.charAt(0) == '[' && tags.charAt(tags.length() - 1) == ']') {
+                    decl.setTags(tags.substring(1, tags.length() - 1));
+                }
+            CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
             }
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -191,9 +191,9 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
         List<Property> properties = process.getProperties();
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
-                    variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType(), decl.getKpi());
-            if (Boolean.parseBoolean(decl.getKpi())) {
-                CustomElement.customKPI.of(variable.getTypedIdentifier()).set(true);
+                    variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType(), decl.getTags());
+            if (decl.getTags() != null) {
+                CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
             }
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/SubProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/SubProcessPropertyWriter.java
@@ -99,8 +99,8 @@ public class SubProcessPropertyWriter extends MultipleInstanceActivityPropertyWr
         declarationList.getDeclarations().forEach(decl -> {
             VariableScope.Variable variable =
                     variableScope.declare(this.process.getId(), decl.getIdentifier(), decl.getType());
-            if (Boolean.parseBoolean(decl.getKpi())) {
-                CustomElement.customKPI.of(variable.getTypedIdentifier()).set(true);
+            if (decl.getTags() != null) {
+                CustomElement.customTags.of(variable.getTypedIdentifier()).set(decl.getTags());
             }
             properties.add(variable.getTypedIdentifier());
             this.itemDefinitions.add(variable.getTypeDeclaration());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ProcessVariableReader.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ProcessVariableReader.java
@@ -36,10 +36,10 @@ class ProcessVariableReader {
 
     private static String toProcessVariableString(Property p) {
         String processVariableName = getProcessVariableName(p);
-        boolean kpi = CustomElement.customKPI.of(p).get();
+        String tags = CustomElement.customTags.of(p).get();
         return Optional.ofNullable(p.getItemSubjectRef())
                 .map(ItemDefinition::getStructureRef)
-                .map(type -> processVariableName + ":" + type + ":" + kpi)
+                .map(type -> processVariableName + ":" + type + ":" + tags)
                 .orElse(processVariableName);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/VariableDeclarationTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/VariableDeclarationTest.java
@@ -55,7 +55,7 @@ public class VariableDeclarationTest {
 
     @Test
     public void testKPI() {
-        String kpi = tested.getKpi();
+        String kpi = tested.getTags();
         assertEquals(kpi, VAR_KPI);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -142,13 +142,13 @@ public class ProcessPropertyWriterTest {
 
     @Test
     public void processVariables() {
-        ProcessVariables processVariables = new ProcessVariables("GV1:Boolean:true,GV2:Boolean:true,GV3:Integer:false");
+        ProcessVariables processVariables = new ProcessVariables("GV1:Boolean:[input],GV2:Boolean:[output;required],GV3:Integer:[customTag;required]");
         p.setProcessVariables(processVariables);
 
         final ProcessPropertyReader pp = new ProcessPropertyReader(
                 p.getProcess(), p.getBpmnDiagram(), p.getShape(), 1.0);
         String processVariablesString = pp.getProcessVariables();
-        assertThat(processVariablesString).isEqualTo("GV1:Boolean:true,GV2:Boolean:true,GV3:Integer:false");
+        assertThat(processVariablesString).isEqualTo("GV1:Boolean:<![CDATA[input]]>,GV2:Boolean:<![CDATA[output;required]]>,GV3:Integer:<![CDATA[customTag;required]]>");
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramServiceTest.java
@@ -187,7 +187,7 @@ public class BPMNClientDiagramServiceTest {
         adHoc = new AdHoc(false);
         processInstanceDescription = new ProcessInstanceDescription("description");
         executable = new Executable(false);
-        globalVariables = new GlobalVariables("GL1:java.lang.String:false,GL2:java.lang.Boolean:false");
+        globalVariables = new GlobalVariables("GL1:java.lang.String:[],GL2:java.lang.Boolean:[]");
         slaDueDate = new SLADueDate("");
         processType = new ProcessType();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/test/java/org/kie/workbench/common/stunner/standalone/backend/services/BPMNStandaloneDiagramServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/test/java/org/kie/workbench/common/stunner/standalone/backend/services/BPMNStandaloneDiagramServiceImplTest.java
@@ -152,7 +152,7 @@ public class BPMNStandaloneDiagramServiceImplTest {
         processInstanceDescription = new ProcessInstanceDescription("description");
         executable = new Executable(false);
         processId = new Id("someUUID");
-        globalVariables = new GlobalVariables("GL1:java.lang.String:false,GL2:java.lang.Boolean:false");
+        globalVariables = new GlobalVariables("GL1:java.lang.String:[],GL2:java.lang.Boolean:[]");
         slaDueDate = new SLADueDate("");
 
         diagramSet = new DiagramSet(processName,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/test/java/org/kie/workbench/common/stunner/standalone/backend/services/BPMNStandaloneDiagramServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/test/java/org/kie/workbench/common/stunner/standalone/backend/services/BPMNStandaloneDiagramServiceImplTest.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.GlobalV
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.Id;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.Package;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.ProcessInstanceDescription;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.ProcessType;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.Version;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.imports.Imports;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dimensions.RectangleDimensionsSet;
@@ -106,6 +107,8 @@ public class BPMNStandaloneDiagramServiceImplTest {
 
     private Documentation processDocumentation;
 
+    private ProcessType processType;
+
     private Id processId;
 
     private Package packageProperty;
@@ -142,6 +145,7 @@ public class BPMNStandaloneDiagramServiceImplTest {
         //DiagramSet
         processName = new Name("someName");
         processDocumentation = new Documentation("someDocumentation");
+        processType = new ProcessType();
         packageProperty = new Package("some.package");
         version = new Version("1.0");
         adHoc = new AdHoc(false);
@@ -155,6 +159,7 @@ public class BPMNStandaloneDiagramServiceImplTest {
                                     processDocumentation,
                                     processId,
                                     packageProperty,
+                                    processType,
                                     version,
                                     adHoc,
                                     processInstanceDescription,


### PR DESCRIPTION
Hi @romartin can you review this PR?

Known issues that I will be fixing while this PR is reviewed:
-When loading a new diagram that has tags, when you add other tags the previous tags are removed (Only one time)
- Additional tests are needed to test the logic of the overlay and adding of the badges/labels and edge cases
- Currently when saving it separates tags with semicolon ; as it caused conflicts with the separation of variables, will fix
- Business Central needs to be tested to ensure that it can save and reload
- Currently when saving CData is skipped (Will find a solution)
- I know there is a merge from Handrey that I need to rebase, but want to get the sonarcloud results first since I know process and global variables from that PR will conflict with this one


