### PR TITLE
AF-2469 :kie-wb-common-ala/kie-wb-common-ala-services-rest tests requires docker image kitematic/hello-world-nginx

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-services-rest/src/test/java/org/guvnor/ala/services/rest/tests/RestRuntimeProvisioningImplTest.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-services-rest/src/test/java/org/guvnor/ala/services/rest/tests/RestRuntimeProvisioningImplTest.java
@@ -67,6 +67,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.uberfire.commons.lifecycle.Disposable;
@@ -140,6 +141,7 @@ public class RestRuntimeProvisioningImplTest {
         Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
     }
 
+    @Ignore("refer https://issues.redhat.com/browse/AF-2469")
     @Test
     public void testAPI() {
 


### PR DESCRIPTION
Ignored test until we find a permanent fix.