### PR TITLE
KOGITO-2166 VSCode editor - Package property: default is not a valid Java package name

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/service/AbstractKogitoClientDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/service/AbstractKogitoClientDiagramService.java
@@ -22,7 +22,7 @@ public abstract class AbstractKogitoClientDiagramService implements KogitoClient
 
     private static final char UNIX_SEPARATOR = '/';
     private static final char WINDOWS_SEPARATOR = '\\';
-    public static final String DEFAULT_DIAGRAM_ID = "default";
+    public static final String DEFAULT_DIAGRAM_ID = "com.example";
 
     /**
      * Making correct ID diagram from path:

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramService.java
@@ -55,7 +55,7 @@ import static org.kie.workbench.common.stunner.bpmn.util.XmlUtils.createValidId;
 @ApplicationScoped
 public class BPMNClientDiagramService extends AbstractKogitoClientDiagramService {
 
-    static final String DEFAULT_PACKAGE = "default";
+    static final String DEFAULT_PACKAGE = "com.example";
     static final String NO_DIAGRAM_MESSAGE = "No BPMN Diagram can be found.";
 
     private final DefinitionManager definitionManager;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramServiceTest.java
@@ -419,7 +419,7 @@ public class BPMNClientDiagramServiceTest {
     public void testGetDiagramTitleWhenIsEmpty() {
         final String actual = tested.createDiagramTitleFromFilePath("");
 
-        assertEquals("default", actual);
+        assertEquals(BPMNClientDiagramService.DEFAULT_PACKAGE, actual);
     }
 
     @Test


### PR DESCRIPTION
Steps:

-    just create a new process without changing the package name, it will be default

Description

 -   This breaks Kogito as the package name generates an invalid class
