### PR TITLE
DROOLS-5245: [DMN Designer] Literal cell value properties are not stored

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
-import java.util.Optional;
-
 import org.kie.workbench.common.dmn.api.definition.model.ImportedValues;
 import org.kie.workbench.common.dmn.api.definition.model.IsLiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
@@ -26,6 +24,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
 
 public class LiteralExpressionPropertyConverter {
 
@@ -59,10 +58,10 @@ public class LiteralExpressionPropertyConverter {
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         if (wb instanceof LiteralExpression) {
-            final ExpressionLanguage expressionLanguage = Optional
-                    .ofNullable(((LiteralExpression) wb).getExpressionLanguage())
-                    .orElse(new ExpressionLanguage());
-            result.setExpressionLanguage(expressionLanguage.getValue());
+            final String expressionLanguage = ((LiteralExpression) wb).getExpressionLanguage().getValue();
+            if (StringUtils.nonEmpty(expressionLanguage)) {
+                result.setExpressionLanguage(expressionLanguage);
+            }
         }
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.backend.definition.v1_1;
 
+import java.util.Optional;
+
 import org.kie.workbench.common.dmn.api.definition.model.ImportedValues;
 import org.kie.workbench.common.dmn.api.definition.model.IsLiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
@@ -55,6 +57,13 @@ public class LiteralExpressionPropertyConverter {
         }
         final org.kie.dmn.model.api.LiteralExpression result = new org.kie.dmn.model.v1_2.TLiteralExpression();
         result.setId(wb.getId().getValue());
+        result.setDescription(wb.getDescription().getValue());
+        if (wb instanceof LiteralExpression) {
+            final ExpressionLanguage expressionLanguage = Optional
+                    .ofNullable(((LiteralExpression) wb).getExpressionLanguage())
+                    .orElse(new ExpressionLanguage());
+            result.setExpressionLanguage(expressionLanguage.getValue());
+        }
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(),
                                             result::setTypeRef);
         result.setText(wb.getText().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/definition/v1_1/LiteralExpressionPropertyConverter.java
@@ -56,7 +56,10 @@ public class LiteralExpressionPropertyConverter {
         }
         final org.kie.dmn.model.api.LiteralExpression result = new org.kie.dmn.model.v1_2.TLiteralExpression();
         result.setId(wb.getId().getValue());
-        result.setDescription(wb.getDescription().getValue());
+        final String description = wb.getDescription().getValue();
+        if (StringUtils.nonEmpty(description)) {
+            result.setDescription(description);
+        }
         if (wb instanceof LiteralExpression) {
             final String expressionLanguage = ((LiteralExpression) wb).getExpressionLanguage().getValue();
             if (StringUtils.nonEmpty(expressionLanguage)) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BaseLiteralExpressionPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/definition/v1_1/BaseLiteralExpressionPropertyConverterTest.java
@@ -23,6 +23,11 @@ import org.kie.dmn.model.api.LiteralExpression;
 import org.kie.dmn.model.v1_2.TImportedValues;
 import org.kie.dmn.model.v1_2.TLiteralExpression;
 import org.kie.workbench.common.dmn.api.definition.model.IsLiteralExpression;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBase.Namespace.KIE;
@@ -38,6 +43,8 @@ public abstract class BaseLiteralExpressionPropertyConverterTest<T extends IsLit
     private static final String LOCAL = "local";
 
     private static final String IMPORTED_ELEMENT = "imported-element";
+
+    private static final String EXPRESSION_LANGUAGE = "expression-language";
 
     @Test
     public void testWBFromDMN() {
@@ -62,6 +69,32 @@ public abstract class BaseLiteralExpressionPropertyConverterTest<T extends IsLit
         assertThat(wb.getImportedValues().getImportedElement()).isEqualTo(IMPORTED_ELEMENT);
 
         assertThat(wb.getImportedValues().getParent()).isEqualTo(wb);
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        final org.kie.workbench.common.dmn.api.definition.model.ImportedValues importedValues = new org.kie.workbench.common.dmn.api.definition.model.ImportedValues();
+        importedValues.setImportedElement(IMPORTED_ELEMENT);
+
+        final org.kie.workbench.common.dmn.api.definition.model.LiteralExpression wb = new org.kie.workbench.common.dmn.api.definition.model.LiteralExpression(
+                new Id(UUID),
+                new Description(DESCRIPTION),
+                BuiltInType.BOOLEAN.asQName(),
+                new Text(TEXT),
+                importedValues,
+                new ExpressionLanguage(EXPRESSION_LANGUAGE)
+        );
+
+        final LiteralExpression dmn = LiteralExpressionPropertyConverter.dmnFromWB(wb);
+
+        assertThat(dmn.getId()).isEqualTo(UUID);
+        assertThat(dmn.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(dmn.getTypeRef().getNamespaceURI()).isEmpty();
+        assertThat(dmn.getTypeRef().getLocalPart()).isEqualTo(BuiltInType.BOOLEAN.getName());
+        assertThat(dmn.getText()).isEqualTo(TEXT);
+        assertThat(dmn.getImportedValues()).isNotNull();
+        assertThat(dmn.getImportedValues().getImportedElement()).isEqualTo(IMPORTED_ELEMENT);
+        assertThat(dmn.getExpressionLanguage()).isEqualTo(EXPRESSION_LANGUAGE);
     }
 
     protected abstract T convertWBFromDMN(final LiteralExpression dmn);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverter.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import com.google.gwt.core.client.GWT;
 import org.kie.workbench.common.dmn.api.definition.model.ImportedValues;
@@ -30,6 +29,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.QName;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITImportedValues;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITLiteralExpression;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
 
 public class LiteralExpressionPropertyConverter {
 
@@ -63,10 +63,10 @@ public class LiteralExpressionPropertyConverter {
         result.setId(wb.getId().getValue());
         result.setDescription(wb.getDescription().getValue());
         if (wb instanceof LiteralExpression) {
-            final ExpressionLanguage expressionLanguage = Optional
-                    .ofNullable(((LiteralExpression) wb).getExpressionLanguage())
-                    .orElse(new ExpressionLanguage());
-            result.setExpressionLanguage(expressionLanguage.getValue());
+            final String expressionLanguage = ((LiteralExpression) wb).getExpressionLanguage().getValue();
+            if (StringUtils.nonEmpty(expressionLanguage)) {
+                result.setExpressionLanguage(expressionLanguage);
+            }
         }
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(), result::setTypeRef);
         result.setText(wb.getText().getValue());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverter.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import com.google.gwt.core.client.GWT;
 import org.kie.workbench.common.dmn.api.definition.model.ImportedValues;
@@ -60,6 +61,13 @@ public class LiteralExpressionPropertyConverter {
         }
         final JSITLiteralExpression result = GWT.create(JSITLiteralExpression.class);
         result.setId(wb.getId().getValue());
+        result.setDescription(wb.getDescription().getValue());
+        if (wb instanceof LiteralExpression) {
+            final ExpressionLanguage expressionLanguage = Optional
+                    .ofNullable(((LiteralExpression) wb).getExpressionLanguage())
+                    .orElse(new ExpressionLanguage());
+            result.setExpressionLanguage(expressionLanguage.getValue());
+        }
         QNamePropertyConverter.setDMNfromWB(wb.getTypeRef(), result::setTypeRef);
         result.setText(wb.getText().getValue());
         final JSITImportedValues importedValues = ImportedValuesConverter.dmnFromWB(wb.getImportedValues());

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverter.java
@@ -61,7 +61,10 @@ public class LiteralExpressionPropertyConverter {
         }
         final JSITLiteralExpression result = GWT.create(JSITLiteralExpression.class);
         result.setId(wb.getId().getValue());
-        result.setDescription(wb.getDescription().getValue());
+        final String description = wb.getDescription().getValue();
+        if (StringUtils.nonEmpty(description)) {
+            result.setDescription(description);
+        }
         if (wb instanceof LiteralExpression) {
             final String expressionLanguage = ((LiteralExpression) wb).getExpressionLanguage().getValue();
             if (StringUtils.nonEmpty(expressionLanguage)) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/converters/model/LiteralExpressionPropertyConverterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.webapp.kogito.common.client.converters.model;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.model.ImportedValues;
+import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
+import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.dmn.api.property.dmn.Text;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITImportedValues;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITLiteralExpression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBase.Namespace.KIE;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class LiteralExpressionPropertyConverterTest {
+
+    private static final String UUID = "uuid";
+
+    private static final String TEXT = "text";
+
+    private static final String DESCRIPTION = "description";
+
+    private static final String IMPORTED_ELEMENT = "imported-element";
+
+    private static final String EXPRESSION_LANGUAGE = "expression-language";
+
+    private static final String TYPE_REF = "type-ref";
+
+    @GwtMock
+    @SuppressWarnings("unused")
+    private JSITLiteralExpression dmn;
+
+    @GwtMock
+    @SuppressWarnings("unused")
+    private LiteralExpression wb;
+
+    @GwtMock
+    @SuppressWarnings("unused")
+    private JSITImportedValues jsitImportedValues;
+
+    @GwtMock
+    @SuppressWarnings("unused")
+    private ImportedValues importedValues;
+
+    @Test
+    public void testWBFromDMN() {
+        when(dmn.getId()).thenReturn(UUID);
+        when(dmn.getDescription()).thenReturn(DESCRIPTION);
+        when(dmn.getTypeRef()).thenReturn(TYPE_REF);
+        when(dmn.getText()).thenReturn(TEXT);
+        when(dmn.getExpressionLanguage()).thenReturn(EXPRESSION_LANGUAGE);
+        when(dmn.getImportedValues()).thenReturn(jsitImportedValues);
+        when(jsitImportedValues.getImportedElement()).thenReturn(IMPORTED_ELEMENT);
+
+        final LiteralExpression result = LiteralExpressionPropertyConverter.wbFromDMN(dmn);
+
+        assertThat(result.getId().getValue()).isEqualTo(UUID);
+        assertThat(result.getDescription().getValue()).isEqualTo(DESCRIPTION);
+        assertThat(result.getTypeRef().getNamespaceURI()).isEmpty();
+        assertThat(result.getTypeRef().getLocalPart()).isEqualTo(TYPE_REF);
+        assertThat(result.getText().getValue()).isEqualTo(TEXT);
+        assertThat(result.getExpressionLanguage().getValue()).isEqualTo(EXPRESSION_LANGUAGE);
+        assertThat(result.getImportedValues().getImportedElement()).isEqualTo(IMPORTED_ELEMENT);
+        assertThat(result.getImportedValues().getParent()).isEqualTo(result);
+    }
+
+    @Test
+    public void testDMNFromWB() {
+        when(wb.getId()).thenReturn(new Id(UUID));
+        when(wb.getDescription()).thenReturn(new Description(DESCRIPTION));
+        when(wb.getTypeRef()).thenReturn(new QName(KIE.getUri(), TYPE_REF, KIE.getPrefix()));
+        when(wb.getText()).thenReturn(new Text(TEXT));
+        when(wb.getExpressionLanguage()).thenReturn(new ExpressionLanguage(EXPRESSION_LANGUAGE));
+
+        final JSITLiteralExpression result = LiteralExpressionPropertyConverter.dmnFromWB(wb);
+
+        verify(result).setId(UUID);
+        verify(result).setDescription(DESCRIPTION);
+        verify(result).setTypeRef("{" + KIE.getUri() + "}" + TYPE_REF);
+        verify(result).setText(TEXT);
+        verify(result).setExpressionLanguage(EXPRESSION_LANGUAGE);
+    }
+}


### PR DESCRIPTION
*Please refer to:* https://issues.redhat.com/browse/DROOLS-5245

*Issue description:* Description and Expression language properties are not stored for Literal cell

*Proposed solution:* Change `LiteralExpressionPropertyConverter` both on back-end service and on kogito side