### PR TITLE
DROOLS-5274: Expose filename of selected file to upload

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidget.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidget.java
@@ -1,20 +1,18 @@
-
-
 /*
-* Copyright 2010 Red Hat, Inc. and/or its affiliates.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.kie.workbench.common.widgets.client.widget;
 
@@ -284,6 +282,10 @@ public class AttachmentFileWidget extends Composite {
 
     public void showMessage(String message) {
         Window.alert(message);
+    }
+
+    public String getFilenameSelectedToUpload() {
+        return up.getFilename();
     }
 }
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidgetTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidgetTest.java
@@ -30,21 +30,32 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.widgets.common.client.common.FileUpload;
 import org.uberfire.ext.widgets.common.client.common.FileUploadFormEncoder;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class AttachmentFileWidgetTest {
 
+    @Spy
     @InjectMocks
     private AttachmentFileWidgetTestWrapper editor;
 
     @GwtMock
     private Form form;
+
+    @Mock
+    private FileUpload fileUpload;
 
     @Mock
     private FileUploadFormEncoder formEncoder;
@@ -122,5 +133,15 @@ public class AttachmentFileWidgetTest {
                      editor.getShownMessages().size());
         assertEquals(CommonConstants.INSTANCE.UploadGenericError(),
                      editor.getShownMessages().get(0));
+    }
+
+    @Test
+    public void testSelectedFileName() {
+        doReturn(fileUpload).when(editor).createUploadWidget(anyBoolean());
+        editor.setup(true);
+
+        when(fileUpload.getFilename()).thenReturn("abcd");
+
+        assertEquals("abcd", editor.getFilenameSelectedToUpload());
     }
 }


### PR DESCRIPTION
Ensemble with:
- https://github.com/kiegroup/drools-wb/pull/1355

The exposed filename will help in XLS/XLSX new file dialogue to determine how to handle file creation.

For more details see https://issues.redhat.com/browse/DROOLS-5274