### PR TITLE
RHPAM-2881 Notification Form in Stunner is limiting the Body content

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetViewImpl.java
@@ -264,7 +264,7 @@ public class NotificationEditorWidgetViewImpl extends Composite implements Notif
     protected void initTextBoxes() {
         subject.setMaxLength(100);
         periodBox.showLabel(false);
-        body.setMaxLength(500);
+        body.setMaxLength(65535);
         body.setHeight("70px");
 
         dateTimePicker.setValue(new Date());


### PR DESCRIPTION
Hi @romartin, @LuboTerifaj,

this one was easy one. But it is good question, do we have any limits on the body? I didn't found any info about it. Maybe @MarianMacik @cristianonicolai have any info?

Also, I found two further possible issues to fix:
* all content after `@` symbol is cutted
* it is not possible to "enlarge" the text area. It is easy to fix, if needed. See on the picture below how it can be. Yes, it looks little bit ugly, but it can be useful and "better than nothing". I found it useful when I looked why part of the body still cut (see previous point).

<img width="892" alt="obrazek" src="https://user-images.githubusercontent.com/1477262/79238702-0398bd80-7e70-11ea-8b3e-88ec43b96c1d.png">
