### PR TITLE
DROOLS-5229: DMNValidate mojo fails XMLSchema validation with included models

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandalone.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandalone.java
@@ -80,7 +80,6 @@ import org.kie.workbench.common.dmn.api.property.dimensions.Width;
 import org.kie.workbench.common.dmn.api.property.dmn.DecisionServiceDividerLineY;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
-import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
 import org.kie.workbench.common.dmn.backend.common.DMNMarshallerImportsHelperStandalone;
 import org.kie.workbench.common.dmn.backend.definition.v1_1.AssociationConverter;
@@ -1114,14 +1113,14 @@ public class DMNMarshallerStandalone implements DiagramMarshaller<Graph, Metadat
         }
 
         final NamedElement namedElement = (NamedElement) dmnElement;
-        final String drgElementPrefix = extractNamespaceFromName(namedElement.getName());
+        final Optional<String> name = Optional.ofNullable(namedElement.getName().getValue());
 
         return definitions
                 .getImport()
                 .stream()
                 .filter(anImport -> {
                     final String importName = anImport.getName().getValue();
-                    return Objects.equals(importName, drgElementPrefix);
+                    return name.map(n -> n.startsWith(importName + ".")).orElse(false);
                 })
                 .map(anImport -> {
                     final String importNamespace = anImport.getNamespace();
@@ -1140,12 +1139,6 @@ public class DMNMarshallerStandalone implements DiagramMarshaller<Graph, Metadat
                 .map(Entry::getKey)
                 .findFirst()
                 .orElse("");
-    }
-
-    private static String extractNamespaceFromName(final Name name) {
-        final String value = name.getValue();
-        final boolean hasNamespace = value.contains(".");
-        return hasNamespace ? value.split("\\.")[0] : "";
     }
 
     private static void applyFontStyle(final FontSet fontSet,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperStandaloneImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperStandaloneImpl.java
@@ -237,7 +237,6 @@ public class DMNMarshallerImportsHelperStandaloneImpl implements DMNMarshallerIm
         final String namespace = anImport.getName();
 
         drgElement.getAdditionalAttributes().put(NAMESPACE, anImport.getNamespace());
-        drgElement.setId(namespace + ":" + drgElement.getId());
         drgElement.setName(namespace + "." + drgElement.getName());
         updateInformationItem(namespace, drgElement);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/HrefBuilder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/HrefBuilder.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
@@ -24,7 +23,6 @@ import org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBas
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
 import org.kie.workbench.common.dmn.api.definition.model.Import;
-import org.kie.workbench.common.dmn.api.property.dmn.Name;
 
 public class HrefBuilder {
 
@@ -38,24 +36,18 @@ public class HrefBuilder {
     }
 
     private static Optional<String> getNamespace(final DRGElement drgElement) {
-        final String drgElementPrefix = extractNamespaceFromName(drgElement.getName());
+        final Optional<String> name = Optional.ofNullable(drgElement.getName().getValue());
         return getDefinitions(drgElement)
                 .map(definitions -> definitions
                         .getImport()
                         .stream()
                         .filter(anImport -> {
                             final String importName = anImport.getName().getValue();
-                            return Objects.equals(importName, drgElementPrefix);
+                            return name.map(n -> n.startsWith(importName + ".")).orElse(false);
                         })
                         .findFirst()
                         .map(Import::getNamespace)
                         .orElse(null));
-    }
-
-    private static String extractNamespaceFromName(final Name name) {
-        final String value = name.getValue();
-        final boolean hasNamespace = value.contains(".");
-        return hasNamespace ? value.split("\\.")[0] : "";
     }
 
     private static Optional<Definitions> getDefinitions(final DRGElement drgElement) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/HrefBuilder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/HrefBuilder.java
@@ -16,36 +16,61 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
-import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
 import org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
+import org.kie.workbench.common.dmn.api.definition.model.Import;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
 
 public class HrefBuilder {
 
     public static String getHref(final DRGElement drgElement) {
-        if (!drgElement.getId().getValue().contains(":")) {
-            return "#" + drgElement.getId().getValue();
-        }
 
-        // If it have ":" it is an imported element
-        final DMNModelInstrumentedBase parent = drgElement.getParent();
-        final Definitions definitions;
-        if (parent instanceof DMNDiagram) {
-            final DMNDiagram diagram = (DMNDiagram) parent;
-            definitions = diagram.getDefinitions();
-        } else {
-            definitions = (Definitions) parent;
-        }
+        final String drgElementId = drgElement.getId().getValue();
 
-        final String[] split = drgElement.getId().getValue().split(":");
-        final String namespace = getNamespaceForImport(split[0], definitions.getNsContext());
-        return namespace + "#" + split[1];
+        return getNamespace(drgElement)
+                .map(namespace -> namespace + "#" + drgElementId)
+                .orElse("#" + drgElementId);
     }
 
-    static String getNamespaceForImport(final String importName, final Map<String, String> nsContext) {
-        return nsContext.get(importName);
+    private static Optional<String> getNamespace(final DRGElement drgElement) {
+        final String drgElementPrefix = extractNamespaceFromName(drgElement.getName());
+        return getDefinitions(drgElement)
+                .map(definitions -> definitions
+                        .getImport()
+                        .stream()
+                        .filter(anImport -> {
+                            final String importName = anImport.getName().getValue();
+                            return Objects.equals(importName, drgElementPrefix);
+                        })
+                        .findFirst()
+                        .map(Import::getNamespace)
+                        .orElse(null));
+    }
+
+    private static String extractNamespaceFromName(final Name name) {
+        final String value = name.getValue();
+        final boolean hasNamespace = value.contains(".");
+        return hasNamespace ? value.split("\\.")[0] : "";
+    }
+
+    private static Optional<Definitions> getDefinitions(final DRGElement drgElement) {
+
+        final DMNModelInstrumentedBase parent = drgElement.getParent();
+
+        if (parent instanceof DMNDiagram) {
+            final DMNDiagram diagram = (DMNDiagram) parent;
+            return Optional.ofNullable(diagram.getDefinitions());
+        }
+
+        if (parent instanceof Definitions) {
+            return Optional.of((Definitions) parent);
+        }
+
+        return Optional.empty();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/common/DMNIncludedNodeFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/editors/common/DMNIncludedNodeFactory.java
@@ -24,7 +24,6 @@ import org.kie.workbench.common.dmn.api.definition.model.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.model.IsInformationItem;
 import org.kie.workbench.common.dmn.api.editors.included.DMNIncludedNode;
 import org.kie.workbench.common.dmn.api.editors.included.IncludedModel;
-import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.uberfire.backend.vfs.Path;
@@ -45,8 +44,6 @@ public class DMNIncludedNodeFactory {
                                      final IncludedModel includeModel) {
 
         final String modelName = includeModel.getModelName();
-
-        drgElement.setId(new Id(modelName + ":" + drgElement.getId().getValue()));
         drgElement.setName(new Name(modelName + "." + drgElement.getName().getValue()));
         drgElement.setAllowOnlyVisualChange(true);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
@@ -2141,6 +2141,44 @@ public class DMNMarshallerStandaloneTest {
     }
 
     @Test
+    public void testGetDmnElementRefWithNamespaceWhenImportHasAnOddName() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+
+        final Name drgElementName = mock(Name.class);
+        final Name importName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Import anImport = mock(org.kie.workbench.common.dmn.api.definition.model.Import.class);
+        final List<org.kie.workbench.common.dmn.api.definition.model.Import> imports = singletonList(anImport);
+        final String includedModelName = "d.i.v.i.";
+        final String namespaceName = "include1";
+        final String importNamespace = "://namespace";
+        final Map<String, String> nsContext = new HashMap<>();
+
+        when(importName.getValue()).thenReturn(includedModelName);
+
+        when(anImport.getName()).thenReturn(importName);
+        when(anImport.getNamespace()).thenReturn(importNamespace);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn(includedModelName + ".Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        nsContext.put(namespaceName, importNamespace);
+        when(definitions.getImport()).thenReturn(imports);
+        when(definitions.getNsContext()).thenReturn(nsContext);
+
+        final String actual = getDmnElementRef(definitions, view).getLocalPart();
+        final String expected = "include1:0000-1111-2222";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testGetDmnElementRefWithFakeNamespace() {
 
         final Decision drgElement = mock(Decision.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
@@ -119,6 +119,7 @@ import org.kie.workbench.common.dmn.api.editors.included.PMMLDocumentMetadata;
 import org.kie.workbench.common.dmn.api.factory.DMNGraphFactoryImpl;
 import org.kie.workbench.common.dmn.api.graph.DMNDiagramUtils;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.backend.common.DMNMarshallerImportsHelperStandalone;
 import org.kie.workbench.common.dmn.backend.definition.v1_1.DecisionConverter;
@@ -155,6 +156,8 @@ import org.uberfire.commons.uuid.UUID;
 import org.xml.sax.InputSource;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -164,12 +167,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.backend.DMNMarshallerStandalone.getDmnElementRef;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1748,7 +1750,6 @@ public class DMNMarshallerStandaloneTest {
 
         when(dmnMarshallerImportsHelper.getImportedDRGElements(importDefinitions)).thenReturn(importedDRGElements);
 
-        doNothing().when(marshaller).updateIDsWithAlias(any(), any());
         doReturn(Optional.of(ref1)).when(marshaller).getReference(importedDRGElements, "REF1");
         doReturn(Optional.of(ref2)).when(marshaller).getReference(importedDRGElements, "REF2");
         doReturn(Optional.of(ref3)).when(marshaller).getReference(importedDRGElements, "REF3");
@@ -1871,53 +1872,6 @@ public class DMNMarshallerStandaloneTest {
         assertTrue(actual);
     }
 
-    @Test
-    public void testUpdateIDsWithAlias() {
-
-        final DMNMarshallerStandalone marshaller = getDMNMarshaller();
-        final HashMap<String, String> indexByUri = new HashMap<>();
-        final String namespace1 = "https://kiegroup.org/dmn/_red";
-        final String namespace2 = "https://kiegroup.org/dmn/_blue";
-        final String namespace3 = "https://kiegroup.org/dmn/_yellow";
-        final String missingNamespace = "missing_namespace";
-
-        final String someWrongAlias = "some wrong alias";
-
-        final String include1 = "include1";
-        final String include2 = "include2";
-        final String include3 = "include3";
-
-        final String id1 = "id1";
-        final String id2 = "id2";
-        final String id3 = "id3";
-        final String id4 = "id4";
-
-        indexByUri.put(namespace1, include1);
-        indexByUri.put(namespace2, include2);
-        indexByUri.put(namespace3, include3);
-
-        final List<org.kie.dmn.model.api.DRGElement> importedDrgElements = new ArrayList<>();
-        final DRGElement element1 = createDRGElementWithNamespaceAndId(namespace1, someWrongAlias + ":" + id1);
-        importedDrgElements.add(element1);
-
-        final DRGElement element2 = createDRGElementWithNamespaceAndId(namespace2, someWrongAlias + ":" + id2);
-        importedDrgElements.add(element2);
-
-        final DRGElement element3 = createDRGElementWithNamespaceAndId(namespace3, someWrongAlias + ":" + id3);
-        importedDrgElements.add(element3);
-
-        final DRGElement element4 = createDRGElementWithNamespaceAndId(missingNamespace, id4);
-        importedDrgElements.add(element4);
-
-        marshaller.updateIDsWithAlias(indexByUri, importedDrgElements);
-
-        verify(element1).setId(include1 + ":" + id1);
-        verify(element2).setId(include2 + ":" + id2);
-        verify(element3).setId(include3 + ":" + id3);
-
-        verify(element4, never()).setId(any());
-    }
-
     private org.kie.dmn.model.api.DRGElement createDRGElementWithNamespaceAndId(final String namespace,
                                                                                 final String id) {
 
@@ -1930,36 +1884,6 @@ public class DMNMarshallerStandaloneTest {
         when(drgElement.getId()).thenReturn(id);
 
         return drgElement;
-    }
-
-    @Test
-    public void testChangeAliasForImportedElement() {
-
-        final DMNMarshallerStandalone marshaller = getDMNMarshaller();
-        final org.kie.dmn.model.api.DRGElement drgElement = mock(org.kie.dmn.model.api.DRGElement.class);
-        final String alias = "include1";
-        final String id = "_01234567";
-
-        when(drgElement.getId()).thenReturn("some another alias:" + id);
-
-        marshaller.changeAlias(alias, drgElement);
-
-        verify(drgElement).setId(alias + ":" + id);
-    }
-
-    @Test
-    public void testChangeAliasForLocalElement() {
-
-        final DMNMarshallerStandalone marshaller = getDMNMarshaller();
-        final org.kie.dmn.model.api.DRGElement drgElement = mock(org.kie.dmn.model.api.DRGElement.class);
-        final String alias = "include1";
-        final String id = "_01234567";
-
-        when(drgElement.getId()).thenReturn(id);
-
-        marshaller.changeAlias(alias, drgElement);
-
-        verify(drgElement, never()).setId(any());
     }
 
     @Test
@@ -2176,6 +2100,92 @@ public class DMNMarshallerStandaloneTest {
 
         roundTripUnmarshalThenMarshalUnmarshal(this.getClass().getResourceAsStream("/imports.dmn"),
                                                this::checkImports);
+    }
+
+    @Test
+    public void testGetDmnElementRefWithNamespace() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+
+        final Name drgElementName = mock(Name.class);
+        final Name importName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Import anImport = mock(org.kie.workbench.common.dmn.api.definition.model.Import.class);
+        final List<org.kie.workbench.common.dmn.api.definition.model.Import> imports = singletonList(anImport);
+        final String includedModelName = "includedModel";
+        final String namespaceName = "include1";
+        final String importNamespace = "://namespace";
+        final Map<String, String> nsContext = new HashMap<>();
+
+        when(importName.getValue()).thenReturn(includedModelName);
+
+        when(anImport.getName()).thenReturn(importName);
+        when(anImport.getNamespace()).thenReturn(importNamespace);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn(includedModelName + ".Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        nsContext.put(namespaceName, importNamespace);
+        when(definitions.getImport()).thenReturn(imports);
+        when(definitions.getNsContext()).thenReturn(nsContext);
+
+        final String actual = getDmnElementRef(definitions, view).getLocalPart();
+        final String expected = "include1:0000-1111-2222";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetDmnElementRefWithFakeNamespace() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+
+        final Name drgElementName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn("fakeNamespace.Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        when(definitions.getImport()).thenReturn(emptyList());
+
+        final String actual = getDmnElementRef(definitions, view).getLocalPart();
+        final String expected = "0000-1111-2222";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetDmnElementRefWithoutNamespace() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+
+        final Name drgElementName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn("Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        when(definitions.getImport()).thenReturn(emptyList());
+
+        final String actual = getDmnElementRef(definitions, view).getLocalPart();
+        final String expected = "0000-1111-2222";
+
+        assertEquals(expected, actual);
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperStandaloneImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/common/DMNMarshallerImportsHelperStandaloneImplTest.java
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.when;
 import static org.uberfire.backend.vfs.PathFactory.PathImpl;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DMNMarshallerImplImportsHelperTest {
+public class DMNMarshallerImportsHelperStandaloneImplTest {
 
     @Mock
     private DMNPathsHelperImpl pathsHelper;
@@ -297,19 +297,19 @@ public class DMNMarshallerImplImportsHelperTest {
         assertEquals(3, elements.size());
 
         final TDecision element1 = (TDecision) elements.get(0);
-        assertEquals("model:0000-1111", element1.getId());
+        assertEquals("0000-1111", element1.getId());
         assertEquals("model.Decision", element1.getName());
         assertEquals("model.tUUID", element1.getVariable().getTypeRef().getLocalPart());
         assertEquals(namespace, getNamespace(element1));
 
         final TInputData element2 = (TInputData) elements.get(1);
-        assertEquals("model:2222-3333", element2.getId());
+        assertEquals("2222-3333", element2.getId());
         assertEquals("model.Input Data", element2.getName());
         assertEquals("model.tAge", element2.getVariable().getTypeRef().getLocalPart());
         assertEquals(namespace, getNamespace(element2));
 
         final TDecisionService element3 = (TDecisionService) elements.get(2);
-        assertEquals("model:4444-5555", element3.getId());
+        assertEquals("4444-5555", element3.getId());
         assertEquals("model.Decision Service", element3.getName());
         assertEquals(builtInTypeNumber, element3.getVariable().getTypeRef().getLocalPart());
         assertEquals(namespace, getNamespace(element3));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/HrefBuilderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/HrefBuilderTest.java
@@ -56,7 +56,7 @@ public class HrefBuilderTest {
     }
 
     @Test
-    public void testGetHrefForImported() {
+    public void testGetHrefForImportedDRGElement() {
 
         final DRGElement drgElement = mock(DRGElement.class);
         final Name drgElementName = mock(Name.class);
@@ -66,6 +66,37 @@ public class HrefBuilderTest {
         final Import anImport = mock(Import.class);
         final List<Import> imports = singletonList(anImport);
         final String includedModelName = "includedModel";
+
+        when(importName.getValue()).thenReturn(includedModelName);
+
+        when(anImport.getName()).thenReturn(importName);
+        when(anImport.getNamespace()).thenReturn("https://github.com/kiegroup/dmn/something");
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn(includedModelName + ".Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        when(definitions.getImport()).thenReturn(imports);
+
+        final String actual = HrefBuilder.getHref(drgElement);
+        final String expected = "https://github.com/kiegroup/dmn/something#0000-1111-2222";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetHrefForImportedDRGElementWhenImportHasAnOddName() {
+
+        final DRGElement drgElement = mock(DRGElement.class);
+        final Name drgElementName = mock(Name.class);
+        final Name importName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final Definitions definitions = mock(Definitions.class);
+        final Import anImport = mock(Import.class);
+        final List<Import> imports = singletonList(anImport);
+        final String includedModelName = "d.i.v.i.";
 
         when(importName.getValue()).thenReturn(includedModelName);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/editors/common/DMNIncludedNodeFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/editors/common/DMNIncludedNodeFactoryTest.java
@@ -51,7 +51,7 @@ public class DMNIncludedNodeFactoryTest {
         final String drgElementName = "Can Drive?";
         final String expectedFileName = "file.dmn";
         final String expectedModelName = "model";
-        final String expectedImportedElementId = "model:0000-1111-3333-4444";
+        final String expectedImportedElementId = "0000-1111-3333-4444";
         final String expectedImportedElementName = "model.Can Drive?";
         final String expectedImportedItemDefinitionName = "model.tCustomBoolean";
         final DRGElement importedElementId = makeDecision(drgElementId, drgElementName, "tCustomBoolean");

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/included/components/DecisionComponentsItemView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/included/components/DecisionComponentsItemView.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.dmn.client.docks.navigator.included.components;
 
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import javax.enterprise.context.Dependent;
@@ -34,11 +32,8 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.api.definition.model.DMNElement;
-import org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.client.DMNShapeSet;
-import org.kie.workbench.common.dmn.client.editors.included.imports.persistence.NamespaceHandler;
-import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.kie.workbench.common.stunner.client.lienzo.components.glyph.ShapeGlyphDragHandler;
 import org.kie.workbench.common.stunner.client.lienzo.components.glyph.ShapeGlyphDragHandler.Callback;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -87,8 +82,6 @@ public class DecisionComponentsItemView implements DecisionComponentsItem.View {
 
     private final ClientTranslationService clientTranslationService;
 
-    private final DMNGraphUtils dmnGraphUtils;
-
     @Inject
     public DecisionComponentsItemView(final HTMLImageElement icon,
                                       final @Named("h5") HTMLHeadingElement name,
@@ -99,8 +92,7 @@ public class DecisionComponentsItemView implements DecisionComponentsItem.View {
                                       final Event<BuildCanvasShapeEvent> buildCanvasShapeEvent,
                                       final HTMLDivElement decisionComponentItem,
                                       final Event<NotificationEvent> notificationEvent,
-                                      final ClientTranslationService clientTranslationService,
-                                      final DMNGraphUtils dmnGraphUtils) {
+                                      final ClientTranslationService clientTranslationService) {
         this.icon = icon;
         this.name = name;
         this.file = file;
@@ -111,7 +103,6 @@ public class DecisionComponentsItemView implements DecisionComponentsItem.View {
         this.decisionComponentItem = decisionComponentItem;
         this.notificationEvent = notificationEvent;
         this.clientTranslationService = clientTranslationService;
-        this.dmnGraphUtils = dmnGraphUtils;
     }
 
     @Override
@@ -148,24 +139,7 @@ public class DecisionComponentsItemView implements DecisionComponentsItem.View {
 
     Callback makeDragProxyCallbackImpl(final DRGElement drgElement,
                                        final ShapeFactory factory) {
-
-        final Map<String, String> nsContext = getNsContext();
-
-        final String alias = NamespaceHandler.addIncludedNamespace(nsContext, drgElement.getDefaultNamespace());
-
-        final String currentId = drgElement.getId().getValue();
-        final String id = currentId.split(":")[1];
-        drgElement.getId().setValue(alias + ":" + id);
-
         return new DragProxyCallbackImpl(drgElement, factory, sessionManager, notificationEvent, clientTranslationService);
-    }
-
-    Map<String, String> getNsContext() {
-
-        final Optional<Diagram> diagram = Optional.of(dmnGraphUtils.getDiagram());
-        return diagram.map(dmnGraphUtils::getDefinitions)
-                .map(DMNModelInstrumentedBase::getNsContext)
-                .orElseThrow(UnsupportedOperationException::new);
     }
 
     Graph<?, Node> getGraph() {
@@ -226,24 +200,17 @@ public class DecisionComponentsItemView implements DecisionComponentsItem.View {
 
         private boolean isDuplicatedNode(final DRGElement drgElement) {
 
-            final Optional<Map.Entry<String, String>> existingAlias = NamespaceHandler.getAlias(getNsContext(), drgElement.getDefaultNamespace());
+            final String id = drgElement.getId().getValue();
+            final Graph<?, Node> graph = getGraph();
 
-            if (existingAlias.isPresent()) {
-
-                final String alias = existingAlias.get().getKey();
-                final String id = alias + ":" + drgElement.getId().getValue().split(":")[1];
-                final Graph<?, Node> graph = getGraph();
-
-                return StreamSupport
-                        .stream(graph.nodes().spliterator(), false)
-                        .filter(node -> node.getContent() instanceof View)
-                        .map(node -> (View) node.getContent())
-                        .filter(view -> view.getDefinition() instanceof DMNElement)
-                        .map(Definition::getDefinition)
-                        .anyMatch(d -> ((DMNElement) d).getId().getValue().equals(id));
-            }
-
-            return false;
+            return StreamSupport
+                    .stream(graph.nodes().spliterator(), false)
+                    .filter(node -> node.getContent() instanceof View)
+                    .map(node -> (View) node.getContent())
+                    .filter(view -> view.getDefinition() instanceof DMNElement)
+                    .map(Definition::getDefinition)
+                    .filter(d -> ((DMNElement) d).getId().getValue().equals(id))
+                    .count() >= 1;
         }
 
         private void fireDuplicatedNodeWarningMessage() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/included/components/DecisionComponentsItemViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/included/components/DecisionComponentsItemViewTest.java
@@ -17,9 +17,7 @@
 package org.kie.workbench.common.dmn.client.docks.navigator.included.components;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.google.gwt.event.dom.client.MouseDownEvent;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -32,10 +30,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.model.DMNElement;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
-import org.kie.workbench.common.dmn.api.definition.model.Definitions;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.client.DMNShapeSet;
-import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
 import org.kie.workbench.common.dmn.client.shape.factory.DMNShapeFactory;
 import org.kie.workbench.common.stunner.client.lienzo.components.glyph.ShapeGlyphDragHandler;
 import org.kie.workbench.common.stunner.client.lienzo.components.glyph.ShapeGlyphDragHandler.Callback;
@@ -56,7 +52,6 @@ import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
 
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DecisionComponentsItemView_DuplicatedNode;
 import static org.mockito.Matchers.any;
@@ -102,9 +97,6 @@ public class DecisionComponentsItemViewTest {
     private ClientTranslationService clientTranslationService;
 
     @Mock
-    private DMNGraphUtils dmnGraphUtils;
-
-    @Mock
     private DecisionComponentsItem presenter;
 
     @Captor
@@ -117,7 +109,7 @@ public class DecisionComponentsItemViewTest {
 
     @Before
     public void setup() {
-        view = spy(new DecisionComponentsItemView(icon, name, file, dmnShapeSet, sessionManager, shapeGlyphDragHandler, buildCanvasShapeEvent, decisionComponentItem, notificationEvent, clientTranslationService, dmnGraphUtils));
+        view = spy(new DecisionComponentsItemView(icon, name, file, dmnShapeSet, sessionManager, shapeGlyphDragHandler, buildCanvasShapeEvent, decisionComponentItem, notificationEvent, clientTranslationService));
         view.init(presenter);
     }
 
@@ -181,10 +173,7 @@ public class DecisionComponentsItemViewTest {
     public void testMakeDragProxyCallbackImplWhenNodeIsDuplicated() {
 
         final ShapeFactory factory = mock(ShapeFactory.class);
-        final Definitions definitions = mock(Definitions.class);
-        final DRGElement drgElement1 = mock(DRGElement.class);
-        final DRGElement drgElement2 = mock(DRGElement.class);
-        final List<DRGElement> drgElements = asList(drgElement1, drgElement2);
+        final DRGElement drgElement = mock(DRGElement.class);
         final int x = 10;
         final int y = 20;
         final String expectedWarnMessage = "This 'DRGElement' already exists!";
@@ -192,32 +181,18 @@ public class DecisionComponentsItemViewTest {
         final Graph<?, Node> graph = mock(Graph.class);
         final List<Node> nodes = new ArrayList<>();
 
-        final String namespace1 = "http://something";
-        final String alias1 = "included1";
-        final String namespace2 = "http://someotherthing";
-        final String alias2 = "included2";
         final String id1 = "123";
-        final String id2 = "456";
+        final String id2 = "123";
 
-        nodes.add(createNode(alias1, id1));
-        nodes.add(createNode(alias2, id2));
+        nodes.add(createNode(id1));
+        nodes.add(createNode(id2));
 
-        final Map<String, String> nsContext = new HashMap<>();
-        nsContext.put(alias1, namespace1);
-        nsContext.put(alias2, namespace2);
-
-        when(drgElement1.getDefaultNamespace()).thenReturn(namespace1);
-        when(drgElement2.getDefaultNamespace()).thenReturn(namespace2);
         when(graph.nodes()).thenReturn(nodes);
-        when(drgElement1.getId()).thenReturn(new Id(alias1 + ":" + id1));
-        when(drgElement2.getId()).thenReturn(new Id(alias2 + ":" + id2));
+        when(drgElement.getId()).thenReturn(new Id(id1));
         when(clientTranslationService.getValue(DecisionComponentsItemView_DuplicatedNode)).thenReturn(expectedWarnMessage);
-        when(dmnGraphUtils.getDefinitions()).thenReturn(definitions);
-        when(definitions.getDrgElement()).thenReturn(drgElements);
-        doReturn(nsContext).when(view).getNsContext();
         doReturn(graph).when(view).getGraph();
 
-        view.makeDragProxyCallbackImpl(drgElement1, factory).onComplete(x, y);
+        view.makeDragProxyCallbackImpl(drgElement, factory).onComplete(x, y);
 
         verify(buildCanvasShapeEvent, never()).fire(any());
         verify(notificationEvent).fire(notificationEventArgumentCaptor.capture());
@@ -228,7 +203,7 @@ public class DecisionComponentsItemViewTest {
         assertEquals(expectedWarnType, notificationEvent.getType());
     }
 
-    private Node createNode(final String alias, final String id) {
+    private Node createNode(final String id) {
 
         final Node n1 = mock(Node.class);
         final View v1 = mock(View.class);
@@ -238,7 +213,7 @@ public class DecisionComponentsItemViewTest {
         when(n1.getContent()).thenReturn(v1);
         when(v1.getDefinition()).thenReturn(d1);
         when(d1.getId()).thenReturn(id1);
-        when(id1.getValue()).thenReturn(alias + ":" + id);
+        when(id1.getValue()).thenReturn(id);
 
         return n1;
     }
@@ -256,37 +231,22 @@ public class DecisionComponentsItemViewTest {
         final List<Node> nodes = new ArrayList<>();
         final int x = 10;
         final int y = 20;
-        final String namespace1 = "http://something";
-        final String alias1 = "included1";
-        final String namespace2 = "http://someotherthing";
-        final String alias2 = "included2";
-        final String namespace3 = "http://someNewNamespace";
-        final String alias3 = "included3";
         final String id1 = "123";
         final String id2 = "456";
         final String id3 = "789";
 
-        nodes.add(createNode(alias1, id1));
-        nodes.add(createNode(alias2, id2));
-
-        final Map<String, String> nsContext = new HashMap<>();
-        nsContext.put(alias1, namespace1);
-        nsContext.put(alias2, namespace2);
-        nsContext.put(alias3, namespace3);
+        nodes.add(createNode(id1));
+        nodes.add(createNode(id2));
 
         when(graph.nodes()).thenReturn(nodes);
 
-        when(drgElement1.getId()).thenReturn(new Id(alias1 + ":" + id1));
-        when(drgElement2.getId()).thenReturn(new Id(alias2 + ":" + id2));
-        when(drgElement3.getId()).thenReturn(new Id(alias3 + ":" + id3));
-        when(drgElement1.getDefaultNamespace()).thenReturn(namespace1);
-        when(drgElement2.getDefaultNamespace()).thenReturn(namespace2);
-        when(drgElement3.getDefaultNamespace()).thenReturn(namespace3);
+        when(drgElement1.getId()).thenReturn(new Id(id1));
+        when(drgElement2.getId()).thenReturn(new Id(id2));
+        when(drgElement3.getId()).thenReturn(new Id(id3));
 
         when(sessionManager.getCurrentSession()).thenReturn(currentSession);
         when(currentSession.getCanvasHandler()).thenReturn(canvasHandler);
 
-        doReturn(nsContext).when(view).getNsContext();
         doReturn(graph).when(view).getGraph();
 
         view.makeDragProxyCallbackImpl(drgElement3, factory).onComplete(x, y);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/DMNMarshallerKogitoMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/DMNMarshallerKogitoMarshaller.java
@@ -193,7 +193,8 @@ public class DMNMarshallerKogitoMarshaller {
                     }
 
                     final String namespaceURI = definitionsStunnerPojo.getDefaultNamespace();
-                    dmnDDDMNDiagram.addDMNDiagramElement(WrapperUtils.getWrappedJSIDMNShape((View<? extends DMNElement>) view,
+                    dmnDDDMNDiagram.addDMNDiagramElement(WrapperUtils.getWrappedJSIDMNShape(definitionsStunnerPojo,
+                                                                                            (View<? extends DMNElement>) view,
                                                                                             namespaceURI));
                 } else if (view.getDefinition() instanceof TextAnnotation) {
                     final TextAnnotation textAnnotation = (TextAnnotation) view.getDefinition();
@@ -201,7 +202,8 @@ public class DMNMarshallerKogitoMarshaller {
                                         textAnnotationConverter.dmnFromNode((Node<View<TextAnnotation>, ?>) node,
                                                                             componentWidthsConsumer));
                     final String namespaceURI = definitionsStunnerPojo.getDefaultNamespace();
-                    dmnDDDMNDiagram.addDMNDiagramElement(WrapperUtils.getWrappedJSIDMNShape((View<? extends DMNElement>) view,
+                    dmnDDDMNDiagram.addDMNDiagramElement(WrapperUtils.getWrappedJSIDMNShape(definitionsStunnerPojo,
+                                                                                            (View<? extends DMNElement>) view,
                                                                                             namespaceURI));
 
                     final List<JSITAssociation> associations = AssociationConverter.dmnFromWB((Node<View<TextAnnotation>, ?>) node);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilder.java
@@ -16,37 +16,61 @@
 
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model;
 
-import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
 import org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBase;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
+import org.kie.workbench.common.dmn.api.definition.model.Import;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
 
 public class HrefBuilder {
 
     public static String getHref(final DRGElement drgElement) {
-        if (!drgElement.getId().getValue().contains(":")) {
-            return "#" + drgElement.getId().getValue();
-        }
 
-        // If it have ":" it is an imported element
-        final DMNModelInstrumentedBase parent = drgElement.getParent();
-        final Definitions definitions;
-        if (parent instanceof DMNDiagram) {
-            final DMNDiagram diagram = (DMNDiagram) parent;
-            definitions = diagram.getDefinitions();
-        } else {
-            definitions = (Definitions) parent;
-        }
+        final String drgElementId = drgElement.getId().getValue();
 
-        final String[] split = drgElement.getId().getValue().split(":");
-        final String namespace = getNamespaceForImport(split[0], definitions.getNsContext());
-        return namespace + "#" + split[1];
+        return getNamespace(drgElement)
+                .map(namespace -> namespace + "#" + drgElementId)
+                .orElse("#" + drgElementId);
     }
 
-    static String getNamespaceForImport(final String importName,
-                                        final Map<String, String> nsContext) {
-        return nsContext.get(importName);
+    private static Optional<String> getNamespace(final DRGElement drgElement) {
+        final String drgElementPrefix = extractNamespaceFromName(drgElement.getName());
+        return getDefinitions(drgElement)
+                .map(definitions -> definitions
+                        .getImport()
+                        .stream()
+                        .filter(anImport -> {
+                            final String importName = anImport.getName().getValue();
+                            return Objects.equals(importName, drgElementPrefix);
+                        })
+                        .findFirst()
+                        .map(Import::getNamespace)
+                        .orElse(null));
+    }
+
+    private static String extractNamespaceFromName(final Name name) {
+        final String value = name.getValue();
+        final boolean hasNamespace = value.contains(".");
+        return hasNamespace ? value.split("\\.")[0] : "";
+    }
+
+    private static Optional<Definitions> getDefinitions(final DRGElement drgElement) {
+
+        final DMNModelInstrumentedBase parent = drgElement.getParent();
+
+        if (parent instanceof DMNDiagram) {
+            final DMNDiagram diagram = (DMNDiagram) parent;
+            return Optional.ofNullable(diagram.getDefinitions());
+        }
+
+        if (parent instanceof Definitions) {
+            return Optional.of((Definitions) parent);
+        }
+
+        return Optional.empty();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilder.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilder.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
@@ -24,7 +23,6 @@ import org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBas
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
 import org.kie.workbench.common.dmn.api.definition.model.Import;
-import org.kie.workbench.common.dmn.api.property.dmn.Name;
 
 public class HrefBuilder {
 
@@ -38,24 +36,18 @@ public class HrefBuilder {
     }
 
     private static Optional<String> getNamespace(final DRGElement drgElement) {
-        final String drgElementPrefix = extractNamespaceFromName(drgElement.getName());
+        final Optional<String> name = Optional.ofNullable(drgElement.getName().getValue());
         return getDefinitions(drgElement)
                 .map(definitions -> definitions
                         .getImport()
                         .stream()
                         .filter(anImport -> {
                             final String importName = anImport.getName().getValue();
-                            return Objects.equals(importName, drgElementPrefix);
+                            return name.map(n -> n.startsWith(importName + ".")).orElse(false);
                         })
                         .findFirst()
                         .map(Import::getNamespace)
                         .orElse(null));
-    }
-
-    private static String extractNamespaceFromName(final Name name) {
-        final String value = name.getValue();
-        final boolean hasNamespace = value.contains(".");
-        return hasNamespace ? value.split("\\.")[0] : "";
     }
 
     private static Optional<Definitions> getDefinitions(final DRGElement drgElement) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtils.java
@@ -15,7 +15,9 @@
  */
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.utils;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
@@ -25,11 +27,14 @@ import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.model.DMNElement;
 import org.kie.workbench.common.dmn.api.definition.model.Decision;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionService;
+import org.kie.workbench.common.dmn.api.definition.model.Definitions;
 import org.kie.workbench.common.dmn.api.definition.model.InputData;
 import org.kie.workbench.common.dmn.api.definition.model.KnowledgeSource;
+import org.kie.workbench.common.dmn.api.definition.model.NamedElement;
 import org.kie.workbench.common.dmn.api.definition.model.TextAnnotation;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
 import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.dd.ColorUtils;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dc.JSIBounds;
@@ -154,9 +159,10 @@ public class WrapperUtils {
         return toReturn;
     }
 
-    public static JSIDMNShape getWrappedJSIDMNShape(final View<? extends DMNElement> v,
+    public static JSIDMNShape getWrappedJSIDMNShape(final Definitions definitionsStunnerPojo,
+                                                    final View<? extends DMNElement> v,
                                                     final String namespaceURI) {
-        JSIDMNShape unwrappedJSIDMNShape = stunnerToDDExt(v, namespaceURI);
+        JSIDMNShape unwrappedJSIDMNShape = stunnerToDDExt(definitionsStunnerPojo, v, namespaceURI);
         JSIDMNShape toReturn = Js.uncheckedCast(JsUtils.getWrappedElement(unwrappedJSIDMNShape));
         JSIName jsiName = JSIDMNShape.getJSIName();
         updateJSIName(jsiName, "dmndi", "DMNShape");
@@ -198,13 +204,12 @@ public class WrapperUtils {
         toUpdate.setString(string);
     }
 
-    private static JSIDMNShape stunnerToDDExt(final View<? extends DMNElement> v,
+    private static JSIDMNShape stunnerToDDExt(final Definitions definitionsStunnerPojo,
+                                              final View<? extends DMNElement> v,
                                               final String namespaceURI) {
         final JSIDMNShape result = new JSIDMNShape();
         result.setId("dmnshape-" + v.getDefinition().getId().getValue());
-        result.setDmnElementRef(new QName(namespaceURI,
-                                          v.getDefinition().getId().getValue(),
-                                          XMLConstants.DEFAULT_NS_PREFIX));
+        result.setDmnElementRef(getDmnElementRef(definitionsStunnerPojo, v, namespaceURI));
         final JSIBounds bounds = new JSIBounds();
         result.setBounds(bounds);
         bounds.setX(xOfBound(upperLeftBound(v)));
@@ -258,6 +263,60 @@ public class WrapperUtils {
         result.setStyle(getWrappedJSIDMNStyle(style));
 
         return result;
+    }
+
+    static QName getDmnElementRef(final Definitions definitions,
+                                  final View<? extends DMNElement> v,
+                                  final String namespaceURI) {
+
+        final DMNElement dmnElement = v.getDefinition();
+        final String dmnElementId = dmnElement.getId().getValue();
+
+        return getImportPrefix(definitions, dmnElement)
+                .map(prefix -> new QName(namespaceURI, prefix + ":" + dmnElementId, XMLConstants.DEFAULT_NS_PREFIX))
+                .orElse(new QName(namespaceURI, dmnElementId, XMLConstants.DEFAULT_NS_PREFIX));
+    }
+
+    private static Optional<String> getImportPrefix(final Definitions definitions,
+                                                    final DMNElement dmnElement) {
+
+        if (!(dmnElement instanceof NamedElement)) {
+            return Optional.empty();
+        }
+
+        final NamedElement namedElement = (NamedElement) dmnElement;
+        final String drgElementPrefix = extractNamespaceFromName(namedElement.getName());
+
+        return definitions
+                .getImport()
+                .stream()
+                .filter(anImport -> {
+                    final String importName = anImport.getName().getValue();
+                    return Objects.equals(importName, drgElementPrefix);
+                })
+                .map(anImport -> {
+                    final String importNamespace = anImport.getNamespace();
+                    return getNsContextsByNamespace(definitions, importNamespace);
+                })
+                .findFirst();
+    }
+
+    private static String getNsContextsByNamespace(final Definitions definitions,
+                                                   final String namespace) {
+        return definitions
+                .getNsContext()
+                .entrySet()
+                .stream()
+                .filter(entry -> Objects.equals(entry.getValue(), namespace))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse("");
+    }
+
+    private static String extractNamespaceFromName(final Name name) {
+        final String value = name.getValue();
+        final boolean hasNamespace = value.contains(".");
+        return hasNamespace ? value.split("\\.")[0] : "";
     }
 
     private static void applyFontStyle(final FontSet fontSet,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtils.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.dmn.api.definition.model.NamedElement;
 import org.kie.workbench.common.dmn.api.definition.model.TextAnnotation;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
 import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
-import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model.dd.ColorUtils;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dc.JSIBounds;
@@ -285,14 +284,14 @@ public class WrapperUtils {
         }
 
         final NamedElement namedElement = (NamedElement) dmnElement;
-        final String drgElementPrefix = extractNamespaceFromName(namedElement.getName());
+        final Optional<String> name = Optional.ofNullable(namedElement.getName().getValue());
 
         return definitions
                 .getImport()
                 .stream()
                 .filter(anImport -> {
                     final String importName = anImport.getName().getValue();
-                    return Objects.equals(importName, drgElementPrefix);
+                    return name.map(n -> n.startsWith(importName + ".")).orElse(false);
                 })
                 .map(anImport -> {
                     final String importNamespace = anImport.getNamespace();
@@ -311,12 +310,6 @@ public class WrapperUtils {
                 .map(Map.Entry::getKey)
                 .findFirst()
                 .orElse("");
-    }
-
-    private static String extractNamespaceFromName(final Name name) {
-        final String value = name.getValue();
-        final boolean hasNamespace = value.contains(".");
-        return hasNamespace ? value.split("\\.")[0] : "";
     }
 
     private static void applyFontStyle(final FontSet fontSet,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.dmn.backend.definition.v1_1;
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model;
 
 import java.util.Collections;
 import java.util.List;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/HrefBuilderTest.java
@@ -56,7 +56,7 @@ public class HrefBuilderTest {
     }
 
     @Test
-    public void testGetHrefForImported() {
+    public void testGetHrefForImportedDRGElement() {
 
         final DRGElement drgElement = mock(DRGElement.class);
         final Name drgElementName = mock(Name.class);
@@ -66,6 +66,37 @@ public class HrefBuilderTest {
         final Import anImport = mock(Import.class);
         final List<Import> imports = singletonList(anImport);
         final String includedModelName = "includedModel";
+
+        when(importName.getValue()).thenReturn(includedModelName);
+
+        when(anImport.getName()).thenReturn(importName);
+        when(anImport.getNamespace()).thenReturn("https://github.com/kiegroup/dmn/something");
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn(includedModelName + ".Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        when(definitions.getImport()).thenReturn(imports);
+
+        final String actual = HrefBuilder.getHref(drgElement);
+        final String expected = "https://github.com/kiegroup/dmn/something#0000-1111-2222";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetHrefForImportedDRGElementWhenImportHasAnOddName() {
+
+        final DRGElement drgElement = mock(DRGElement.class);
+        final Name drgElementName = mock(Name.class);
+        final Name importName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final Definitions definitions = mock(Definitions.class);
+        final Import anImport = mock(Import.class);
+        final List<Import> imports = singletonList(anImport);
+        final String includedModelName = "d.i.v.i.";
 
         when(importName.getValue()).thenReturn(includedModelName);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtilsTest.java
@@ -81,6 +81,46 @@ public class WrapperUtilsTest {
     }
 
     @Test
+    public void testGetDmnElementRefWithNamespaceWhenImportHasAnOddName() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+
+        final Name drgElementName = mock(Name.class);
+        final Name importName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Import anImport = mock(org.kie.workbench.common.dmn.api.definition.model.Import.class);
+        final List<Import> imports = singletonList(anImport);
+        final String includedModelName = "d.i.v.i.";
+        final String defaultNamespace = "://default";
+        final String namespaceName = "include1";
+        final String importNamespace = "://namespace";
+        final Map<String, String> nsContext = new HashMap<>();
+
+        when(importName.getValue()).thenReturn(includedModelName);
+
+        when(anImport.getName()).thenReturn(importName);
+        when(anImport.getNamespace()).thenReturn(importNamespace);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn(includedModelName + ".Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        nsContext.put(namespaceName, importNamespace);
+        when(definitions.getImport()).thenReturn(imports);
+        when(definitions.getNsContext()).thenReturn(nsContext);
+
+        final QName actual = getDmnElementRef(definitions, view, defaultNamespace);
+
+        assertEquals(defaultNamespace, actual.getNamespaceURI());
+        assertEquals("include1:0000-1111-2222", actual.getLocalPart());
+        assertEquals("", actual.getPrefix());
+    }
+
+    @Test
     public void testGetDmnElementRefWithFakeNamespace() {
 
         final Decision drgElement = mock(Decision.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/utils/WrapperUtilsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+import org.kie.workbench.common.dmn.api.definition.model.DMNElement;
+import org.kie.workbench.common.dmn.api.definition.model.Decision;
+import org.kie.workbench.common.dmn.api.definition.model.Import;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.utils.WrapperUtils.getDmnElementRef;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WrapperUtilsTest {
+
+    @Test
+    public void testGetDmnElementRefWithNamespace() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+
+        final Name drgElementName = mock(Name.class);
+        final Name importName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Import anImport = mock(org.kie.workbench.common.dmn.api.definition.model.Import.class);
+        final List<Import> imports = singletonList(anImport);
+        final String includedModelName = "includedModel";
+        final String defaultNamespace = "://default";
+        final String namespaceName = "include1";
+        final String importNamespace = "://namespace";
+        final Map<String, String> nsContext = new HashMap<>();
+
+        when(importName.getValue()).thenReturn(includedModelName);
+
+        when(anImport.getName()).thenReturn(importName);
+        when(anImport.getNamespace()).thenReturn(importNamespace);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn(includedModelName + ".Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        nsContext.put(namespaceName, importNamespace);
+        when(definitions.getImport()).thenReturn(imports);
+        when(definitions.getNsContext()).thenReturn(nsContext);
+
+        final QName actual = getDmnElementRef(definitions, view, defaultNamespace);
+
+        assertEquals(defaultNamespace, actual.getNamespaceURI());
+        assertEquals("include1:0000-1111-2222", actual.getLocalPart());
+        assertEquals("", actual.getPrefix());
+    }
+
+    @Test
+    public void testGetDmnElementRefWithFakeNamespace() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+        final String defaultNamespace = "://default";
+
+        final Name drgElementName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn("fakeNamespace.Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        when(definitions.getImport()).thenReturn(emptyList());
+
+        final QName actual = getDmnElementRef(definitions, view, defaultNamespace);
+
+        assertEquals(defaultNamespace, actual.getNamespaceURI());
+        assertEquals("0000-1111-2222", actual.getLocalPart());
+        assertEquals("", actual.getPrefix());
+    }
+
+    @Test
+    public void testGetDmnElementRefWithoutNamespace() {
+
+        final Decision drgElement = mock(Decision.class);
+        final View<? extends DMNElement> view = new ViewImpl<>(drgElement, null);
+        final String defaultNamespace = "://default";
+
+        final Name drgElementName = mock(Name.class);
+        final Id id = mock(Id.class);
+        final org.kie.workbench.common.dmn.api.definition.model.Definitions definitions = mock(org.kie.workbench.common.dmn.api.definition.model.Definitions.class);
+
+        when(id.getValue()).thenReturn("0000-1111-2222");
+        when(drgElementName.getValue()).thenReturn("Decision");
+        when(drgElement.getId()).thenReturn(id);
+        when(drgElement.getName()).thenReturn(drgElementName);
+        when(drgElement.getParent()).thenReturn(definitions);
+
+        when(definitions.getImport()).thenReturn(emptyList());
+
+        final QName actual = getDmnElementRef(definitions, view, defaultNamespace);
+
+        assertEquals(defaultNamespace, actual.getNamespaceURI());
+        assertEquals("0000-1111-2222", actual.getLocalPart());
+        assertEquals("", actual.getPrefix());
+    }
+}


### PR DESCRIPTION
See: https://issues.redhat.com/browse/DROOLS-5229

Before:
```xml
<!-- ... -->
<dmndi:DMNShape id="dmnshape-included1:_ADC4CFCC-385B-42FE-8C61-0B2DA34AC20B" dmnElementRef="included1:_ADC4CFCC-385B-42FE-8C61-0B2DA34AC20B" isCollapsed="false">
  <!-- ... -->
</dmndi:DMNShape>
<!-- ... -->
```

After:
```xml
<!-- ... -->
<dmndi:DMNShape id="dmnshape-_ADC4CFCC-385B-42FE-8C61-0B2DA34AC20B" dmnElementRef="included1:_ADC4CFCC-385B-42FE-8C61-0B2DA34AC20B" isCollapsed="false">
  <!-- ... -->
</dmndi:DMNShape>
<!-- ... -->
```

This PR removes the `"included1:"` from Shape id, preventing this XML validation error:
```
DMN: Failed XML validation of DMN file: cvc-datatype-valid.1.2.1: 'dmnshape-included1:_50B0350A-72CE-4803-AE8B-7ED16409BC1B' is not a valid value for 'NCName'.
```
Also, I'm intentionally keeping the duplication between the server and the client-side implementation for this to keep things simpler in the (short-term) work of marshaller unification.

---

@danielzhe When you open your PR for the included models, may you double-check changes on `WrapperUtils` and `HrefBuilder`? :-) Since we don't have included models enabled on Kogito, I couldn't manually test these two classes (but I do believe they are already working as expected).