### PR TITLE
AF-2514 : Execution Server UI breaks if connected to a KIE Server that has a KContainer deployed that its jar is not on BC internal Maven repo

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenter.java
@@ -75,8 +75,10 @@ public class ContainerRemoteStatusPresenter {
         if ( serverInstanceUpdated != null &&
                 serverInstanceUpdated.getServerInstance() != null ) {
             final String updatedServerInstanceKey = serverInstanceUpdated.getServerInstance().getServerInstanceId();
-            if ( index.containsKey( updatedServerInstanceKey ) ) {
-                final Map<String, ContainerCardPresenter> oldIndex = new HashMap<String, ContainerCardPresenter>( index.remove( updatedServerInstanceKey ) );
+            if ( index.containsKey( updatedServerInstanceKey ) || index.isEmpty() ) {
+                final Map<String, ContainerCardPresenter> oldIndex = index.isEmpty() ?
+                        new HashMap<String, ContainerCardPresenter>() :
+                        new HashMap<String, ContainerCardPresenter>( index.remove( updatedServerInstanceKey ) );
                 final Map<String, ContainerCardPresenter> newIndexIndex = new HashMap<String, ContainerCardPresenter>( serverInstanceUpdated.getServerInstance().getContainers().size() );
                 index.put( updatedServerInstanceKey, newIndexIndex );
                 for ( final Container container : serverInstanceUpdated.getServerInstance().getContainers() ) {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/remote/card/ContainerCardPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/remote/card/ContainerCardPresenter.java
@@ -54,7 +54,9 @@ public class ContainerCardPresenter {
 
     public void setup( final Container container ) {
         final LinkTitlePresenter linkTitlePresenter = presenterProvider.select( LinkTitlePresenter.class ).get();
-        linkTitlePresenter.setup( container.getContainerName(),
+        linkTitlePresenter.setup( container.getContainerName() != null ?
+                                          container.getContainerName() :
+                                          container.getContainerSpecId(),
                                   new Command() {
                                       @Override
                                       public void execute() {
@@ -82,7 +84,9 @@ public class ContainerCardPresenter {
 
     private ContainerSpecKey buildContainerSpecKey( final Container container ) {
         return new ContainerSpecKey( container.getContainerSpecId(),
-                                     container.getContainerName(),
+                                     container.getContainerName() != null ?
+                                             container.getContainerName() :
+                                             container.getContainerSpecId(),
                                      new ServerTemplateKey( container.getServerInstanceKey().getServerTemplateId(), "" ) );
 
     }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/remote/card/ContainerCardPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/remote/card/ContainerCardPresenterTest.java
@@ -140,4 +140,47 @@ public class ContainerCardPresenterTest {
         verify( containerSpecSelectedEvent ).fire( eq( new ContainerSpecSelected( containerSpecKey ) ) );
     }
 
+    @Test
+    public void testSetupWithUnNamedContainer() {
+        final InfoTitlePresenter infoTitlePresenter = mock(InfoTitlePresenter.class);
+        when(infoTitlePresenterProvider.get()).thenReturn(infoTitlePresenter);
+
+        final LinkTitlePresenter linkTitlePresenter = spy(new LinkTitlePresenter(mock(LinkTitlePresenter.View.class)));
+        when(linkTitlePresenterProvider.get()).thenReturn(linkTitlePresenter);
+
+        final BodyPresenter bodyPresenter = mock(BodyPresenter.class);
+        when(bodyPresenterProvider.get()).thenReturn(bodyPresenter);
+        final FooterPresenter footerPresenter = mock(FooterPresenter.class);
+        when(footerPresenterProvider.get()).thenReturn(footerPresenter);
+        final CardPresenter.View cardPresenterView = mock(CardPresenter.View.class);
+        final CardPresenter cardPresenter = spy(new CardPresenter(cardPresenterView));
+        when(cardPresenterProvider.get()).thenReturn(cardPresenter);
+
+        final ServerInstanceKey serverInstanceKey = new ServerInstanceKey("templateId",
+                                                                          "serverName",
+                                                                          "serverInstanceId",
+                                                                          "url");
+        final Message message = new Message(Severity.INFO, "testMessage");
+        final ReleaseId resolvedReleasedId = new ReleaseId("org.kie",
+                                                           "container",
+                                                           "1.0.0");
+        final Container container = new Container("containerSpecId",
+                                                  null,
+                                                  serverInstanceKey,
+                                                  Collections.singletonList(message),
+                                                  resolvedReleasedId, null);
+
+        presenter.setup(container);
+
+        verify(linkTitlePresenter).setup(eq(container.getContainerSpecId()), any(Command.class));
+        verify(view).setCard(cardPresenterView);
+        linkTitlePresenter.onSelect();
+
+        final ContainerSpecKey containerSpecKey = new ContainerSpecKey(container.getContainerSpecId(),
+                                                                       container.getContainerSpecId(),
+                                                                       new ServerTemplateKey(container.getServerInstanceKey().getServerTemplateId(), ""));
+
+        verify(containerSpecSelectedEvent).fire(eq(new ContainerSpecSelected(containerSpecKey)));
+    }
+
 }


### PR DESCRIPTION
 * If container-alias is not available for a container, then the ContainerSpec is created with ContainerSpecId.

Deployable WAR: https://drive.google.com/open?id=15xPtrTK2vR8DpYe-Fcy8TUDbFk-VwOY7