### PR TITLE
DROOLS-5266 Remove unused compile dependencies

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/pom.xml
@@ -45,11 +45,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.workbench.widgets</groupId>
-      <artifactId>kie-wb-config-resource-widget</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-structure-api</artifactId>
     </dependency>
@@ -87,11 +82,6 @@
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-security-api</artifactId>
     </dependency>
 
     <dependency>
@@ -184,10 +174,6 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-client-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
     </dependency>
 
@@ -201,10 +187,6 @@
       <artifactId>gwtbootstrap3-extras</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-widgets-core-client</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-commons</artifactId>
@@ -299,11 +281,6 @@
     <dependency>
       <groupId>com.google.elemental2</groupId>
       <artifactId>elemental2-promise</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.workbench.screens</groupId>
-      <artifactId>kie-wb-common-library-spaces-screen</artifactId>
     </dependency>
 
     <!-- test -->

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/LibraryClient.gwt.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/resources/org/kie/workbench/common/screens/library/LibraryClient.gwt.xml
@@ -7,8 +7,6 @@
 
   <inherits name="com.google.gwt.i18n.I18N"/>
 
-  <inherits name="org.uberfire.UberfireClientAll"/>
-
   <inherits name="org.kie.workbench.common.screens.library.LibraryAPI"/>
 
   <inherits name="org.kie.workbench.common.workbench.KieDefaultWorkbenchClient"/>

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/pom.xml
@@ -46,27 +46,13 @@
       <artifactId>uberfire-client-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-project-datamodel-commons</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-project-datamodel-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-services-api</artifactId>
     </dependency>
 
     <!-- GWT and GWT Extensions -->

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/resources/org/kie/workbench/common/widgets/configresource/KieWorkbenchConfigResourceWidget.gwt.xml
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/resources/org/kie/workbench/common/widgets/configresource/KieWorkbenchConfigResourceWidget.gwt.xml
@@ -26,9 +26,7 @@
   <inherits name="com.google.gwt.user.User"/>
 
   <inherits name="org.kie.soup.project.datamodel.ProjectDataModelAPI"/>
-  <inherits name="org.kie.soup.project.datamodel.commons.ProjectDataModelCommons"/>
 
-  <inherits name='org.kie.workbench.common.services.KieWorkbenchCommonServicesAPI'/>
   <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>
 
 </module>


### PR DESCRIPTION
This PR removes unused compile dependencies of modules:
- kie-wb-common-library-client
- kie-wb-config-resource-widget

For more details see https://issues.redhat.com/browse/DROOLS-5266