### PR TITLE
[AF-2464] Upgrade com.thoughtworks.xstream version (1.4.10 -> 1.4.11.1)

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/kie-all-templates/src/main/xslt/dependencies.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/kie-all-templates/src/main/xslt/dependencies.xml
@@ -43,13 +43,13 @@
   <dependency>
     <groupId>junit</groupId>
     <artifactId>junit</artifactId>
-    <version>4.12</version>
+    <version>${version.junit}</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>com.thoughtworks.xstream</groupId>
     <artifactId>xstream</artifactId>
-    <version>1.4.11.1</version>
+    <version>${version.com.thoughtworks.xstream}</version>
     <scope>test</scope>
   </dependency>
 </dependencies>

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/kie-all-templates/src/main/xslt/dependencies.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/kie-all-templates/src/main/xslt/dependencies.xml
@@ -49,7 +49,7 @@
   <dependency>
     <groupId>com.thoughtworks.xstream</groupId>
     <artifactId>xstream</artifactId>
-    <version>1.4.10</version>
+    <version>1.4.11.1</version>
     <scope>test</scope>
   </dependency>
 </dependencies>


### PR DESCRIPTION
**Task**:[ AF-2464](https://issues.redhat.com/browse/AF-2464)

**Validation**:
1. Create a new project
2. Create an asset
3. Open the project explorer
4. Change to "_Repository view_" (Settings icon)
5. Find and open `pom.xml` file
6. Check `com.thoughtworks.xstream` dependency version