### PR TITLE
DROOLS-5253: [DMN Designer] Copied node should be distinguished from original one

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -122,43 +122,43 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
     }
 
     private void cloneDRGElementBasicInfo(final DRGElement source, final DRGElement target) {
-        final String distinguishedName = composeDistinguishedNodeName(source.getName().getValue());
+        final String uniqueNodeName = composeUniqueNodeName(source.getName().getValue());
         target.setId(new Id());
-        target.setNameHolder(new NameHolder(new Name(distinguishedName)));
+        target.setNameHolder(new NameHolder(new Name(uniqueNodeName)));
         target.setDescription(source.getDescription().copy());
         target.setParent(source.getParent());
         target.getLinksHolder().getValue().getLinks().addAll(cloneExternalLinkList(source));
     }
 
     private void cloneTextElementBasicInfo(final HasText source, final HasText target) {
-        final String distinguishedName = composeDistinguishedNodeName(source.getText().getValue());
-        target.setText(new Text(distinguishedName));
+        final String uniqueNodeName = composeUniqueNodeName(source.getText().getValue());
+        target.setText(new Text(uniqueNodeName));
     }
 
-    String composeDistinguishedNodeName(final String name) {
+    String composeUniqueNodeName(final String name) {
         final String originalName = Optional.ofNullable(name).orElse("");
-        String distinguishedName = originalName + CLONED_DEFAULT_SUFFIX;
+        String uniqueName = originalName + CLONED_DEFAULT_SUFFIX;
 
         try {
             final MatchResult nameSuffixMatcher = NAME_SUFFIX_REGEX.exec(originalName);
             if (nameSuffixMatcher != null) {
-                distinguishedName = buildNameWithIncrementedSuffixIndex(originalName, nameSuffixMatcher);
+                uniqueName = buildNameWithIncrementedSuffixIndex(originalName, nameSuffixMatcher);
             }
         } catch (Exception e) {
             LOGGER.warning("There was an issue while parsing node with name " + originalName + " - A fallback will be used for it");
         }
 
-        return ensureNodeNameUniqueness(distinguishedName);
+        return ensureNodeNameUniqueness(uniqueName);
     }
 
-    private String ensureNodeNameUniqueness(final String distinguishedName) {
+    private String ensureNodeNameUniqueness(final String uniqueName) {
         return StreamSupport.stream(getGraphNodes().spliterator(), true)
                 .map(this::nodeNamesMapper)
                 .filter(Objects::nonNull)
-                .filter(Predicate.isEqual(distinguishedName))
+                .filter(Predicate.isEqual(uniqueName))
                 .findAny()
-                .map(this::composeDistinguishedNodeName)
-                .orElse(distinguishedName);
+                .map(this::composeUniqueNodeName)
+                .orElse(uniqueName);
     }
 
     private String nodeNamesMapper(final Node<View, Edge> node) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -185,7 +185,7 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
     private String buildNameWithIncrementedSuffixIndex(final String nameValue, final MatchResult matchResult) {
         final String suffix = matchResult.getGroup(0);
         int suffixIndex = Integer.parseInt(suffix.substring(1));
-        final String nameValueWithoutSuffix = nameValue.split(suffix)[0];
+        final String nameValueWithoutSuffix = Optional.ofNullable(nameValue.split(suffix)[0]).orElse("");
         final String computedSuffix = HYPHEN + (++suffixIndex);
         return nameValueWithoutSuffix + computedSuffix;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -84,6 +84,8 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
      * <p>It defines additive fields, specific to DMN domain, to be included in the target</p>
      * <p>Then, the "classic" clone operation, defined in {@link DeepCloneProcess} will be executed</p>
      * <p>Note that {@link DeepCloneProcess} is already taking care of aspects related to look&feel, such as background color, font, etc.</p>
+     * <p>Every time we copy a node, in order to respect the name uniqueness logic, a new node will be created with a suffix {@code -X},
+     * where {@code X} it is an incremental numeric value</p>
      *
      * @param source node to be cloned
      * @param target destination of the cloning operation

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.client.commands.clone;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -59,7 +58,6 @@ import org.kie.workbench.common.stunner.core.util.ClassUtils;
 @Alternative
 public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneProcess {
 
-    private static final Logger LOGGER = Logger.getLogger(DMNDeepCloneProcess.class.getName());
     private static final RegExp NAME_SUFFIX_REGEX = RegExp.compile("[?!-]\\d+$");
     private static final String HYPHEN = "-";
     private final SessionManager sessionManager;
@@ -139,13 +137,9 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
     protected String composeUniqueNodeName(final String name) {
         final String originalName = Optional.ofNullable(name).orElse("");
 
-        try {
-            final MatchResult nameSuffixMatcher = NAME_SUFFIX_REGEX.exec(originalName);
-            if (nameSuffixMatcher != null) {
-                return buildNameWithIncrementedSuffixIndex(originalName, nameSuffixMatcher);
-            }
-        } catch (Exception e) {
-            LOGGER.warning("There was an issue while parsing node with name " + originalName + " - A fallback will be used for it");
+        final MatchResult nameSuffixMatcher = NAME_SUFFIX_REGEX.exec(originalName);
+        if (nameSuffixMatcher != null) {
+            return buildNameWithIncrementedSuffixIndex(originalName, nameSuffixMatcher);
         }
 
         return joinPrefixWithIndexedSuffix(originalName);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -179,12 +179,12 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
 
     private String nodeNamesMapper(final Node<View, Edge> node) {
         if (node.getContent().getDefinition() instanceof NamedElement) {
-            NamedElement namedElement = (NamedElement) node.getContent().getDefinition();
+            final NamedElement namedElement = (NamedElement) node.getContent().getDefinition();
             return namedElement.getName().getValue();
         }
         if (node.getContent().getDefinition() instanceof HasText) {
-            HasText hasText = (HasText) node.getContent().getDefinition();
-            return hasText.getText().getValue();
+            final HasText textWrapper = (HasText) node.getContent().getDefinition();
+            return textWrapper.getText().getValue();
         }
         return null;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -47,6 +47,8 @@ import org.kie.workbench.common.dmn.api.property.dmn.LocationURI;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.Question;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.TextFormat;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.api.property.font.FontSet;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
@@ -81,6 +83,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     private static final String QUESTION = "question?";
     private static final String ANSWER = "answer";
     private static final String NAME_SUFFIX = "-1";
+    private static final String TEXT_DATA = "text-data";
     private DMNDeepCloneProcess dmnDeepCloneProcess;
 
     @Mock
@@ -143,6 +146,29 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
                 new Description(),
                 new Name(INPUT_DATA_NAME),
                 buildInformationItemPrimary(BuiltInType.STRING),
+                new BackgroundSet(),
+                new FontSet(),
+                new GeneralRectangleDimensionsSet()
+        );
+    }
+
+    @Test
+    public void testCloneWhenSourceIsTextAnnotation() {
+        final TextAnnotation source = buildTextAnnotation();
+
+        final TextAnnotation cloned = dmnDeepCloneProcess.clone(source, new TextAnnotation());
+
+        assertThat(cloned).isNotNull();
+        assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
+        assertThat(cloned.getText().getValue()).isEqualTo(TEXT_DATA + NAME_SUFFIX);
+    }
+
+    private TextAnnotation buildTextAnnotation() {
+        return new TextAnnotation(
+                new Id(SOURCE_ID),
+                new Description(),
+                new Text(TEXT_DATA),
+                new TextFormat(),
                 new BackgroundSet(),
                 new FontSet(),
                 new GeneralRectangleDimensionsSet()

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -33,6 +33,7 @@ import org.kie.workbench.common.dmn.api.definition.model.InformationItemPrimary;
 import org.kie.workbench.common.dmn.api.definition.model.InputData;
 import org.kie.workbench.common.dmn.api.definition.model.KnowledgeSource;
 import org.kie.workbench.common.dmn.api.definition.model.NamedElement;
+import org.kie.workbench.common.dmn.api.definition.model.TextAnnotation;
 import org.kie.workbench.common.dmn.api.property.background.BackgroundSet;
 import org.kie.workbench.common.dmn.api.property.dimensions.DecisionServiceRectangleDimensionsSet;
 import org.kie.workbench.common.dmn.api.property.dimensions.GeneralRectangleDimensionsSet;
@@ -310,44 +311,44 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     }
 
     @Test
-    public void testComposingDistinguishedNodeName() {
-        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(INPUT_DATA_NAME))
+    public void testComposingUniqueNodeName() {
+        assertThat(dmnDeepCloneProcess.composeUniqueNodeName(INPUT_DATA_NAME))
                 .isEqualTo(INPUT_DATA_NAME + NAME_SUFFIX);
     }
 
     @Test
-    public void testComposingDistinguishedNodeNameWhenItAlreadyContainsSuffix() {
-        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(INPUT_DATA_NAME + "-3"))
+    public void testComposingUniqueNodeNameWhenItAlreadyContainsIndexedSuffix() {
+        assertThat(dmnDeepCloneProcess.composeUniqueNodeName(INPUT_DATA_NAME + "-3"))
                 .isEqualTo(INPUT_DATA_NAME + "-4");
     }
 
     @Test
-    public void testComposingDistinguishedNodeNameWhenItContainsWrongSuffix() {
-        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(INPUT_DATA_NAME + "-A3"))
+    public void testComposingUniqueNodeNameWhenItContainsNotIndexedSuffix() {
+        assertThat(dmnDeepCloneProcess.composeUniqueNodeName(INPUT_DATA_NAME + "-A3"))
                 .isEqualTo(INPUT_DATA_NAME + "-A3" + NAME_SUFFIX);
     }
 
     @Test
-    public void testComposingDistinguishedNodeNameWhenNameAlreadyPresent() {
+    public void testComposingUniqueNodeNameWhenNextIndexInSequenceAlreadyPresent() {
         when(graph.nodes()).thenReturn(Collections.singletonList(node));
         when(node.getContent()).thenReturn(content);
         when(content.getDefinition()).thenReturn(definition);
         when(definition.getName()).thenReturn(name);
         when(name.getValue()).thenReturn(INPUT_DATA_NAME + "-6");
 
-        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(INPUT_DATA_NAME + "-5"))
+        assertThat(dmnDeepCloneProcess.composeUniqueNodeName(INPUT_DATA_NAME + "-5"))
                 .isEqualTo(INPUT_DATA_NAME + "-7");
     }
 
     @Test
-    public void testComposingDistinguishedNodeNameWhenItIsEmpty() {
-        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(""))
+    public void testComposingUniqueNodeNameWhenItIsEmpty() {
+        assertThat(dmnDeepCloneProcess.composeUniqueNodeName(""))
                 .isEqualTo(NAME_SUFFIX);
     }
 
     @Test
-    public void testComposingDistinguishedNodeNameWhenItIsNull() {
-        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(null))
+    public void testComposingUniqueNodeNameWhenItIsNull() {
+        assertThat(dmnDeepCloneProcess.composeUniqueNodeName(null))
                 .isEqualTo(NAME_SUFFIX);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -17,12 +17,14 @@
 package org.kie.workbench.common.dmn.client.commands.clone;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.HasText;
 import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.model.Context;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
@@ -102,16 +104,22 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     private Graph graph;
 
     @Mock
-    private Node node;
+    private Node nodeWithName, nodeWithText, nodeWithNone;
 
     @Mock
-    private View content;
+    private View namedElementContent, textElementContent, noneContent;
 
     @Mock
-    private NamedElement definition;
+    private NamedElement namedElementDefinition;
+
+    @Mock
+    private HasText hasTextDefinition;
 
     @Mock
     private Name name;
+
+    @Mock
+    private Text text;
 
     @Before
     public void setUp() throws Exception {
@@ -356,14 +364,23 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
 
     @Test
     public void testComposingUniqueNodeNameWhenNextIndexInSequenceAlreadyPresent() {
-        when(graph.nodes()).thenReturn(Collections.singletonList(node));
-        when(node.getContent()).thenReturn(content);
-        when(content.getDefinition()).thenReturn(definition);
-        when(definition.getName()).thenReturn(name);
+        when(graph.nodes()).thenReturn(Arrays.asList(nodeWithName, nodeWithText, nodeWithNone));
+
+        when(nodeWithName.getContent()).thenReturn(namedElementContent);
+        when(namedElementContent.getDefinition()).thenReturn(namedElementDefinition);
+        when(namedElementDefinition.getName()).thenReturn(name);
         when(name.getValue()).thenReturn(INPUT_DATA_NAME + "-6");
 
+        when(nodeWithText.getContent()).thenReturn(textElementContent);
+        when(textElementContent.getDefinition()).thenReturn(hasTextDefinition);
+        when(hasTextDefinition.getText()).thenReturn(text);
+        when(text.getValue()).thenReturn(INPUT_DATA_NAME + "-7");
+
+        when(nodeWithNone.getContent()).thenReturn(noneContent);
+        when(noneContent.getDefinition()).thenReturn(new Object());
+
         assertThat(dmnDeepCloneProcess.composeUniqueNodeName(INPUT_DATA_NAME + "-5"))
-                .isEqualTo(INPUT_DATA_NAME + "-7");
+                .isEqualTo(INPUT_DATA_NAME + "-8");
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -84,8 +84,11 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     private static final String DECISION_SOURCE_NAME = "decision-source";
     private static final String QUESTION = "question?";
     private static final String ANSWER = "answer";
-    private static final String FIRST_INDEX_IN_SUFFIX = "-1";
     private static final String TEXT_DATA = "text-data";
+    private static final String FIRST_INDEX_IN_SUFFIX = "-1";
+    private static final String SECOND_INDEX_IN_SUFFIX = "-2";
+    private static final String THIRD_INDEX_IN_SUFFIX = "-3";
+    private static final String FORTH_INDEX_IN_SUFFIX = "-4";
     private DMNDeepCloneProcess dmnDeepCloneProcess;
 
     @Mock
@@ -357,7 +360,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
         mockSingleNodeInTheGraph();
 
         assertThat(dmnDeepCloneProcess.composeUniqueNodeName(INPUT_DATA_NAME + FIRST_INDEX_IN_SUFFIX))
-                .isEqualTo(INPUT_DATA_NAME + "-2");
+                .isEqualTo(INPUT_DATA_NAME + SECOND_INDEX_IN_SUFFIX);
     }
 
     private void mockSingleNodeInTheGraph() {
@@ -380,7 +383,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
         mockMultipleNodesInTheGraph();
 
         assertThat(dmnDeepCloneProcess.composeUniqueNodeName(INPUT_DATA_NAME + FIRST_INDEX_IN_SUFFIX))
-                .isEqualTo(INPUT_DATA_NAME + "-4");
+                .isEqualTo(INPUT_DATA_NAME + FORTH_INDEX_IN_SUFFIX);
     }
 
     private void mockMultipleNodesInTheGraph() {
@@ -389,12 +392,12 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
         when(nodeWithName.getContent()).thenReturn(namedElementContent);
         when(namedElementContent.getDefinition()).thenReturn(namedElementDefinition);
         when(namedElementDefinition.getName()).thenReturn(name);
-        when(name.getValue()).thenReturn(INPUT_DATA_NAME + "-2");
+        when(name.getValue()).thenReturn(INPUT_DATA_NAME + SECOND_INDEX_IN_SUFFIX);
 
         when(nodeWithText.getContent()).thenReturn(textElementContent);
         when(textElementContent.getDefinition()).thenReturn(hasTextDefinition);
         when(hasTextDefinition.getText()).thenReturn(text);
-        when(text.getValue()).thenReturn(INPUT_DATA_NAME + "-3");
+        when(text.getValue()).thenReturn(INPUT_DATA_NAME + THIRD_INDEX_IN_SUFFIX);
 
         when(nodeWithNone.getContent()).thenReturn(noneContent);
         when(noneContent.getDefinition()).thenReturn(new Object());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -53,18 +53,19 @@ import static org.kie.workbench.common.dmn.api.definition.model.FunctionDefiniti
 
 public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
 
-    public static final String SOURCE_ID = "source-id";
-    public static final String INPUT_DATA_NAME = "input-data";
-    public static final String FIRST_URL = "firstURL";
-    public static final String SECOND_URL = "secondURL";
-    public static final String DECISION_SERVICE_NAME = "decision-service";
-    public static final String KNOWLEDGE_SOURCE_NAME = "knowledge-source";
-    public static final String FUNCTION_ID = "function-id";
-    public static final String CONTEXT_ID = "context-id";
-    public static final String BKM_SOURCE_NAME = "bkm-source";
-    public static final String DECISION_SOURCE_NAME = "decision-source";
-    public static final String QUESTION = "question?";
-    public static final String ANSWER = "answer";
+    private static final String SOURCE_ID = "source-id";
+    private static final String INPUT_DATA_NAME = "input-data";
+    private static final String FIRST_URL = "firstURL";
+    private static final String SECOND_URL = "secondURL";
+    private static final String DECISION_SERVICE_NAME = "decision-service";
+    private static final String KNOWLEDGE_SOURCE_NAME = "knowledge-source";
+    private static final String FUNCTION_ID = "function-id";
+    private static final String CONTEXT_ID = "context-id";
+    private static final String BKM_SOURCE_NAME = "bkm-source";
+    private static final String DECISION_SOURCE_NAME = "decision-source";
+    private static final String QUESTION = "question?";
+    private static final String ANSWER = "answer";
+    private static final String NAME_SUFFIX = "-1";
     private DMNDeepCloneProcess dmnDeepCloneProcess;
 
     @Before
@@ -82,7 +83,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
-        assertThat(cloned.getName().getValue()).isEqualTo(INPUT_DATA_NAME);
+        assertThat(cloned.getName().getValue()).isEqualTo(INPUT_DATA_NAME + NAME_SUFFIX);
         assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.STRING.asQName());
         assertThat(cloned.getLinksHolder().getValue().getLinks())
                 .hasSize(2)
@@ -109,7 +110,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
-        assertThat(cloned.getName().getValue()).isEqualTo(DECISION_SERVICE_NAME);
+        assertThat(cloned.getName().getValue()).isEqualTo(DECISION_SERVICE_NAME + NAME_SUFFIX);
         assertThat(cloned.getVariable().getTypeRef()).isEqualTo(BuiltInType.BOOLEAN.asQName());
     }
 
@@ -139,7 +140,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
-        assertThat(cloned.getName().getValue()).isEqualTo(KNOWLEDGE_SOURCE_NAME);
+        assertThat(cloned.getName().getValue()).isEqualTo(KNOWLEDGE_SOURCE_NAME + NAME_SUFFIX);
         assertThat(cloned.getLinksHolder().getValue().getLinks())
                 .hasSize(2)
                 .extracting(DMNExternalLink::getUrl).contains(FIRST_URL, SECOND_URL);
@@ -167,7 +168,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
-        assertThat(cloned.getName().getValue()).isEqualTo(BKM_SOURCE_NAME);
+        assertThat(cloned.getName().getValue()).isEqualTo(BKM_SOURCE_NAME + NAME_SUFFIX);
         assertThat(cloned.getLinksHolder().getValue().getLinks())
                 .hasSize(2)
                 .extracting(DMNExternalLink::getUrl).contains(FIRST_URL, SECOND_URL);
@@ -190,7 +191,7 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);
-        assertThat(cloned.getName().getValue()).isEqualTo(DECISION_SOURCE_NAME);
+        assertThat(cloned.getName().getValue()).isEqualTo(DECISION_SOURCE_NAME + NAME_SUFFIX);
         assertThat(cloned.getLinksHolder().getValue().getLinks())
                 .hasSize(2)
                 .extracting(DMNExternalLink::getUrl).contains(FIRST_URL, SECOND_URL);
@@ -260,5 +261,35 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
                                          .getLinks()
                                          .add(new DMNExternalLink(link, "description"))
                 );
+    }
+
+    @Test
+    public void testComposingDistinguishedNodeName() {
+        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(INPUT_DATA_NAME))
+                .isEqualTo(INPUT_DATA_NAME + NAME_SUFFIX);
+    }
+
+    @Test
+    public void testComposingDistinguishedNodeNameWhenItAlreadyContainsSuffix() {
+        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(INPUT_DATA_NAME + "-3"))
+                .isEqualTo(INPUT_DATA_NAME + "-4");
+    }
+
+    @Test
+    public void testComposingDistinguishedNodeNameWhenItContainsWrongSuffix() {
+        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(INPUT_DATA_NAME + "-A3"))
+                .isEqualTo(INPUT_DATA_NAME + "-A3" + NAME_SUFFIX);
+    }
+
+    @Test
+    public void testComposingDistinguishedNodeNameWhenItIsEmpty() {
+        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(""))
+                .isEqualTo(NAME_SUFFIX);
+    }
+
+    @Test
+    public void testComposingDistinguishedNodeNameWhenItIsNull() {
+        assertThat(dmnDeepCloneProcess.composeDistinguishedNodeName(null))
+                .isEqualTo(NAME_SUFFIX);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
@@ -239,9 +239,6 @@ public class DMNDesignerKogitoSeleniumIT {
                 .areIdentical();
     }
 
-    /**
-     * Reproducer for DROOLS-4424
-     */
     @Test
     public void testCopyAndPaste() throws Exception {
         final String source = loadResource("business-knowledge-model.xml");

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
@@ -250,6 +250,7 @@ public class DMNDesignerKogitoSeleniumIT {
         expandDecisionNavigatorDock();
 
         final String nodeName = "BusinessKnowledgeModel-1";
+        final String copiedNodeName = "BusinessKnowledgeModel-2";
         waitOperation()
                 .withMessage(format(NOT_PRESENT_IN_NAVIGATOR, nodeName))
                 .until(element(NODE, nodeName))
@@ -269,7 +270,12 @@ public class DMNDesignerKogitoSeleniumIT {
         XmlAssert.assertThat(actual)
                 .withNamespaceContext(NAMESPACES)
                 .valueByXPath("count(//dmn:businessKnowledgeModel[@name='" + nodeName + "'])")
-                .isEqualTo(2);
+                .isEqualTo(1);
+
+        XmlAssert.assertThat(actual)
+                .withNamespaceContext(NAMESPACES)
+                .valueByXPath("count(//dmn:businessKnowledgeModel[@name='" + copiedNodeName + "'])")
+                .isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
*Please refer to:* https://issues.redhat.com/browse/DROOLS-5253

*Issue description:* If user copy a DMN diagram node, the copy has exactly the same name as the original node. It causes validation issues as the node names have to be unique. 

*Proposed solution:* Every time we copy a node, a new node will be created with a suffix `-X`, where `X` it is an incremental numeric value.
Logic on uniqueness is performed. For instance, when copying the node `InputData-1`, if, for some reason, `InputData-2` is already present, then the name of the copied node will be `InputData-3`.