### PR TITLE
BXMSPROD-756 timeout added to EmbeddedControllerIT tests

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/EmbeddedControllerIT.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/EmbeddedControllerIT.java
@@ -29,7 +29,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.ReleaseId;
@@ -78,6 +80,9 @@ public class EmbeddedControllerIT extends AbstractAutoControllerIT {
     public static void setup() {
         KieServerDeployer.createAndDeployKJar(RELEASE_ID);
     }
+
+    @Rule
+    public Timeout globalTimeout = Timeout.millis(6000000);
 
     @Test
     @RunAsClient


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-756
This is a random issue during wildly stop/undeploy. The failure jobs have already expired, I can't reproduce it and I can't investigate it deeper. I would at least add a timeout for the failure test in order not to wait for pipeline timeout and start investigating why the timeout has been reached.
wdyt? It's not very elegant solution but at least until we are able to investigate properly...