### PR TITLE
KOGITO-2166 VSCode editor - Package property: default is not a valid Java package name

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramService.java
@@ -55,7 +55,7 @@ import static org.kie.workbench.common.stunner.bpmn.util.XmlUtils.createValidId;
 @ApplicationScoped
 public class BPMNClientDiagramService extends AbstractKogitoClientDiagramService {
 
-    static final String DEFAULT_PACKAGE = "default";
+    static final String DEFAULT_PACKAGE = "com.example";
     static final String NO_DIAGRAM_MESSAGE = "No BPMN Diagram can be found.";
 
     private final DefinitionManager definitionManager;


### PR DESCRIPTION
Steps:
- just create a new process without changing the package name, it will be default

Description
- This breaks Kogito as the package name generates an invalid class