### PR TITLE
RHPAM-2674 :Exception thrown when a test scenerio containing a tag is renamed without saving

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
@@ -317,8 +317,15 @@ public class Builder implements Serializable {
     }
 
     public IncrementalBuildResults addResource(final Path resource) {
-        return addResource(resource,
-                           ioService.newInputStream(resource));
+        IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
+        // This validation prevents faulty update resource operation that may come during save and rename operation
+        // For more information see https://github.com/kiegroup/kie-wb-common/pull/3277
+        if (ioService.exists(resource)) {
+            results = addResource(resource,
+                                  ioService.newInputStream(resource));
+        }
+
+        return results;
     }
 
     private IncrementalBuildResults addResource(final Path resource,


### PR DESCRIPTION
This exception was thrown in the build pipeline stage due to the asynchronous processing of events in incremental builds. During "Save and rename" operation for any resource,  Though the resource was moved, Resource modified event for original resource was queued in the build execution pipeline,  which result in NoSuchFileException. 

Please note that this exception happens in all resource types. To reproduce
1. Open resource (eg. .drl) 
2. Change any content
3. Click on rename
4. Select "Save and rename" 