### PR TITLE
RHPAM-2432 it is possible to break process by setting incorrect called element

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/activities/ReusableSubprocessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/activities/ReusableSubprocessConverter.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
+import static org.kie.workbench.common.stunner.core.util.StringUtils.replaceIllegalCharsAttribute;
 
 public class ReusableSubprocessConverter {
 
@@ -51,7 +52,7 @@ public class ReusableSubprocessConverter {
         BaseReusableSubprocessTaskExecutionSet executionSet = definition.getExecutionSet();
         p.setOnEntryAction(executionSet.getOnEntryAction());
         p.setOnExitAction(executionSet.getOnExitAction());
-        p.setCalledElement(executionSet.getCalledElement().getValue());
+        p.setCalledElement(replaceIllegalCharsAttribute(executionSet.getCalledElement().getValue()));
         p.setAsync(executionSet.getIsAsync().getValue());
         p.setIndependent(executionSet.getIndependent().getValue());
         if (Boolean.FALSE.equals(executionSet.getIndependent().getValue())) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/activities/CallActivityConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/activities/CallActivityConverter.java
@@ -43,6 +43,8 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
+import static org.kie.workbench.common.stunner.core.util.StringUtils.revertIllegalCharsAttribute;
+
 public class CallActivityConverter extends BaseCallActivityConverter<ReusableSubprocess, ReusableSubprocessTaskExecutionSet> {
 
     public CallActivityConverter(TypedFactoryManager factoryManager,
@@ -58,7 +60,7 @@ public class CallActivityConverter extends BaseCallActivityConverter<ReusableSub
     @Override
     protected ReusableSubprocessTaskExecutionSet createReusableSubprocessTaskExecutionSet(CallActivity activity,
                                                                                           CallActivityPropertyReader p) {
-        return new ReusableSubprocessTaskExecutionSet(new CalledElement(activity.getCalledElement()),
+        return new ReusableSubprocessTaskExecutionSet(new CalledElement(revertIllegalCharsAttribute(activity.getCalledElement())),
                                                       new IsCase(p.isCase()),
                                                       new Independent(p.isIndependent()),
                                                       new AbortParent(p.isAbortParent()),

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -1853,7 +1853,7 @@ public class BPMNDirectDiagramMarshallerTest {
 
         assertEquals("my subprocess",
                      generalSet.getName().getValue());
-        assertEquals("my-called-element",
+        assertEquals("my-called-element\" <&> \"",
                      executionSet.getCalledElement().getValue());
         assertEquals(false,
                      executionSet.getIndependent().getValue());
@@ -2928,7 +2928,7 @@ public class BPMNDirectDiagramMarshallerTest {
                       3,
                       2);
 
-        assertTrue(result.contains("<bpmn2:callActivity id=\"_FC6D8570-8C67-40C2-8B7B-953DE15765FB\" drools:independent=\"false\" drools:waitForCompletion=\"true\" name=\"my subprocess\" calledElement=\"my-called-element\">"));
+        assertTrue(result.contains("<bpmn2:callActivity id=\"_FC6D8570-8C67-40C2-8B7B-953DE15765FB\" drools:independent=\"false\" drools:waitForCompletion=\"true\" name=\"my subprocess\" calledElement=\"my-called-element&quot; &lt;&amp;&gt; &quot;\">"));
 
         assertTrue(result.contains("<bpmn2:dataInput id=\"_FC6D8570-8C67-40C2-8B7B-953DE15765FB_input1InputX\" drools:dtype=\"String\" itemSubjectRef=\"__FC6D8570-8C67-40C2-8B7B-953DE15765FB_input1InputXItem\" name=\"input1\"/>"));
         assertTrue(result.contains("<bpmn2:dataOutput id=\"_FC6D8570-8C67-40C2-8B7B-953DE15765FB_output2OutputX\" drools:dtype=\"Float\" itemSubjectRef=\"__FC6D8570-8C67-40C2-8B7B-953DE15765FB_output2OutputXItem\" name=\"output2\"/>"));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/reusableSubprocessCalledElement.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/reusableSubprocessCalledElement.bpmn
@@ -14,7 +14,7 @@
     <bpmn2:endEvent id="_8B7A5BE1-CA89-4F00-B57D-10CFE84FEB1E">
       <bpmn2:incoming>_7E18FB7B-605E-4DBC-895A-D8709E26F681</bpmn2:incoming>
     </bpmn2:endEvent>
-    <bpmn2:callActivity id="_FC6D8570-8C67-40C2-8B7B-953DE15765FB" drools:independent="false" drools:waitForCompletion="true" name="my subprocess" calledElement="my-called-element">
+    <bpmn2:callActivity id="_FC6D8570-8C67-40C2-8B7B-953DE15765FB" drools:independent="false" drools:waitForCompletion="true" name="my subprocess" calledElement="my-called-element&quot; &lt;&amp;&gt; &quot;">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
           <drools:metaValue><![CDATA[my subprocess]]></drools:metaValue>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/activities/ReusableSubprocessConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/activities/ReusableSubprocessConverter.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories.bpmn2;
+import static org.kie.workbench.common.stunner.core.util.StringUtils.replaceIllegalCharsAttribute;
 
 public class ReusableSubprocessConverter {
 
@@ -51,7 +52,7 @@ public class ReusableSubprocessConverter {
         BaseReusableSubprocessTaskExecutionSet executionSet = definition.getExecutionSet();
         p.setOnEntryAction(executionSet.getOnEntryAction());
         p.setOnExitAction(executionSet.getOnExitAction());
-        p.setCalledElement(executionSet.getCalledElement().getValue());
+        p.setCalledElement(replaceIllegalCharsAttribute(executionSet.getCalledElement().getValue()));
         p.setAsync(executionSet.getIsAsync().getValue());
         p.setIndependent(executionSet.getIndependent().getValue());
         if (Boolean.FALSE.equals(executionSet.getIndependent().getValue())) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/activities/CallActivityConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/activities/CallActivityConverter.java
@@ -43,6 +43,8 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
+import static org.kie.workbench.common.stunner.core.util.StringUtils.revertIllegalCharsAttribute;
+
 public class CallActivityConverter extends BaseCallActivityConverter<ReusableSubprocess, ReusableSubprocessTaskExecutionSet> {
 
     public CallActivityConverter(TypedFactoryManager factoryManager,
@@ -58,7 +60,7 @@ public class CallActivityConverter extends BaseCallActivityConverter<ReusableSub
     @Override
     protected ReusableSubprocessTaskExecutionSet createReusableSubprocessTaskExecutionSet(CallActivity activity,
                                                                                           CallActivityPropertyReader p) {
-        return new ReusableSubprocessTaskExecutionSet(new CalledElement(activity.getCalledElement()),
+        return new ReusableSubprocessTaskExecutionSet(new CalledElement(revertIllegalCharsAttribute(activity.getCalledElement())),
                                                       new IsCase(p.isCase()),
                                                       new Independent(p.isIndependent()),
                                                       new AbortParent(p.isAbortParent()),


### PR DESCRIPTION
To test this PR I used `testProject.processName~!@#$%^&*()+``-={}[]:"|;'\<>?,./_` and full business central build. Works to me now.