### PR TITLE
KOGITO-1577: Esc doesn't cancel context menus in DMN grid

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUriPopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUriPopoverImpl.java
@@ -25,11 +25,11 @@ import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.kie.workbench.common.dmn.api.property.dmn.DMNExternalLink;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.AbstractPopoverImpl;
 
 @ApplicationScoped
-public class NameAndUriPopoverImpl implements NameAndUrlPopoverView.Presenter {
-
-    private NameAndUrlPopoverView view;
+public class NameAndUriPopoverImpl extends AbstractPopoverImpl<NameAndUrlPopoverView, NameAndUrlPopoverView.Presenter> implements NameAndUrlPopoverView.Presenter {
 
     public NameAndUriPopoverImpl() {
         //CDI proxy
@@ -37,7 +37,7 @@ public class NameAndUriPopoverImpl implements NameAndUrlPopoverView.Presenter {
 
     @Inject
     public NameAndUriPopoverImpl(final NameAndUrlPopoverView view) {
-        this.view = view;
+        super(view);
     }
 
     @PostConstruct
@@ -48,6 +48,11 @@ public class NameAndUriPopoverImpl implements NameAndUrlPopoverView.Presenter {
     @Override
     public HTMLElement getElement() {
         return view.getElement();
+    }
+
+    @Override
+    public void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback) {
+        view.setOnClosedByKeyboardCallback(callback);
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUrlPopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUrlPopoverViewImpl.java
@@ -162,6 +162,11 @@ public class NameAndUrlPopoverViewImpl extends AbstractPopoverViewImpl implement
         this.presenter = presenter;
     }
 
+    @Override
+    protected void onShownFocus() {
+        okButton.focus();
+    }
+
     public Consumer<DMNExternalLink> getOnExternalLinkCreated() {
         return onExternalLinkCreated;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverImpl.java
@@ -17,23 +17,20 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.dtable.hitpolicy;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.model.BuiltinAggregator;
 import org.kie.workbench.common.dmn.api.definition.model.HitPolicy;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.AbstractPopoverImpl;
 
 @ApplicationScoped
-public class HitPolicyPopoverImpl implements HitPolicyPopoverView.Presenter {
+public class HitPolicyPopoverImpl extends AbstractPopoverImpl<HitPolicyPopoverView, HasHitPolicyControl> implements HitPolicyPopoverView.Presenter {
 
-    private HitPolicyPopoverView view;
     private TranslationService translationService;
-    private Optional<HasHitPolicyControl> binding = Optional.empty();
 
     public HitPolicyPopoverImpl() {
         //CDI proxy
@@ -43,17 +40,12 @@ public class HitPolicyPopoverImpl implements HitPolicyPopoverView.Presenter {
     public HitPolicyPopoverImpl(final HitPolicyPopoverView view,
                                 final TranslationService translationService,
                                 final BuiltinAggregatorUtils builtinAggregatorUtils) {
-        this.view = view;
+        super(view);
         this.translationService = translationService;
 
         view.init(this);
         view.initHitPolicies(Arrays.asList(HitPolicy.values()));
         view.initBuiltinAggregators(builtinAggregatorUtils.getAllValues());
-    }
-
-    @Override
-    public HTMLElement getElement() {
-        return view.getElement();
     }
 
     @Override
@@ -65,7 +57,7 @@ public class HitPolicyPopoverImpl implements HitPolicyPopoverView.Presenter {
     public void bind(final HasHitPolicyControl bound,
                      final int uiRowIndex,
                      final int uiColumnIndex) {
-        binding = Optional.ofNullable(bound);
+        super.bind(bound, uiRowIndex, uiColumnIndex);
         refresh();
     }
 
@@ -92,15 +84,5 @@ public class HitPolicyPopoverImpl implements HitPolicyPopoverView.Presenter {
     @Override
     public void setBuiltinAggregator(final BuiltinAggregator aggregator) {
         binding.ifPresent(b -> b.setBuiltinAggregator(aggregator));
-    }
-
-    @Override
-    public void show() {
-        binding.ifPresent(b -> view.show(Optional.ofNullable(getPopoverTitle())));
-    }
-
-    @Override
-    public void hide() {
-        binding.ifPresent(b -> view.hide());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.html
@@ -15,7 +15,7 @@
   -->
 <div data-field="popover" data-toggle="popover" data-trigger="manual" data-container="#popover-container" title="i18ned" data-close="true">
     <div id="popover-container"></div>
-    <div id="popover-content">
+    <div id="popover-content" tabindex="0">
         <div class="kie-dmn-hit-policy-container">
             <form id="#HitPolicyForm">
                 <label for="kieHitPolicy"><span data-field="hitPolicyLabel"></span></label>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverImpl.java
@@ -16,22 +16,18 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.function.kindselector;
 
-import java.util.Optional;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.AbstractPopoverImpl;
 
 @ApplicationScoped
-public class KindPopoverImpl implements KindPopoverView.Presenter {
+public class KindPopoverImpl extends AbstractPopoverImpl<KindPopoverView, HasKindSelectControl> implements KindPopoverView.Presenter {
 
-    private KindPopoverView view;
     private TranslationService translationService;
-    private Optional<HasKindSelectControl> binding = Optional.empty();
 
     public KindPopoverImpl() {
         //CDI proxy
@@ -40,7 +36,7 @@ public class KindPopoverImpl implements KindPopoverView.Presenter {
     @Inject
     public KindPopoverImpl(final KindPopoverView view,
                            final TranslationService translationService) {
-        this.view = view;
+        super(view);
         this.translationService = translationService;
 
         view.init(this);
@@ -48,28 +44,8 @@ public class KindPopoverImpl implements KindPopoverView.Presenter {
     }
 
     @Override
-    public void show() {
-        binding.ifPresent(b -> view.show(Optional.ofNullable(getPopoverTitle())));
-    }
-
-    @Override
-    public void hide() {
-        binding.ifPresent(b -> view.hide());
-    }
-
-    @Override
     public String getPopoverTitle() {
         return translationService.getTranslation(DMNEditorConstants.FunctionEditor_SelectFunctionKind);
-    }
-
-    @Override
-    public void bind(final HasKindSelectControl bound, final int uiRowIndex, final int uiColumnIndex) {
-        binding = Optional.ofNullable(bound);
-    }
-
-    @Override
-    public HTMLElement getElement() {
-        return view.getElement();
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImpl.html
@@ -15,7 +15,7 @@
   -->
 <div data-field="popover" data-toggle="popover" data-trigger="manual" data-container="#popover-container" title="i18ned" data-close="true" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html">
     <div id="popover-container"></div>
-    <div id="popover-content">
+    <div id="popover-content" tabindex="0">
 
         <div id="kie-dmn-kind-selector-container" class="open">
             <div class="uf-no-select">

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImpl.java
@@ -40,9 +40,13 @@ public class KindPopoverViewImpl extends AbstractPopoverViewImpl implements Kind
     @DataField("definitions-container")
     private UnorderedList definitionsContainer;
 
-    private final ManagedInstance<ListSelectorTextItemView> listSelectorTextItemViews;
+    private ManagedInstance<ListSelectorTextItemView> listSelectorTextItemViews;
 
     private KindPopoverView.Presenter presenter;
+
+    public KindPopoverViewImpl() {
+        //CDI proxy
+    }
 
     @Inject
     public KindPopoverViewImpl(final UnorderedList definitionsContainer,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverImpl.java
@@ -23,18 +23,16 @@ import java.util.Optional;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.definition.model.InformationItem;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.AbstractPopoverImpl;
 
 @ApplicationScoped
-public class ParametersPopoverImpl implements ParametersPopoverView.Presenter {
+public class ParametersPopoverImpl extends AbstractPopoverImpl<ParametersPopoverView, HasParametersControl> implements ParametersPopoverView.Presenter {
 
-    private ParametersPopoverView view;
     private TranslationService translationService;
-    private Optional<HasParametersControl> binding = Optional.empty();
 
     public ParametersPopoverImpl() {
         //CDI proxy
@@ -43,15 +41,10 @@ public class ParametersPopoverImpl implements ParametersPopoverView.Presenter {
     @Inject
     public ParametersPopoverImpl(final ParametersPopoverView view,
                                  final TranslationService translationService) {
-        this.view = view;
+        super(view);
         this.translationService = translationService;
 
         view.init(this);
-    }
-
-    @Override
-    public HTMLElement getElement() {
-        return view.getElement();
     }
 
     @Override
@@ -63,10 +56,8 @@ public class ParametersPopoverImpl implements ParametersPopoverView.Presenter {
     public void bind(final HasParametersControl bound,
                      final int uiRowIndex,
                      final int uiColumnIndex) {
-        binding = Optional.ofNullable(bound);
-        binding.ifPresent(b -> {
-            view.setParameters(b.getParameters());
-        });
+        super.bind(bound, uiRowIndex, uiColumnIndex);
+        binding.ifPresent(b -> view.setParameters(b.getParameters()));
     }
 
     private void refresh() {
@@ -89,11 +80,6 @@ public class ParametersPopoverImpl implements ParametersPopoverView.Presenter {
         if (!parameters.isEmpty()) {
             view.focusParameter(parameters.size() - 1);
         }
-    }
-
-    @Override
-    public void hide() {
-        binding.ifPresent(b -> view.hide());
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImpl.html
@@ -15,7 +15,7 @@
   -->
 <div data-field="popover" data-toggle="popover" data-trigger="manual" data-container="#popover-container" title="i18ned" data-close="true">
     <div id="popover-container"></div>
-    <div id="popover-content">
+    <div id="popover-content" tabindex="0">
         <form id="#ParametersForm">
             <button class="btn btn-default" type="button" data-field="addParameter" data-i18n-key="addParameter"></button>
             <div class="kie-dmn-parameters-container">

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverImpl.java
@@ -16,28 +16,24 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.selector;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.UndefinedExpressionGrid;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.AbstractPopoverImpl;
 
 @ApplicationScoped
-public class UndefinedExpressionSelectorPopoverImpl implements UndefinedExpressionSelectorPopoverView.Presenter {
+public class UndefinedExpressionSelectorPopoverImpl extends AbstractPopoverImpl<UndefinedExpressionSelectorPopoverView, UndefinedExpressionGrid> implements UndefinedExpressionSelectorPopoverView.Presenter {
 
-    private UndefinedExpressionSelectorPopoverView view;
     private TranslationService translationService;
-
-    private Optional<UndefinedExpressionGrid> binding = Optional.empty();
 
     public UndefinedExpressionSelectorPopoverImpl() {
         //CDI proxy
@@ -47,7 +43,7 @@ public class UndefinedExpressionSelectorPopoverImpl implements UndefinedExpressi
     public UndefinedExpressionSelectorPopoverImpl(final UndefinedExpressionSelectorPopoverView view,
                                                   final TranslationService translationService,
                                                   final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier) {
-        this.view = view;
+        super(view);
         this.translationService = translationService;
 
         view.init(this);
@@ -68,29 +64,7 @@ public class UndefinedExpressionSelectorPopoverImpl implements UndefinedExpressi
     }
 
     @Override
-    public HTMLElement getElement() {
-        return view.getElement();
-    }
-
-    @Override
     public String getPopoverTitle() {
         return translationService.getTranslation(DMNEditorConstants.UndefinedExpressionEditor_SelectorTitle);
-    }
-
-    @Override
-    public void bind(final UndefinedExpressionGrid bound,
-                     final int uiRowIndex,
-                     final int uiColumnIndex) {
-        binding = Optional.ofNullable(bound);
-    }
-
-    @Override
-    public void show() {
-        binding.ifPresent(b -> view.show(Optional.ofNullable(getPopoverTitle())));
-    }
-
-    @Override
-    public void hide() {
-        binding.ifPresent(b -> view.hide());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverViewImpl.html
@@ -15,7 +15,7 @@
   -->
 <div data-field="popover" data-toggle="popover" data-trigger="manual" data-container="#popover-container" title="i18ned" data-close="true">
     <div id="popover-container"></div>
-    <div id="popover-content">
+    <div id="popover-content" tabindex="0">
         <div id="kie-dmn-undefined-expression-selector-container" class="open">
             <div class="uf-no-select">
                 <ul id="definitions-container" class="dropdown-menu dropdown-menu-overrides"></ul>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverImpl.java
@@ -94,6 +94,11 @@ public class ValueAndDataTypePopoverImpl implements ValueAndDataTypePopoverView.
     }
 
     @Override
+    public void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback) {
+        binding.ifPresent(b -> view.setOnClosedByKeyboardCallback(callback));
+    }
+
+    @Override
     public void show() {
         binding.ifPresent(b -> view.show(Optional.ofNullable(getPopoverTitle())));
     }
@@ -101,11 +106,6 @@ public class ValueAndDataTypePopoverImpl implements ValueAndDataTypePopoverView.
     @Override
     public void hide() {
         binding.ifPresent(b -> view.hide());
-    }
-
-    @Override
-    public void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback) {
-        view.setOnClosedByKeyboardCallback(callback);
     }
 
     public void onDataTypePageNavTabActiveEvent(final @Observes DataTypePageTabActiveEvent event) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverView.java
@@ -26,14 +26,12 @@ import org.uberfire.client.mvp.UberElement;
  * Definition of the _view_ to edit a domain object implementing {@link HasValueAndTypeRef}
  */
 public interface ValueAndDataTypePopoverView extends PopoverView,
-                                                     UberElement<ValueAndDataTypePopoverView.Presenter>,
-                                                     CanBeClosedByKeyboard {
+                                                     UberElement<ValueAndDataTypePopoverView.Presenter> {
 
     /**
      * Definition of the _presenter_ to edit a domain object implementing {@link HasValueAndTypeRef}
      */
-    interface Presenter extends HasCellEditorControls.Editor<HasValueAndTypeRef>,
-                                CanBeClosedByKeyboard {
+    interface Presenter extends HasCellEditorControls.Editor<HasValueAndTypeRef> {
 
         /**
          * Sets the domain object value. The {@link String} value from the UI that has been _normalised_.

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/PopupEditorControls.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/PopupEditorControls.java
@@ -17,8 +17,10 @@
 package org.kie.workbench.common.dmn.client.widgets.grid.controls;
 
 import org.jboss.errai.common.client.api.IsElement;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
 
-public interface PopupEditorControls extends IsElement {
+public interface PopupEditorControls extends IsElement,
+                                             CanBeClosedByKeyboard {
 
     /**
      * Returns the {@link String} for the {@link PopupEditorControls} title used to to edit properties.

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/JQueryDropdownMenu.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/JQueryDropdownMenu.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.controls.list;
+
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsType;
+
+import static jsinterop.annotations.JsPackage.GLOBAL;
+
+@JsType(isNative = true)
+public abstract class JQueryDropdownMenu {
+
+    @JsMethod(namespace = GLOBAL, name = "jQuery")
+    public native static JQueryDropdownMenu $(final String selector);
+
+    public native JQueryDropdownMenu find(final String selector);
+
+    public native boolean is(final String selector);
+
+    public native JQueryDropdownMenu dropdown(final String action);
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelector.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelector.java
@@ -17,19 +17,15 @@
 package org.kie.workbench.common.dmn.client.widgets.grid.controls.list;
 
 import java.util.List;
-import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.jboss.errai.common.client.dom.HTMLElement;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl.ListSelectorItem;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.AbstractPopoverImpl;
 
 @Dependent
-public class ListSelector implements ListSelectorView.Presenter {
-
-    private ListSelectorView view;
-    private Optional<HasListSelectorControl> binding = Optional.empty();
+public class ListSelector extends AbstractPopoverImpl<ListSelectorView, HasListSelectorControl> implements ListSelectorView.Presenter {
 
     public ListSelector() {
         //CDI proxy
@@ -37,13 +33,8 @@ public class ListSelector implements ListSelectorView.Presenter {
 
     @Inject
     public ListSelector(final ListSelectorView view) {
-        this.view = view;
+        super(view);
         this.view.init(this);
-    }
-
-    @Override
-    public HTMLElement getElement() {
-        return view.getElement();
     }
 
     @Override
@@ -55,7 +46,8 @@ public class ListSelector implements ListSelectorView.Presenter {
     public void bind(final HasListSelectorControl bound,
                      final int uiRowIndex,
                      final int uiColumnIndex) {
-        binding = Optional.ofNullable(bound);
+        super.bind(bound, uiRowIndex, uiColumnIndex);
+
         binding.ifPresent(b -> {
             final List<ListSelectorItem> items = b.getItems(uiRowIndex,
                                                             uiColumnIndex);
@@ -69,16 +61,5 @@ public class ListSelector implements ListSelectorView.Presenter {
                                          uiColumnIndex));
             }
         });
-    }
-
-    @Override
-    @SuppressWarnings("unused")
-    public void show() {
-        binding.ifPresent(b -> view.show());
-    }
-
-    @Override
-    public void hide() {
-        binding.ifPresent(b -> view.hide());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorView.java
@@ -18,19 +18,18 @@ package org.kie.workbench.common.dmn.client.widgets.grid.controls.list;
 
 import java.util.List;
 
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorControls;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.popover.PopoverView;
 import org.uberfire.client.mvp.UberElement;
 
-public interface ListSelectorView extends org.jboss.errai.ui.client.local.api.IsElement,
+public interface ListSelectorView extends PopoverView,
                                           UberElement<ListSelectorView.Presenter> {
 
     void setItems(final List<HasListSelectorControl.ListSelectorItem> items);
 
-    void show();
-
-    void hide();
-
-    interface Presenter extends HasCellEditorControls.Editor<HasListSelectorControl> {
+    interface Presenter extends HasCellEditorControls.Editor<HasListSelectorControl>,
+                                CanBeClosedByKeyboard {
 
         void onItemSelected(final HasListSelectorControl.ListSelectorItem item);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.html
@@ -14,6 +14,10 @@
   ~ limitations under the License.
   -->
 
-<div class="uf-no-select">
-    <ul data-field="items-container" class="dropdown-menu"></ul>
+<!--Bootstraps dropdown does not respond to the keyboard when it is bound to an anchor element-->
+<div>
+    <div id="dropdown" class="dropdown">
+        <button id="dropdown-trigger" data-toggle="dropdown"></button>
+        <ul data-field="items-container" class="dropdown-menu"></ul>
+    </div>
 </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.html
@@ -18,6 +18,6 @@
 <div>
     <div id="dropdown" class="dropdown">
         <button id="dropdown-trigger" data-toggle="dropdown"></button>
-        <ul data-field="items-container" class="dropdown-menu"></ul>
+        <ul id="dropdown-menu" data-field="items-container" class="dropdown-menu"></ul>
     </div>
 </div>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.Scheduler;
 import org.jboss.errai.common.client.api.IsElement;
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.UnorderedList;
@@ -37,7 +38,7 @@ import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSel
 @Dependent
 public class ListSelectorViewImpl implements ListSelectorView {
 
-    private static final String OPEN = "open";
+    static final String ACTION = "toggle";
 
     @DataField("items-container")
     private UnorderedList itemsContainer;
@@ -101,11 +102,34 @@ public class ListSelectorViewImpl implements ListSelectorView {
 
     @Override
     public void show() {
-        getElement().getClassList().add(OPEN);
+        //Schedule programmatic display of dropdown as it has not been attached to the DOM at this point.
+        schedule(() -> {
+            if (isDropdownMenuHidden()) {
+                dropdownTrigger().dropdown(ACTION);
+            }
+        });
     }
 
     @Override
     public void hide() {
-        getElement().getClassList().remove(OPEN);
+        if (!isDropdownMenuHidden()) {
+            dropdownTrigger().dropdown(ACTION);
+        }
+    }
+
+    void schedule(final Scheduler.ScheduledCommand command) {
+        Scheduler.get().scheduleDeferred(command);
+    }
+
+    JQueryDropdownMenu dropdown() {
+        return JQueryDropdownMenu.$("#dropdown");
+    }
+
+    JQueryDropdownMenu dropdownTrigger() {
+        return JQueryDropdownMenu.$("#dropdown-trigger");
+    }
+
+    boolean isDropdownMenuHidden() {
+        return dropdown().find(".dropdown-menu").is(":hidden");
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImpl.less
@@ -13,4 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+[data-i18n-prefix="ListSelectorViewImpl."] {
 
+  /*
+   * Bootstraps dropdown does not respond to the keyboard when the button element has display:none
+   * Therefore apply styling to make the "dropdown" and "trigger" consume zero space.
+   */
+
+  #dropdown, #dropdown-trigger {
+    width: 0px;
+    height: 0px;
+    border: 0px;
+    padding: 0px;
+  }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.controls.popover;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
+import org.kie.workbench.common.dmn.client.widgets.grid.controls.HasCellEditorControls;
+
+public abstract class AbstractPopoverImpl<V extends PopoverView, B> implements HasCellEditorControls.Editor<B> {
+
+    protected V view;
+    protected Optional<B> binding = Optional.empty();
+
+    protected AbstractPopoverImpl() {
+        //CDI proxy
+    }
+
+    protected AbstractPopoverImpl(final V view) {
+        this.view = view;
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return view.getElement();
+    }
+
+    @Override
+    public void bind(final B bound,
+                     final int uiRowIndex,
+                     final int uiColumnIndex) {
+        binding = Optional.ofNullable(bound);
+    }
+
+    @Override
+    public void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback) {
+        binding.ifPresent(b -> view.setOnClosedByKeyboardCallback(callback));
+    }
+
+    @Override
+    public void show() {
+        binding.ifPresent(b -> view.show(Optional.ofNullable(getPopoverTitle())));
+    }
+
+    @Override
+    public void hide() {
+        binding.ifPresent(b -> view.hide());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverViewImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverViewImpl.java
@@ -18,14 +18,25 @@ package org.kie.workbench.common.dmn.client.widgets.grid.controls.popover;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 
+import com.google.gwt.dom.client.BrowserEvents;
+import elemental2.dom.KeyboardEvent;
 import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.EventListener;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
 import org.uberfire.client.views.pfly.widgets.JQueryProducer;
 import org.uberfire.client.views.pfly.widgets.Popover;
 import org.uberfire.client.views.pfly.widgets.PopoverOptions;
 
-public class AbstractPopoverViewImpl implements PopoverView {
+public abstract class AbstractPopoverViewImpl implements PopoverView {
+
+    static final String ESCAPE_KEY = "Escape";
+
+    static final String ESC_KEY = "Esc";
+
+    static final String ENTER_KEY = "Enter";
 
     static final String PLACEMENT = "auto top";
 
@@ -39,7 +50,11 @@ public class AbstractPopoverViewImpl implements PopoverView {
 
     protected Popover popover;
 
-    private boolean isVisible;
+    protected boolean isVisible;
+
+    protected EventListener closedByKeyboardEventListener = null;
+
+    protected Optional<Consumer<CanBeClosedByKeyboard>> closedByKeyboardCallback = Optional.empty();
 
     protected AbstractPopoverViewImpl() {
         //CDI proxy
@@ -54,15 +69,27 @@ public class AbstractPopoverViewImpl implements PopoverView {
     }
 
     @Override
+    public void setOnClosedByKeyboardCallback(final Consumer<CanBeClosedByKeyboard> callback) {
+        closedByKeyboardCallback = Optional.ofNullable(callback);
+    }
+
+    @Override
     public void show(final Optional<String> popoverTitle) {
         final PopoverOptions options = createOptions();
 
         popoverTitle.ifPresent(t -> popoverElement.setAttribute("title", t));
         popover = jQueryPopover.wrap(this.getElement());
         popover.addShowListener(() -> isVisible = true);
-        popover.addShownListener(() -> isVisible = true);
+        popover.addShownListener(() -> {
+            isVisible = true;
+            setKeyDownListeners();
+            onShownFocus();
+        });
         popover.addHideListener(() -> isVisible = false);
-        popover.addHiddenListener(() -> isVisible = false);
+        popover.addHiddenListener(() -> {
+            isVisible = false;
+            clearKeyDownListeners();
+        });
         popover.popover(options);
         popover.show();
     }
@@ -81,6 +108,11 @@ public class AbstractPopoverViewImpl implements PopoverView {
         return new PopoverOptions();
     }
 
+    protected void onShownFocus() {
+        popoverContentElement.getStyle().setProperty("outline", "none");
+        popoverContentElement.focus();
+    }
+
     @Override
     public void hide() {
         if (Objects.nonNull(popover)) {
@@ -91,5 +123,58 @@ public class AbstractPopoverViewImpl implements PopoverView {
 
     public boolean isVisible() {
         return isVisible;
+    }
+
+    protected void setKeyDownListeners() {
+        if (Objects.isNull(closedByKeyboardEventListener)) {
+            closedByKeyboardEventListener = getKeyDownEventListener();
+            popoverElement.addEventListener(BrowserEvents.KEYDOWN,
+                                            closedByKeyboardEventListener,
+                                            false);
+        }
+    }
+
+    protected void clearKeyDownListeners() {
+        if (Objects.nonNull(closedByKeyboardEventListener)) {
+            popoverElement.removeEventListener(BrowserEvents.KEYDOWN,
+                                               closedByKeyboardEventListener,
+                                               false);
+            closedByKeyboardEventListener = null;
+        }
+    }
+
+    protected EventListener getKeyDownEventListener() {
+        return (e) -> keyDownEventListener(e);
+    }
+
+    public void keyDownEventListener(final Object event) {
+        if (event instanceof KeyboardEvent) {
+            final KeyboardEvent keyEvent = (KeyboardEvent) event;
+            if (isEnterKeyPressed(keyEvent)) {
+                hide();
+                keyEvent.stopPropagation();
+                onClosedByKeyboard();
+            } else if (isEscapeKeyPressed(keyEvent)) {
+                reset();
+                hide();
+                onClosedByKeyboard();
+            }
+        }
+    }
+
+    public boolean isEscapeKeyPressed(final KeyboardEvent event) {
+        return Objects.equals(event.key, ESC_KEY) || Objects.equals(event.key, ESCAPE_KEY);
+    }
+
+    public boolean isEnterKeyPressed(final KeyboardEvent event) {
+        return Objects.equals(event.key, ENTER_KEY);
+    }
+
+    public void onClosedByKeyboard() {
+        getClosedByKeyboardCallback().ifPresent(c -> c.accept(this));
+    }
+
+    public Optional<Consumer<CanBeClosedByKeyboard>> getClosedByKeyboardCallback() {
+        return closedByKeyboardCallback;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/PopoverView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/PopoverView.java
@@ -18,9 +18,19 @@ package org.kie.workbench.common.dmn.client.widgets.grid.controls.popover;
 
 import java.util.Optional;
 
-public interface PopoverView extends org.jboss.errai.ui.client.local.api.IsElement {
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
+
+public interface PopoverView extends org.jboss.errai.ui.client.local.api.IsElement,
+                                     CanBeClosedByKeyboard {
 
     void show(final Optional<String> popoverTitle);
 
     void hide();
+
+    /**
+     * Reset the the Popover to it's _initial_ state when first shown. No operation by default.
+     */
+    default void reset() {
+        //NOP
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverImplTest.java
@@ -128,12 +128,25 @@ public class ValueAndDataTypePopoverImplTest {
     }
 
     @Test
-    public void testSetOnClosedByKeyboardCallback() {
+    @SuppressWarnings("unchecked")
+    public void testSetOnClosedByKeyboardCallback_WhenBound() {
         final Consumer callback = mock(Consumer.class);
+
+        editor.bind(bound, 0, 0);
 
         editor.setOnClosedByKeyboardCallback(callback);
 
         verify(view).setOnClosedByKeyboardCallback(callback);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSetOnClosedByKeyboardCallback_WhenNotBound() {
+        final Consumer callback = mock(Consumer.class);
+
+        editor.setOnClosedByKeyboardCallback(callback);
+
+        verify(view, never()).setOnClosedByKeyboardCallback(any(Consumer.class));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.widgets.grid.controls.list;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -75,7 +76,7 @@ public class ListSelectorTest {
 
         listSelector.show();
 
-        verify(view).show();
+        verify(view).show(Optional.empty());
     }
 
     @Test
@@ -97,7 +98,7 @@ public class ListSelectorTest {
 
         listSelector.show();
 
-        verify(view).show();
+        verify(view).show(Optional.empty());
     }
 
     @Test
@@ -111,7 +112,7 @@ public class ListSelectorTest {
 
         listSelector.show();
 
-        verify(view, never()).show();
+        verify(view, never()).show(Optional.empty());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/list/ListSelectorViewImplTest.java
@@ -17,6 +17,8 @@
 package org.kie.workbench.common.dmn.client.widgets.grid.controls.list;
 
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -26,8 +28,12 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
+import org.uberfire.client.views.pfly.selectpicker.JQuery;
+import org.uberfire.client.views.pfly.selectpicker.JQueryEvent;
 import org.uberfire.mvp.Command;
 
 import static org.mockito.Matchers.any;
@@ -88,6 +94,12 @@ public class ListSelectorViewImplTest {
 
     @Mock
     private JQueryDropdownMenu jQueryDropdownMenu;
+
+    @Mock
+    private Consumer<CanBeClosedByKeyboard> closedByKeyboardConsumer;
+
+    @Captor
+    private ArgumentCaptor<JQuery.CallbackFunction> jQueryCallbackFunctionCaptor;
 
     private ListSelectorViewImpl view;
 
@@ -160,27 +172,42 @@ public class ListSelectorViewImplTest {
     public void testShowWhenNotShown() {
         doReturn(true).when(view).isDropdownMenuHidden();
 
-        view.show();
+        view.show(Optional.empty());
 
-        verify(jQueryDropdownMenu).dropdown(eq(ListSelectorViewImpl.ACTION));
+        verify(jQueryDropdownMenu).dropdown(eq(ListSelectorViewImpl.DROPDOWN_ACTION));
     }
 
     @Test
     public void testShowWhenAlreadyShown() {
         doReturn(false).when(view).isDropdownMenuHidden();
 
-        view.show();
+        view.show(Optional.empty());
 
         verify(jQueryDropdownMenu, never()).dropdown(anyString());
     }
 
     @Test
-    public void testHidenWhenNotHidden() {
+    public void testShowWhenNotShownWithCanBeClosedByKeyboardHandler() {
+        doReturn(true).when(view).isDropdownMenuHidden();
+
+        view.setOnClosedByKeyboardCallback(closedByKeyboardConsumer);
+
+        view.show(Optional.empty());
+
+        verify(view).dropdownHiddenHandler(jQueryCallbackFunctionCaptor.capture());
+        final JQuery.CallbackFunction jQueryCallbackFunction = jQueryCallbackFunctionCaptor.getValue();
+        jQueryCallbackFunction.call(mock(JQueryEvent.class));
+
+        verify(closedByKeyboardConsumer).accept(view);
+    }
+
+    @Test
+    public void testHideWhenNotHidden() {
         doReturn(false).when(view).isDropdownMenuHidden();
 
         view.hide();
 
-        verify(jQueryDropdownMenu).dropdown(eq(ListSelectorViewImpl.ACTION));
+        verify(jQueryDropdownMenu).dropdown(eq(ListSelectorViewImpl.DROPDOWN_ACTION));
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.widgets.grid.controls.popover;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class AbstractPopoverImplTest {
+
+    private static final int UI_ROW_INDEX = 0;
+
+    private static final int UI_COLUMN_INDEX = 1;
+
+    @Mock
+    private PopoverView view;
+
+    @Mock
+    private Consumer<CanBeClosedByKeyboard> callback;
+
+    private Object control = new Object();
+
+    private AbstractPopoverImpl<PopoverView, Object> popover;
+
+    @Before
+    public void setup() {
+        this.popover = spy(new AbstractPopoverImpl<PopoverView, Object>(view) {
+            //NOP
+        });
+    }
+
+    @Test
+    public void testGetElement() {
+        final HTMLElement element = mock(HTMLElement.class);
+
+        when(popover.getElement()).thenReturn(element);
+
+        final HTMLElement actual = popover.getElement();
+
+        assertEquals(element, actual);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSetOnClosedByKeyboardCallbackNullControl() {
+        popover.setOnClosedByKeyboardCallback(callback);
+
+        verify(view, never()).setOnClosedByKeyboardCallback(any(Consumer.class));
+    }
+
+    @Test
+    public void testSetOnClosedByKeyboardCallbackNonNullControl() {
+        popover.bind(control,
+                     UI_ROW_INDEX,
+                     UI_COLUMN_INDEX);
+
+        popover.setOnClosedByKeyboardCallback(callback);
+
+        verify(view).setOnClosedByKeyboardCallback(callback);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testShowNullControl() {
+        popover.show();
+
+        verify(view, never()).show(any(Optional.class));
+    }
+
+    @Test
+    public void testShowNonNullControl() {
+        popover.bind(control,
+                     UI_ROW_INDEX,
+                     UI_COLUMN_INDEX);
+
+        reset(view);
+
+        popover.show();
+
+        verify(view).show(eq(Optional.empty()));
+    }
+
+    @Test
+    public void testHideNullControl() {
+        popover.hide();
+
+        verify(view, never()).hide();
+    }
+
+    @Test
+    public void testHideNonNullControl() {
+        popover.bind(control,
+                     UI_ROW_INDEX,
+                     UI_COLUMN_INDEX);
+
+        reset(view);
+
+        popover.hide();
+
+        verify(view).hide();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverViewImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverViewImplTest.java
@@ -16,31 +16,148 @@
 
 package org.kie.workbench.common.dmn.client.widgets.grid.controls.popover;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Event;
+import elemental2.dom.KeyboardEvent;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
 import org.uberfire.client.views.pfly.widgets.PopoverOptions;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class AbstractPopoverViewImplTest {
 
+    private AbstractPopoverViewImpl view;
+
+    @Before
+    public void setup() {
+        this.view = spy(new AbstractPopoverViewImpl() {
+            //Nothing to implement
+        });
+    }
+
     @Test
     public void testCreateOptions() {
 
-        final AbstractPopoverViewImpl popoverView = spy(new AbstractPopoverViewImpl());
         final PopoverOptions options = mock(PopoverOptions.class);
 
-        doReturn(options).when(popoverView).createPopoverOptionsInstance();
+        doReturn(options).when(view).createPopoverOptionsInstance();
 
-        popoverView.createOptions();
+        view.createOptions();
 
         verify(options).setAnimation(false);
         verify(options).setHtml(true);
         verify(options).setPlacement(AbstractPopoverViewImpl.PLACEMENT);
+    }
+
+    @Test
+    public void testOnClosedByKeyboard() {
+        final Consumer consumer = mock(Consumer.class);
+        final Optional opt = Optional.of(consumer);
+        doReturn(opt).when(view).getClosedByKeyboardCallback();
+
+        view.onClosedByKeyboard();
+
+        verify(consumer).accept(view);
+    }
+
+    @Test
+    public void testSetOnClosedByKeyboardCallback() {
+        final Consumer consumer = mock(Consumer.class);
+        view.setOnClosedByKeyboardCallback(consumer);
+
+        final Optional<Consumer<CanBeClosedByKeyboard>> actual = view.getClosedByKeyboardCallback();
+
+        assertTrue(actual.isPresent());
+        assertEquals(consumer, actual.get());
+    }
+
+    @Test
+    public void testSetOnClosedByKeyboardCallbackNullCallback() {
+        view.setOnClosedByKeyboardCallback(null);
+
+        final Optional<Consumer<CanBeClosedByKeyboard>> actual = view.getClosedByKeyboardCallback();
+
+        assertFalse(actual.isPresent());
+        assertEquals(Optional.empty(), actual);
+    }
+
+    @Test
+    public void testKeyDownEventListenerEnterKey() {
+        final KeyboardEvent event = mock(KeyboardEvent.class);
+
+        doNothing().when(view).hide();
+        doNothing().when(view).onClosedByKeyboard();
+
+        doReturn(true).when(view).isEnterKeyPressed(event);
+
+        view.keyDownEventListener(event);
+
+        verify(view).hide();
+        verify(event).stopPropagation();
+        verify(view).onClosedByKeyboard();
+        verify(view, never()).isEscapeKeyPressed(event);
+    }
+
+    @Test
+    public void testKeyDownEventListenerEscKey() {
+        final KeyboardEvent event = mock(KeyboardEvent.class);
+
+        doNothing().when(view).hide();
+        doNothing().when(view).reset();
+        doNothing().when(view).onClosedByKeyboard();
+
+        doReturn(false).when(view).isEnterKeyPressed(event);
+        doReturn(true).when(view).isEscapeKeyPressed(event);
+
+        view.keyDownEventListener(event);
+
+        verify(view).hide();
+        verify(view).reset();
+        verify(view).onClosedByKeyboard();
+    }
+
+    @Test
+    public void testKeyDownEventListenerWhenIsNotAHandledKey() {
+
+        final KeyboardEvent event = mock(KeyboardEvent.class);
+
+        doReturn(false).when(view).isEnterKeyPressed(event);
+        doReturn(false).when(view).isEscapeKeyPressed(event);
+
+        view.keyDownEventListener(event);
+
+        verify(view, never()).hide();
+        verify(event, never()).stopPropagation();
+        verify(view, never()).onClosedByKeyboard();
+        verify(view, never()).reset();
+    }
+
+    @Test
+    public void testKeyDownEventListenerWhenIsNotKeyboardEvent() {
+
+        final Event event = mock(Event.class);
+        view.keyDownEventListener(event);
+
+        verify(view, never()).hide();
+        verify(event, never()).stopPropagation();
+        verify(view, never()).onClosedByKeyboard();
+        verify(view, never()).isEscapeKeyPressed(any());
+        verify(view, never()).reset();
     }
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-1577

_Context menus_ were not responding to keyboard events.

After a couple of days of trying alternatives this is the _only_ working solution I could find.