### PR TITLE
KOGITO-1752 / KOGITO-1692 : [DMN Designer] Data Types - Drag and Drop does work as expected on Kogito webapps / New custom data type can not be added into onboarding-example

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/common/PropertiesPanelNotifier.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/common/PropertiesPanelNotifier.java
@@ -125,9 +125,10 @@ public class PropertiesPanelNotifier {
     void notifyOutdatedElement(final Node node,
                                final HasTypeRef elementTypeRef) {
 
-        final QName typeRef = elementTypeRef.getTypeRef();
+        final Optional<QName> typeRef = Optional.ofNullable(elementTypeRef.getTypeRef());
+        final boolean isOutdated = typeRef.map(type -> Objects.equals(type.getLocalPart(), oldLocalPart)).orElse(false);
 
-        if (Objects.equals(typeRef.getLocalPart(), oldLocalPart)) {
+        if (isOutdated) {
             elementTypeRef.setTypeRef(newQName);
             refreshFormProperties(node);
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/common/PropertiesPanelNotifierTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/persistence/handlers/common/PropertiesPanelNotifierTest.java
@@ -202,6 +202,25 @@ public class PropertiesPanelNotifierTest {
     }
 
     @Test
+    public void testNotifyOutdatedNodeWhenNodeDoesNotHaveTypeRef() {
+
+        final Node node = mock(Node.class);
+        final HasTypeRef elementTypeRef = mock(HasTypeRef.class);
+        final QName newQName = mock(QName.class);
+        final String oldLocalPart = "tPerson";
+
+        when(elementTypeRef.getTypeRef()).thenReturn(null);
+        doNothing().when(notifier).refreshFormProperties(any());
+
+        notifier.withOldLocalPart(oldLocalPart)
+                .withNewQName(newQName)
+                .notifyOutdatedElement(node, elementTypeRef);
+
+        verify(elementTypeRef, never()).setTypeRef(any());
+        verify(notifier, never()).refreshFormProperties(any());
+    }
+
+    @Test
     public void testNotifyOutdatedNodeWhenNodeIsNotOutdated() {
 
         final Node node = mock(Node.class);


### PR DESCRIPTION
See:
- https://issues.redhat.com/browse/KOGITO-1752
- https://issues.redhat.com/browse/KOGITO-1692

---

**KOGITO-1752: [DMN Designer] Data Types - Drag and Drop does work as expected on Kogito webapps**

Before:
![before](https://user-images.githubusercontent.com/1079279/78728516-f0d13680-790d-11ea-9c33-d1a1ece68c33.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/78728531-f62e8100-790d-11ea-8dd5-184cd82f72f9.gif)

---

**KOGITO-1692: New custom data type can not be added into onboarding-example**

Before:
![before](https://user-images.githubusercontent.com/1079279/78729106-8c16db80-790f-11ea-8867-d03590911305.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/78729115-92a55300-790f-11ea-800a-9d90f384ec46.gif)

