### PR TITLE
DROOLS-5148: [DMN Designer] Copy/Paste is not working

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Binding.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Binding.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -34,6 +35,13 @@ public class Binding extends DMNModelInstrumentedBase implements HasExpression,
 
     private InformationItem parameter;
     private Expression expression;
+
+    public Binding copy() {
+        final Binding bindingCloned = new Binding();
+        bindingCloned.parameter = parameter.copy();
+        bindingCloned.expression = Optional.ofNullable(expression).map(Expression::copy).orElse(null);
+        return bindingCloned;
+    }
 
     public InformationItem getParameter() {
         return parameter;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -55,7 +56,9 @@ public class Context extends Expression {
         clonedContext.description = description.copy();
         clonedContext.typeRef = typeRef.copy();
         clonedContext.componentWidths = new ArrayList<>(componentWidths);
-        clonedContext.contextEntry = contextEntry.stream().map(ContextEntry::copy).collect(Collectors.toList());
+        clonedContext.contextEntry = Optional.ofNullable(contextEntry)
+                .map(contextEntryList -> contextEntryList.stream().map(ContextEntry::copy).collect(Collectors.toList()))
+                .orElse(null);
         return clonedContext;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
@@ -46,6 +47,16 @@ public class Context extends Expression {
         super(id,
               description,
               typeRef);
+    }
+
+    @Override
+    public Context copy() {
+        final Context clonedContext = new Context();
+        clonedContext.description = description.copy();
+        clonedContext.typeRef = typeRef.copy();
+        clonedContext.componentWidths = new ArrayList<>(componentWidths);
+        clonedContext.contextEntry = contextEntry.stream().map(ContextEntry::copy).collect(Collectors.toList());
+        return clonedContext;
     }
 
     public List<ContextEntry> getContextEntry() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -36,6 +37,13 @@ public class ContextEntry extends DMNModelInstrumentedBase implements HasExpress
 
     private InformationItem variable;
     private Expression expression;
+
+    public ContextEntry copy() {
+        final ContextEntry clonedContextEntry = new ContextEntry();
+        clonedContextEntry.variable = Optional.ofNullable(variable).map(InformationItem::copy).orElse(null);
+        clonedContextEntry.expression = Optional.ofNullable(expression).map(Expression::copy).orElse(null);
+        return clonedContextEntry;
+    }
 
     @Override
     public InformationItem getVariable() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
@@ -49,6 +50,15 @@ public class DecisionRule extends DMNElement implements HasTypeRefs {
               description);
         this.inputEntry = inputEntry;
         this.outputEntry = outputEntry;
+    }
+
+    public DecisionRule copy() {
+        DecisionRule clonedDecisionRule = new DecisionRule();
+        clonedDecisionRule.description = description.copy();
+        clonedDecisionRule.inputEntry = inputEntry.stream().map(UnaryTests::copy).collect(Collectors.toList());
+        clonedDecisionRule.outputEntry = outputEntry.stream().map(LiteralExpression::copy).collect(Collectors.toList());
+        clonedDecisionRule.annotationEntry = annotationEntry.stream().map(RuleAnnotationClauseText::copy).collect(Collectors.toList());
+        return clonedDecisionRule;
     }
 
     public List<RuleAnnotationClauseText> getAnnotationEntry() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -57,7 +58,10 @@ public class DecisionRule extends DMNElement implements HasTypeRefs {
         clonedDecisionRule.description = description.copy();
         clonedDecisionRule.inputEntry = inputEntry.stream().map(UnaryTests::copy).collect(Collectors.toList());
         clonedDecisionRule.outputEntry = outputEntry.stream().map(LiteralExpression::copy).collect(Collectors.toList());
-        clonedDecisionRule.annotationEntry = annotationEntry.stream().map(RuleAnnotationClauseText::copy).collect(Collectors.toList());
+        clonedDecisionRule.annotationEntry = Optional.ofNullable(annotationEntry)
+                .map(annotationEntryList ->
+                             annotationEntryList.stream().map(RuleAnnotationClauseText::copy).collect(Collectors.toList()))
+                .orElse(null);
         return clonedDecisionRule;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -86,7 +87,10 @@ public class DecisionTable extends Expression {
         clonedDecisionTable.input = input.stream().map(InputClause::copy).collect(Collectors.toList());
         clonedDecisionTable.output = output.stream().map(OutputClause::copy).collect(Collectors.toList());
         clonedDecisionTable.rule = rule.stream().map(DecisionRule::copy).collect(Collectors.toList());
-        clonedDecisionTable.annotations = annotations.stream().map(RuleAnnotationClause::copy).collect(Collectors.toList());
+        clonedDecisionTable.annotations = Optional.ofNullable(annotations)
+                .map(annotationEntryList ->
+                             annotationEntryList.stream().map(RuleAnnotationClause::copy).collect(Collectors.toList()))
+                .orElse(null);
         clonedDecisionTable.hitPolicy = hitPolicy;
         clonedDecisionTable.aggregation = aggregation;
         clonedDecisionTable.preferredOrientation = preferredOrientation;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
@@ -74,6 +75,23 @@ public class DecisionTable extends Expression {
         this.aggregation = aggregation;
         this.preferredOrientation = preferredOrientation;
         this.outputLabel = outputLabel;
+    }
+
+    @Override
+    public DecisionTable copy() {
+        final DecisionTable clonedDecisionTable = new DecisionTable();
+        clonedDecisionTable.description = description.copy();
+        clonedDecisionTable.typeRef = typeRef.copy();
+        clonedDecisionTable.componentWidths = new ArrayList<>(componentWidths);
+        clonedDecisionTable.input = input.stream().map(InputClause::copy).collect(Collectors.toList());
+        clonedDecisionTable.output = output.stream().map(OutputClause::copy).collect(Collectors.toList());
+        clonedDecisionTable.rule = rule.stream().map(DecisionRule::copy).collect(Collectors.toList());
+        clonedDecisionTable.annotations = annotations.stream().map(RuleAnnotationClause::copy).collect(Collectors.toList());
+        clonedDecisionTable.hitPolicy = hitPolicy;
+        clonedDecisionTable.aggregation = aggregation;
+        clonedDecisionTable.preferredOrientation = preferredOrientation;
+        clonedDecisionTable.outputLabel = outputLabel;
+        return clonedDecisionTable;
     }
 
     public List<RuleAnnotationClause> getAnnotations() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
@@ -45,6 +45,10 @@ public abstract class Expression extends DMNElement implements HasTypeRef,
         this.typeRef = typeRef;
     }
 
+    /**
+     * It represents a contract for all subclasses of {@link Expression}.
+     * Its purpose is to exploit polymorphism when we deeply copy the Expression boxed inside the {@link Decision}
+     */
     public abstract Expression copy();
 
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
@@ -45,6 +45,8 @@ public abstract class Expression extends DMNElement implements HasTypeRef,
         this.typeRef = typeRef;
     }
 
+    public abstract Expression copy();
+
     // -----------------------
     // DMN properties
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinition.java
@@ -17,7 +17,10 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -56,6 +59,36 @@ public class FunctionDefinition extends Expression implements HasExpression {
               description,
               typeRef);
         this.expression = expression;
+    }
+
+    @Override
+    public FunctionDefinition copy() {
+        final FunctionDefinition clonedFunctionDefinition = new FunctionDefinition();
+        clonedFunctionDefinition.description = description.copy();
+        clonedFunctionDefinition.typeRef = typeRef.copy();
+        clonedFunctionDefinition.componentWidths = new ArrayList<>(componentWidths);
+        clonedFunctionDefinition.expression = Optional.ofNullable(expression).map(Expression::copy).orElse(null);
+        clonedFunctionDefinition.formalParameter = cloneFormalParameterList();
+        clonedFunctionDefinition.kind = kind;
+        clonedFunctionDefinition.getAdditionalAttributes().putAll(cloneAdditionalAttributes());
+        return clonedFunctionDefinition;
+    }
+
+    private List<InformationItem> cloneFormalParameterList() {
+        return getFormalParameter()
+                .stream()
+                .map(InformationItem::copy)
+                .collect(Collectors.toList());
+    }
+
+    private Map<QName, String> cloneAdditionalAttributes() {
+        return getAdditionalAttributes().keySet()
+                .stream()
+                .map(QName::copy)
+                .collect(Collectors.toMap(
+                        typeRef -> typeRef,
+                        typeRef -> getAdditionalAttributes().get(typeRef)
+                ));
     }
 
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValues.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValues.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -92,7 +93,7 @@ public class ImportedValues extends Import implements DMNPropertySet,
         clonedImportedValues.locationURI = locationURI.copy();
         clonedImportedValues.importType = importType;
         clonedImportedValues.importedElement = importedElement;
-        clonedImportedValues.expressionLanguage = expressionLanguage.copy();
+        clonedImportedValues.expressionLanguage = Optional.ofNullable(expressionLanguage).map(ExpressionLanguage::copy).orElse(null);
         return clonedImportedValues;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValues.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValues.java
@@ -22,6 +22,7 @@ import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.soup.commons.util.Sets;
 import org.kie.workbench.common.dmn.api.property.DMNPropertySet;
 import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
 import org.kie.workbench.common.dmn.api.resource.i18n.DMNAPIConstants;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FieldParam;
@@ -82,6 +83,17 @@ public class ImportedValues extends Import implements DMNPropertySet,
               importType);
         this.importedElement = importedElement;
         this.expressionLanguage = expressionLanguage;
+    }
+
+    public ImportedValues copy() {
+        ImportedValues clonedImportedValues = new ImportedValues();
+        clonedImportedValues.id = new Id();
+        clonedImportedValues.namespace = namespace;
+        clonedImportedValues.locationURI = locationURI.copy();
+        clonedImportedValues.importType = importType;
+        clonedImportedValues.importedElement = importedElement;
+        clonedImportedValues.expressionLanguage = expressionLanguage.copy();
+        return clonedImportedValues;
     }
 
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InformationItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InformationItem.java
@@ -102,12 +102,13 @@ public class InformationItem extends NamedElement implements DMNPropertySet,
     // -----------------------
 
     public InformationItem copy() {
-        return new InformationItem(
-                new Id(),
-                description,
-                new Name(name.getValue()),
-                typeRef.copy()
-        );
+        final InformationItem clonedInformationItem = new InformationItem();
+        clonedInformationItem.description = description.copy();
+        clonedInformationItem.name = name.copy();
+        clonedInformationItem.nameHolder = nameHolder.copy();
+        clonedInformationItem.typeRef = typeRef.copy();
+        clonedInformationItem.typeRefHolder = typeRefHolder.copy();
+        return clonedInformationItem;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InformationItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InformationItem.java
@@ -101,6 +101,15 @@ public class InformationItem extends NamedElement implements DMNPropertySet,
     // DMN properties
     // -----------------------
 
+    public InformationItem copy() {
+        return new InformationItem(
+                new Id(),
+                description,
+                new Name(name.getValue()),
+                typeRef.copy()
+        );
+    }
+
     @Override
     public QName getTypeRef() {
         return typeRefHolder.getValue();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
@@ -85,6 +85,15 @@ public class InputClause extends DMNElement implements HasTypeRefs,
         this.inputValues = inputValues;
     }
 
+    public InputClause copy() {
+        return new InputClause(
+                new Id(),
+                description.copy(),
+                inputExpression.copy(),
+                inputValues.copy()
+        );
+    }
+
     @Override
     public List<HasTypeRef> getHasTypeRefs() {
         return new ArrayList<>(getNotNullHasTypeRefs(getInputExpression()));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.Valid;
@@ -113,6 +114,16 @@ public class InputClauseLiteralExpression extends DMNModelInstrumentedBase imple
         this.typeRefHolder = new QNameHolder(typeRef);
         this.text = text;
         this.importedValues = importedValues;
+    }
+
+    public InputClauseLiteralExpression copy() {
+        final InputClauseLiteralExpression clonedInputClauseLiteralExpression = new InputClauseLiteralExpression();
+        clonedInputClauseLiteralExpression.description = description.copy();
+        clonedInputClauseLiteralExpression.typeRef = typeRef.copy();
+        clonedInputClauseLiteralExpression.typeRefHolder = typeRefHolder.copy();
+        clonedInputClauseLiteralExpression.text = text.copy();
+        clonedInputClauseLiteralExpression.importedValues = Optional.ofNullable(importedValues).map(ImportedValues::copy).orElse(null);
+        return clonedInputClauseLiteralExpression;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTests.java
@@ -89,6 +89,14 @@ public class InputClauseUnaryTests extends DMNModelInstrumentedBase implements I
         this.constraintTypeProperty = new ConstraintTypeProperty(constraintTypeString);
     }
 
+    public InputClauseUnaryTests copy() {
+        return new InputClauseUnaryTests(
+                new Id(),
+                text.copy(),
+                ConstraintType.fromString(constraintTypeProperty.getValue())
+        );
+    }
+
     // -----------------------
     // DMN properties
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Invocation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Invocation.java
@@ -17,6 +17,8 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -55,6 +57,17 @@ public class Invocation extends Expression implements HasExpression {
               typeRef);
         this.expression = expression;
         this.binding = binding;
+    }
+
+    @Override
+    public Invocation copy() {
+        final Invocation clonedInvocation = new Invocation();
+        clonedInvocation.description = description.copy();
+        clonedInvocation.typeRef = typeRef.copy();
+        clonedInvocation.componentWidths = new ArrayList<>(componentWidths);
+        clonedInvocation.expression = Optional.ofNullable(expression).map(Expression::copy).orElse(null);
+        clonedInvocation.binding = binding.stream().map(Binding::copy).collect(Collectors.toList());
+        return clonedInvocation;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/List.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/List.java
@@ -16,6 +16,9 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
@@ -49,6 +52,24 @@ public class List extends Expression {
               description,
               typeRef);
         this.expression = expression;
+    }
+
+    @Override
+    public List copy() {
+        final List clonedList = new List();
+        clonedList.description = description.copy();
+        clonedList.typeRef = typeRef.copy();
+        clonedList.componentWidths = new ArrayList<>(componentWidths);
+        clonedList.expression = expression.stream().map(expressionWrapperMappingFn(clonedList)).collect(Collectors.toList());
+        return clonedList;
+    }
+
+    private Function<HasExpression, HasExpression> expressionWrapperMappingFn(final List clonedList) {
+        return exp ->
+                HasExpression.wrap(
+                        clonedList,
+                        Optional.ofNullable(exp.getExpression()).map(Expression::copy).orElse(null)
+                );
     }
 
     public java.util.List<HasExpression> getExpression() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpression.java
@@ -15,6 +15,8 @@
  */
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.ArrayList;
+import java.util.Optional;
 import java.util.Set;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -89,6 +91,18 @@ public class LiteralExpression extends Expression implements IsLiteralExpression
         this.text = text;
         this.importedValues = importedValues;
         this.expressionLanguage = expressionLanguage;
+    }
+
+    @Override
+    public LiteralExpression copy() {
+        final LiteralExpression clonedLiteralExpression = new LiteralExpression();
+        clonedLiteralExpression.description = description.copy();
+        clonedLiteralExpression.typeRef = typeRef.copy();
+        clonedLiteralExpression.componentWidths = new ArrayList<>(componentWidths);
+        clonedLiteralExpression.text = text.copy();
+        clonedLiteralExpression.importedValues = Optional.ofNullable(importedValues).map(ImportedValues::copy).orElse(null);
+        clonedLiteralExpression.expressionLanguage = expressionLanguage.copy();
+        return clonedLiteralExpression;
     }
 
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
@@ -95,6 +95,17 @@ public class OutputClause extends DMNElement implements HasTypeRef,
         this.typeRef = typeRef;
     }
 
+    public OutputClause copy() {
+        return new OutputClause(
+                new Id(),
+                description.copy(),
+                outputValues.copy(),
+                defaultOutputEntry.copy(),
+                name,
+                typeRef.copy()
+        );
+    }
+
     @Override
     public List<HasTypeRef> getHasTypeRefs() {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpression.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpression.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -103,6 +104,16 @@ public class OutputClauseLiteralExpression extends DMNModelInstrumentedBase impl
         this.typeRef = typeRef;
         this.text = text;
         this.importedValues = importedValues;
+    }
+
+    public OutputClauseLiteralExpression copy() {
+        return new OutputClauseLiteralExpression(
+                new Id(),
+                description.copy(),
+                typeRef.copy(),
+                text.copy(),
+                Optional.ofNullable(importedValues).map(ImportedValues::copy).orElse(null)
+        );
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
@@ -73,6 +73,14 @@ public class OutputClauseUnaryTests extends DMNModelInstrumentedBase implements 
         this.constraintType = constraintTypeField;
     }
 
+    public OutputClauseUnaryTests copy() {
+        return new OutputClauseUnaryTests(
+                new Id(),
+                text.copy(),
+                constraintType
+        );
+    }
+
     // -----------------------
     // DMN properties
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
@@ -16,6 +16,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
@@ -52,6 +53,17 @@ public class Relation extends Expression {
               typeRef);
         this.column = column;
         this.row = row;
+    }
+
+    @Override
+    public Relation copy() {
+        final Relation clonedRelation = new Relation();
+        clonedRelation.description = description.copy();
+        clonedRelation.typeRef = typeRef.copy();
+        clonedRelation.componentWidths = new ArrayList<>(componentWidths);
+        clonedRelation.column = column.stream().map(InformationItem::copy).collect(Collectors.toList());
+        clonedRelation.row = row.stream().map(List::copy).collect(Collectors.toList());
+        return clonedRelation;
     }
 
     public java.util.List<InformationItem> getColumn() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClause.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClause.java
@@ -31,6 +31,12 @@ public class RuleAnnotationClause extends DMNElement implements HasName {
         this.name = new Name();
     }
 
+    public RuleAnnotationClause copy() {
+        final RuleAnnotationClause clonedRuleAnnotationClause = new RuleAnnotationClause();
+        clonedRuleAnnotationClause.name = name.copy();
+        return clonedRuleAnnotationClause;
+    }
+
     @Override
     public Name getName() {
         return this.name;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseText.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseText.java
@@ -31,6 +31,12 @@ public class RuleAnnotationClauseText extends DMNElement implements HasText {
         this.text = new Text();
     }
 
+    public RuleAnnotationClauseText copy() {
+        final RuleAnnotationClauseText clonedRuleAnnotationClauseText = new RuleAnnotationClauseText();
+        clonedRuleAnnotationClauseText.text = text.copy();
+        return clonedRuleAnnotationClauseText;
+    }
+
     @Override
     public Text getText() {
         return text;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/UnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/UnaryTests.java
@@ -86,6 +86,16 @@ public class UnaryTests extends DMNElement implements IsUnaryTests,
         this.constraintType = constraintType;
     }
 
+    public UnaryTests copy() {
+        return new UnaryTests(
+                new Id(),
+                description.copy(),
+                text.copy(),
+                expressionLanguage.copy(),
+                constraintType
+        );
+    }
+
     // -----------------------
     // Stunner core properties
     // -----------------------

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/AllowedAnswers.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/AllowedAnswers.java
@@ -43,6 +43,10 @@ public class AllowedAnswers implements DMNProperty {
         this.value = value;
     }
 
+    public AllowedAnswers copy() {
+        return new AllowedAnswers(value);
+    }
+
     public String getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Description.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Description.java
@@ -43,6 +43,10 @@ public class Description implements DMNProperty {
         this.value = value;
     }
 
+    public Description copy() {
+        return new Description(value);
+    }
+
     public String getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguage.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguage.java
@@ -43,6 +43,10 @@ public class ExpressionLanguage implements DMNProperty {
         this.value = value;
     }
 
+    public ExpressionLanguage copy() {
+        return new ExpressionLanguage(value);
+    }
+
     public String getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/LocationURI.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/LocationURI.java
@@ -43,6 +43,10 @@ public class LocationURI implements DMNProperty {
         this.value = value;
     }
 
+    public LocationURI copy() {
+        return new LocationURI(value);
+    }
+
     public String getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Name.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Name.java
@@ -34,6 +34,10 @@ public class Name implements DMNProperty {
         this.value = value;
     }
 
+    public Name copy() {
+        return new Name(value);
+    }
+
     public String getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/NameHolder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/NameHolder.java
@@ -53,6 +53,10 @@ public class NameHolder implements DMNProperty {
         this.value = value;
     }
 
+    public NameHolder copy() {
+        return new NameHolder(value.copy());
+    }
+
     public Name getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QName.java
@@ -63,6 +63,10 @@ public class QName implements DMNProperty {
         this.prefix = PortablePreconditions.checkNotNull("prefix", prefix);
     }
 
+    public QName copy() {
+        return new QName(namespaceURI, localPart, prefix);
+    }
+
     public String getNamespaceURI() {
         return namespaceURI;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QNameHolder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/QNameHolder.java
@@ -48,6 +48,10 @@ public class QNameHolder implements DMNProperty {
         this.value = value;
     }
 
+    public QNameHolder copy() {
+        return new QNameHolder(value.copy());
+    }
+
     public PropertyType getType() {
         return type;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Question.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Question.java
@@ -43,6 +43,10 @@ public class Question implements DMNProperty {
         this.value = value;
     }
 
+    public Question copy() {
+        return new Question(value);
+    }
+
     public String getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Text.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/property/dmn/Text.java
@@ -42,6 +42,10 @@ public class Text implements DMNProperty {
         this.value = value;
     }
 
+    public Text copy() {
+        return new Text(value);
+    }
+
     public String getValue() {
         return value;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
@@ -23,10 +23,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -37,6 +44,9 @@ import static org.mockito.Mockito.when;
 
 public class BindingTest {
 
+    public static final String ITEM_ID = "ITEM-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String INFORMATION_ITEM_NAME = "INFORMATION-ITEM-NAME";
     private Binding binding;
 
     @Before
@@ -92,5 +102,22 @@ public class BindingTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final Binding source = new Binding();
+        final InformationItem informationItem = new InformationItem(new Id(ITEM_ID), new Description(DESCRIPTION), new Name(INFORMATION_ITEM_NAME), BuiltInType.BOOLEAN.asQName());
+        source.setParameter(informationItem);
+
+        final Binding target = source.copy();
+
+        assertNotNull(target);
+        assertNull(target.getExpression());
+        assertNotNull(target.getParameter());
+        assertNotEquals(ITEM_ID, target.getParameter().getId().getValue());
+        assertEquals(DESCRIPTION, target.getParameter().getDescription().getValue());
+        assertEquals(INFORMATION_ITEM_NAME, target.getParameter().getName().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getParameter().getTypeRef());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
@@ -44,9 +44,9 @@ import static org.mockito.Mockito.when;
 
 public class BindingTest {
 
-    public static final String ITEM_ID = "ITEM-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String INFORMATION_ITEM_NAME = "INFORMATION-ITEM-NAME";
+    private static final String ITEM_ID = "ITEM-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String INFORMATION_ITEM_NAME = "INFORMATION-ITEM-NAME";
     private Binding binding;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntryTest.java
@@ -22,10 +22,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -34,6 +41,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ContextEntryTest {
 
+    private static final String ITEM_ID = "item-id";
+    private static final String DESCRIPTION = "description";
+    private static final String INFORMATION_ITEM_NAME = "item-name";
     private ContextEntry contextEntry;
 
     @Before
@@ -60,5 +70,22 @@ public class ContextEntryTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final ContextEntry source = new ContextEntry();
+        final InformationItem informationItem = new InformationItem(new Id(ITEM_ID), new Description(DESCRIPTION), new Name(INFORMATION_ITEM_NAME), BuiltInType.BOOLEAN.asQName());
+        source.setVariable(informationItem);
+
+        final ContextEntry target = source.copy();
+
+        assertNotNull(target);
+        assertNull(target.getExpression());
+        assertNotNull(target.getVariable());
+        assertNotEquals(ITEM_ID, target.getVariable().getId().getValue());
+        assertEquals(DESCRIPTION, target.getVariable().getDescription().getValue());
+        assertEquals(INFORMATION_ITEM_NAME, target.getVariable().getName().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getVariable().getTypeRef());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
@@ -23,10 +23,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -35,6 +40,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ContextTest {
 
+    public static final String CONTEXT_ID = "CONTEXT-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
     private Context context;
 
     @Before
@@ -67,5 +74,17 @@ public class ContextTest {
         assertEquals(context.getRequiredComponentWidthCount(),
                      context.getComponentWidths().size());
         context.getComponentWidths().forEach(Assert::assertNull);
+    }
+
+    @Test
+    public void testCopy() {
+        final Context source = new Context(new Id(CONTEXT_ID), new Description(DESCRIPTION), BuiltInType.BOOLEAN.asQName());
+
+        final Context target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(CONTEXT_ID, target.getId().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
@@ -40,8 +40,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ContextTest {
 
-    public static final String CONTEXT_ID = "CONTEXT-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
+    private static final String CONTEXT_ID = "CONTEXT-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
     private Context context;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
@@ -16,16 +16,22 @@
 
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -34,6 +40,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class DecisionRuleTest {
 
+    public static final String DECISION_RULE_ID = "DECISION_RULE_ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
     private DecisionRule decisionRule;
 
     @Before
@@ -56,5 +64,18 @@ public class DecisionRuleTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(literalExpression1, literalExpression2);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final DecisionRule source = new DecisionRule(new Id(DECISION_RULE_ID), new Description(DESCRIPTION), new ArrayList<>(), new ArrayList<>());
+
+        final DecisionRule target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(DECISION_RULE_ID, target.getId().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertTrue(target.getInputEntry().isEmpty());
+        assertTrue(target.getOutputEntry().isEmpty());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
@@ -40,8 +40,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class DecisionRuleTest {
 
-    public static final String DECISION_RULE_ID = "DECISION_RULE_ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
+    private static final String DECISION_RULE_ID = "DECISION_RULE_ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
     private DecisionRule decisionRule;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -23,10 +24,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.api.definition.model.BuiltinAggregator.SUM;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -36,6 +44,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 public class DecisionTableTest {
 
+    public static final String TABLE_ID = "TABLE-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String OUTPUT_LABEL = "OUTPUT-LABEL";
     private DecisionTable decisionTable;
 
     @Before
@@ -89,5 +100,33 @@ public class DecisionTableTest {
         assertEquals(decisionTable.getRequiredComponentWidthCount(),
                      decisionTable.getComponentWidths().size());
         decisionTable.getComponentWidths().forEach(Assert::assertNull);
+    }
+
+    @Test
+    public void testCopy() {
+        final DecisionTable source = new DecisionTable(new Id(TABLE_ID),
+                                                       new Description(DESCRIPTION),
+                                                       BuiltInType.BOOLEAN.asQName(),
+                                                       new ArrayList<>(),
+                                                       new ArrayList<>(),
+                                                       new ArrayList<>(),
+                                                       HitPolicy.UNIQUE,
+                                                       SUM,
+                                                       DecisionTableOrientation.RULE_AS_ROW,
+                                                       OUTPUT_LABEL);
+
+        final DecisionTable target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(TABLE_ID, target.getId().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+        assertTrue(target.getInput().isEmpty());
+        assertTrue(target.getOutput().isEmpty());
+        assertTrue(target.getRule().isEmpty());
+        assertEquals(HitPolicy.UNIQUE, target.getHitPolicy());
+        assertEquals(SUM, target.getAggregation());
+        assertEquals(DecisionTableOrientation.RULE_AS_ROW, target.getPreferredOrientation());
+        assertEquals(OUTPUT_LABEL, target.getOutputLabel());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
@@ -44,9 +44,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 public class DecisionTableTest {
 
-    public static final String TABLE_ID = "TABLE-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String OUTPUT_LABEL = "OUTPUT-LABEL";
+    private static final String TABLE_ID = "TABLE-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String OUTPUT_LABEL = "OUTPUT-LABEL";
     private DecisionTable decisionTable;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ExpressionTest.java
@@ -34,6 +34,11 @@ public class ExpressionTest {
     public void setup() {
         this.expression = new Expression() {
             @Override
+            public Expression copy() {
+                return expression;
+            }
+
+            @Override
             public int getRequiredComponentWidthCount() {
                 return 1;
             }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
@@ -23,10 +23,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -36,6 +41,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 public class FunctionDefinitionTest {
 
+    public static final String FUNCTION_ID = "FUNCTION-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
     private FunctionDefinition functionDefinition;
 
     @Before
@@ -72,5 +79,22 @@ public class FunctionDefinitionTest {
         assertEquals(functionDefinition.getRequiredComponentWidthCount(),
                      functionDefinition.getComponentWidths().size());
         functionDefinition.getComponentWidths().forEach(Assert::assertNull);
+    }
+
+    @Test
+    public void testCopy() {
+        final FunctionDefinition source = new FunctionDefinition();
+        source.setId(new Id(FUNCTION_ID));
+        source.setDescription(new Description(DESCRIPTION));
+        source.setTypeRef(BuiltInType.BOOLEAN.asQName());
+        source.setKind(FunctionDefinition.Kind.JAVA);
+
+        final FunctionDefinition target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(FUNCTION_ID, target.getId().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+        assertEquals(FunctionDefinition.Kind.JAVA, target.getKind());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
@@ -41,8 +41,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 public class FunctionDefinitionTest {
 
-    public static final String FUNCTION_ID = "FUNCTION-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
+    private static final String FUNCTION_ID = "FUNCTION-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
     private FunctionDefinition functionDefinition;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValuesTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValuesTest.java
@@ -25,11 +25,11 @@ import static org.junit.Assert.assertNotNull;
 
 public class ImportedValuesTest {
 
-    public static final String NAMESPACE = "NAMESPACE";
-    public static final String LOCATION_URI = "LOCATION-URI";
-    public static final String IMPORT_TYPE = "IMPORT-TYPE";
-    public static final String IMPORTED_ELEMENT = "IMPORTED-ELEMENT";
-    public static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
+    private static final String NAMESPACE = "NAMESPACE";
+    private static final String LOCATION_URI = "LOCATION-URI";
+    private static final String IMPORT_TYPE = "IMPORT-TYPE";
+    private static final String IMPORTED_ELEMENT = "IMPORTED-ELEMENT";
+    private static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
 
     @Test
     public void testCopy() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValuesTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ImportedValuesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ImportedValuesTest {
+
+    public static final String NAMESPACE = "NAMESPACE";
+    public static final String LOCATION_URI = "LOCATION-URI";
+    public static final String IMPORT_TYPE = "IMPORT-TYPE";
+    public static final String IMPORTED_ELEMENT = "IMPORTED-ELEMENT";
+    public static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
+
+    @Test
+    public void testCopy() {
+        final ImportedValues source = new ImportedValues(
+                NAMESPACE,
+                new LocationURI(LOCATION_URI),
+                IMPORT_TYPE,
+                IMPORTED_ELEMENT,
+                new ExpressionLanguage(EXPRESSION_LANGUAGE)
+        );
+
+        final ImportedValues target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(NAMESPACE, target.getNamespace());
+        assertEquals(LOCATION_URI, target.getLocationURI().getValue());
+        assertEquals(IMPORT_TYPE, target.getImportType());
+        assertEquals(IMPORTED_ELEMENT, target.getImportedElement());
+        assertEquals(EXPRESSION_LANGUAGE, target.getExpressionLanguage().getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InformationItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InformationItemTest.java
@@ -35,9 +35,9 @@ import static org.junit.Assert.assertNotNull;
 
 public class InformationItemTest {
 
-    public static final String ITEM_ID = "ITEM_ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String INFORMATION_ITEM_NAME = "INFORMATION_ITEM_NAME";
+    private static final String ITEM_ID = "ITEM_ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String INFORMATION_ITEM_NAME = "INFORMATION_ITEM_NAME";
     private InformationItem informationItem;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InformationItemTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InformationItemTest.java
@@ -21,14 +21,23 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.QNameHolder;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class InformationItemTest {
 
+    public static final String ITEM_ID = "ITEM_ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String INFORMATION_ITEM_NAME = "INFORMATION_ITEM_NAME";
     private InformationItem informationItem;
 
     @Before
@@ -67,5 +76,18 @@ public class InformationItemTest {
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(informationItem);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final InformationItem source = new InformationItem(new Id(ITEM_ID), new Description(DESCRIPTION), new Name(INFORMATION_ITEM_NAME), BuiltInType.BOOLEAN.asQName());
+
+        final InformationItem target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(ITEM_ID, target.getId().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(INFORMATION_ITEM_NAME, target.getName().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
@@ -21,12 +21,21 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class InputClauseLiteralExpressionTest {
 
+    public static final String CLAUSE_ID = "CLAUSE_ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String TEXT = "TEXT";
     private InputClauseLiteralExpression inputClauseLiteralExpression;
 
     @Before
@@ -40,5 +49,24 @@ public class InputClauseLiteralExpressionTest {
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(inputClauseLiteralExpression);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final InputClauseLiteralExpression source = new InputClauseLiteralExpression(
+                new Id(CLAUSE_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new Text(TEXT),
+                new ImportedValues()
+        );
+
+        final InputClauseLiteralExpression target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(CLAUSE_ID, target.getId());
+        assertEquals(TEXT, target.getText().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertNotNull;
 
 public class InputClauseLiteralExpressionTest {
 
-    public static final String CLAUSE_ID = "CLAUSE_ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String TEXT = "TEXT";
+    private static final String CLAUSE_ID = "CLAUSE_ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String TEXT = "TEXT";
     private InputClauseLiteralExpression inputClauseLiteralExpression;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
@@ -22,10 +22,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -34,6 +40,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class InputClauseTest {
 
+    public static final String UNARY_ID = "UNARY-ID";
+    public static final String INPUT_ID = "INPUT-ID";
+    public static final String TEXT = "TEXT";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String CLAUSE_ID = "CLAUSE-ID";
     private InputClause inputClause;
 
     @Before
@@ -55,5 +66,48 @@ public class InputClauseTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(hasTypeRef1, hasTypeRef2);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final InputClause source = new InputClause(
+                new Id(INPUT_ID),
+                new Description(DESCRIPTION),
+                buildInputClauseLiteralExpression(),
+                buildInputClauseUnaryTests()
+        );
+
+        final InputClause target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(INPUT_ID, target.getId().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertNotNull(target.getInputExpression());
+        assertNotEquals(CLAUSE_ID, target.getInputExpression().getId());
+        assertEquals(TEXT, target.getInputExpression().getText().getValue());
+        assertEquals(DESCRIPTION, target.getInputExpression().getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getInputExpression().getTypeRef());
+        assertNotNull(target.getInputValues());
+        assertNotEquals(UNARY_ID, target.getInputValues().getId());
+        assertEquals(TEXT, target.getInputValues().getText().getValue());
+        assertEquals(ConstraintType.ENUMERATION, target.getInputValues().getConstraintType());
+    }
+
+    private InputClauseUnaryTests buildInputClauseUnaryTests() {
+        return new InputClauseUnaryTests(
+                new Id(UNARY_ID),
+                new Text(TEXT),
+                ConstraintType.ENUMERATION
+        );
+    }
+
+    private InputClauseLiteralExpression buildInputClauseLiteralExpression() {
+        return new InputClauseLiteralExpression(
+                new Id(CLAUSE_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new Text(TEXT),
+                new ImportedValues()
+        );
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
@@ -40,11 +40,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class InputClauseTest {
 
-    public static final String UNARY_ID = "UNARY-ID";
-    public static final String INPUT_ID = "INPUT-ID";
-    public static final String TEXT = "TEXT";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String CLAUSE_ID = "CLAUSE-ID";
+    private static final String UNARY_ID = "UNARY-ID";
+    private static final String INPUT_ID = "INPUT-ID";
+    private static final String TEXT = "TEXT";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String CLAUSE_ID = "CLAUSE-ID";
     private InputClause inputClause;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTestsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTestsTest.java
@@ -30,8 +30,8 @@ import static org.kie.workbench.common.dmn.api.definition.model.ConstraintType.N
 @RunWith(MockitoJUnitRunner.class)
 public class InputClauseUnaryTestsTest {
 
-    public static final String TEXT = "TEXT";
-    public static final String UNARY_ID = "UNARY_ID";
+    private static final String TEXT = "TEXT";
+    private static final String UNARY_ID = "UNARY_ID";
 
     @Test
     public void testDefaultConstraintTypeProperty() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTestsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseUnaryTestsTest.java
@@ -23,10 +23,15 @@ import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.kie.workbench.common.dmn.api.definition.model.ConstraintType.NONE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InputClauseUnaryTestsTest {
+
+    public static final String TEXT = "TEXT";
+    public static final String UNARY_ID = "UNARY_ID";
 
     @Test
     public void testDefaultConstraintTypeProperty() {
@@ -88,5 +93,21 @@ public class InputClauseUnaryTestsTest {
                                                                             constraintType);
 
         assertEquals(constraintType, inputClause.getConstraintType());
+    }
+
+    @Test
+    public void testCopy() {
+        final InputClauseUnaryTests source = new InputClauseUnaryTests(
+                new Id(UNARY_ID),
+                new Text(TEXT),
+                ConstraintType.ENUMERATION
+        );
+
+        final InputClauseUnaryTests target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(UNARY_ID, target.getId());
+        assertEquals(TEXT, target.getText().getValue());
+        assertEquals(ConstraintType.ENUMERATION, target.getConstraintType());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -23,10 +24,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -36,6 +44,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 public class InvocationTest {
 
+    public static final String INVOCATION_ID = "INVOCATION-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
     private Invocation invocation;
 
     @Before
@@ -72,5 +82,25 @@ public class InvocationTest {
         assertEquals(invocation.getRequiredComponentWidthCount(),
                      invocation.getComponentWidths().size());
         invocation.getComponentWidths().forEach(Assert::assertNull);
+    }
+
+    @Test
+    public void testCopy() {
+        final Invocation source = new Invocation(
+                new Id(INVOCATION_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                null,
+                new ArrayList<>()
+        );
+
+        final Invocation target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(INVOCATION_ID, target.getId());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+        assertNull(target.getExpression());
+        assertTrue(target.getBinding().isEmpty());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
@@ -44,8 +44,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 public class InvocationTest {
 
-    public static final String INVOCATION_ID = "INVOCATION-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
+    private static final String INVOCATION_ID = "INVOCATION-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
     private Invocation invocation;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
@@ -43,8 +43,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ListTest {
 
-    public static final String LIST_ID = "LIST_ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
+    private static final String LIST_ID = "LIST_ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
     private org.kie.workbench.common.dmn.api.definition.model.List list;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -24,10 +25,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -36,6 +43,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ListTest {
 
+    public static final String LIST_ID = "LIST_ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
     private org.kie.workbench.common.dmn.api.definition.model.List list;
 
     @Before
@@ -67,5 +76,23 @@ public class ListTest {
         assertEquals(list.getRequiredComponentWidthCount(),
                      list.getComponentWidths().size());
         list.getComponentWidths().forEach(Assert::assertNull);
+    }
+
+    @Test
+    public void testCopy() {
+        final org.kie.workbench.common.dmn.api.definition.model.List source = new org.kie.workbench.common.dmn.api.definition.model.List(
+                new Id(LIST_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new ArrayList<>()
+        );
+
+        final org.kie.workbench.common.dmn.api.definition.model.List target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(LIST_ID, target.getId());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+        assertTrue(target.getExpression().isEmpty());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
@@ -21,14 +21,26 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LiteralExpressionTest {
 
+    public static final String LITERAL_ID = "LITERAL-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String TEXT = "TEXT";
+    public static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
     private LiteralExpression literalExpression;
 
     @Before
@@ -49,5 +61,27 @@ public class LiteralExpressionTest {
         assertEquals(literalExpression.getRequiredComponentWidthCount(),
                      literalExpression.getComponentWidths().size());
         literalExpression.getComponentWidths().forEach(Assert::assertNull);
+    }
+
+    @Test
+    public void testCopy() {
+        final LiteralExpression source = new LiteralExpression(
+                new Id(LITERAL_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new Text(TEXT),
+                null,
+                new ExpressionLanguage(EXPRESSION_LANGUAGE)
+        );
+
+        final LiteralExpression target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(LITERAL_ID, target.getId());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+        assertEquals(TEXT, target.getText().getValue());
+        assertNull(target.getImportedValues());
+        assertEquals(EXPRESSION_LANGUAGE, target.getExpressionLanguage().getValue());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
@@ -37,10 +37,10 @@ import static org.junit.Assert.assertNull;
 @RunWith(MockitoJUnitRunner.class)
 public class LiteralExpressionTest {
 
-    public static final String LITERAL_ID = "LITERAL-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String TEXT = "TEXT";
-    public static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
+    private static final String LITERAL_ID = "LITERAL-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String TEXT = "TEXT";
+    private static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
     private LiteralExpression literalExpression;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpressionTest.java
@@ -34,9 +34,9 @@ import static org.junit.Assert.assertNull;
 
 public class OutputClauseLiteralExpressionTest {
 
-    public static final String TEXT = "TEXT";
-    public static final String CLAUSE_ID = "CLAUSE-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
+    private static final String TEXT = "TEXT";
+    private static final String CLAUSE_ID = "CLAUSE-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
     private OutputClauseLiteralExpression outputClauseLiteralExpression;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpressionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseLiteralExpressionTest.java
@@ -21,12 +21,22 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class OutputClauseLiteralExpressionTest {
 
+    public static final String TEXT = "TEXT";
+    public static final String CLAUSE_ID = "CLAUSE-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
     private OutputClauseLiteralExpression outputClauseLiteralExpression;
 
     @Before
@@ -40,5 +50,25 @@ public class OutputClauseLiteralExpressionTest {
         final List<HasTypeRef> expectedHasTypeRefs = singletonList(outputClauseLiteralExpression);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final OutputClauseLiteralExpression source = new OutputClauseLiteralExpression(
+                new Id(CLAUSE_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new Text(TEXT),
+                null
+        );
+
+        final OutputClauseLiteralExpression target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(CLAUSE_ID, target.getId());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+        assertEquals(TEXT, target.getText().getValue());
+        assertNull(target.getImportedValues());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
@@ -40,12 +40,12 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class OutputClauseTest {
 
-    public static final String OUTPUT_ID = "OUTPUT-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String NAME = "NAME";
-    public static final String TEXT = "TEXT";
-    public static final String CLAUSE_ID = "CLAUSE_ID";
-    public static final String UNARY_ID = "UNARY_ID";
+    private static final String OUTPUT_ID = "OUTPUT-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String NAME = "NAME";
+    private static final String TEXT = "TEXT";
+    private static final String CLAUSE_ID = "CLAUSE_ID";
+    private static final String UNARY_ID = "UNARY_ID";
     private OutputClause outputClause;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
@@ -22,10 +22,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -34,6 +40,12 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class OutputClauseTest {
 
+    public static final String OUTPUT_ID = "OUTPUT-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String NAME = "NAME";
+    public static final String TEXT = "TEXT";
+    public static final String CLAUSE_ID = "CLAUSE_ID";
+    public static final String UNARY_ID = "UNARY_ID";
     private OutputClause outputClause;
 
     @Before
@@ -55,5 +67,48 @@ public class OutputClauseTest {
         final List<HasTypeRef> expectedHasTypeRefs = asList(outputClause, hasTypeRef1, hasTypeRef2);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
+    }
+
+    @Test
+    public void testCopy() {
+        final OutputClause source = new OutputClause(
+                new Id(OUTPUT_ID),
+                new Description(DESCRIPTION),
+                buildOutputClauseUnaryTests(),
+                buildOutputClauseLiteralExpression(),
+                NAME,
+                BuiltInType.BOOLEAN.asQName()
+        );
+
+        final OutputClause target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(OUTPUT_ID, target.getId().getValue());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertNotNull(target.getOutputValues());
+        assertNotEquals(CLAUSE_ID, target.getOutputValues().getId());
+        assertEquals(TEXT, target.getOutputValues().getText().getValue());
+        assertNotNull(target.getOutputValues());
+        assertNotEquals(UNARY_ID, target.getOutputValues().getId());
+        assertEquals(TEXT, target.getOutputValues().getText().getValue());
+        assertEquals(ConstraintType.ENUMERATION, target.getOutputValues().getConstraintType());
+    }
+
+    private OutputClauseUnaryTests buildOutputClauseUnaryTests() {
+        return new OutputClauseUnaryTests(
+                new Id(UNARY_ID),
+                new Text(TEXT),
+                ConstraintType.ENUMERATION
+        );
+    }
+
+    private OutputClauseLiteralExpression buildOutputClauseLiteralExpression() {
+        return new OutputClauseLiteralExpression(
+                new Id(CLAUSE_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new Text(TEXT),
+                new ImportedValues()
+        );
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTestsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTestsTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertNotNull;
 
 public class OutputClauseUnaryTestsTest {
 
-    public static final String UNARY_ID = "UNARY_ID";
-    public static final String TEXT = "TEXT";
+    private static final String UNARY_ID = "UNARY_ID";
+    private static final String TEXT = "TEXT";
 
     @Test
     public void testCopy() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTestsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTestsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class OutputClauseUnaryTestsTest {
+
+    public static final String UNARY_ID = "UNARY_ID";
+    public static final String TEXT = "TEXT";
+
+    @Test
+    public void testCopy() {
+        final OutputClauseUnaryTests source = new OutputClauseUnaryTests(
+                new Id(UNARY_ID),
+                new Text(TEXT),
+                ConstraintType.ENUMERATION
+        );
+
+        final OutputClauseUnaryTests target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(UNARY_ID, target.getId());
+        assertEquals(TEXT, target.getText().getValue());
+        assertEquals(ConstraintType.ENUMERATION, target.getConstraintType());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -23,10 +24,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -35,6 +42,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RelationTest {
 
+    public static final String RELATION_ID = "RELATION-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
     private Relation relation;
 
     @Before
@@ -74,5 +83,25 @@ public class RelationTest {
         assertEquals(relation.getRequiredComponentWidthCount(),
                      relation.getComponentWidths().size());
         relation.getComponentWidths().forEach(Assert::assertNull);
+    }
+
+    @Test
+    public void testCopy() {
+        final Relation source = new Relation(
+                new Id(RELATION_ID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new ArrayList<>(),
+                new ArrayList<>()
+        );
+
+        final Relation target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(RELATION_ID, target.getId());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+        assertTrue(target.getColumn().isEmpty());
+        assertTrue(target.getRow().isEmpty());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
@@ -42,8 +42,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RelationTest {
 
-    public static final String RELATION_ID = "RELATION-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
+    private static final String RELATION_ID = "RELATION-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
     private Relation relation;
 
     @Before

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class RuleAnnotationClauseTest {
+
+    public static final String RULE_NAME = "RULE-NAME";
+
+    @Test
+    public void testCopy() {
+        final RuleAnnotationClause source = new RuleAnnotationClause();
+        source.setName(new Name(RULE_NAME));
+
+        final RuleAnnotationClause target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(RULE_NAME, target.getName().getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class RuleAnnotationClauseTest {
 
-    public static final String RULE_NAME = "RULE-NAME";
+    private static final String RULE_NAME = "RULE-NAME";
 
     @Test
     public void testCopy() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTextTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class RuleAnnotationClauseTextTest {
+
+    public static final String TEXT_VALUE = "TEXT-VALUE";
+
+    @Test
+    public void testCopy() {
+        final RuleAnnotationClauseText source = new RuleAnnotationClauseText();
+        source.setText(new Text(TEXT_VALUE));
+
+        final RuleAnnotationClauseText target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(TEXT_VALUE, target.getText().getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RuleAnnotationClauseTextTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class RuleAnnotationClauseTextTest {
 
-    public static final String TEXT_VALUE = "TEXT-VALUE";
+    private static final String TEXT_VALUE = "TEXT-VALUE";
 
     @Test
     public void testCopy() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/UnaryTestsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/UnaryTestsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.kie.workbench.common.dmn.api.definition.model.ConstraintType.NONE;
+
+public class UnaryTestsTest {
+
+    public static final String UNARY_ID = "UNARY-ID";
+    public static final String DESCRIPTION = "DESCRIPTION";
+    public static final String TEXT_VALUE = "TEXT-VALUE";
+    public static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
+
+    @Test
+    public void testCopy() {
+        final UnaryTests source = new UnaryTests(
+                new Id(UNARY_ID),
+                new Description(DESCRIPTION),
+                new Text(TEXT_VALUE),
+                new ExpressionLanguage(EXPRESSION_LANGUAGE),
+                NONE
+        );
+
+        final UnaryTests target = source.copy();
+
+        assertNotNull(target);
+        assertNotEquals(UNARY_ID, target.getId());
+        assertEquals(DESCRIPTION, target.getDescription().getValue());
+        assertEquals(TEXT_VALUE, target.getText().getValue());
+        assertEquals(EXPRESSION_LANGUAGE, target.getExpressionLanguage().getValue());
+        assertEquals(NONE, target.getConstraintType());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/UnaryTestsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/UnaryTestsTest.java
@@ -29,10 +29,10 @@ import static org.kie.workbench.common.dmn.api.definition.model.ConstraintType.N
 
 public class UnaryTestsTest {
 
-    public static final String UNARY_ID = "UNARY-ID";
-    public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String TEXT_VALUE = "TEXT-VALUE";
-    public static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
+    private static final String UNARY_ID = "UNARY-ID";
+    private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String TEXT_VALUE = "TEXT-VALUE";
+    private static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
 
     @Test
     public void testCopy() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/AllowedAnswersTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/AllowedAnswersTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AllowedAnswersTest {
+
+    private static final String ALLOWED_ANSWER_VALUE = "ALLOWED-ANSWER-VALUE";
+
+    @Test
+    public void testCopy() {
+        final AllowedAnswers source = new AllowedAnswers(ALLOWED_ANSWER_VALUE);
+
+        final AllowedAnswers target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(ALLOWED_ANSWER_VALUE, target.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/DescriptionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/DescriptionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class DescriptionTest {
+
+    private static final String DESCRIPTION_VALUE = "DESCRIPTION_VALUE";
+
+    @Test
+    public void testCopy() {
+        final Description source = new Description(DESCRIPTION_VALUE);
+
+        final Description target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(DESCRIPTION_VALUE, target.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguageTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/ExpressionLanguageTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.api.property.dmn;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ExpressionLanguageTest {
 
@@ -46,5 +47,15 @@ public class ExpressionLanguageTest {
         this.expressionLanguage.setValue(VALUE);
 
         assertEquals(VALUE, expressionLanguage.getValue());
+    }
+
+    @Test
+    public void testCopy() {
+        final ExpressionLanguage source = new ExpressionLanguage(VALUE);
+
+        final ExpressionLanguage target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(VALUE, target.getValue());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/LocationURITest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/LocationURITest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LocationURITest {
+
+    private static final String LOCATION_URI = "LOCATION-URI";
+
+    @Test
+    public void testCopy() {
+        final LocationURI source = new LocationURI(LOCATION_URI);
+
+        final LocationURI target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(LOCATION_URI, target.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/NameHolderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/NameHolderTest.java
@@ -75,4 +75,14 @@ public class NameHolderTest {
         assertNotEquals(holder1.hashCode(), holder3.hashCode());
         assertNotEquals(holder2.hashCode(), holder3.hashCode());
     }
+
+    @Test
+    public void testCopy() {
+        final NameHolder source = new NameHolder(new Name(NAME));
+
+        final NameHolder target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(NAME, target.getValue().getValue());
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/NameTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/NameTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class NameTest {
+
+    private static final String NAME_VALUE = "NAME-VALUE";
+
+    @Test
+    public void testCopy() {
+        final Name source = new Name(NAME_VALUE);
+
+        final Name target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(NAME_VALUE, target.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameHolderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameHolderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class QNameHolderTest {
+
+    @Test
+    public void testCopy() {
+        final QNameHolder source = new QNameHolder(BuiltInType.BOOLEAN.asQName());
+
+        final QNameHolder target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(BuiltInType.BOOLEAN.asQName(), target.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QNameTest.java
@@ -23,6 +23,7 @@ import org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBas
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class QNameTest {
@@ -75,5 +76,17 @@ public class QNameTest {
         final QName qname = new QName(BuiltInType.STRING);
         assertEquals(qname.getLocalPart(), BuiltInType.STRING.getName());
         assertEquals(qname.getNamespaceURI(), QName.NULL_NS_URI);
+    }
+
+    @Test
+    public void testCopy() {
+        final QName source = new QName(NAMESPACE_URI, LOCAL_PART, PREFIX);
+
+        final QName target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(NAMESPACE_URI, target.getNamespaceURI());
+        assertEquals(LOCAL_PART, target.getLocalPart());
+        assertEquals(PREFIX, target.getPrefix());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QuestionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/QuestionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class QuestionTest {
+
+    private static final String QUESTION_VALUE = "QUESTION-VALUE";
+
+    @Test
+    public void testCopy() {
+        final Question source = new Question(QUESTION_VALUE);
+
+        final Question target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(QUESTION_VALUE, target.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/TextTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/property/dmn/TextTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.property.dmn;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TextTest {
+
+    private static final String TEXT_VALUE = "TEXT-VALUE";
+
+    @Test
+    public void testCopy() {
+        final Text source = new Text(TEXT_VALUE);
+
+        final Text target = source.copy();
+
+        assertNotNull(target);
+        assertEquals(TEXT_VALUE, target.getValue());
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.commands.clone;
+
+import java.util.AbstractMap;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import elemental2.dom.DomGlobal;
+import org.jboss.errai.databinding.client.BindableProxy;
+import org.jboss.errai.databinding.client.BindableProxyFactory;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
+import org.kie.workbench.common.stunner.core.definition.clone.AbstractCloneProcess;
+import org.kie.workbench.common.stunner.core.definition.clone.IDeepCloneProcess;
+import org.kie.workbench.common.stunner.core.util.ClassUtils;
+
+@Alternative
+public class DMNDeepCloneProcess extends AbstractCloneProcess implements IDeepCloneProcess {
+
+    private final ClassUtils classUtils;
+
+    private final AdapterManager adapterManager1;
+
+    protected DMNDeepCloneProcess() {
+        this(null,
+             null,
+             null);
+    }
+
+    @Inject
+    public DMNDeepCloneProcess(final FactoryManager factoryManager,
+                               final AdapterManager adapterManager,
+                               final ClassUtils classUtils) {
+        super(factoryManager,
+              adapterManager);
+        this.classUtils = classUtils;
+        this.adapterManager1 = adapterManager;
+    }
+
+    @Override
+    public <S, T> T clone(S source,
+                          T target) {
+        DomGlobal.console.log("=====================>> IT WORKS");
+        adapterManager1.forDefinition().getProperties(source)
+                .stream()
+                .filter(p -> !adapterManager1.forProperty().isReadOnly(p))
+                .map(p -> {
+                    String id = adapterManager1.forProperty().getId(p);
+                    Optional<?> propertyTarget = adapterManager1.forDefinition().getProperties(target)
+                            .stream()
+                            .filter(prop -> Objects.equals(adapterManager1.forProperty().getId(prop),
+                                                           id))
+                            .findFirst();
+                    return propertyTarget.isPresent() ? new AbstractMap.SimpleEntry(p,
+                                                                                    propertyTarget.get()) : null;
+                })
+                .filter(Objects::nonNull)
+                .filter(entry -> isAllowedToClone(adapterManager1.forProperty().getValue(entry.getKey())))
+                .forEach(entry -> {
+                    Object value = adapterManager1.forProperty().getValue(entry.getKey());
+                    adapterManager1.forProperty().setValue(entry.getValue(),
+                                                           cloneValue(value));
+                });
+
+        return target;
+    }
+
+    private boolean isAllowedToClone(Object value) {
+        return Objects.nonNull(value) && (isSimpleValue(value) || BindableProxyFactory.isBindableType(value));
+    }
+
+    private boolean isSimpleValue(Object value) {
+        return (value instanceof String) || classUtils.isPrimitiveClass(value.getClass());
+    }
+
+    private Object cloneValue(Object value) {
+        if (value == null || isSimpleValue(value)) {
+            return value;
+        } else {
+            BindableProxy bindableProxy = (BindableProxy) BindableProxyFactory.getBindableProxy(value);
+            return bindableProxy.deepUnwrap();
+        }
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -37,6 +37,10 @@ import org.kie.workbench.common.stunner.core.definition.clone.DeepCloneProcess;
 import org.kie.workbench.common.stunner.core.definition.clone.IDeepCloneProcess;
 import org.kie.workbench.common.stunner.core.util.ClassUtils;
 
+/**
+ * <p>It represents the custom implementation of cloning process for DMN nodes.</p>
+ * <p>It is extending the cloning mechanism provided by {@link DeepCloneProcess}, including additional fields and expressions</p>
+ */
 @Alternative
 public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneProcess {
 
@@ -53,6 +57,15 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
         super(factoryManager, adapterManager, classUtils);
     }
 
+    /**
+     * <p>It defines additive fields, specific to DMN domain, to be included in the target</p>
+     * <p>Then, the "classic" clone operation, defined in {@link DeepCloneProcess} will be executed</p>
+     * <p>Note that {@link DeepCloneProcess} is already taking care of aspects related to look&feel, such as background color, font, etc.</p>
+     *
+     * @param source node to be cloned
+     * @param target destination of the cloning operation
+     * @return cloned instance, i.e. target element
+     */
     @Override
     public <S, T> T clone(final S source,
                           final T target) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/META-INF/ErraiApp.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/META-INF/ErraiApp.properties
@@ -28,4 +28,5 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
+errai.ioc.enabled.alternatives=org.kie.workbench.common.dmn.client.commands.clone.DMNDeepCloneProcess
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.clone;
+
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
+import org.kie.workbench.common.dmn.api.definition.model.Context;
+import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
+import org.kie.workbench.common.dmn.api.definition.model.Decision;
+import org.kie.workbench.common.dmn.api.definition.model.DecisionService;
+import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
+import org.kie.workbench.common.dmn.api.definition.model.InformationItemPrimary;
+import org.kie.workbench.common.dmn.api.definition.model.InputData;
+import org.kie.workbench.common.dmn.api.definition.model.KnowledgeSource;
+import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
+import org.kie.workbench.common.dmn.api.property.dimensions.DecisionServiceRectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dimensions.GeneralRectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dmn.AllowedAnswers;
+import org.kie.workbench.common.dmn.api.property.dmn.DMNExternalLink;
+import org.kie.workbench.common.dmn.api.property.dmn.DecisionServiceDividerLineY;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.KnowledgeSourceType;
+import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.dmn.api.property.dmn.Question;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.dmn.api.property.font.FontSet;
+import org.kie.workbench.common.stunner.core.definition.clone.AbstractCloneProcessTest;
+import org.kie.workbench.common.stunner.core.util.ClassUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition.Kind.JAVA;
+
+public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
+
+    public static final String SOURCE_ID = "source-id";
+    public static final String INPUT_DATA_NAME = "input-data";
+    public static final String FIRST_URL = "firstURL";
+    public static final String SECOND_URL = "secondURL";
+    public static final String DECISION_SERVICE_NAME = "decision-service";
+    public static final String KNOWLEDGE_SOURCE_NAME = "knowledge-source";
+    public static final String FUNCTION_ID = "function-id";
+    public static final String CONTEXT_ID = "context-id";
+    public static final String BKM_SOURCE_NAME = "bkm-source";
+    public static final String DECISION_SOURCE_NAME = "decision-source";
+    public static final String QUESTION = "question?";
+    public static final String ANSWER = "answer";
+    private DMNDeepCloneProcess dmnDeepCloneProcess;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        dmnDeepCloneProcess = new DMNDeepCloneProcess(factoryManager, adapterManager, new ClassUtils());
+    }
+
+    @Test
+    public void testCloneWhenSourceIsInputData() {
+        final InputData source = buildInputData();
+        setLinks(source, FIRST_URL, SECOND_URL);
+
+        final InputData cloned = dmnDeepCloneProcess.clone(source, new InputData());
+
+        assertThat(cloned).isNotNull();
+        assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
+        assertThat(cloned.getName().getValue()).isEqualTo(INPUT_DATA_NAME);
+        assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.STRING.asQName());
+        assertThat(cloned.getLinksHolder().getValue().getLinks()).hasSize(2);
+        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(FIRST_URL);
+    }
+
+    private InputData buildInputData() {
+        return new InputData(
+                new Id(SOURCE_ID),
+                new Description(),
+                new Name(INPUT_DATA_NAME),
+                buildInformationItemPrimary(BuiltInType.STRING),
+                new BackgroundSet(),
+                new FontSet(),
+                new GeneralRectangleDimensionsSet()
+        );
+    }
+
+    @Test
+    public void testCloneWhenSourceIsDecisionService() {
+        final DecisionService source = buildDecisionService();
+
+        final DecisionService cloned = dmnDeepCloneProcess.clone(source, new DecisionService());
+
+        assertThat(cloned).isNotNull();
+        assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
+        assertThat(cloned.getName().getValue()).isEqualTo(DECISION_SERVICE_NAME);
+        assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
+    }
+
+    private DecisionService buildDecisionService() {
+        return new DecisionService(
+                new Id(SOURCE_ID),
+                new Description(),
+                new Name(DECISION_SERVICE_NAME),
+                buildInformationItemPrimary(BuiltInType.BOOLEAN),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new BackgroundSet(),
+                new FontSet(),
+                new DecisionServiceRectangleDimensionsSet(),
+                new DecisionServiceDividerLineY()
+        );
+    }
+
+    @Test
+    public void testCloneWhenSourceIsKnowledgeSource() {
+        final KnowledgeSource source = buildKnowledgeSource();
+        setLinks(source, SECOND_URL);
+
+        final KnowledgeSource cloned = dmnDeepCloneProcess.clone(source, new KnowledgeSource());
+
+        assertThat(cloned).isNotNull();
+        assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
+        assertThat(cloned.getName().getValue()).isEqualTo(KNOWLEDGE_SOURCE_NAME);
+        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(SECOND_URL);
+    }
+
+    private KnowledgeSource buildKnowledgeSource() {
+        return new KnowledgeSource(
+                new Id(SOURCE_ID),
+                new Description(),
+                new Name(KNOWLEDGE_SOURCE_NAME),
+                new KnowledgeSourceType(),
+                new LocationURI(),
+                new BackgroundSet(),
+                new FontSet(),
+                new GeneralRectangleDimensionsSet()
+        );
+    }
+
+    @Test
+    public void testCloneWhenSourceIsBusinessKnowledgeModel() {
+        final BusinessKnowledgeModel source = buildBusinessKnowledgeModel();
+        setLinks(source, FIRST_URL);
+
+        final BusinessKnowledgeModel cloned = dmnDeepCloneProcess.clone(source, new BusinessKnowledgeModel());
+
+        assertThat(cloned).isNotNull();
+        assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
+        assertThat(cloned.getName().getValue()).isEqualTo(BKM_SOURCE_NAME);
+        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(FIRST_URL);
+        assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
+        assertThat(cloned.getEncapsulatedLogic()).isNotNull();
+        assertThat(cloned.getEncapsulatedLogic().getId().getValue()).isNotEqualTo(FUNCTION_ID);
+        assertThat(cloned.getEncapsulatedLogic().getKind()).isEqualTo(JAVA);
+        assertThat(cloned.getEncapsulatedLogic().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
+        assertThat(cloned.getEncapsulatedLogic().getExpression()).isInstanceOf(Context.class);
+        assertThat(cloned.getEncapsulatedLogic().getExpression().getId()).isNotEqualTo(CONTEXT_ID);
+        assertThat(cloned.getEncapsulatedLogic().getExpression().getTypeRef()).isEqualTo(BuiltInType.NUMBER.asQName());
+    }
+
+    @Test
+    public void testCloneWhenSourceIsDecision() {
+        final Decision source = buildDecision();
+        setLinks(source, SECOND_URL);
+
+        final Decision cloned = dmnDeepCloneProcess.clone(source, new Decision());
+
+        assertThat(cloned).isNotNull();
+        assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
+        assertThat(cloned.getName().getValue()).isEqualTo(DECISION_SOURCE_NAME);
+        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(SECOND_URL);
+        assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
+        assertThat(cloned.getQuestion().getValue()).isEqualTo(QUESTION);
+        assertThat(cloned.getAllowedAnswers().getValue()).isEqualTo(ANSWER);
+
+        assertThat(cloned.getExpression()).isNotNull();
+        assertThat(cloned.getExpression()).isInstanceOf(FunctionDefinition.class);
+        assertThat(cloned.getExpression().getId().getValue()).isNotEqualTo(FUNCTION_ID);
+        assertThat(cloned.getExpression().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
+        assertThat(((FunctionDefinition) cloned.getExpression()).getExpression()).isInstanceOf(Context.class);
+        assertThat(((FunctionDefinition) cloned.getExpression()).getExpression().getId()).isNotEqualTo(CONTEXT_ID);
+        assertThat(((FunctionDefinition) cloned.getExpression()).getExpression().getTypeRef()).isEqualTo(BuiltInType.NUMBER.asQName());
+    }
+
+    private BusinessKnowledgeModel buildBusinessKnowledgeModel() {
+        return new BusinessKnowledgeModel(
+                new Id(SOURCE_ID),
+                new Description(),
+                new Name(BKM_SOURCE_NAME),
+                buildInformationItemPrimary(BuiltInType.BOOLEAN),
+                buildFunctionDefinition(),
+                new BackgroundSet(),
+                new FontSet(),
+                new GeneralRectangleDimensionsSet()
+        );
+    }
+
+    private Decision buildDecision() {
+        return new Decision(
+                new Id(SOURCE_ID),
+                new Description(),
+                new Name(DECISION_SOURCE_NAME),
+                new Question(QUESTION),
+                new AllowedAnswers(ANSWER),
+                buildInformationItemPrimary(BuiltInType.BOOLEAN),
+                buildFunctionDefinition(),
+                new BackgroundSet(),
+                new FontSet(),
+                new GeneralRectangleDimensionsSet()
+        );
+    }
+
+    private FunctionDefinition buildFunctionDefinition() {
+        final FunctionDefinition encapsulatedLogic = new FunctionDefinition(
+                new Id(FUNCTION_ID),
+                new Description(),
+                new QName(BuiltInType.BOOLEAN),
+                new Context(new Id(CONTEXT_ID), new Description(), new QName(BuiltInType.NUMBER))
+        );
+        encapsulatedLogic.setKind(JAVA);
+        return encapsulatedLogic;
+    }
+
+    private InformationItemPrimary buildInformationItemPrimary(final BuiltInType builtInType) {
+        final InformationItemPrimary informationItemPrimary = new InformationItemPrimary();
+        informationItemPrimary.setTypeRef(new QName(builtInType));
+        return informationItemPrimary;
+    }
+
+    private void setLinks(final DRGElement drgElement, final String... links) {
+        Stream.of(links)
+                .forEach(link ->
+                                 drgElement.getLinksHolder()
+                                         .getValue()
+                                         .getLinks()
+                                         .add(new DMNExternalLink(link, "description"))
+                );
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -84,8 +84,9 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
         assertThat(cloned.getName().getValue()).isEqualTo(INPUT_DATA_NAME);
         assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.STRING.asQName());
-        assertThat(cloned.getLinksHolder().getValue().getLinks()).hasSize(2);
-        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(FIRST_URL);
+        assertThat(cloned.getLinksHolder().getValue().getLinks())
+                .hasSize(2)
+                .extracting(DMNExternalLink::getUrl).contains(FIRST_URL, SECOND_URL);
     }
 
     private InputData buildInputData() {
@@ -132,14 +133,16 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     @Test
     public void testCloneWhenSourceIsKnowledgeSource() {
         final KnowledgeSource source = buildKnowledgeSource();
-        setLinks(source, SECOND_URL);
+        setLinks(source, FIRST_URL, SECOND_URL);
 
         final KnowledgeSource cloned = dmnDeepCloneProcess.clone(source, new KnowledgeSource());
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
         assertThat(cloned.getName().getValue()).isEqualTo(KNOWLEDGE_SOURCE_NAME);
-        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(SECOND_URL);
+        assertThat(cloned.getLinksHolder().getValue().getLinks())
+                .hasSize(2)
+                .extracting(DMNExternalLink::getUrl).contains(FIRST_URL, SECOND_URL);
     }
 
     private KnowledgeSource buildKnowledgeSource() {
@@ -158,14 +161,16 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     @Test
     public void testCloneWhenSourceIsBusinessKnowledgeModel() {
         final BusinessKnowledgeModel source = buildBusinessKnowledgeModel();
-        setLinks(source, FIRST_URL);
+        setLinks(source, FIRST_URL, SECOND_URL);
 
         final BusinessKnowledgeModel cloned = dmnDeepCloneProcess.clone(source, new BusinessKnowledgeModel());
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
         assertThat(cloned.getName().getValue()).isEqualTo(BKM_SOURCE_NAME);
-        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(FIRST_URL);
+        assertThat(cloned.getLinksHolder().getValue().getLinks())
+                .hasSize(2)
+                .extracting(DMNExternalLink::getUrl).contains(FIRST_URL, SECOND_URL);
         assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
         assertThat(cloned.getEncapsulatedLogic()).isNotNull();
         assertThat(cloned.getEncapsulatedLogic().getId().getValue()).isNotEqualTo(FUNCTION_ID);
@@ -179,14 +184,16 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     @Test
     public void testCloneWhenSourceIsDecision() {
         final Decision source = buildDecision();
-        setLinks(source, SECOND_URL);
+        setLinks(source, FIRST_URL, SECOND_URL);
 
         final Decision cloned = dmnDeepCloneProcess.clone(source, new Decision());
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
         assertThat(cloned.getName().getValue()).isEqualTo(DECISION_SOURCE_NAME);
-        assertThat(cloned.getLinksHolder().getValue().getLinks()).first().extracting("url").isEqualTo(SECOND_URL);
+        assertThat(cloned.getLinksHolder().getValue().getLinks())
+                .hasSize(2)
+                .extracting(DMNExternalLink::getUrl).contains(FIRST_URL, SECOND_URL);
         assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
         assertThat(cloned.getQuestion().getValue()).isEqualTo(QUESTION);
         assertThat(cloned.getAllowedAnswers().getValue()).isEqualTo(ANSWER);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/CloneManagerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/CloneManagerImpl.java
@@ -34,7 +34,7 @@ public class CloneManagerImpl implements CloneManager {
     }
 
     @Inject
-    public CloneManagerImpl(DeepCloneProcess deepCloneProcess, DefaultCloneProcess defaultCloneProcess, NoneCloneProcess noneCloneProcess) {
+    public CloneManagerImpl(IDeepCloneProcess deepCloneProcess, DefaultCloneProcess defaultCloneProcess, NoneCloneProcess noneCloneProcess) {
         this.cloneProcessMap = new Maps.Builder<ClonePolicy, CloneProcess>()
                 .put(ClonePolicy.ALL, deepCloneProcess)
                 .put(ClonePolicy.DEFAULT, defaultCloneProcess)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/DeepCloneProcess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/DeepCloneProcess.java
@@ -30,7 +30,7 @@ import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.util.ClassUtils;
 
 @ApplicationScoped
-public class DeepCloneProcess extends AbstractCloneProcess {
+public class DeepCloneProcess extends AbstractCloneProcess implements IDeepCloneProcess {
 
     private final ClassUtils classUtils;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/IDeepCloneProcess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/IDeepCloneProcess.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.definition.clone;
+
+public interface IDeepCloneProcess extends CloneProcess{
+
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/IDeepCloneProcess.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/definition/clone/IDeepCloneProcess.java
@@ -16,6 +16,14 @@
 
 package org.kie.workbench.common.stunner.core.definition.clone;
 
-public interface IDeepCloneProcess extends CloneProcess{
+import javax.enterprise.inject.Alternative;
+
+/**
+ * <p>This interface represent a type that has been injected in the {@link CloneManagerImpl}</p>
+ * <p>All classes that implements {@link IDeepCloneProcess} (e.g. {@link DeepCloneProcess}) can specify a different strategy for cloning </p>
+ * <p>At runtime, the correct {@link IDeepCloneProcess} instance will be selected, depending on the class annotated by {@link Alternative} </p>
+ * <p>If, for a specific module, no alternative has been specified, the fallback will be {@link DeepCloneProcess}</p>
+ */
+public interface IDeepCloneProcess extends CloneProcess {
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/definition/clone/AbstractCloneProcessTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/definition/clone/AbstractCloneProcessTest.java
@@ -172,7 +172,7 @@ public abstract class AbstractCloneProcessTest {
                      nameArgumentCaptor.getValue());
     }
 
-    interface BindableTypeMock extends BindableProxy {
+    protected interface BindableTypeMock extends BindableProxy {
 
     }
 }


### PR DESCRIPTION
*Please refer to:* https://issues.redhat.com/browse/DROOLS-5148

*Issue description:* Ctrl + C / Ctrl + V was not working on DMN editor. When users try to copy and paste a node, the name and the boxed expression are not copied.

*Proposed solution:* Extension of already existing `DeepCloneProcess` for DMN nodes, by using Errai `@Alternative` (https://docs.jboss.org/author/display/ERRAI/Alternatives%20and%20Mocks.html)
Core solution is in https://github.com/kiegroup/kie-wb-common/compare/master...vpellegrino:DROOLS-5148?expand=1#diff-28472fc6825a3ec1d291b65d60da5ab1
Several other classes are providing a specific `copy()` method that is used during cloning phase.