### PR TITLE
KOGITO-1687: DMN invalid data type names are not reported

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientServicesProxyImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientServicesProxyImpl.java
@@ -86,7 +86,7 @@ public class DMNClientServicesProxyImpl implements DMNClientServicesProxy {
     @Override
     public void isValidVariableName(final String source,
                                     final ServiceCallback<Boolean> callback) {
-        callback.onSuccess(true);
+        callback.onSuccess(FEELSyntaxLightValidator.isVariableNameValid(source));
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidator.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidator.java
@@ -44,7 +44,7 @@ public class FEELSyntaxLightValidator {
 
     private static final String[] RESERVED_KEYWORDS = new String[]{
             "for", "return", "if", "then", "else", "some", "every", "satisfies", "instance", "of",
-            "function", "external", "or", "and", "between", "not", "null", "true", "false"
+            "in", "function", "external", "or", "and", "between", "not", "null", "true", "false"
     };
 
     private static final Function<Character, String> CHAR_TO_STRING_MAPPER = c -> Character.toString(c);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidator.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.services;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static java.util.stream.Stream.of;
+
+/**
+ * <p>It provides a light validation for variable names, respect to the FEEL syntax</p>
+ * <p>We already have a validation mechanism on back-end side, provided by <strong>FeelParser</strong></p>
+ * <p>However, as for now, we cannot use back-end services in dmn client, so the aim of this class is to provide a more accurate as possible validation</p>
+ * <p>Its purpose is to be temporary for the short/middle term</p>
+ */
+public class FEELSyntaxLightValidator {
+
+    private static final Character[] FORBIDDEN_CHARS = new Character[]{
+            '!', '@', '#', '$', '$', '%', '&', '^', '(', ')', '\"',
+            '{', '}', '[', ']', '|', '\\', '"', '<', '>', ';', ':', ','
+    };
+
+    private static final Character[] FORBIDDEN_CHARS_AS_INITIAL = Stream.concat(
+            of(FORBIDDEN_CHARS),
+            of('-', '.', '/', '\'', '*', '+')
+    ).toArray(Character[]::new);
+
+    private static final String[] RESERVED_KEYWORDS = new String[]{
+            "for", "return", "if", "then", "else", "some", "every", "satisfies", "instance", "of",
+            "function", "external", "or", "and", "between", "not", "null", "true", "false"
+    };
+
+    public static boolean isVariableNameValid(final String variableName) {
+        return notEmpty(variableName)
+                && firstCharacterIsValid(variableName)
+                && firstWordIsNotReservedKeyword(variableName)
+                && doesNotContainForbiddenChars(variableName);
+    }
+
+    private static boolean notEmpty(final String variableName) {
+        return variableName != null && !variableName.trim().isEmpty();
+    }
+
+    private static boolean firstCharacterIsValid(final String variableName) {
+        final char firstLetter = variableName.charAt(0);
+        return !Character.isDigit(firstLetter) && containsNone(firstLetter, FORBIDDEN_CHARS_AS_INITIAL);
+    }
+
+    private static boolean firstWordIsNotReservedKeyword(final String variableName) {
+        return containsNone(variableName.split("[ \\-]")[0], RESERVED_KEYWORDS);
+    }
+
+    private static boolean doesNotContainForbiddenChars(final String variableName) {
+        final String variableNameWithoutInitial = variableName.substring(1);
+        return Stream.of(FORBIDDEN_CHARS)
+                .map(c -> Character.toString(c))
+                .noneMatch(variableNameWithoutInitial::contains);
+    }
+
+    private static <T> boolean containsNone(final T inputStr, final T[] items) {
+        return Arrays.stream(items).noneMatch(inputStr::equals);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientServicesProxyImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/DMNClientServicesProxyImplTest.java
@@ -118,11 +118,12 @@ public class DMNClientServicesProxyImplTest {
 
     @Test
     public void testIsValidVariableName() {
-        final ServiceCallback<Boolean> callback = newServiceCallback(actual -> assertThat(actual).isTrue());
+        final ServiceCallback<Boolean> trueCallback = newServiceCallback(actual -> assertThat(actual).isTrue());
+        final ServiceCallback<Boolean> falseCallback = newServiceCallback(actual -> assertThat(actual).isFalse());
 
-        service.isValidVariableName("", callback);
-        service.isValidVariableName("anything", callback);
-        service.isValidVariableName("   bad value  ", callback);
+        service.isValidVariableName("", falseCallback);
+        service.isValidVariableName("anything", trueCallback);
+        service.isValidVariableName("   accepted in business central  ", trueCallback);
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidatorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidatorTest.java
@@ -48,6 +48,11 @@ public class FEELSyntaxLightValidatorTest {
     public void testValidationWhenVariableNameStartsWithReservedKeyword() {
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("for variable")).isFalse();
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("for-name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for.name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for/name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for'name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for*name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for+name")).isFalse();
     }
 
     @Test
@@ -99,6 +104,40 @@ public class FEELSyntaxLightValidatorTest {
 
     @Test
     public void testValidationWhenVariableNameContainsInvalidCharacters() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ! name")).isFalse();
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable @ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable # name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable $ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable $ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable % name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable & name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ^ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ( name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ) name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable \" name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ° name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable § name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ← name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable → name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ↓ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ¢ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable µ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable { name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable } name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable [ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ] name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable | name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable \\ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable = name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable < name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable > name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ; name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable : name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable , name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ¶ name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable « name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable » name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable ” name")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable “ name")).isFalse();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidatorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.services;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FEELSyntaxLightValidatorTest {
+
+    @Test
+    public void testValidationWhenVariableNameIsEmpty() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid(null)).isFalse();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameStartsWithValidSymbol() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("_variable")).isTrue();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("?variable")).isTrue();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameStartsWithNumber() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("2variable")).isFalse();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameStartsWithInvalidSymbol() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("@variable")).isFalse();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameStartsWithReservedKeyword() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for variable")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for-name")).isFalse();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameIsSimpleCharSequence() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid(" valid variable name")).isTrue();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("valid variable name")).isTrue();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for_name")).isTrue();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("form name")).isTrue();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameContainsValidSymbols() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("?_873./-'+*valid")).isTrue();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameContainsStrangeButValidSymbols() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("🐎")).isTrue();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("版")).isTrue();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameContainsReservedKeyword() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("name for variable")).isTrue();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameIsReservedKeyword() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("for")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("return")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("if")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("then")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("else")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("some")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("every")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("satisfies")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("instance")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("of")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("function")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("external")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("or")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("and")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("between")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("not")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("null")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("true")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("false")).isFalse();
+    }
+
+    @Test
+    public void testValidationWhenVariableNameContainsInvalidCharacters() {
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("variable @ name")).isFalse();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidatorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/services/FEELSyntaxLightValidatorTest.java
@@ -91,6 +91,7 @@ public class FEELSyntaxLightValidatorTest {
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("satisfies")).isFalse();
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("instance")).isFalse();
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("of")).isFalse();
+        assertThat(FEELSyntaxLightValidator.isVariableNameValid("in")).isFalse();
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("function")).isFalse();
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("external")).isFalse();
         assertThat(FEELSyntaxLightValidator.isVariableNameValid("or")).isFalse();


### PR DESCRIPTION
*Please refer to:* https://issues.redhat.com/browse/KOGITO-1687

*Issue description:* Data type name validation is not present in Kogito

*Proposed solution:* Data type name validation is present in Business Central, in particular in the class `FeelParser`.
However, as for now, we cannot use back-end services in dmn client, so for the short/middle term, the solution is to have a tiny&simple validation mechanism for variable names, that would cover as more cases as possible.