### PR TITLE
JBPM-9165 - Stunner - Global / Process variables allow empty value as data type

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/popup/editor/defaultImport/DefaultImportListItemWidgetView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/popup/editor/defaultImport/DefaultImportListItemWidgetView.java
@@ -155,11 +155,11 @@ public class DefaultImportListItemWidgetView extends Composite implements Import
         classNamesComboBox.setListBoxValues(classNameListBoxValues);
 
         String className = getModel().getClassName();
-        if (className == null) {
-            className = "";
+        if (className == null || className.isEmpty()) {
+            className = Object.class.getSimpleName();
         }
 
-        String displayName = dataTypes.getOrDefault(className, className);
+        String displayName = parentWidget.getDataType(className);
         defaultClassNames.setValue(displayName);
 
         classNamesComboBox.init(this,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentRow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentRow.java
@@ -40,7 +40,12 @@ public class AssignmentRow {
     private static long lastId = 0;
 
     public AssignmentRow() {
-        this(null, null, null, null, null, null);
+        this(null,
+             null,
+             Object.class.getSimpleName(),
+             null,
+             null,
+             null);
     }
 
     public AssignmentRow(final String name,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRow.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRow.java
@@ -25,36 +25,41 @@ import org.jboss.errai.databinding.client.api.Bindable;
 @Bindable
 public class VariableRow {
 
-    private long id;
+    long id;
 
-    private String name;
+    String name;
 
-    private Variable.VariableType variableType = Variable.VariableType.PROCESS;
+    Variable.VariableType variableType = Variable.VariableType.PROCESS;
 
-    private String dataTypeDisplayName;
+    String dataTypeDisplayName;
 
-    private String customDataType;
+    String customDataType;
 
-    private List<String> tags;
+    List<String> tags;
 
     // Field which is incremented for each row.
     // Required to implement equals function which needs a unique field
-    private static long lastId = 0;
+    static long lastId = 0;
 
     public VariableRow() {
         this(Variable.VariableType.PROCESS, null, null, null, new ArrayList<>());
-        this.id = lastId++;
     }
 
     public VariableRow(final Variable.VariableType variableType,
                        final String name,
                        final String dataTypeDisplayName,
                        final String customDataType) {
-        this.id = lastId++;
-        this.variableType = variableType;
-        this.name = name;
-        this.dataTypeDisplayName = dataTypeDisplayName;
-        this.customDataType = customDataType;
+        this(variableType, name, dataTypeDisplayName, customDataType, new ArrayList<>());
+    }
+
+    public VariableRow(final Variable variable,
+                       final Map<String, String> mapDataTypeNamesToDisplayNames) {
+        this(variable.getVariableType(), variable.getName(), null, variable.getCustomDataType(), variable.getTags());
+        if (variable.getDataType() != null && mapDataTypeNamesToDisplayNames.containsKey(variable.getDataType())) {
+            this.dataTypeDisplayName = mapDataTypeNamesToDisplayNames.get(variable.getDataType());
+        } else {
+            this.dataTypeDisplayName = variable.getDataType();
+        }
     }
 
     public VariableRow(final Variable.VariableType variableType,
@@ -68,20 +73,6 @@ public class VariableRow {
         this.dataTypeDisplayName = dataTypeDisplayName;
         this.customDataType = customDataType;
         this.tags = tags;
-    }
-
-    public VariableRow(final Variable variable,
-                       final Map<String, String> mapDataTypeNamesToDisplayNames) {
-        this.id = lastId++;
-        this.variableType = variable.getVariableType();
-        this.name = variable.getName();
-        if (variable.getDataType() != null && mapDataTypeNamesToDisplayNames.containsKey(variable.getDataType())) {
-            this.dataTypeDisplayName = mapDataTypeNamesToDisplayNames.get(variable.getDataType());
-        } else {
-            this.dataTypeDisplayName = variable.getDataType();
-        }
-        this.customDataType = variable.getCustomDataType();
-        this.tags = variable.getTags();
     }
 
     public List<String> getTags() {
@@ -149,7 +140,7 @@ public class VariableRow {
 
     @Override
     public int hashCode() {
-        return ~~(int) (id ^ (id >>> 32));
+        return (int) (id ^ (id >>> 32));
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
@@ -62,7 +62,6 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
     ListBoxValues dataTypeListBoxValues;
 
     private VariablesEditorWidgetView view;
-    private Variable.VariableType variableType = Variable.VariableType.PROCESS;
     private List<String> dataTypes = new ArrayList<>();
     private Graph graph;
     private Path path;
@@ -127,9 +126,7 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
         if (as.isEmpty()) {
             view.setTableDisplayStyle();
         }
-        VariableRow newVariable = new VariableRow();
-        newVariable.setVariableType(variableType);
-        as.add(newVariable);
+        as.add(createVariableRow());
         VariableListItemWidgetView widget = view.getVariableWidget(view.getVariableRowsCount() - 1);
 
         widget.setDataTypes(dataTypeListBoxValues);
@@ -303,8 +300,14 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
         }
     }
 
-    public static Set<String> getDefaultTagsSet() {
-        return  defaultTagsSet;
+    static VariableRow createVariableRow() {
+        VariableRow newVariable = new VariableRow();
+        newVariable.setVariableType(Variable.VariableType.PROCESS);
+        newVariable.setDataTypeDisplayName("Object");
+        return newVariable;
     }
 
+    public static Set<String> getDefaultTagsSet() {
+        return defaultTagsSet;
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
@@ -41,6 +41,7 @@ public class ListBoxValues {
     protected String editPrefix;
     public static final String EDIT_SUFFIX = " ...";
     protected int maxDisplayLength;
+    boolean allowEmpty;
 
     protected static final int DEFAULT_MAX_DISPLAY_LENGTH = -1;
 
@@ -49,33 +50,43 @@ public class ListBoxValues {
         String getNonCustomValueForUserString(final String userValue);
     }
 
-    ValueTester valueTester = null;
+    ValueTester valueTester;
+
+    public ListBoxValues(final String customPrompt,
+                         final String editPrefix,
+                         final ValueTester valueTester,
+                         final int maxDisplayLength,
+                         final boolean allowEmpty) {
+        this.customPrompt = customPrompt;
+        this.editPrefix = editPrefix;
+        this.valueTester = valueTester;
+        this.maxDisplayLength = maxDisplayLength;
+        this.allowEmpty = allowEmpty;
+    }
 
     public ListBoxValues(final String customPrompt,
                          final String editPrefix,
                          final ValueTester valueTester,
                          final int maxDisplayLength) {
-        this.customPrompt = customPrompt;
-        this.editPrefix = editPrefix;
-        this.valueTester = valueTester;
-        this.maxDisplayLength = maxDisplayLength;
+        this(customPrompt, editPrefix, valueTester, maxDisplayLength, false);
+    }
+
+    public ListBoxValues(final String customPrompt,
+                         final String editPrefix,
+                         final ValueTester valueTester,
+                         final boolean allowEmpty) {
+        this(customPrompt, editPrefix, valueTester, DEFAULT_MAX_DISPLAY_LENGTH, allowEmpty);
     }
 
     public ListBoxValues(final String customPrompt,
                          final String editPrefix,
                          final ValueTester valueTester) {
-        this.customPrompt = customPrompt;
-        this.editPrefix = editPrefix;
-        this.valueTester = valueTester;
-        this.maxDisplayLength = DEFAULT_MAX_DISPLAY_LENGTH;
+        this(customPrompt, editPrefix, valueTester, DEFAULT_MAX_DISPLAY_LENGTH, false);
     }
 
     public ListBoxValues(final ListBoxValues copy,
                          final boolean copyCustomValues) {
-        this.customPrompt = copy.customPrompt;
-        this.editPrefix = copy.editPrefix;
-        this.valueTester = copy.valueTester;
-        this.maxDisplayLength = copy.maxDisplayLength;
+        this(copy.customPrompt, copy.editPrefix, copy.valueTester, copy.maxDisplayLength, copy.allowEmpty);
         this.addValues(copy.acceptableValuesWithoutCustomValues);
         if (copyCustomValues) {
             for (String copyCustomValue : copy.customValues) {
@@ -94,7 +105,9 @@ public class ListBoxValues {
         if (acceptableValues != null) {
             List<String> displayValues = createDisplayValues(acceptableValues);
             acceptableValuesWithoutCustomValues.addAll(displayValues);
-            acceptableValuesWithCustomValues.add("");
+            if (allowEmpty) {
+                acceptableValuesWithCustomValues.add("");
+            }
             acceptableValuesWithCustomValues.add(customPrompt);
             acceptableValuesWithCustomValues.addAll(displayValues);
         }
@@ -108,7 +121,9 @@ public class ListBoxValues {
         List<String> keys = new ArrayList<>(acceptableValues.keySet());
         java.util.Collections.sort(keys);
 
-        acceptableValuesWithCustomValues.add("");
+        if (allowEmpty) {
+            acceptableValuesWithCustomValues.add("");
+        }
         acceptableValuesWithCustomValues.add(customPrompt);
         for (String groupName : keys) {
             String displayName = acceptableValues.get(groupName);
@@ -223,6 +238,7 @@ public class ListBoxValues {
      * <p/>
      * The first display value for values which are the same is of the form "\"abcdeabcde...\"" and subsequent display values
      * are of the form "\"abcdeabcde...(01)\""
+     *
      * @param value the value
      * @return the displayValue for value
      */
@@ -278,6 +294,7 @@ public class ListBoxValues {
 
     /**
      * Returns real unquoted value for a DisplayValue
+     *
      * @param key
      * @return
      */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorViewImplTest.java
@@ -135,10 +135,9 @@ public class ActivityDataIOEditorViewImplTest {
         view.setPossibleInputAssignmentsDataTypes(dataTypes);
         verify(inputAssignmentsWidget).setDataTypes(valuesCaptor.capture());
         List<String> typesWithCustomValue = valuesCaptor.getValue().getAcceptableValuesWithCustomValues();
-        assertEquals(3,
+        assertEquals(2,
                      typesWithCustomValue.size());
-        assertTrue(typesWithCustomValue.containsAll(Arrays.asList("",
-                                                                  "Custom ...",
+        assertTrue(typesWithCustomValue.containsAll(Arrays.asList("Custom ...",
                                                                   "String")));
     }
 
@@ -148,10 +147,9 @@ public class ActivityDataIOEditorViewImplTest {
         view.setPossibleOutputAssignmentsDataTypes(dataTypes);
         verify(outputAssignmentsWidget).setDataTypes(valuesCaptor.capture());
         List<String> typesWithCustomValue = valuesCaptor.getValue().getAcceptableValuesWithCustomValues();
-        assertEquals(3,
+        assertEquals(2,
                      typesWithCustomValue.size());
-        assertTrue(typesWithCustomValue.containsAll(Arrays.asList("",
-                                                                  "Custom ...",
+        assertTrue(typesWithCustomValue.containsAll(Arrays.asList("Custom ...",
                                                                   "String")));
     }
 
@@ -161,10 +159,9 @@ public class ActivityDataIOEditorViewImplTest {
         view.setInputAssignmentsProcessVariables(variables);
         verify(inputAssignmentsWidget).setProcessVariables(valuesCaptor.capture());
         List<String> variablesWithCustomValue = valuesCaptor.getValue().getAcceptableValuesWithCustomValues();
-        assertEquals(3,
+        assertEquals(2,
                      variablesWithCustomValue.size());
-        assertTrue(variablesWithCustomValue.containsAll(Arrays.asList("",
-                                                                      "Expression ...",
+        assertTrue(variablesWithCustomValue.containsAll(Arrays.asList("Expression ...",
                                                                       "variable")));
     }
 
@@ -174,10 +171,9 @@ public class ActivityDataIOEditorViewImplTest {
         view.setOutputAssignmentsProcessVariables(variables);
         verify(outputAssignmentsWidget).setProcessVariables(valuesCaptor.capture());
         List<String> variablesWithCustomValue = valuesCaptor.getValue().getAcceptableValuesWithCustomValues();
-        assertEquals(3,
+        assertEquals(2,
                      variablesWithCustomValue.size());
-        assertTrue(variablesWithCustomValue.containsAll(Arrays.asList("",
-                                                                      "Expression ...",
+        assertTrue(variablesWithCustomValue.containsAll(Arrays.asList("Expression ...",
                                                                       "variable")));
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
@@ -208,7 +208,7 @@ public class AssignmentListItemWidgetTest {
         verify(constant,
                never()).setVisible(anyBoolean());
         verify(widget).getCustomDataType();
-        verify(widget).getDataType();
+        verify(widget, times(2)).getDataType();
         verify(widget).getExpression();
         verify(widget).getProcessVar();
     }
@@ -220,7 +220,7 @@ public class AssignmentListItemWidgetTest {
         verify(deleteButton).setIcon(IconType.TRASH);
         verify(constant).setVisible(false);
         verify(widget).getCustomDataType();
-        verify(widget).getDataType();
+        verify(widget, times(2)).getDataType();
         verify(widget).getExpression();
         verify(widget).getProcessVar();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
@@ -232,7 +232,7 @@ public class AssignmentListItemWidgetViewImplTest {
 
     @Test
     public void testSetListBoxModelValueDataType() {
-        assertNull(view.getModel().getDataType());
+        assertEquals("Object", view.getModel().getDataType());
         view.setListBoxModelValue(dataType, "abc");
 
         assertEquals("abc", view.getModel().getDataType());
@@ -248,7 +248,7 @@ public class AssignmentListItemWidgetViewImplTest {
 
         assertEquals("abc", view.getModel().getProcessVar());
         assertNull(view.getModel().getExpression());
-        assertNull(view.getModel().getDataType());
+        assertEquals("Object", view.getModel().getDataType());
         assertEquals("abc", view.getModelValue(processVar));
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/popup/editor/defaultImport/DefaultImportListItemWidgetViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/importsEditor/popup/editor/defaultImport/DefaultImportListItemWidgetViewTest.java
@@ -100,6 +100,7 @@ public class DefaultImportListItemWidgetViewTest {
         map.put("Boolean", "Boolean");
         when(parent.getDataTypes()).thenReturn(map);
         when(parent.getDataType("Boolean")).thenReturn("Boolean");
+        when(parent.getDataType("randomValue")).thenReturn("randomValue");
 
         doCallRealMethod().when(tested).init();
         doCallRealMethod().when(tested).initListItem();
@@ -174,7 +175,7 @@ public class DefaultImportListItemWidgetViewTest {
         defaultImport.setClassName("Boolean");
         tested.initListItem();
 
-        verify(defaultClassNames, times(2)).setValue("");
+        verify(defaultClassNames, times(2)).setValue(null);
         verify(defaultClassNames, times(1)).setValue("Boolean");
         verify(defaultClassNames, times(1)).setValue("randomValue");
         verify(classNamesComboBox, times(4)).setShowCustomValues(true);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRowTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableRowTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.forms.fields.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VariableRowTest {
+
+    private static final int ID = 100;
+    private static final int LAST_ID = 50;
+    private static final Variable.VariableType VARIABLE_TYPE = Variable.VariableType.PROCESS;
+    private static final String NAME = "Variable Name";
+    private static final String DATA_TYPE = "Boolean";
+    private static final String DATA_TYPE_DISPLAY_NAME = "Boolean Display Name";
+    private static final String CUSTOM_DATA_TYPE = "CustomData";
+    private static final String TAG_1 = "Tag 1";
+    private static final String TAG_2 = "Tag 2";
+    private static final String TAG_3 = "Tag 3";
+    private static final ArrayList<String> TAGS = new ArrayList<>(Arrays.asList(TAG_1, TAG_2, TAG_3));
+    private static final Map<String, String> MAP_DATA_TYPE_NAMES_TO_DISPLAY_NAMES = new HashMap<String, String>() {{
+        put(DATA_TYPE, DATA_TYPE_DISPLAY_NAME);
+    }};
+
+    @Test
+    public void getTags() {
+        VariableRow tested = new VariableRow();
+        tested.tags = TAGS;
+        assertEquals(TAGS, tested.getTags());
+    }
+
+    @Test
+    public void setTags() {
+        VariableRow tested = new VariableRow();
+        tested.tags = TAGS;
+        assertEquals(TAGS, tested.tags);
+    }
+
+    @Test
+    public void getId() {
+        VariableRow.lastId = LAST_ID;
+        VariableRow tested = new VariableRow();
+        assertEquals(LAST_ID, tested.id);
+        assertEquals(LAST_ID + 1, VariableRow.lastId);
+
+        tested.id = ID;
+        assertEquals(ID, tested.getId());
+    }
+
+    @Test
+    public void setId() {
+        VariableRow tested = new VariableRow();
+        tested.setId(ID);
+        assertEquals(ID, tested.id);
+    }
+
+    @Test
+    public void getVariableType() {
+        VariableRow tested = new VariableRow();
+        tested.variableType = VARIABLE_TYPE;
+        assertEquals(VARIABLE_TYPE, tested.getVariableType());
+    }
+
+    @Test
+    public void setVariableType() {
+        VariableRow tested = new VariableRow();
+        tested.setVariableType(VARIABLE_TYPE);
+        assertEquals(VARIABLE_TYPE, tested.variableType);
+    }
+
+    @Test
+    public void getName() {
+        VariableRow tested = new VariableRow();
+        tested.name = NAME;
+        assertEquals(NAME, tested.getName());
+    }
+
+    @Test
+    public void setName() {
+        VariableRow tested = new VariableRow();
+        tested.setName(NAME);
+        assertEquals(NAME, tested.name);
+    }
+
+    @Test
+    public void getDataTypeDisplayName() {
+        VariableRow tested1 = new VariableRow();
+        tested1.dataTypeDisplayName = DATA_TYPE_DISPLAY_NAME;
+        assertEquals(DATA_TYPE_DISPLAY_NAME, tested1.getDataTypeDisplayName());
+
+        Variable variable2 = new Variable(NAME, VARIABLE_TYPE, DATA_TYPE, null, null);
+        VariableRow tested2 = new VariableRow(variable2, MAP_DATA_TYPE_NAMES_TO_DISPLAY_NAMES);
+        assertEquals(DATA_TYPE_DISPLAY_NAME, tested2.getDataTypeDisplayName());
+
+        String dataType = "Object";
+        Variable variable3 = new Variable(NAME, VARIABLE_TYPE, dataType, null, null);
+        VariableRow tested3 = new VariableRow(variable3, MAP_DATA_TYPE_NAMES_TO_DISPLAY_NAMES);
+        assertEquals(dataType, tested3.getDataTypeDisplayName());
+    }
+
+    @Test
+    public void setDataTypeDisplayName() {
+        VariableRow tested = new VariableRow();
+        tested.setDataTypeDisplayName(DATA_TYPE_DISPLAY_NAME);
+        assertEquals(DATA_TYPE_DISPLAY_NAME, tested.dataTypeDisplayName);
+    }
+
+    @Test
+    public void getCustomDataType() {
+        VariableRow tested = new VariableRow();
+        tested.customDataType = CUSTOM_DATA_TYPE;
+        assertEquals(CUSTOM_DATA_TYPE, tested.getCustomDataType());
+    }
+
+    @Test
+    public void setCustomDataType() {
+        VariableRow tested = new VariableRow();
+        tested.setCustomDataType(CUSTOM_DATA_TYPE);
+        assertEquals(CUSTOM_DATA_TYPE, tested.customDataType);
+    }
+
+    @Test
+    public void testEquals() {
+        VariableRow tested1 = new VariableRow();
+        assertTrue(tested1.equals(tested1));
+
+        VariableRow tested2 = new VariableRow();
+        assertFalse(tested2.equals(null));
+
+        VariableRow tested3 = new VariableRow();
+        assertFalse(tested3.equals(new Object()));
+
+        VariableRow tested4 = new VariableRow();
+        tested4.setId(ID);
+        VariableRow otherVariableRow4 = new VariableRow();
+        otherVariableRow4.setId(ID);
+        assertTrue(tested4.equals(otherVariableRow4));
+
+        VariableRow tested5 = new VariableRow();
+        tested5.setId(ID);
+        VariableRow otherTested5 = new VariableRow();
+        otherTested5.setId(LAST_ID);
+        assertFalse(tested5.equals(otherTested5));
+    }
+
+    @Test
+    public void testHashCode() {
+        VariableRow tested1 = new VariableRow();
+        tested1.setId(ID);
+        assertEquals(ID, tested1.hashCode());
+
+        VariableRow tested2 = new VariableRow();
+        tested2.setId(LAST_ID);
+        assertEquals(LAST_ID, tested2.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        VariableRow tested = new VariableRow(Variable.VariableType.PROCESS, NAME, DATA_TYPE, CUSTOM_DATA_TYPE, TAGS);
+        String expected = "VariableRow [variableType=PROCESS, name=Variable Name, dataTypeDisplayName=Boolean, customDataType=CustomData, tags=Tag 1,Tag 2,Tag 3]";
+        assertEquals(expected, tested.toString());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
@@ -407,4 +407,11 @@ public class VariablesEditorFieldRendererTest {
         verify(variablesEditorWidgetView,
                times(1)).setReadOnly(false);
     }
+
+    @Test
+    public void testCreateVariableRow() {
+        VariableRow variableRow = VariablesEditorFieldRenderer.createVariableRow();
+        assertEquals(Variable.VariableType.PROCESS, variableRow.getVariableType());
+        assertEquals("Object", variableRow.getDataTypeDisplayName());
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
@@ -16,10 +16,12 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -27,9 +29,15 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.assignmentsEdit
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentData;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ListBoxValuesTest {
+
+    final String EMPTY_STRING = "";
+    final String CUSTOM_VALUE = "Custom Value";
+    final String EDIT_CUSTOM_VALUE = "Edit Custom Value ...";
 
     /**
      * General test for adding custom values to ProcessVar ListBoxValues
@@ -76,14 +84,13 @@ public class ListBoxValuesTest {
                 "performance"
         };
         String[] expectedAcceptableValuesWithCustomValues = {
-                "",
+                "Constant ...",
                 "\"jkl\"",
                 "Edit \"jkl\" ...",
                 "123",
                 "\"employee\"",
                 "\"def\"",
                 "\"abc\"",
-                "Constant ...",
                 "** Variable Definitions **",
                 "employee",
                 "reason",
@@ -154,12 +161,11 @@ public class ListBoxValuesTest {
                 "TestTypesLine [org.kie.test]"
         };
         String[] expectedAcceptableValuesWithCustomValues = {
-                "",
+                "Custom ...",
                 "com.test.HisType",
                 "Edit com.test.HisType ...",
                 "com.test.YourType",
                 "com.test.MyType",
-                "Custom ...",
                 "Integer",
                 "Boolean",
                 "Float",
@@ -327,6 +333,18 @@ public class ListBoxValuesTest {
         value = processVarValues.getValueForDisplayValue(displayValue);
         Assert.assertEquals(displayValue,
                             value);
+
+        final String keyFirst = "1st";
+        final String valueFirst = "First";
+        final String keySecond = "Second";
+        final String valueSecond = "Second";
+        ListBoxValues test2 = new ListBoxValues("Constant ...",
+                                                "Edit ",
+                                                null);
+        test2.mapDisplayValuesToValues.put(keyFirst, valueFirst);
+        test2.mapDisplayValuesToValues.put(keySecond, valueSecond);
+        assertEquals(keyFirst, test2.addDisplayValue(valueFirst));
+        assertEquals(keySecond, test2.addDisplayValue(valueSecond));
     }
 
     @Test
@@ -349,7 +367,7 @@ public class ListBoxValuesTest {
         // Copy custom values as well as non-custom
         ListBoxValues copy1 = new ListBoxValues(listBoxValues,
                                                 true);
-        assertTrue(copy1.getAcceptableValuesWithCustomValues().size() == 8);
+        assertTrue(copy1.getAcceptableValuesWithCustomValues().size() == 7);
         assertTrue(copy1.getAcceptableValuesWithoutCustomValues().size() == 4);
         assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"abc\""));
         assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"def\""));
@@ -357,7 +375,7 @@ public class ListBoxValuesTest {
         // Don't copy custom values as well as non-custom
         ListBoxValues copy2 = new ListBoxValues(listBoxValues,
                                                 false);
-        assertTrue(copy2.getAcceptableValuesWithCustomValues().size() == 6);
+        assertTrue(copy2.getAcceptableValuesWithCustomValues().size() == 5);
         assertTrue(copy2.getAcceptableValuesWithoutCustomValues().size() == 4);
         Assert.assertFalse(copy2.getAcceptableValuesWithCustomValues().contains("\"abc\""));
         Assert.assertFalse(copy2.getAcceptableValuesWithCustomValues().contains("\"def\""));
@@ -380,7 +398,7 @@ public class ListBoxValuesTest {
                                                  null);
         Map<String, String> testEmpty = new HashMap<>();
         values.addValues(testEmpty);
-        assertEquals(2, values.getAcceptableValuesWithCustomValues().size());
+        assertEquals(1, values.getAcceptableValuesWithCustomValues().size());
         assertTrue(values.getAcceptableValuesWithoutCustomValues().isEmpty());
         assertTrue(values.mapDisplayValuesToValues.isEmpty());
     }
@@ -399,7 +417,7 @@ public class ListBoxValuesTest {
         testMap.put(valueName2, displayName2);
         values.addValues(testMap);
 
-        assertEquals(4, values.getAcceptableValuesWithCustomValues().size());
+        assertEquals(3, values.getAcceptableValuesWithCustomValues().size());
         assertEquals(2, values.getAcceptableValuesWithoutCustomValues().size());
         assertEquals(2, values.mapDisplayValuesToValues.size());
         assertEquals(displayName1, values.getDisplayNameForValue(valueName1));
@@ -419,5 +437,166 @@ public class ListBoxValuesTest {
 
         String nonMappedValue = "nonMappedValue";
         assertEquals(nonMappedValue, values.getDisplayNameForValue(nonMappedValue));
+    }
+
+    @Test
+    public void testAddValues() {
+        List<String> processVarStartValuesList = Arrays.asList(
+                "** Variable Definitions **",
+                "employee",
+                "reason",
+                "performance"
+        );
+
+        Map<String, String> processVarStartValuesMap = new TreeMap<>();
+        processVarStartValuesMap.put("def", "** Variable Definitions **");
+        processVarStartValuesMap.put("emp", "employee");
+        processVarStartValuesMap.put("rea", "reason");
+        processVarStartValuesMap.put("per", "performance");
+
+        ListBoxValues test1 = new ListBoxValues("CustomPrompt",
+                                                "Edit",
+                                                null,
+                                                ActivityDataIOEditorViewImpl.EXPRESSION_MAX_DISPLAY_LENGTH,
+                                                false);
+        test1.addValues(processVarStartValuesList);
+
+        Assert.assertFalse(test1.acceptableValuesWithCustomValues.contains(""));
+
+        ListBoxValues test2 = new ListBoxValues("CustomPrompt",
+                                                "Edit",
+                                                null,
+                                                ActivityDataIOEditorViewImpl.EXPRESSION_MAX_DISPLAY_LENGTH,
+                                                true);
+        test2.addValues(processVarStartValuesList);
+
+        Assert.assertTrue(test2.acceptableValuesWithCustomValues.contains(""));
+
+        ListBoxValues test3 = new ListBoxValues("CustomPrompt",
+                                                "Edit",
+                                                null,
+                                                true);
+        test3.addValues(processVarStartValuesList);
+
+        Assert.assertTrue(test3.acceptableValuesWithCustomValues.contains(""));
+
+        ListBoxValues test4 = new ListBoxValues("CustomPrompt",
+                                                "Edit",
+                                                null,
+                                                true);
+        List<String> emptyList = null;
+        test4.addValues(emptyList);
+
+        ListBoxValues test5 = new ListBoxValues("CustomPrompt",
+                                                "Edit",
+                                                null,
+                                                true);
+        test5.addValues(processVarStartValuesMap);
+        Assert.assertTrue(test5.acceptableValuesWithCustomValues.contains(""));
+
+        ListBoxValues test6 = new ListBoxValues("CustomPrompt",
+                                                "Edit",
+                                                null,
+                                                false);
+        test6.addValues(processVarStartValuesMap);
+        Assert.assertFalse(test6.acceptableValuesWithCustomValues.contains(""));
+    }
+
+    @Test
+    public void testAddCustomValues() {
+        ListBoxValues processVarValues = new ListBoxValues("Constant ...",
+                                                           "Edit ",
+                                                           null);
+
+//        assertNull(processVarValues.addCustomValue(null, null));
+//        assertEquals(EMPTY_STRING, processVarValues.addCustomValue(EMPTY_STRING, null));
+
+        processVarValues.customValues.add(CUSTOM_VALUE);
+        assertEquals(CUSTOM_VALUE, processVarValues.addCustomValue(CUSTOM_VALUE, null));
+    }
+
+    @Test
+    public void testUpdate() {
+        final String first = "1st";
+        final String second = "2nd";
+
+        ListBoxValues test1 = new ListBoxValues("Constant ...",
+                                                "Edit ",
+                                                null);
+        test1.customValues.add(CUSTOM_VALUE);
+
+        List<String> result1 = test1.update(CUSTOM_VALUE);
+        assertEquals(1, result1.size());
+        assertEquals(EDIT_CUSTOM_VALUE, result1.get(0));
+
+        ListBoxValues test2 = new ListBoxValues("Constant ...",
+                                                "Edit ",
+                                                null);
+        test2.customValues.add(CUSTOM_VALUE);
+
+        test2.customValues.add(CUSTOM_VALUE);
+        test2.acceptableValuesWithCustomValues.add(first);
+        test2.acceptableValuesWithCustomValues.add(second);
+
+        List<String> result2 = test2.update(CUSTOM_VALUE);
+        assertEquals(3, result2.size());
+        assertEquals(first, result2.get(0));
+        assertEquals(second, result2.get(1));
+        assertEquals(EDIT_CUSTOM_VALUE, result2.get(2));
+    }
+
+    @Test
+    public void testIsCustomValue() {
+        ListBoxValues processVarValues = new ListBoxValues("Constant ...",
+                                                           "Edit ",
+                                                           null);
+
+        processVarValues.addCustomValue(CUSTOM_VALUE, null);
+
+        assertFalse(processVarValues.isCustomValue(null));
+        assertFalse(processVarValues.isCustomValue(EMPTY_STRING));
+        assertTrue(processVarValues.isCustomValue(CUSTOM_VALUE));
+    }
+
+    @Test
+    public void testGetEditValuePrompt() {
+        ListBoxValues processVarValues = new ListBoxValues("Constant ...",
+                                                           "Edit ",
+                                                           null);
+        assertNull(processVarValues.getEditValuePrompt(CUSTOM_VALUE));
+
+        processVarValues.addCustomValue(CUSTOM_VALUE, null);
+        assertEquals(CUSTOM_VALUE, processVarValues.getEditValuePrompt(CUSTOM_VALUE));
+    }
+
+    @Test
+    public void testCreateDisplayValues() {
+        List<String> acceptableValues = new ArrayList<>();
+        acceptableValues.add(CUSTOM_VALUE);
+        acceptableValues.add(null);
+
+        ListBoxValues processVarValues = new ListBoxValues("Constant ...",
+                                                           "Edit ",
+                                                           null);
+        List<String> result = processVarValues.createDisplayValues(acceptableValues);
+        assertEquals(1, result.size());
+        assertEquals(CUSTOM_VALUE, result.get(0));
+    }
+
+    @Test
+    public void testToString() {
+        ListBoxValues processVarValues = new ListBoxValues("Constant ...",
+                                                           "Edit ",
+                                                           null);
+        processVarValues.acceptableValuesWithoutCustomValues.add(CUSTOM_VALUE);
+        processVarValues.acceptableValuesWithCustomValues.add(CUSTOM_VALUE);
+        String expected = "acceptableValuesWithoutCustomValues:\n" +
+                "\tCustom Value,\n" +
+                "\n" +
+                "acceptableValuesWithCustomValues:\n" +
+                "\tCustom Value,\n";
+
+        String result = processVarValues.toString();
+        assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9165

This removes the empty value from the data type combo box and uses the value "Object" as the default value.

[Business-Central](https://drive.google.com/file/d/1YjOX8505d50fNrUBWa-PXgW0cAv00bWA/view?usp=sharing)

[VS Code Extension](https://drive.google.com/file/d/1qwqNaelzwd30pL1qUMq4tDw7-wP386wb/view?usp=sharing)