### PR TITLE
DROOLS-5129: Remove unused dependencies

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
@@ -152,12 +152,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-widgets-core-client</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
@@ -51,10 +51,6 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-security-server</artifactId>
-    </dependency>
 
     <!-- Stunner -->
     <dependency>


### PR DESCRIPTION
This PR removes two unused dependencies
- uberfire-widgets-core-client
- errai-security-server

Both seems be leftovers from modules reorganization done in past.