### PR TITLE
KOGITO-395 BPMN Serialization reusing ID

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/src/main/java/org/eclipse/emf/ecore/xmi/resource/xml/XMLSave.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/src/main/java/org/eclipse/emf/ecore/xmi/resource/xml/XMLSave.java
@@ -29,7 +29,26 @@ import com.google.gwt.xml.client.Attr;
 import com.google.gwt.xml.client.Document;
 import com.google.gwt.xml.client.Element;
 import com.google.gwt.xml.client.Node;
+import org.eclipse.bpmn2.Assignment;
 import org.eclipse.bpmn2.BaseElement;
+import org.eclipse.bpmn2.CompensateEventDefinition;
+import org.eclipse.bpmn2.ConditionalEventDefinition;
+import org.eclipse.bpmn2.DataInputAssociation;
+import org.eclipse.bpmn2.DataOutputAssociation;
+import org.eclipse.bpmn2.Documentation;
+import org.eclipse.bpmn2.ErrorEventDefinition;
+import org.eclipse.bpmn2.EscalationEventDefinition;
+import org.eclipse.bpmn2.FormalExpression;
+import org.eclipse.bpmn2.InputOutputSpecification;
+import org.eclipse.bpmn2.InputSet;
+import org.eclipse.bpmn2.LaneSet;
+import org.eclipse.bpmn2.MessageEventDefinition;
+import org.eclipse.bpmn2.MultiInstanceLoopCharacteristics;
+import org.eclipse.bpmn2.OutputSet;
+import org.eclipse.bpmn2.Relationship;
+import org.eclipse.bpmn2.SignalEventDefinition;
+import org.eclipse.bpmn2.TerminateEventDefinition;
+import org.eclipse.bpmn2.TimerEventDefinition;
 import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -377,7 +396,7 @@ public class XMLSave {
         } else {
             // DOM serialization
             if (handler instanceof XMLDOMHandler) {
-                ((XMLDOMHandler) handler).setExtendedMetaData(extendedMetaData);
+                handler.setExtendedMetaData(extendedMetaData);
             }
         }
         processDanglingHREF = (String) options.get(XMLResource.OPTION_PROCESS_DANGLING_HREF);
@@ -2015,6 +2034,30 @@ public class XMLSave {
         return svalue;
     }
 
+    private static boolean isIdNeeded(EObject o) {
+        return !(
+                o instanceof Documentation
+                        || o instanceof LaneSet
+                        || o instanceof InputOutputSpecification
+                        || o instanceof InputSet
+                        || o instanceof OutputSet
+                        || o instanceof DataInputAssociation
+                        || o instanceof DataOutputAssociation
+                        || o instanceof Assignment
+                        || o instanceof TimerEventDefinition
+                        || o instanceof CompensateEventDefinition
+                        || o instanceof SignalEventDefinition
+                        || o instanceof ErrorEventDefinition
+                        || o instanceof TerminateEventDefinition
+                        || o instanceof MessageEventDefinition
+                        || o instanceof EscalationEventDefinition
+                        || o instanceof ConditionalEventDefinition
+                        || o instanceof MultiInstanceLoopCharacteristics
+                        || o instanceof Relationship
+                        || o instanceof FormalExpression
+        );
+    }
+
     protected void saveElementID(EObject o) {
         String id = helper.getID(o);
 
@@ -2024,7 +2067,7 @@ public class XMLSave {
         // See also XMLHelper#getHREF(EObject)
         if (null == id && o instanceof BaseElement) {
             String eId = ((BaseElement) o).getId();
-            if (null == eId) {
+            if (null == eId && isIdNeeded(o)) {
                 id = EcoreUtil.generateUUID();
                 ((BaseElement) o).setId(id);
             }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/src/test/java/org/eclipse/emf/ecore/xmi/resource/xml/XMLSaveTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/src/test/java/org/eclipse/emf/ecore/xmi/resource/xml/XMLSaveTest.java
@@ -18,6 +18,7 @@ package org.eclipse.emf.ecore.xmi.resource.xml;
 
 import com.google.gwt.xml.client.Attr;
 import com.google.gwt.xml.client.Node;
+import org.eclipse.bpmn2.FormalExpression;
 import org.eclipse.bpmn2.impl.BaseElementImpl;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
@@ -76,10 +77,13 @@ public class XMLSaveTest {
     @Test
     public void testSaveElementID() {
         BaseElementImpl obj = mock(BaseElementImpl.class);
+        FormalExpression expression = mock(FormalExpression.class);
+        when(currentNode.getParentNode()).thenReturn(currentNode);
         when(xmlHelper.getID(any(EObject.class))).thenReturn(null);
         Attr attr = mock(Attr.class);
         when(gwtDOMHandler.createAttributeNS(anyString(), anyString())).thenReturn(attr);
         tested.saveElementID(obj);
+        tested.saveElementID(expression);
         ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
         verify(obj, times(1)).setId(idCaptor.capture());
         String id = idCaptor.getValue();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/UserTaskPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/UserTaskPropertyWriter.java
@@ -38,7 +38,6 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.reassignment.Re
 import org.kie.workbench.common.stunner.bpmn.definition.property.reassignment.ReassignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnEntryAction;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnExitAction;
-import org.uberfire.commons.uuid.UUID;
 
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories.bpmn2;
 
@@ -134,7 +133,6 @@ public class UserTaskPropertyWriter extends MultipleInstanceActivityPropertyWrit
     public void setActors(Actors actors) {
         for (String actor : fromActorString(actors.getValue())) {
             PotentialOwner potentialOwner = bpmn2.createPotentialOwner();
-            potentialOwner.setId(UUID.uuid());
 
             FormalExpression formalExpression = bpmn2.createFormalExpression();
             FormalExpressionBodyHandler.of(formalExpression).setBody(actor);


### PR DESCRIPTION
Hi @romartin, @LuboTerifaj, @domhanak, @krisv 

this PR removes all ID without use from BPMN file in KOGITO (Business Central is not affected we have separate jira issue for it). Two ids are still generates on every save, but they are used somewhere, so I didn't remove it, we will handle it as separate jira issue.

### This PR removes IDs for following elements
* Documentaion
* LaneSet
* ioSpecification
* inputSet
* outputSet
* dataInputAssociation
* DataOutputAssociation
* Assignment
* TimerEventDefinition
* CompensateEventDefinition
* SignalEventDefinition
* errorEventDefinition
* completionCondition
* messageEventDefinition
* escalationEventDefinition
* conditionalEventDefinition
* terminateEventDefinition
* MultiInstanceLoopCharacteristics
* Potential Owner (User Task → Actor property)
* FormalExpression tags such as:
    * CompletionCondition
    * ConditionExpression
    * Condition
    * TimeDate
    * TimeDuration
    * from
    * to

ID's removed because they are not used and regenerated on every save and it creates a lot of nose and make impossible to see difference between two BPMN files.

You can check that IDs for mentioned elements never used in whole BPMN file. Just locate any mentioned element, copy ID and search it in the BPMN file. You will find just one occurrence 

### Element where IDs still regenerated on every save because they used somewhere else

* Definition tag (root tag), also used in 
    * Definition → Relationship → Target (XML)
    * Definition → Relationship → Source (XML)
* Message tag, also used in
    * messageEventDefinition tag as messageRef attribute

Listed elements will be fixed as separate jira issue.

I tested this PR with https://github.com/kiegroup/kogito-travel-agency-tutorial/tree/master/01-kogito-travel-agency I opened all 3 files in Kogito Webapp (VS Code plugin doesn't work to me again) and slightly modified it (just moved a node). Than saved new file versions without IDs to the test project and was able to pass all tests, compile and start the application. Also I did some REST request and all looks good to me.

@krisv can I ask you to confirm that if IDs are not used anywhere in the file - they are useless and can be removed?

So this PR is ready for review. Thank you! 