### PR TITLE
DROOLS-5262: Do not allow to remove java built in type imports

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenter.java
@@ -22,6 +22,7 @@ import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
 import org.kie.workbench.common.widgets.client.widget.ListItemView;
+import org.kie.workbench.common.widgets.configresource.client.widget.BuiltInTypeImportHelper;
 
 public class ExternalDataObjectsItemPresenter extends ListItemPresenter<Import, ExternalDataObjectsPresenter, ExternalDataObjectsItemPresenter.View> {
 
@@ -82,7 +83,7 @@ public class ExternalDataObjectsItemPresenter extends ListItemPresenter<Import, 
     }
 
     private void setRemoveButtonVisibility(final String typeName) {
-        if (typeName != null && (typeName.startsWith("java.lang.") || typeName.startsWith("java.util."))) {
+        if (BuiltInTypeImportHelper.isBuiltIn(typeName)) {
             view.hideRemoveButton();
         } else {
             view.showRemoveButton();

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenter.java
@@ -18,8 +18,6 @@ package org.kie.workbench.common.screens.library.client.settings.sections.extern
 
 import javax.inject.Inject;
 
-import elemental2.dom.Element;
-import elemental2.dom.Event;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
@@ -35,6 +33,10 @@ public class ExternalDataObjectsItemPresenter extends ListItemPresenter<Import, 
                                   IsElement {
 
         void setTypeName(final String typeName);
+
+        void hideRemoveButton();
+
+        void showRemoveButton();
     }
 
     @Inject
@@ -52,6 +54,9 @@ public class ExternalDataObjectsItemPresenter extends ListItemPresenter<Import, 
         view.init(this);
         view.setTypeName(import_.getType());
 
+        final String typeName = import_.getType();
+        setRemoveButtonVisibility(typeName);
+
         return this;
     }
 
@@ -61,9 +66,10 @@ public class ExternalDataObjectsItemPresenter extends ListItemPresenter<Import, 
         parentPresenter.fireChangeEvent();
     }
 
-    public void onTypeNameChange(final String typeName){
+    public void onTypeNameChange(final String typeName) {
         import_.setType(typeName);
         parentPresenter.fireChangeEvent();
+        setRemoveButtonVisibility(typeName);
     }
 
     @Override
@@ -73,5 +79,13 @@ public class ExternalDataObjectsItemPresenter extends ListItemPresenter<Import, 
 
     public View getView() {
         return view;
+    }
+
+    private void setRemoveButtonVisibility(final String typeName) {
+        if (typeName != null && (typeName.startsWith("java.lang.") || typeName.startsWith("java.util."))) {
+            view.hideRemoveButton();
+        } else {
+            view.showRemoveButton();
+        }
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemView.java
@@ -55,6 +55,16 @@ public class ExternalDataObjectsItemView implements ExternalDataObjectsItemPrese
         this.typeName.value = typeName;
     }
 
+    @Override
+    public void hideRemoveButton() {
+        removeButton.hidden = true;
+    }
+
+    @Override
+    public void showRemoveButton() {
+        removeButton.hidden = false;
+    }
+
     @EventHandler("type-name")
     public void onVersionChange(final @ForEvent("change") Event event) {
         presenter.onTypeNameChange(typeName.value);

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenterTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -30,26 +31,38 @@ public class ExternalDataObjectsItemPresenterTest {
 
     @Test
     public void testSetup() {
-        final Import import_ = new Import("type");
-        externalDataObjectsItemPresenter.setup(import_, mock(ExternalDataObjectsPresenter.class));
-
-        verify(view).init(eq(externalDataObjectsItemPresenter));
-        verify(view).setTypeName(eq("type"));
-        verify(view).showRemoveButton();
-        verify(view, never()).hideRemoveButton();
-        assertEquals(import_, externalDataObjectsItemPresenter.getObject());
+        testSetupOfType("type");
+        testSetupOfRemoveButton(true);
     }
 
     @Test
-    public void testSetupWhenBuiltInTypeIsImported() {
-        final Import import_ = new Import("java.lang.Number");
-        externalDataObjectsItemPresenter.setup(import_, mock(ExternalDataObjectsPresenter.class));
+    public void testSetupWhenBuiltInJavaLangTypeIsImported() {
+        testSetupOfType("java.lang.Number");
+        testSetupOfRemoveButton(false);
+    }
 
-        verify(view).init(eq(externalDataObjectsItemPresenter));
-        verify(view).setTypeName(eq("java.lang.Number"));
-        verify(view, never()).showRemoveButton();
-        verify(view).hideRemoveButton();
-        assertEquals(import_, externalDataObjectsItemPresenter.getObject());
+    @Test
+    public void testSetupWhenBuiltInJavaUtilTypeIsImported() {
+        testSetupOfType("java.util.List");
+        testSetupOfRemoveButton(false);
+    }
+
+    @Test
+    public void testTypeChange() {
+        testTypeChange("NewType");
+        testSetupOfRemoveButton(true);
+    }
+
+    @Test
+    public void testTypeChangeWhenBuiltInJavaLangTypeIsImported() {
+        testTypeChange("java.lang.Number");
+        testSetupOfRemoveButton(false);
+    }
+
+    @Test
+    public void testTypeChangeWhenBuiltInJavaUtilTypeIsImported() {
+        testTypeChange("java.util.List");
+        testSetupOfRemoveButton(false);
     }
 
     @Test
@@ -64,5 +77,35 @@ public class ExternalDataObjectsItemPresenterTest {
 
         verify(listPresenter).remove(eq(externalDataObjectsItemPresenter));
         verify(parentPresenter).fireChangeEvent();
+    }
+
+    private void testSetupOfType(final String type) {
+        final Import import_ = new Import(type);
+        externalDataObjectsItemPresenter.setup(import_, mock(ExternalDataObjectsPresenter.class));
+
+        verify(view).init(eq(externalDataObjectsItemPresenter));
+        verify(view).setTypeName(eq(type));
+        assertEquals(import_, externalDataObjectsItemPresenter.getObject());
+    }
+
+    private void testTypeChange(final String newType) {
+        final Import import_ = new Import("com.sample.OriginalType");
+        externalDataObjectsItemPresenter.setup(import_, mock(ExternalDataObjectsPresenter.class));
+        reset(view);
+
+        externalDataObjectsItemPresenter.onTypeNameChange(newType);
+
+        assertEquals(newType, externalDataObjectsItemPresenter.getObject().getType());
+    }
+
+    private void testSetupOfRemoveButton(final boolean visible) {
+        if (visible) {
+            verify(view).showRemoveButton();
+            verify(view, never()).hideRemoveButton();
+        } else {
+
+            verify(view, never()).showRemoveButton();
+            verify(view).hideRemoveButton();
+        }
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/settings/sections/externaldataobjects/ExternalDataObjectsItemPresenterTest.java
@@ -11,9 +11,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExternalDataObjectsItemPresenterTest {
@@ -35,6 +35,20 @@ public class ExternalDataObjectsItemPresenterTest {
 
         verify(view).init(eq(externalDataObjectsItemPresenter));
         verify(view).setTypeName(eq("type"));
+        verify(view).showRemoveButton();
+        verify(view, never()).hideRemoveButton();
+        assertEquals(import_, externalDataObjectsItemPresenter.getObject());
+    }
+
+    @Test
+    public void testSetupWhenBuiltInTypeIsImported() {
+        final Import import_ = new Import("java.lang.Number");
+        externalDataObjectsItemPresenter.setup(import_, mock(ExternalDataObjectsPresenter.class));
+
+        verify(view).init(eq(externalDataObjectsItemPresenter));
+        verify(view).setTypeName(eq("java.lang.Number"));
+        verify(view, never()).showRemoveButton();
+        verify(view).hideRemoveButton();
         assertEquals(import_, externalDataObjectsItemPresenter.getObject());
     }
 

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
@@ -26,14 +26,13 @@ public class BuiltInTypeImportHelper {
 
     /**
      * Check if the import is java built in type ("java.lang.*" or "java.util.*")
-     *
      * @return false if type is from listed packages, true otherwise
      */
-    public static boolean isImportRemovable(final Import importedType) {
+    public static boolean isBuiltIn(final Import importedType) {
         final String type = importedType.getType();
         final boolean isJavaLang = type != null && type.startsWith("java.lang.");
         final boolean isJavaUtil = type != null && type.startsWith("java.util.");
 
-        return !isJavaLang && !isJavaUtil;
+        return isJavaLang || isJavaUtil;
     }
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
@@ -30,9 +30,14 @@ public class BuiltInTypeImportHelper {
      */
     public static boolean isBuiltIn(final Import importedType) {
         final String type = importedType.getType();
-        final boolean isJavaLang = type != null && type.startsWith("java.lang.");
-        final boolean isJavaUtil = type != null && type.startsWith("java.util.");
+        return isBuiltIn(type);
+    }
 
-        return isJavaLang || isJavaUtil;
+    /**
+     * Check if the given type is java built in type ("java.lang.*" or "java.util.*")
+     * @return false if type is from listed packages, true otherwise
+     */
+    public static boolean isBuiltIn(final String type) {
+        return type != null && (type.startsWith("java.lang.") || type.startsWith("java.util."));
     }
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
@@ -20,6 +20,10 @@ import org.kie.soup.project.datamodel.imports.Import;
 
 public class BuiltInTypeImportHelper {
 
+    private BuiltInTypeImportHelper() {
+        // Suggested by Sonar Cloud
+    }
+
     /**
      * Check if the import is java built in type ("java.lang.*" or "java.util.*")
      *

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.configresource.client.widget;
+
+import org.kie.soup.project.datamodel.imports.Import;
+
+public class BuiltInTypeImportHelper {
+
+    /**
+     * Check if the import is java built in type ("java.lang.*" or "java.util.*")
+     *
+     * @return false if type is from listed packages, true otherwise
+     */
+    public static boolean isImportRemovable(final Import importedType) {
+        final String type = importedType.getType();
+        final boolean isJavaLang = type != null && type.startsWith("java.lang.");
+        final boolean isJavaUtil = type != null && type.startsWith("java.util.");
+
+        return !isJavaLang && !isJavaUtil;
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetPresenter.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetPresenter.java
@@ -96,6 +96,7 @@ public class ImportsWidgetPresenter implements ImportsWidgetView.Presenter,
                         getExternalFactTypes(),
                         getModelFactTypes(),
                         isReadOnly);
+        view.updateRenderedColumns();
     }
 
     @Override
@@ -112,6 +113,7 @@ public class ImportsWidgetPresenter implements ImportsWidgetView.Presenter,
         //Signal change to any other interested consumers (e.g. some editors support rendering of unknown fact-types)
         importAddedEvent.fire(new ImportAddedEvent(dmo,
                                                    importType));
+        view.updateRenderedColumns();
     }
 
     @Override
@@ -123,6 +125,7 @@ public class ImportsWidgetPresenter implements ImportsWidgetView.Presenter,
         //Signal change to any other interested consumers (e.g. some editors support rendering of unknown fact-types)
         importRemovedEvent.fire(new ImportRemovedEvent(dmo,
                                                        importType));
+        view.updateRenderedColumns();
     }
 
     @Override

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetView.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetView.java
@@ -46,4 +46,10 @@ public interface ImportsWidgetView
                     final List<Import> externalFactTypes,
                     final List<Import> modelFactTypes,
                     final boolean isReadOnly);
+
+    /**
+     * Method refresh the set of used columns according to actual imports.
+     * We do not render 'Remove' column if just non removable imports are present.
+     */
+    void updateRenderedColumns();
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImpl.java
@@ -85,6 +85,69 @@ public class ImportsWidgetViewImpl
 
     private boolean isReadOnly = false;
 
+    final TextColumn<Import> importTypeColumn = new TextColumn<Import>() {
+
+        @Override
+        public String getValue(final Import importType) {
+            return importType.getType();
+        }
+    };
+
+    private ButtonCell deleteImportButton = new ButtonCell(IconType.TRASH,
+                                                           ButtonType.DANGER,
+                                                           ButtonSize.SMALL) {
+        @Override
+        public void render(final com.google.gwt.cell.client.Cell.Context context,
+                           final SafeHtml data,
+                           final SafeHtmlBuilder sb) {
+            //Don't render a "Delete" button for "internal" Fact Types
+            if (isExternalImport(context.getIndex()) &&
+                    !BuiltInTypeImportHelper.isBuiltIn(getDataProvider().getList().get(context.getIndex()))) {
+                super.render(context,
+                             data,
+                             sb);
+            }
+        }
+
+        @Override
+        public void onBrowserEvent(final Context context,
+                                   final Element parent,
+                                   final String value,
+                                   final NativeEvent event,
+                                   final ValueUpdater<String> valueUpdater) {
+            //Don't act on cell interactions for "internal" Fact Types
+            if (isExternalImport(context.getIndex())) {
+                super.onBrowserEvent(context,
+                                     parent,
+                                     value,
+                                     event,
+                                     valueUpdater);
+            }
+        }
+
+        @Override
+        protected void onEnterKeyDown(final Context context,
+                                      final Element parent,
+                                      final String value,
+                                      final NativeEvent event,
+                                      final ValueUpdater<String> valueUpdater) {
+            //Don't act on cell interactions for "internal" Fact Types
+            if (isExternalImport(context.getIndex())) {
+                super.onEnterKeyDown(context,
+                                     parent,
+                                     value,
+                                     event,
+                                     valueUpdater);
+            }
+        }
+    };
+    private Column<Import, String> deleteImportColumn = new Column<Import, String>(deleteImportButton) {
+        @Override
+        public String getValue(final Import importType) {
+            return ImportConstants.INSTANCE.remove();
+        }
+    };
+
     public ImportsWidgetViewImpl() {
         //CDI proxy
     }
@@ -110,68 +173,11 @@ public class ImportsWidgetViewImpl
         table.setEmptyTableWidget(new Label(ImportConstants.INSTANCE.noImportsDefined()));
 
         //Columns
-        final TextColumn<Import> importTypeColumn = new TextColumn<Import>() {
+        table.addColumn(importTypeColumn,
+                        new TextHeader(ImportConstants.INSTANCE.importType()));
+        table.addColumn(deleteImportColumn,
+                        ImportConstants.INSTANCE.remove());
 
-            @Override
-            public String getValue(final Import importType) {
-                return importType.getType();
-            }
-        };
-
-        final ButtonCell deleteImportButton = new ButtonCell(IconType.TRASH,
-                                                             ButtonType.DANGER,
-                                                             ButtonSize.SMALL) {
-            @Override
-            public void render(final com.google.gwt.cell.client.Cell.Context context,
-                               final SafeHtml data,
-                               final SafeHtmlBuilder sb) {
-                //Don't render a "Delete" button for "internal" Fact Types
-                if (isExternalImport(context.getIndex()) &&
-                        BuiltInTypeImportHelper.isImportRemovable((getDataProvider().getList().get(context.getIndex())))) {
-                    super.render(context,
-                                 data,
-                                 sb);
-                }
-            }
-
-            @Override
-            public void onBrowserEvent(final Context context,
-                                       final Element parent,
-                                       final String value,
-                                       final NativeEvent event,
-                                       final ValueUpdater<String> valueUpdater) {
-                //Don't act on cell interactions for "internal" Fact Types
-                if (isExternalImport(context.getIndex())) {
-                    super.onBrowserEvent(context,
-                                         parent,
-                                         value,
-                                         event,
-                                         valueUpdater);
-                }
-            }
-
-            @Override
-            protected void onEnterKeyDown(final Context context,
-                                          final Element parent,
-                                          final String value,
-                                          final NativeEvent event,
-                                          final ValueUpdater<String> valueUpdater) {
-                //Don't act on cell interactions for "internal" Fact Types
-                if (isExternalImport(context.getIndex())) {
-                    super.onEnterKeyDown(context,
-                                         parent,
-                                         value,
-                                         event,
-                                         valueUpdater);
-                }
-            }
-        };
-        final Column<Import, String> deleteImportColumn = new Column<Import, String>(deleteImportButton) {
-            @Override
-            public String getValue(final Import importType) {
-                return ImportConstants.INSTANCE.remove();
-            }
-        };
         deleteImportColumn.setFieldUpdater((index,
                                             importType,
                                             value) -> {
@@ -185,11 +191,6 @@ public class ImportsWidgetViewImpl
                                                                                   null);
             confirm.show();
         });
-
-        table.addColumn(importTypeColumn,
-                        new TextHeader(ImportConstants.INSTANCE.importType()));
-        table.addColumn(deleteImportColumn,
-                        ImportConstants.INSTANCE.remove());
 
         //Link display
         getDataProvider().addDataDisplay(table);
@@ -259,5 +260,20 @@ public class ImportsWidgetViewImpl
 
     ListDataProvider<Import> getDataProvider() {
         return dataProvider;
+    }
+
+    @Override
+    public void updateRenderedColumns() {
+        final boolean isAtLeastOneImportRemovable = getDataProvider().getList()
+                .stream()
+                .anyMatch(iType -> isExternalImport(iType) && !BuiltInTypeImportHelper.isBuiltIn(iType));
+
+        final int columnCount = table.getColumnCount();
+        if (isAtLeastOneImportRemovable && columnCount == 1) {
+            table.addColumn(deleteImportColumn,
+                            ImportConstants.INSTANCE.remove());
+        } else if (!isAtLeastOneImportRemovable && columnCount > 1) {
+            table.removeColumn(deleteImportColumn);
+        }
     }
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImpl.java
@@ -48,6 +48,7 @@ import org.gwtbootstrap3.client.ui.gwt.ButtonCell;
 import org.gwtbootstrap3.client.ui.gwt.CellTable;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.workbench.common.widgets.configresource.client.resources.i18n.ImportConstants;
+import org.kie.workbench.common.widgets.configresource.client.widget.BuiltInTypeImportHelper;
 import org.kie.workbench.common.widgets.configresource.client.widget.Sorters;
 import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.widgets.common.client.common.popups.YesNoCancelPopup;
@@ -125,7 +126,8 @@ public class ImportsWidgetViewImpl
                                final SafeHtml data,
                                final SafeHtmlBuilder sb) {
                 //Don't render a "Delete" button for "internal" Fact Types
-                if (isExternalImport(context.getIndex())) {
+                if (isExternalImport(context.getIndex()) &&
+                        BuiltInTypeImportHelper.isImportRemovable((getDataProvider().getList().get(context.getIndex())))) {
                     super.render(context,
                                  data,
                                  sb);

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetPresenter.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetPresenter.java
@@ -47,6 +47,7 @@ public class ImportsWidgetPresenter
 
         view.setContent(importTypes.getImports().getImports(),
                         isReadOnly);
+        view.updateRenderedColumns();
     }
 
     @Override

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetView.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetView.java
@@ -37,4 +37,10 @@ public interface ImportsWidgetView
 
     void setContent(final List<Import> importTypes,
                     final boolean isReadOnly);
+
+    /**
+     * Method refresh the set of used columns according to actual imports.
+     * We do not render 'Remove' column if just non removable imports are present.
+     */
+    void updateRenderedColumns();
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetViewImpl.java
@@ -127,7 +127,7 @@ public class ImportsWidgetViewImpl
             public void render(final Cell.Context context,
                                final Import object,
                                final SafeHtmlBuilder sb) {
-                if (BuiltInTypeImportHelper.isImportRemovable(object)) {
+                if (!BuiltInTypeImportHelper.isBuiltIn(object)) {
                     super.render(context, object, sb);
                 }
             }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetViewImpl.java
@@ -22,8 +22,10 @@ import java.util.List;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import com.google.gwt.cell.client.Cell;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
@@ -43,6 +45,7 @@ import org.gwtbootstrap3.client.ui.gwt.ButtonCell;
 import org.gwtbootstrap3.client.ui.gwt.CellTable;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.workbench.common.widgets.configresource.client.resources.i18n.ImportConstants;
+import org.kie.workbench.common.widgets.configresource.client.widget.BuiltInTypeImportHelper;
 import org.kie.workbench.common.widgets.configresource.client.widget.Sorters;
 import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
@@ -118,6 +121,15 @@ public class ImportsWidgetViewImpl
             @Override
             public String getValue(final Import importType) {
                 return ImportConstants.INSTANCE.remove();
+            }
+
+            @Override
+            public void render(final Cell.Context context,
+                               final Import object,
+                               final SafeHtmlBuilder sb) {
+                if (BuiltInTypeImportHelper.isImportRemovable(object)) {
+                    super.render(context, object, sb);
+                }
             }
         };
         deleteImportColumn.setFieldUpdater((index, importType, value) -> {

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelperTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelperTest.java
@@ -25,32 +25,32 @@ import static org.junit.Assert.assertTrue;
 public class BuiltInTypeImportHelperTest {
 
     @Test
-    public void testIsImportRemovableNull() {
-        assertTrue("user can remove null",
-                   BuiltInTypeImportHelper.isImportRemovable(new Import()));
+    public void testIsImportBuiltInNull() {
+        assertFalse("null is not built in",
+                    BuiltInTypeImportHelper.isBuiltIn(new Import()));
     }
 
     @Test
-    public void testIsImportRemovableEmpty() {
-        assertTrue("user can remove empty",
-                   BuiltInTypeImportHelper.isImportRemovable(new Import("")));
+    public void testIsImportBuiltInEmpty() {
+        assertFalse("empty is not built in",
+                    BuiltInTypeImportHelper.isBuiltIn(new Import("")));
     }
 
     @Test
-    public void testIsImportRemovableJavaLang() {
-        assertFalse("user can not remove java.lang.*",
-                    BuiltInTypeImportHelper.isImportRemovable(new Import("java.lang.Number")));
+    public void testIsImportBuiltInJavaLang() {
+        assertTrue("java.lang.* is built in",
+                   BuiltInTypeImportHelper.isBuiltIn(new Import("java.lang.Number")));
     }
 
     @Test
     public void testIsImportRemovableJavaUtil() {
-        assertFalse("user can not remove java.util.*",
-                    BuiltInTypeImportHelper.isImportRemovable(new Import("java.util.ArrayList")));
+        assertTrue("java.util.* is built in",
+                   BuiltInTypeImportHelper.isBuiltIn(new Import("java.util.ArrayList")));
     }
 
     @Test
-    public void testIsImportRemovableRegular() {
-        assertTrue("user can removed regular type",
-                   BuiltInTypeImportHelper.isImportRemovable(new Import("com.sample.Person")));
+    public void testIsImportBuiltInRegular() {
+        assertFalse("Person is not built in",
+                    BuiltInTypeImportHelper.isBuiltIn(new Import("com.sample.Person")));
     }
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelperTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelperTest.java
@@ -25,20 +25,32 @@ import static org.junit.Assert.assertTrue;
 public class BuiltInTypeImportHelperTest {
 
     @Test
+    public void testIsImportRemovableNull() {
+        assertTrue("user can remove null",
+                   BuiltInTypeImportHelper.isImportRemovable(new Import()));
+    }
+
+    @Test
+    public void testIsImportRemovableEmpty() {
+        assertTrue("user can remove empty",
+                   BuiltInTypeImportHelper.isImportRemovable(new Import("")));
+    }
+
+    @Test
     public void testIsImportRemovableJavaLang() {
-        assertFalse("can not remove java.lang.*",
+        assertFalse("user can not remove java.lang.*",
                     BuiltInTypeImportHelper.isImportRemovable(new Import("java.lang.Number")));
     }
 
     @Test
     public void testIsImportRemovableJavaUtil() {
-        assertFalse("can not remove java.util.*",
+        assertFalse("user can not remove java.util.*",
                     BuiltInTypeImportHelper.isImportRemovable(new Import("java.util.ArrayList")));
     }
 
     @Test
     public void testIsImportRemovableRegular() {
-        assertTrue("regular import can be removed*",
+        assertTrue("user can removed regular type",
                    BuiltInTypeImportHelper.isImportRemovable(new Import("com.sample.Person")));
     }
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelperTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/BuiltInTypeImportHelperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.configresource.client.widget;
+
+import org.junit.Test;
+import org.kie.soup.project.datamodel.imports.Import;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BuiltInTypeImportHelperTest {
+
+    @Test
+    public void testIsImportRemovableJavaLang() {
+        assertFalse("can not remove java.lang.*",
+                    BuiltInTypeImportHelper.isImportRemovable(new Import("java.lang.Number")));
+    }
+
+    @Test
+    public void testIsImportRemovableJavaUtil() {
+        assertFalse("can not remove java.util.*",
+                    BuiltInTypeImportHelper.isImportRemovable(new Import("java.util.ArrayList")));
+    }
+
+    @Test
+    public void testIsImportRemovableRegular() {
+        assertTrue("regular import can be removed*",
+                   BuiltInTypeImportHelper.isImportRemovable(new Import("com.sample.Person")));
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetPresenterTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetPresenterTest.java
@@ -104,6 +104,8 @@ public class ImportsWidgetPresenterTest {
                                     importsFactTypesCaptor.capture(),
                                     eq(false));
 
+        verify(view).updateRenderedColumns();
+
         assertEquals(3,
                      internalFactTypesCaptor.getValue().size());
         assertContains("Internal1",
@@ -231,6 +233,8 @@ public class ImportsWidgetPresenterTest {
                times(1)).fire(importAddedEventCaptor.capture());
         assertEquals("NewImport1",
                      importAddedEventCaptor.getValue().getImport().getType());
+
+        verify(view, times(2)).updateRenderedColumns();
     }
 
     @Test
@@ -253,6 +257,8 @@ public class ImportsWidgetPresenterTest {
                              importsNew,
                              false);
 
+        verify(view, times(2)).updateRenderedColumns();
+
         assertEquals(1, presenter.getInternalFactTypes().size());
         assertEquals("A", presenter.getInternalFactTypes().get(0).getType());
 
@@ -272,6 +278,8 @@ public class ImportsWidgetPresenterTest {
                              false);
 
         presenter.onAddImport(new Import("org.pkg1.External1"));
+
+        verify(view, times(2)).updateRenderedColumns();
 
         assertEquals(1,
                      imports.getImports().size());
@@ -294,6 +302,8 @@ public class ImportsWidgetPresenterTest {
 
         presenter.onRemoveImport(new Import("Internal1"));
 
+        verify(view, times(2)).updateRenderedColumns();
+
         assertEquals(0,
                      imports.getImports().size());
 
@@ -315,6 +325,8 @@ public class ImportsWidgetPresenterTest {
                              false);
 
         presenter.onRemoveImport(new Import("org.pkg1.External1"));
+
+        verify(view, times(2)).updateRenderedColumns();
 
         assertEquals(0,
                      imports.getImports().size());

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImplTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImplTest.java
@@ -20,7 +20,9 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.cellview.client.Column;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.gwt.CellTable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,9 +32,11 @@ import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,6 +68,8 @@ public class ImportsWidgetViewImplTest {
     public void setup() {
         this.view = new ImportsWidgetViewImpl(addImportPopup,
                                               lockRequired);
+        view.table = mock(CellTable.class);
+
         this.view.init(presenter);
 
         internalFactTypes.add(internal1);
@@ -147,6 +153,66 @@ public class ImportsWidgetViewImplTest {
         verify(addImportPopup).setContent(eq(view.getAddImportCommand()),
                                           eq(externalFactTypes));
         verify(addImportPopup).show();
+    }
+
+    @Test
+    public void testUpdateRenderedColumnsUpdateNotNeeded() {
+        when(view.table.getColumnCount()).thenReturn(2);
+        view.setContent(Collections.singletonList(new Import("com.demo.Address")),
+                        Collections.singletonList(new Import("com.demo.Address")),
+                        Collections.emptyList(),
+                        false);
+
+        view.updateRenderedColumns();
+
+        verify(view.table, never()).removeColumn(any(Column.class));
+        verify(view.table, never()).addColumn(any(Column.class),
+                                              anyString());
+    }
+
+    @Test
+    public void testUpdateRenderedColumnsRemoveNotNeededBecauseBuiltIn() {
+        when(view.table.getColumnCount()).thenReturn(2);
+        view.setContent(Collections.singletonList(new Import("java.lang.Number")),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        false);
+
+        view.updateRenderedColumns();
+
+        verify(view.table).removeColumn(any(Column.class));
+        verify(view.table, never()).addColumn(any(Column.class),
+                                              anyString());
+    }
+
+    @Test
+    public void testUpdateRenderedColumnsRemoveColumnNeeded() {
+        when(view.table.getColumnCount()).thenReturn(1);
+        view.setContent(Collections.singletonList(new Import("com.demo.Address")),
+                        Collections.singletonList(new Import("com.demo.Address")),
+                        Collections.emptyList(),
+                        false);
+
+        view.updateRenderedColumns();
+
+        verify(view.table, never()).removeColumn(any(Column.class));
+        verify(view.table).addColumn(any(Column.class),
+                                     eq("remove"));
+    }
+
+    @Test
+    public void testUpdateRenderedColumnsRemoveColumnNotNeeded() {
+        when(view.table.getColumnCount()).thenReturn(2);
+        view.setContent(Collections.singletonList(internal1),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        false);
+
+        view.updateRenderedColumns();
+
+        verify(view.table).removeColumn(any(Column.class));
+        verify(view.table, never()).addColumn(any(Column.class),
+                                              anyString());
     }
 
     @Test

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetPresenterTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetPresenterTest.java
@@ -27,8 +27,11 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ImportsWidgetPresenterTest {

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetPresenterTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetPresenterTest.java
@@ -68,6 +68,7 @@ public class ImportsWidgetPresenterTest {
         verify(view,
                times(1)).setContent(importsArgumentCaptor.capture(),
                                     eq(false));
+        verify(view).updateRenderedColumns();
 
         final List<Import> importsArgument = importsArgumentCaptor.getValue();
 


### PR DESCRIPTION
This PR prevents users from removing java built in type imports on three places:
- Project Settings -> External Dependencies tab
- project.imports file
- Guided editors -> Data Objects tab

For more details see the jira: https://issues.redhat.com/browse/DROOLS-5262