### PR TITLE
BXMSPROD-741: Remove Node and npm versions

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/pom.xml
@@ -14,12 +14,6 @@
   <name>Kie Workbench - Common - Library - Spaces Screen</name>
   <description>Kie Workbench - Common - Library - Spaces Screen</description>
 
-  <properties>
-    <node.version>v11.6.0</node.version>
-    <yarn.version>v1.12.3</yarn.version>
-    <npm.version>6.9.0</npm.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -68,10 +62,6 @@
             <goals>
               <goal>install-node-and-yarn</goal>
             </goals>
-            <configuration>
-              <nodeVersion>${node.version}</nodeVersion>
-              <yarnVersion>${yarn.version}</yarnVersion>
-            </configuration>
           </execution>
           <execution>
             <id>install node and npm</id>
@@ -79,10 +69,6 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <configuration>
-              <nodeVersion>${node.version}</nodeVersion>
-              <npmVersion>${npm.version}</npmVersion>
-            </configuration>
           </execution>
           <execution>
             <id>npm install lock-treatment-tool and run-node</id>


### PR DESCRIPTION
They are now managed by kie-parent.

PR group:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1273
- https://github.com/kiegroup/appformer/pull/943
- https://github.com/kiegroup/droolsjbpm-integration/pull/2064
- https://github.com/kiegroup/kie-wb-common/pull/3269
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/296
- https://github.com/kiegroup/optaweb-employee-rostering/pull/425