### PR TITLE
JBPM-9110 business rule tasks cannot be configured properly

### DIFF
--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
@@ -45,12 +45,13 @@ import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.metadata.model.KObject;
 import org.uberfire.ext.metadata.model.KProperty;
 import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystemNotFoundException;
 import org.uberfire.paging.PageResponse;
 
 @ApplicationScoped
 public class FindRuleFlowNamesQuery extends AbstractFindQuery implements NamedQuery {
 
-    private static final Logger logger = LoggerFactory.getLogger(FindRuleFlowNamesQuery.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FindRuleFlowNamesQuery.class);
 
     @Inject
     @Named("ioStrategy")
@@ -153,17 +154,21 @@ public class FindRuleFlowNamesQuery extends AbstractFindQuery implements NamedQu
             }
             for (KProperty property : kObject.getProperties()) {
                 if (property.getName().equals(SharedPartIndexTerm.TERM + ":" + PartType.RULEFLOW_GROUP.toString())) {
-                    if (ruleFlowGroupNames.containsKey(property.getValue().toString())) {
-                        final Path path = Paths.convert(ioService.get(URI.create(kObject.getKey())));
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
-                    } else {
-                        final Path path = Paths.convert(ioService.get(URI.create(kObject.getKey())));
-                        ruleFlowGroupNames.put(property.getValue().toString(), new HashMap<String, String>());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
+                    try {
+                        if (ruleFlowGroupNames.containsKey(property.getValue().toString())) {
+                            final Path path = Paths.convert(ioService.get(URI.create(kObject.getKey())));
+                            ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
+                            ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
+                            ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
+                        } else {
+                            final Path path = Paths.convert(ioService.get(URI.create(kObject.getKey())));
+                            ruleFlowGroupNames.put(property.getValue().toString(), new HashMap<String, String>());
+                            ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
+                            ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
+                            ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
+                        }
+                    } catch (FileSystemNotFoundException ex) {
+                        LOGGER.error(ex.toString());
                     }
                 }
             }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -58,6 +59,16 @@ public class FindRuleFlowNamesQuery extends AbstractFindQuery implements NamedQu
     private RuleFlowNamesResponseBuilder responseBuilder = new RuleFlowNamesResponseBuilder();
 
     public static final String NAME = FindRuleFlowNamesQuery.class.getSimpleName();
+    public static final String SHARED_TERM = SharedPartIndexTerm.TERM + ":" + PartType.RULEFLOW_GROUP.toString();
+
+    // For the testing purposes
+    void setIoService(IOService service) {
+        ioService = service;
+    }
+
+    public static boolean isSharedRuleFlowGroup(String parameter) {
+        return SHARED_TERM.equals(parameter);
+    }
 
     @Override
     public String getName() {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
@@ -148,32 +148,32 @@ public class FindRuleFlowNamesQuery extends AbstractFindQuery implements NamedQu
         }
 
         private Map<String, Map<String, String>> getRuleFlowGroupNamesNamesFromKObject(final KObject kObject) {
-            final Map<String, Map<String, String>> ruleFlowGroupNames = new HashMap<String, Map<String, String>>();
+            final Map<String, Map<String, String>> ruleFlowGroupNames = new HashMap<>();
             if (kObject == null) {
                 return ruleFlowGroupNames;
             }
-            for (KProperty property : kObject.getProperties()) {
-                if (property.getName().equals(SharedPartIndexTerm.TERM + ":" + PartType.RULEFLOW_GROUP.toString())) {
-                    try {
-                        if (ruleFlowGroupNames.containsKey(property.getValue().toString())) {
-                            final Path path = Paths.convert(ioService.get(URI.create(kObject.getKey())));
-                            ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
-                            ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
-                            ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
-                        } else {
-                            final Path path = Paths.convert(ioService.get(URI.create(kObject.getKey())));
-                            ruleFlowGroupNames.put(property.getValue().toString(), new HashMap<String, String>());
-                            ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
-                            ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
-                            ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
-                        }
-                    } catch (FileSystemNotFoundException ex) {
-                        LOGGER.error(ex.toString());
+            for (KProperty<?> property : kObject.getProperties()) {
+                if (SHARED_TERM.equals(property.getName())) {
+                    Path path = getPath(kObject);
+                    if (path != null) {
+                        ruleFlowGroupNames.put(property.getValue().toString(), new HashMap<>());
+                        ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
+                        ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
+                        ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
                     }
                 }
             }
 
             return ruleFlowGroupNames;
+        }
+
+        private Path getPath(KObject kObject) {
+            try {
+                return Paths.convert(ioService.get(URI.create(kObject.getKey())));
+            } catch (FileSystemNotFoundException ex) {
+                LOGGER.error(ex.toString());
+                return null;
+            }
         }
     }
 }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
@@ -53,19 +53,17 @@ public class FindRuleFlowNamesQuery extends AbstractFindQuery implements NamedQu
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FindRuleFlowNamesQuery.class);
 
+    private final IOService ioService;
+
     @Inject
-    @Named("ioStrategy")
-    private IOService ioService;
+    public FindRuleFlowNamesQuery(@Named("ioStrategy") IOService ioService) {
+        this.ioService = ioService;
+    }
 
     private RuleFlowNamesResponseBuilder responseBuilder = new RuleFlowNamesResponseBuilder();
 
     public static final String NAME = FindRuleFlowNamesQuery.class.getSimpleName();
     public static final String SHARED_TERM = SharedPartIndexTerm.TERM + ":" + PartType.RULEFLOW_GROUP.toString();
-
-    // For the testing purposes
-    void setIoService(IOService service) {
-        ioService = service;
-    }
 
     public static boolean isSharedRuleFlowGroup(String parameter) {
         return SHARED_TERM.equals(parameter);

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
@@ -1,0 +1,97 @@
+package org.kie.workbench.common.services.refactoring.backend.server.query.standard;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.ext.metadata.model.KProperty;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystemNotFoundException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import static java.lang.String.format;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FindRuleFlowNamesQueryTest {
+
+    @Mock
+    private KObject kObject;
+    @Mock
+    private KProperty property;
+    @Mock
+    private IOService ioService;
+    private static final String GROUP_NAME = "Group_Name";
+    private static final String FILE_NOT_EXIST_PATH = "default://master@SpaceA/ProjectA/src/main/resources/Rule_not_exist.rdrl";
+    private static final String FILE_NAME = "Rule_number_two.rdrl";
+    private static final String FILE_PATH = "default://master@SpaceA/ProjectA/src/main/resources/" + FILE_NAME;
+    private static final URI FILE_NOT_EXIST_URI = URI.create(FILE_NOT_EXIST_PATH);
+    private static final URI FILE_URI = URI.create(FILE_PATH);
+    private static final SimpleFileSystemProvider fileSystemProvider = new SimpleFileSystemProvider();
+    private static final Path path = fileSystemProvider.getPath(FILE_URI);
+    private List<KObject> kObjects = new ArrayList<>();
+    private List<KProperty<?>> properties = new ArrayList<>();
+
+    // Tested classes
+    private static final FindRuleFlowNamesQuery query = new FindRuleFlowNamesQuery();
+    private ResponseBuilder testedBuilder;
+
+    @Before
+    public void init() {
+        // IO Service mock
+        when(ioService.get(FILE_NOT_EXIST_URI)).thenThrow(new FileSystemNotFoundException(format("No filesystem for uri %s found.", FILE_NOT_EXIST_URI.toString())));
+        when(ioService.get(FILE_URI)).thenReturn(path);
+        query.setIoService(ioService);
+
+        // Indexed RuleFlow groups mock
+        when(property.getName()).thenReturn(FindRuleFlowNamesQuery.SHARED_TERM);
+        when(property.getValue()).thenReturn(GROUP_NAME);
+        properties.add(property);
+
+        // Class under test
+        testedBuilder = query.getResponseBuilder();
+    }
+
+    @Test
+    public void testNullObject() {
+        fail("finish it");
+    }
+
+    @Test
+    public void testNoProperties() {
+        fail("finish it");
+    }
+
+    @Test
+    public void testNonGroupTermIsIgnored() {
+        fail("finish it");
+    }
+
+    @Test
+    public void testNewGroupAdded() {
+        fail("finish it");
+    }
+
+    @Test
+    public void testExistentGroupUpdated() {
+        fail("finish it");
+    }
+
+    @Test
+    public void testFileWithGroupIsDeletedOrNotExist() {
+        when(kObject.getProperties()).thenReturn(properties);
+        when(kObject.getKey()).thenReturn(FILE_NOT_EXIST_PATH);
+        kObjects.add(kObject);
+        testedBuilder.buildResponse(kObjects);
+        fail("finish it");
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2020  Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
@@ -44,8 +44,6 @@ public class FindRuleFlowNamesQueryTest {
     private List<KObject> kObjects = new ArrayList<>();
     private List<KProperty<?>> properties = new ArrayList<>();
 
-    // Tested classes
-    private static final FindRuleFlowNamesQuery query = new FindRuleFlowNamesQuery();
     private ResponseBuilder testedBuilder;
 
     @Before
@@ -53,7 +51,8 @@ public class FindRuleFlowNamesQueryTest {
         // IO Service mock
         when(ioService.get(FILE_NOT_EXIST_URI)).thenThrow(new FileSystemNotFoundException(format("No filesystem for uri %s found.", FILE_NOT_EXIST_URI.toString())));
         when(ioService.get(FILE_URI)).thenReturn(path);
-        query.setIoService(ioService);
+        // Tested classes
+        FindRuleFlowNamesQuery query = new FindRuleFlowNamesQuery(ioService);
 
         // Indexed RuleFlow groups mock
         when(property.getName()).thenReturn(FindRuleFlowNamesQuery.SHARED_TERM);

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
@@ -3,11 +3,14 @@ package org.kie.workbench.common.services.refactoring.backend.server.query.stand
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.refactoring.backend.server.query.response.ResponseBuilder;
+import org.kie.workbench.common.services.refactoring.model.query.RefactoringMapPageRow;
+import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.metadata.model.KObject;
@@ -18,7 +21,7 @@ import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static java.lang.String.format;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -55,7 +58,7 @@ public class FindRuleFlowNamesQueryTest {
         // Indexed RuleFlow groups mock
         when(property.getName()).thenReturn(FindRuleFlowNamesQuery.SHARED_TERM);
         when(property.getValue()).thenReturn(GROUP_NAME);
-        properties.add(property);
+        when(kObject.getProperties()).thenReturn(properties);
 
         // Class under test
         testedBuilder = query.getResponseBuilder();
@@ -63,35 +66,70 @@ public class FindRuleFlowNamesQueryTest {
 
     @Test
     public void testNullObject() {
-        fail("finish it");
+        List<RefactoringPageRow> list = testedBuilder.buildResponse(kObjects);
+
+        assertEquals(0, list.size());
     }
 
     @Test
     public void testNoProperties() {
-        fail("finish it");
+        kObjects.add(kObject);
+        List<RefactoringPageRow> list = testedBuilder.buildResponse(kObjects);
+
+        assertEquals(0, list.size());
     }
 
     @Test
     public void testNonGroupTermIsIgnored() {
-        fail("finish it");
+        when(property.getName()).thenReturn("Random value");
+        properties.add(property);
+        kObjects.add(kObject);
+        List<RefactoringPageRow> list = testedBuilder.buildResponse(kObjects);
+
+        assertEquals(0, list.size());
     }
 
     @Test
     public void testNewGroupAdded() {
-        fail("finish it");
+        properties.add(property);
+        kObjects.add(kObject);
+        when(kObject.getKey()).thenReturn(FILE_PATH);
+
+        List<RefactoringPageRow> list = testedBuilder.buildResponse(kObjects);
+        RefactoringMapPageRow row = (RefactoringMapPageRow) list.get(0);
+        assertEquals(1, list.size());
+        Map<?, ?> map = row.getValue();
+        assertEquals(3, map.size());
+        assertEquals(FILE_NAME, map.get("filename"));
+        assertEquals(path.toUri().toString(), map.get("pathuri"));
+        assertEquals(GROUP_NAME, map.get("name"));
     }
 
     @Test
     public void testExistentGroupUpdated() {
-        fail("finish it");
+        properties.add(property);
+        properties.add(property);
+
+        kObjects.add(kObject);
+        when(kObject.getKey()).thenReturn(FILE_PATH);
+
+        List<RefactoringPageRow> list = testedBuilder.buildResponse(kObjects);
+        RefactoringMapPageRow row = (RefactoringMapPageRow) list.get(0);
+        assertEquals(1, list.size());
+        Map<?, ?> map = row.getValue();
+        assertEquals(3, map.size());
+        assertEquals(FILE_NAME, map.get("filename"));
+        assertEquals(path.toUri().toString(), map.get("pathuri"));
+        assertEquals(GROUP_NAME, map.get("name"));
     }
 
     @Test
     public void testFileWithGroupIsDeletedOrNotExist() {
-        when(kObject.getProperties()).thenReturn(properties);
+        properties.add(property);
         when(kObject.getKey()).thenReturn(FILE_NOT_EXIST_PATH);
         kObjects.add(kObject);
-        testedBuilder.buildResponse(kObjects);
-        fail("finish it");
+        List<RefactoringPageRow> list = testedBuilder.buildResponse(kObjects);
+
+        assertEquals(0, list.size());
     }
 }

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020  Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.workbench.common.services.refactoring.backend.server.query.standard;
 
 import java.net.URI;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupQueryServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupQueryServiceTest.java
@@ -23,12 +23,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindRuleFlowNamesQuery;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueSharedPartIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
 import org.kie.workbench.common.services.refactoring.service.PartType;
+import org.uberfire.io.IOService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -38,11 +41,14 @@ import static org.mockito.Mockito.when;
 
 public class RuleFlowGroupQueryServiceTest {
 
+    @Inject
+    private IOService ioService;
+
     private final static String ERROR_MSG = PartType.ACTIVATION_GROUP.toString() + "' can not be used";
 
     @Test
     public void findRuleFlowNamesQueryTermsTest() {
-        FindRuleFlowNamesQuery query = new FindRuleFlowNamesQuery();
+        FindRuleFlowNamesQuery query = new FindRuleFlowNamesQuery(ioService);
 
         Set<ValueIndexTerm> queryTerms = new HashSet<>();
         try {


### PR DESCRIPTION
Hi @romartin this fix is inspired by the similar one: https://github.com/kiegroup/kie-wb-common/pull/2950/files

Also, I think there is still two issues on Business Central side.
1. Rules should be removed from the index when project is removed, because now we still have a message in a log about missing file
```
20:07:58,208 ERROR [org.kie.workbench.common.services.refactoring.backend.server.query.standard.FindRuleFlowNamesQuery] (default task-6) org.uberfire.java.nio.file.FileSystemNotFoundException: No filesystem for uri (default://master@MySpace/ProjectA/src/main/resources/com/myspace/projecta/TestGroup1.rdrl) found.
```
2. I think [FileSystemNotFoundException](https://github.com/kiegroup/appformer/blob/ae323c023e1fab4a45fba3bf2e7f7c5f20987b8e/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/FileSystemNotFoundException.java) should be a checked exception. During the change all similar possible issues we have across the system will be fixed and I guess it can help us to deal with issues with broken **.niogit** repository. Change is not small, but in my opinion worth to do. @porcelli, @ederign WDYT? I know Java has a similar one and it is Runtime but, maybe it is why we created a similar exception, to have an ability to change it? :)



