### PR TITLE
KOGITO-1508: Add initial selenium tests for kogito bpmn client

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -30,6 +30,14 @@
   <name>Kie Workbench - Common - Stunner - BPMN Definition Set - Kogito Runtime</name>
   <description>Kie Workbench - Common - Stunner - BPMN Definition Set - Kogito Runtime</description>
 
+  <properties>
+    <skipITs>false</skipITs>
+    <org.kie.bpmn.kogito.browser.headless>true</org.kie.bpmn.kogito.browser.headless>
+    <!-- We do not want to run selenium tests in default profile -->
+    <kogito.it.tests.excludes>**/*IT.java</kogito.it.tests.excludes>
+  </properties>
+
+
   <dependencies>
     <!--Logs-->
     <dependency>
@@ -651,6 +659,33 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-java</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-assertj</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.github.bonigarcia</groupId>
+      <artifactId>webdrivermanager</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -860,6 +895,20 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>${kogito.it.tests.excludes}</exclude>
+          </excludes>
+          <systemPropertyVariables>
+            <org.kie.bpmn.kogito.browser.headless>${org.kie.bpmn.kogito.browser.headless}</org.kie.bpmn.kogito.browser.headless>
+            <org.kie.bpmn.kogito.screenshots.dir>${project.build.directory}/screenshots</org.kie.bpmn.kogito.screenshots.dir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
     </plugins>
 
   </build>
@@ -918,6 +967,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>kogito-it-tests</id>
+      <activation>
+        <property>
+          <name>integration-tests</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <!-- We want to run selenium tests in kogito-tests profile -->
+        <kogito.it.tests.excludes></kogito.it.tests.excludes>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,11 +60,8 @@ public class BPMNDesignerKogitoSeleniumIT {
     private static final String GET_CONTENT_TEMPLATE =
             "return gwtEditorBeans.get(\"BPMNDiagramEditor\").get().getContent()";
 
-
     private static final String INDEX_HTML = "target/kie-wb-common-stunner-bpmn-kogito-runtime/index.html";
     private static final String INDEX_HTML_PATH = "file:///" + new File(INDEX_HTML).getAbsolutePath();
-
-
 
     private static final String NOT_PRESENT_IN_NAVIGATOR = "' was not present in the process navigator";
     private static final String PROPERTIES_PANEL = "qe-docks-item-E-DiagramEditorPropertiesScreen";
@@ -72,15 +69,9 @@ public class BPMNDesignerKogitoSeleniumIT {
     private static final String DIAGRAM_EXPLORER_EXPANDED = "qe-docks-bar-expanded-E";
     private static final String DIAGRAM_PANEL = "qe-static-workbench-panel-view";
     private static final String ACE_EDITOR = "//div[@class='ace_content']";
-    private static final String PALETTE = "//div[@data-field=\"kie-palette\"]";
-    private static final String PALETTE_START_EVENTS_CATEGORY_BUTTON = "//button[@data-field='categoryItem', @title=`Start Events`]";
     private static final String ERROR_MODAL_DIALOG = "//div[@class='modal-dialog']";
     private static final String ERROR_MODAL_BODY = "//div[@class='modal-body']";
-
-    private static final String CREATE_NEW_DIAGRAM_BUTTON = "//input[@value=\"Create new Diagram\"]";
-
     private static final String PROCESS_NODE = "//div[@data-field='explorerPanelBody']//a[text()='%s']";
-
     private static final Boolean HEADLESS = Boolean.valueOf(System.getProperty("org.kie.bpmn.kogito.browser.headless"));
     private static final String SCREENSHOTS_DIR = System.getProperty("org.kie.bpmn.kogito.screenshots.dir");
 
@@ -93,11 +84,6 @@ public class BPMNDesignerKogitoSeleniumIT {
      * Properties panel of BPMN Designer
      */
     private WebElement propertiesPanel;
-
-    /**
-     * Start events category button in Palette
-     */
-    private WebElement paletteStartEventCategory;
 
     /**
      * Explore diagram panel of BPMN Designer
@@ -180,7 +166,7 @@ public class BPMNDesignerKogitoSeleniumIT {
         // Verify ACE editor (default text editor) is in place and shown to user
         final WebElement aceEditor = waitOperation().until(element(ACE_EDITOR));
         assertThat(aceEditor)
-                .as("If invalid dmn is loaded, ace editor needs to be shown")
+                .as("If invalid bpmn is loaded, ace editor needs to be shown")
                 .isNotNull();
     }
 
@@ -224,6 +210,14 @@ public class BPMNDesignerKogitoSeleniumIT {
                 .and(expected)
                 .ignoreComments()
                 .ignoreWhitespace()
+                // KOGITO-1795
+                .withAttributeFilter(
+                        attr -> (!(Objects.equals(attr.getName(), "id") &&
+                                 !(Objects.equals(attr.getOwnerElement().getTagName(), "bpmn2:defintions"))))
+                )
+                .withNodeFilter(
+                        node -> !(Objects.equals(node.getNodeName(), "bpmn2:source")
+                                || Objects.equals(node.getNodeName(), "bpmn2:target")))
                 .areIdentical();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
@@ -27,12 +27,10 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -140,20 +138,8 @@ public class BPMNDesignerKogitoSeleniumIT {
     };
 
     @Test
-    @Ignore
     public void testHandlingInvalidContent() {
         setContent("<!!!invalid!!!>");
-
-        // Check that there is error modal dialog shown to user
-        final WebElement errorDialogModal = waitOperation().until(element(ERROR_MODAL_DIALOG));
-        assertThat(errorDialogModal)
-                .as("If invalid BPMN is loaded, error dialog modal should be shown.")
-                .isNotNull();
-        // Check that there is a message explaining what happened
-        assertThat(errorDialogModal.findElement(By.xpath(ERROR_MODAL_BODY)).getText())
-                .as("If error dialog is shown, it show show proper message.")
-                .contains("Invalid BPMN file. Opening default text editor instead.");
-        errorDialogModal.click();
 
         // Verify ACE editor (default text editor) is in place and shown to user
         final WebElement aceEditor = waitOperation().until(element(ACE_EDITOR));
@@ -166,6 +152,8 @@ public class BPMNDesignerKogitoSeleniumIT {
     public void testNewDiagram() throws Exception {
         final String expected = loadResource("new-diagram.bpmn2");
         setContent("");
+
+        waitPropertiesAndExplorer();
 
         final String actual = getContent();
         assertThat(actual).isNotBlank();
@@ -189,6 +177,8 @@ public class BPMNDesignerKogitoSeleniumIT {
     public void testBasicModel() throws Exception {
         final String expected = loadResource("basic-process.bpmn2");
         setContent(expected);
+
+        waitPropertiesAndExplorer();
 
         assertDiagramNodeIsPresentInProcessNavigator("Start");
         assertDiagramNodeIsPresentInProcessNavigator("Add user to database");
@@ -257,12 +247,7 @@ public class BPMNDesignerKogitoSeleniumIT {
         return scd;
     }
 
-    private void setContent(final String xml) {
-        try {
-            ((JavascriptExecutor) driver).executeScript(String.format(SET_CONTENT_TEMPLATE, xml));
-        } catch (Exception e) {
-            LOG.error("Exception during JS execution. Ex: {}", e.getMessage());
-        }
+    private void waitPropertiesAndExplorer() {
         final WebElement propertiesPanelDockIcon = waitOperation()
                 .until(visibilityOfElementLocated(className(PROPERTIES_PANEL)));
         assertThat(propertiesPanelDockIcon)
@@ -276,6 +261,15 @@ public class BPMNDesignerKogitoSeleniumIT {
                 .as("Once content is set diagram explorer panel dock icon visibility is a prerequisite" +
                             "for further test execution.")
                 .isNotNull();
+
+    }
+
+    private void setContent(final String xml) {
+        try {
+            ((JavascriptExecutor) driver).executeScript(String.format(SET_CONTENT_TEMPLATE, xml));
+        } catch (Exception e) {
+            LOG.error("Exception during JS execution. Ex: {}", e.getMessage());
+        }
     }
 
     private String getContent() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.kogito.client.selenium;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmlunit.assertj.XmlAssert;
+
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.By.className;
+import static org.openqa.selenium.By.xpath;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
+
+public class BPMNDesignerKogitoSeleniumIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BPMNDesignerKogitoSeleniumIT.class);
+
+    private static final String SET_CONTENT_TEMPLATE =
+            "gwtEditorBeans.get(\"BPMNDiagramEditor\").get().setContent(\"\", '%s')";
+    private static final String GET_CONTENT_TEMPLATE =
+            "return gwtEditorBeans.get(\"BPMNDiagramEditor\").get().getContent()";
+
+
+    private static final String INDEX_HTML = "target/kie-wb-common-stunner-bpmn-kogito-runtime/index.html";
+    private static final String INDEX_HTML_PATH = "file:///" + new File(INDEX_HTML).getAbsolutePath();
+
+
+
+    private static final String NOT_PRESENT_IN_NAVIGATOR = "' was not present in the process navigator";
+    private static final String PROPERTIES_PANEL = "qe-docks-item-E-DiagramEditorPropertiesScreen";
+    private static final String DIAGRAM_EXPLORER = "qe-docks-item-E-ProjectDiagramExplorerScreen";
+    private static final String DIAGRAM_EXPLORER_EXPANDED = "qe-docks-bar-expanded-E";
+    private static final String DIAGRAM_PANEL = "qe-static-workbench-panel-view";
+    private static final String ACE_EDITOR = "//div[@class='ace_content']";
+    private static final String PALETTE = "//div[@data-field=\"kie-palette\"]";
+    private static final String PALETTE_START_EVENTS_CATEGORY_BUTTON = "//button[@data-field='categoryItem', @title=`Start Events`]";
+    private static final String ERROR_MODAL_DIALOG = "//div[@class='modal-dialog']";
+    private static final String ERROR_MODAL_BODY = "//div[@class='modal-body']";
+
+    private static final String CREATE_NEW_DIAGRAM_BUTTON = "//input[@value=\"Create new Diagram\"]";
+
+    private static final String PROCESS_NODE = "//div[@data-field='explorerPanelBody']//a[text()='%s']";
+
+    private static final Boolean HEADLESS = Boolean.valueOf(System.getProperty("org.kie.bpmn.kogito.browser.headless"));
+    private static final String SCREENSHOTS_DIR = System.getProperty("org.kie.bpmn.kogito.screenshots.dir");
+
+    /**
+     * Selenium web driver
+     */
+    private WebDriver driver;
+
+    /**
+     * Properties panel of BPMN Designer
+     */
+    private WebElement propertiesPanel;
+
+    /**
+     * Start events category button in Palette
+     */
+    private WebElement paletteStartEventCategory;
+
+    /**
+     * Explore diagram panel of BPMN Designer
+     */
+    private WebElement bpmnDesignerExplorerButton;
+
+
+    @BeforeClass
+    public static void setupClass() {
+        WebDriverManager.firefoxdriver().setup();
+    }
+
+    @Before
+    public void openBPMNDesigner() {
+        final FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.setHeadless(HEADLESS);
+        driver = new FirefoxDriver(firefoxOptions);
+        driver.manage().window().maximize();
+
+        driver.get(INDEX_HTML_PATH);
+
+        // init diagram to initial state to see if we can load properties panel and diagram explorer
+        setContent("");
+       ((JavascriptExecutor) driver).executeScript(String.format(SET_CONTENT_TEMPLATE, ""));
+
+        propertiesPanel = waitOperation()
+                .until(visibilityOfElementLocated(className(PROPERTIES_PANEL)));
+        assertThat(propertiesPanel)
+                .as("Presence of properties panel expand button is prerequisite for all tests")
+                .isNotNull();
+
+        bpmnDesignerExplorerButton = waitOperation()
+                .until(visibilityOfElementLocated(className(DIAGRAM_EXPLORER)));
+        assertThat(bpmnDesignerExplorerButton)
+                .as("Presence of Explorer Diagram is prerequisite for all tests")
+                .isNotNull();
+    }
+
+    private final File screenshotDirectory = initScreenshotDirectory();
+
+    @Rule
+    public TestWatcher takeScreenShotAndCleanUp = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            final File screenshotFile = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+            final String testClassName = description.getTestClass().getSimpleName();
+            final String testMethodName = description.getMethodName();
+            final String filename = testClassName + "_" + testMethodName;
+            try {
+                copyFile(screenshotFile, new File(screenshotDirectory, filename + ".png"));
+            } catch (IOException ioe) {
+                LOG.error("Unable to take screenshot", ioe);
+            }
+        }
+
+        @Override
+        protected void finished(Description description) {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    };
+
+
+    @Test
+    public void testHandlingInvalidContent() {
+        setContent("<!!!invalid!!!>");
+
+        // Check that there is error modal dialog shown to user
+        final WebElement errorDialogModal = waitOperation().until(element(ERROR_MODAL_DIALOG));
+        assertThat(errorDialogModal)
+                .as("If invalid dmn is loaded, error dialog modal should be shown.")
+                .isNotNull();
+        // Check that there is a message explaining what happened
+        assertThat(errorDialogModal.findElement(By.xpath(ERROR_MODAL_BODY)).getText())
+                .as("If error dialog is shown, it show show proper message.")
+                .contains("Invalid BPMN file. Opening default text editor instead.");
+        errorDialogModal.click();
+
+        // Verify ACE editor (default text editor) is in place and shown to user
+        final WebElement aceEditor = waitOperation().until(element(ACE_EDITOR));
+        assertThat(aceEditor)
+                .as("If invalid dmn is loaded, ace editor needs to be shown")
+                .isNotNull();
+    }
+
+    @Test
+    public void testNewDiagram() throws Exception {
+        final String expected = loadResource("new-diagram.bpmn2");
+        setContent("");
+
+        final String actual = getContent();
+        assertThat(actual).isNotBlank();
+
+        // Skip, id, name and namespace in the comparison - they are dynamic
+        XmlAssert.assertThat(actual)
+                .and(expected)
+                .ignoreComments()
+                .ignoreWhitespace()
+                .withAttributeFilter(
+                        attr -> !(Objects.equals(attr.getName(), "id")
+                                || Objects.equals(attr.getName(), "name")
+                                || Objects.equals(attr.getName(), "namespace")))
+                .withNodeFilter(
+                        node -> !(Objects.equals(node.getNodeName(), "bpmn2:source")
+                                || Objects.equals(node.getNodeName(), "bpmn2:target")))
+                .areIdentical();
+    }
+
+    @Test
+    public void testBasicModel() throws Exception {
+        final String expected = loadResource("basic-process.bpmn2");
+        setContent(expected);
+
+
+        assertDiagramNodeIsPresentInProcessNavigator("Start");
+        assertDiagramNodeIsPresentInProcessNavigator("Add user to database");
+        assertDiagramNodeIsPresentInProcessNavigator("End");
+
+        final String actual = getContent();
+        assertThat(actual).isNotBlank();
+
+        XmlAssert.assertThat(actual)
+                .and(expected)
+                .ignoreComments()
+                .ignoreWhitespace()
+                .areIdentical();
+    }
+
+    private void assertDiagramNodeIsPresentInProcessNavigator(final String nodeName) {
+        expandBpmnNavigatorDock();
+        final WebElement node = waitOperation().until(element(PROCESS_NODE, nodeName));
+        assertThat(node)
+                .as("Node '" + nodeName + NOT_PRESENT_IN_NAVIGATOR)
+                .isNotNull();
+        collapseBpmnNavigatorDock();
+    }
+
+    private void expandBpmnNavigatorDock() {
+        bpmnDesignerExplorerButton.click();
+    }
+
+    private void collapseBpmnNavigatorDock() {
+        final WebElement expandedDiagramNavigator = waitOperation()
+                .until(visibilityOfElementLocated(className(DIAGRAM_EXPLORER_EXPANDED)));
+        assertThat(expandedDiagramNavigator)
+                .as("Unable to locate expanded decision navigator dock")
+                .isNotNull();
+
+        expandedDiagramNavigator.findElement(className("fa")).click();
+    }
+
+
+    private File initScreenshotDirectory() {
+        if (SCREENSHOTS_DIR == null) {
+            throw new IllegalStateException(
+                    "Property org.kie.dmn.kogito.screenshots.dir (where screenshot taken by WebDriver will be put) was null");
+        }
+        File scd = new File(SCREENSHOTS_DIR);
+        if (!scd.exists()) {
+            boolean mkdirSuccess = scd.mkdir();
+            if (!mkdirSuccess) {
+                throw new IllegalStateException("Creation of screenshots dir failed " + scd);
+            }
+        }
+        if (!scd.canWrite()) {
+            throw new IllegalStateException("The screenshotDir must be writable" + scd);
+        }
+        return scd;
+    }
+
+    private void setContent(final String xml) {
+        try {
+            ((JavascriptExecutor) driver).executeScript(String.format(SET_CONTENT_TEMPLATE, xml));
+        } catch (Exception e) {
+            LOG.error("Exception during JS execution. Ex: {}", e.getMessage());
+        }
+        final WebElement designer = waitOperation()
+                .until(visibilityOfElementLocated(className(DIAGRAM_PANEL)));
+        assertThat(designer)
+                .as("Designer was not loaded")
+                .isNotNull();
+    }
+
+    private String getContent() {
+        final Object result = ((JavascriptExecutor) driver).executeScript(String.format(GET_CONTENT_TEMPLATE));
+        assertThat(result).isInstanceOf(String.class);
+        return (String) result;
+    }
+    /**
+     * Use this for loading BPMN model placed in src/test/resources
+     * @param filename
+     * @return Text content of the file
+     * @throws IOException
+     */
+    private String loadResource(final String filename) throws IOException {
+        return IOUtils.readLines(this.getClass().getResourceAsStream(filename), StandardCharsets.UTF_8)
+                .stream()
+                .collect(Collectors.joining(""));
+    }
+
+
+    private ExpectedCondition<WebElement> element(final String xpathLocator, final String... parameters) {
+        return visibilityOfElementLocated(xpath(String.format(xpathLocator, parameters)));
+    }
+
+    private WebDriverWait waitOperation() {
+        return new WebDriverWait(driver, Duration.ofSeconds(10).getSeconds());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/selenium/BPMNDesignerKogitoSeleniumIT.java
@@ -27,6 +27,7 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -149,13 +150,14 @@ public class BPMNDesignerKogitoSeleniumIT {
 
 
     @Test
+    @Ignore
     public void testHandlingInvalidContent() {
         setContent("<!!!invalid!!!>");
 
         // Check that there is error modal dialog shown to user
         final WebElement errorDialogModal = waitOperation().until(element(ERROR_MODAL_DIALOG));
         assertThat(errorDialogModal)
-                .as("If invalid dmn is loaded, error dialog modal should be shown.")
+                .as("If invalid BPMN is loaded, error dialog modal should be shown.")
                 .isNotNull();
         // Check that there is a message explaining what happened
         assertThat(errorDialogModal.findElement(By.xpath(ERROR_MODAL_BODY)).getText())
@@ -197,7 +199,6 @@ public class BPMNDesignerKogitoSeleniumIT {
     public void testBasicModel() throws Exception {
         final String expected = loadResource("basic-process.bpmn2");
         setContent(expected);
-
 
         assertDiagramNodeIsPresentInProcessNavigator("Start");
         assertDiagramNodeIsPresentInProcessNavigator("Add user to database");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/basic-process.bpmn2
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/basic-process.bpmn2
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions id="_hImTMHArEDiY0b-88EQFvg" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools">
+    <bpmn2:interface id="_E486B83F-1225-436D-94D5-C6817A74884C_ServiceInterface" name="" implementationRef="">
+        <bpmn2:operation id="_E486B83F-1225-436D-94D5-C6817A74884C_ServiceOperation" name="" implementationRef="" />
+    </bpmn2:interface>
+    <bpmn2:process id="AddUserBasicService" drools:packageName="org.project" drools:version="1.0" drools:adHoc="false" name="BasicModel" isExecutable="true" processType="Public">
+        <bpmn2:sequenceFlow id="_945FC403-B19A-4AB1-9A9A-B13E6CD19D4B" sourceRef="_E486B83F-1225-436D-94D5-C6817A74884C" targetRef="_96CAC0E9-FA73-4154-84A6-A963ACD1ED04">
+            <bpmn2:extensionElements>
+                <drools:metaData name="isAutoConnection.source">
+                    <drools:metaValue><![CDATA[true]]></drools:metaValue>
+                </drools:metaData>
+                <drools:metaData name="isAutoConnection.target">
+                    <drools:metaValue><![CDATA[true]]></drools:metaValue>
+                </drools:metaData>
+            </bpmn2:extensionElements>
+        </bpmn2:sequenceFlow>
+        <bpmn2:sequenceFlow id="_CF5E4B33-67E4-4424-9524-37114A55D4CA" sourceRef="_13126CFF-A8A6-4168-A236-C45A07DFF6DE" targetRef="_E486B83F-1225-436D-94D5-C6817A74884C">
+            <bpmn2:extensionElements>
+                <drools:metaData name="isAutoConnection.source">
+                    <drools:metaValue><![CDATA[true]]></drools:metaValue>
+                </drools:metaData>
+                <drools:metaData name="isAutoConnection.target">
+                    <drools:metaValue><![CDATA[true]]></drools:metaValue>
+                </drools:metaData>
+            </bpmn2:extensionElements>
+        </bpmn2:sequenceFlow>
+        <bpmn2:endEvent id="_96CAC0E9-FA73-4154-84A6-A963ACD1ED04">
+            <bpmn2:incoming>_945FC403-B19A-4AB1-9A9A-B13E6CD19D4B</bpmn2:incoming>
+        </bpmn2:endEvent>
+        <bpmn2:serviceTask id="_E486B83F-1225-436D-94D5-C6817A74884C" drools:serviceimplementation="Java" drools:serviceinterface="" drools:serviceoperation="" name="Add user to database" implementation="Java" operationRef="_E486B83F-1225-436D-94D5-C6817A74884C_ServiceOperation">
+            <bpmn2:extensionElements>
+                <drools:metaData name="elementname">
+                    <drools:metaValue><![CDATA[Add user to database]]></drools:metaValue>
+                </drools:metaData>
+            </bpmn2:extensionElements>
+            <bpmn2:incoming>_CF5E4B33-67E4-4424-9524-37114A55D4CA</bpmn2:incoming>
+            <bpmn2:outgoing>_945FC403-B19A-4AB1-9A9A-B13E6CD19D4B</bpmn2:outgoing>
+        </bpmn2:serviceTask>
+        <bpmn2:startEvent id="_13126CFF-A8A6-4168-A236-C45A07DFF6DE">
+            <bpmn2:outgoing>_CF5E4B33-67E4-4424-9524-37114A55D4CA</bpmn2:outgoing>
+        </bpmn2:startEvent>
+    </bpmn2:process>
+    <bpmndi:BPMNDiagram>
+        <bpmndi:BPMNPlane bpmnElement="AddUserBasicService">
+            <bpmndi:BPMNShape id="shape__13126CFF-A8A6-4168-A236-C45A07DFF6DE" bpmnElement="_13126CFF-A8A6-4168-A236-C45A07DFF6DE">
+                <dc:Bounds height="56" width="56" x="577" y="247" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="shape__E486B83F-1225-436D-94D5-C6817A74884C" bpmnElement="_E486B83F-1225-436D-94D5-C6817A74884C">
+                <dc:Bounds height="102" width="154" x="713" y="224" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="shape__96CAC0E9-FA73-4154-84A6-A963ACD1ED04" bpmnElement="_96CAC0E9-FA73-4154-84A6-A963ACD1ED04">
+                <dc:Bounds height="56" width="56" x="947" y="247" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="edge_shape__13126CFF-A8A6-4168-A236-C45A07DFF6DE_to_shape__E486B83F-1225-436D-94D5-C6817A74884C" bpmnElement="_CF5E4B33-67E4-4424-9524-37114A55D4CA">
+                <di:waypoint x="633" y="275" />
+                <di:waypoint x="713" y="275" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="edge_shape__E486B83F-1225-436D-94D5-C6817A74884C_to_shape__96CAC0E9-FA73-4154-84A6-A963ACD1ED04" bpmnElement="_945FC403-B19A-4AB1-9A9A-B13E6CD19D4B">
+                <di:waypoint x="867" y="275" />
+                <di:waypoint x="947" y="275" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+    <bpmn2:relationship type="BPSimData">
+        <bpmn2:extensionElements>
+            <bpsim:BPSimData>
+                <bpsim:Scenario id="default" name="Simulationscenario">
+                    <bpsim:ScenarioParameters />
+                    <bpsim:ElementParameters elementRef="_13126CFF-A8A6-4168-A236-C45A07DFF6DE">
+                        <bpsim:TimeParameters>
+                            <bpsim:ProcessingTime>
+                                <bpsim:NormalDistribution mean="0" standardDeviation="0" />
+                            </bpsim:ProcessingTime>
+                        </bpsim:TimeParameters>
+                    </bpsim:ElementParameters>
+                    <bpsim:ElementParameters elementRef="_E486B83F-1225-436D-94D5-C6817A74884C">
+                        <bpsim:TimeParameters>
+                            <bpsim:ProcessingTime>
+                                <bpsim:NormalDistribution mean="0" standardDeviation="0" />
+                            </bpsim:ProcessingTime>
+                        </bpsim:TimeParameters>
+                        <bpsim:ResourceParameters>
+                            <bpsim:Availability>
+                                <bpsim:FloatingParameter value="0" />
+                            </bpsim:Availability>
+                            <bpsim:Quantity>
+                                <bpsim:FloatingParameter value="0" />
+                            </bpsim:Quantity>
+                        </bpsim:ResourceParameters>
+                        <bpsim:CostParameters>
+                            <bpsim:UnitCost>
+                                <bpsim:FloatingParameter value="0" />
+                            </bpsim:UnitCost>
+                        </bpsim:CostParameters>
+                    </bpsim:ElementParameters>
+                </bpsim:Scenario>
+            </bpsim:BPSimData>
+        </bpmn2:extensionElements>
+        <bpmn2:source>_hImTMHArEDiY0b-88EQFvg</bpmn2:source>
+        <bpmn2:target>_hImTMHArEDiY0b-88EQFvg</bpmn2:target>
+    </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/new-diagram.bpmn2
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/new-diagram.bpmn2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" id="_955w4Gz1EDiUcotpIqqUsA" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
-  <bpmn2:process xmlns:drools="http://www.jboss.org/drools" id="new-file" drools:version="1.0" drools:packageName="default" drools:adHoc="false" name="new-file" isExecutable="true" processType="Public"/>
+  <bpmn2:process xmlns:drools="http://www.jboss.org/drools" id="new-file" drools:version="1.0" drools:packageName="com.example" drools:adHoc="false" name="new-file" isExecutable="true" processType="Public"/>
   <bpmndi:BPMNDiagram xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI">
     <bpmndi:BPMNPlane bpmnElement="default"/>
   </bpmndi:BPMNDiagram>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/new-diagram.bpmn2
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/new-diagram.bpmn2
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" id="_955w4Gz1EDiUcotpIqqUsA" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:process xmlns:drools="http://www.jboss.org/drools" id="new-file" drools:version="1.0" drools:packageName="default" drools:adHoc="false" name="new-file" isExecutable="true" processType="Public"/>
+  <bpmndi:BPMNDiagram xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI">
+    <bpmndi:BPMNPlane bpmnElement="default"/>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData xmlns:bpsim="http://www.bpsim.org/schemas/1.0">
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_955w4Gz1EDiUcotpIqqUsA</bpmn2:source>
+    <bpmn2:target>_955w4Gz1EDiUcotpIqqUsA</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
@hasys @romartin please take a look at this. I have more tests in progress, but I keep getting fails
in these 3 smoke tests so I decided to bring this up to more eyes.
They use `index.html` and JS execution to load up the editor.

As of now 2 will fails with following reasons:

- `testInvalidContent` fails because there is dialog with unreasonable message shown to user.
Reported here: https://issues.redhat.com/browse/KOGITO-2147

- `testBasicModel` fails because upon reopening a diagram, some of it's id attributes are changed to different values.
Reported here: https://issues.redhat.com/browse/KOGITO-1795

To run locally, build kogito-client and run `mvn verify -Pkogito-it-tests` (omit clean to keep target folder with the editor)



