### PR TITLE
DROOLS-3685: [DMN Designer] Boxed expressions - Decision Table - Output clause - Creating Decision Table, sub-columns are auto-created for structured type

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ItemDefinition.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ItemDefinition.java
@@ -127,6 +127,13 @@ public class ItemDefinition extends NamedElement implements HasTypeRef,
         this.isCollection = value;
     }
 
+    /**
+     * @return true if current instance of {@link ItemDefinition} is related to an imported model
+     */
+    public boolean isImported() {
+        return allowOnlyVisualChange;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/RegisterNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/RegisterNodeCommand.java
@@ -68,5 +68,6 @@ public class RegisterNodeCommand extends org.kie.workbench.common.stunner.core.g
         function.setExpression(le);
         le.setParent(function);
         businessKnowledgeModel.setEncapsulatedLogic(function);
+        function.setParent(businessKnowledgeModel);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -64,6 +64,7 @@ import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 
+import static org.kie.workbench.common.dmn.api.editors.types.BuiltInTypeUtils.isBuiltInType;
 import static org.kie.workbench.common.dmn.api.property.dmn.QName.NULL_NS_URI;
 import static org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType.ANY;
 
@@ -170,7 +171,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
     }
 
     private List<ClauseRequirement> generateOutputClauseRequirements(final Definitions definitions, final QName typeRef, final String name) {
-        if (typeRefMatchesBuiltInType(typeRef)) {
+        if (isBuiltInType(typeRef.getLocalPart())) {
             return Collections.singletonList(new ClauseRequirement(name, typeRef));
         }
 
@@ -200,7 +201,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
     }
 
     private boolean typeRefDoesNotMatchAnyDefinition(final QName typeRef) {
-        return !typeRefMatchesBuiltInType(typeRef) &&
+        return !isBuiltInType(typeRef.getLocalPart()) &&
                 dmnGraphUtils.getDefinitions().getItemDefinition()
                         .stream()
                         .noneMatch(typeRefIsCustom(typeRef));
@@ -298,7 +299,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                                            final List<ClauseRequirement> inputClauseRequirements,
                                            final String text) {
         //TypeRef matches a BuiltInType
-        if (typeRefMatchesBuiltInType(typeRef)) {
+        if (isBuiltInType(typeRef.getLocalPart())) {
             inputClauseRequirements.add(new ClauseRequirement(text, typeRef));
             return;
         }
@@ -323,17 +324,6 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                                                                         inputClauseRequirements,
                                                                         text + "." + itemComponent.getName().getValue()));
         }
-    }
-
-    private boolean typeRefMatchesBuiltInType(final QName typeRef) {
-        for (BuiltInType bi : BuiltInType.values()) {
-            for (String biName : bi.getNames()) {
-                if (Objects.equals(biName, typeRef.getLocalPart())) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     private Predicate<ItemDefinition> typeRefIsCustom(final QName typeRef) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.dmn.api.definition.model.DecisionRule;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionTableOrientation;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
+import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
 import org.kie.workbench.common.dmn.api.definition.model.HitPolicy;
 import org.kie.workbench.common.dmn.api.definition.model.InformationItem;
 import org.kie.workbench.common.dmn.api.definition.model.InputClause;
@@ -148,7 +149,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
     }
 
     void buildOutputClausesByDataType(final HasExpression hasExpression, final DecisionTable dTable, final DecisionRule decisionRule) {
-        final HasTypeRef hasTypeRef = TypeRefUtils.getTypeRefOfExpression(dTable, hasExpression);
+        final HasTypeRef hasTypeRef = getHasTypeRef(hasExpression, dTable);
         final QName typeRef = !Objects.isNull(hasTypeRef) ? hasTypeRef.getTypeRef() : BuiltInType.UNDEFINED.asQName();
         final String name = DecisionTableDefaultValueUtilities.getNewOutputClauseName(dTable);
 
@@ -169,6 +170,16 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                         populateOutputEntries(decisionRule);
                     });
         }
+    }
+
+    private HasTypeRef getHasTypeRef(final HasExpression hasExpression, final DecisionTable dTable) {
+        if (hasExpression instanceof FunctionDefinition) {
+            final DMNModelInstrumentedBase parent = hasExpression.asDMNModelInstrumentedBase().getParent();
+            if (parent instanceof HasVariable) {
+                return ((HasVariable) parent).getVariable();
+            }
+        }
+        return TypeRefUtils.getTypeRefOfExpression(dTable, hasExpression);
     }
 
     private List<ClauseRequirement> generateOutputClauseRequirements(final Definitions definitions, final QName typeRef, final String name) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -154,14 +154,18 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
 
         if (outputClausesRequirement.isEmpty()) {
             dTable.getOutput().add(
-                    buildOutputClause(dTable, decisionRule, typeRef, name)
+                    buildOutputClause(dTable, typeRef, name)
             );
+            populateOutputEntries(decisionRule);
         } else {
             outputClausesRequirement
                     .stream()
                     .sorted(Comparator.comparing(outputClauseRequirement -> outputClauseRequirement.text))
-                    .map(outputClauseRequirement -> buildOutputClause(dTable, decisionRule, outputClauseRequirement.typeRef, outputClauseRequirement.text))
-                    .forEach(dTable.getOutput()::add);
+                    .map(outputClauseRequirement -> buildOutputClause(dTable, outputClauseRequirement.typeRef, outputClauseRequirement.text))
+                    .forEach(outputClause -> {
+                        dTable.getOutput().add(outputClause);
+                        populateOutputEntries(decisionRule);
+                    });
         }
     }
 
@@ -202,18 +206,19 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                         .noneMatch(typeRefIsCustom(typeRef));
     }
 
-    private OutputClause buildOutputClause(final DecisionTable dtable, final DecisionRule decisionRule, final QName typeRef, final String text) {
+    private OutputClause buildOutputClause(final DecisionTable dtable, final QName typeRef, final String text) {
         final OutputClause outputClause = new OutputClause();
         outputClause.setName(text);
         outputClause.setTypeRef(typeRef);
         outputClause.setParent(dtable);
+        return outputClause;
+    }
 
+    private void populateOutputEntries(final DecisionRule decisionRule) {
         final LiteralExpression decisionRuleLiteralExpression = new LiteralExpression();
         decisionRuleLiteralExpression.getText().setValue(DecisionTableDefaultValueUtilities.OUTPUT_CLAUSE_EXPRESSION_TEXT);
         decisionRuleLiteralExpression.setParent(decisionRule);
         decisionRule.getOutputEntry().add(decisionRuleLiteralExpression);
-
-        return outputClause;
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -327,7 +327,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
     }
 
     private Predicate<ItemDefinition> typeRefIsCustom(final QName typeRef) {
-        return itemDef -> itemDef.getName().getValue().equals(typeRef.getLocalPart());
+        return itemDef -> Objects.equals(itemDef.getName().getValue(), typeRef.getLocalPart());
     }
 
     private QName getQName(final ItemDefinition itemDefinition) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -71,6 +71,7 @@ import static org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType.AN
 @ApplicationScoped
 public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorModelEnricher<DecisionTable> {
 
+    private static final String DOT_CHAR = ".";
     private SessionManager sessionManager;
     private DMNGraphUtils dmnGraphUtils;
     private ItemDefinitionUtils itemDefinitionUtils;
@@ -192,7 +193,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
 
     private ClauseRequirement definitionToClauseRequirementMapper(final ItemDefinition itemDefinition) {
         final QName typeRef = itemDefinition.getTypeRef();
-        final String name = itemDefinition.getName().getValue();
+        final String name = computeClauseName(itemDefinition);
 
         if (Objects.isNull(typeRef) || typeRefDoesNotMatchAnyDefinition(typeRef)) {
             return new ClauseRequirement(name, ANY.asQName());
@@ -322,8 +323,20 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
             itemDefinition.getItemComponent()
                     .forEach(itemComponent -> addInputClauseRequirement(itemComponent,
                                                                         inputClauseRequirements,
-                                                                        text + "." + itemComponent.getName().getValue()));
+                                                                        text + DOT_CHAR + computeClauseName(itemComponent)));
         }
+    }
+
+    String computeClauseName(final ItemDefinition itemComponent) {
+        final String originalName = itemComponent.getName().getValue();
+        String nameWithoutModelRef = originalName;
+        if (itemComponent.isImported()) {
+            final int positionOfLastDot = originalName.lastIndexOf(DOT_CHAR) + 1;
+            if (positionOfLastDot > 0 && positionOfLastDot != originalName.length()) {
+                nameWithoutModelRef = originalName.substring(positionOfLastDot);
+            }
+        }
+        return nameWithoutModelRef;
     }
 
     private Predicate<ItemDefinition> typeRefIsCustom(final QName typeRef) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -358,10 +358,8 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
     }
 
     void enrichOutputClauses(final DecisionTable dtable) {
-        if (dtable.getParent() instanceof ContextEntry) {
+        if (dtable.getParent() instanceof ContextEntry && dtable.getOutput().isEmpty()) {
             final ContextEntry contextEntry = (ContextEntry) dtable.getParent();
-            dtable.getOutput().clear();
-            dtable.getRule().stream().forEach(decisionRule -> decisionRule.getOutputEntry().clear());
 
             final OutputClause outputClause = new OutputClause();
             outputClause.setName(getOutputClauseName(contextEntry).orElse(DecisionTableDefaultValueUtilities.getNewOutputClauseName(dtable)));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -71,6 +71,19 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
     private DMNGraphUtils dmnGraphUtils;
     private ItemDefinitionUtils itemDefinitionUtils;
 
+    public DecisionTableEditorDefinitionEnricher() {
+        //CDI proxy
+    }
+
+    @Inject
+    public DecisionTableEditorDefinitionEnricher(final SessionManager sessionManager,
+                                                 final DMNGraphUtils dmnGraphUtils,
+                                                 final ItemDefinitionUtils itemDefinitionUtils) {
+        this.sessionManager = sessionManager;
+        this.dmnGraphUtils = dmnGraphUtils;
+        this.itemDefinitionUtils = itemDefinitionUtils;
+    }
+
     @Override
     public void enrich(final Optional<String> nodeUUID,
                        final HasExpression hasExpression,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManager.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManager.java
@@ -105,7 +105,7 @@ public class DataTypeManager {
     }
 
     public DataTypeManager from(final ItemDefinition itemDefinition) {
-        final boolean isReadOnly = isImportedItemDefinition(itemDefinition);
+        final boolean isReadOnly = itemDefinition.isImported();
         return this
                 .newDataType(isReadOnly)
                 .withUUID()
@@ -117,10 +117,6 @@ public class DataTypeManager {
                 .withItemDefinitionCollection()
                 .withItemDefinitionSubDataTypes()
                 .withIndexedItemDefinition();
-    }
-
-    private boolean isImportedItemDefinition(final ItemDefinition itemDefinition) {
-        return itemDefinition.isAllowOnlyVisualChange();
     }
 
     public DataTypeManager from(final BuiltInType builtInType) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -624,7 +624,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         final ItemDefinition tPerson = mock(ItemDefinition.class);
         final ItemDefinition name = mock(ItemDefinition.class);
         final ItemDefinition age = mock(ItemDefinition.class);
-        final List<DecisionTableEditorDefinitionEnricher.InputClauseRequirement> inputClauseRequirements = new ArrayList<>();
+        final List<DecisionTableEditorDefinitionEnricher.ClauseRequirement> inputClauseRequirements = new ArrayList<>();
         final String inputData = "InputData";
         final DecisionTableEditorDefinitionEnricher enricher = new DecisionTableEditorDefinitionEnricher(null, null, itemDefinitionUtils);
 
@@ -647,12 +647,12 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         when(tPerson.getTypeRef()).thenReturn(null);
         when(tPerson.getItemComponent()).thenReturn(asList(name, age));
 
-        enricher.addInputClauseRequirement(tPerson, inputClauseRequirements, inputData);
+        enricher.addClauseRequirement(tPerson, inputClauseRequirements, inputData);
 
         assertEquals(2, inputClauseRequirements.size());
 
-        final DecisionTableEditorDefinitionEnricher.InputClauseRequirement inputClause1 = inputClauseRequirements.get(0);
-        final DecisionTableEditorDefinitionEnricher.InputClauseRequirement inputClause2 = inputClauseRequirements.get(1);
+        final DecisionTableEditorDefinitionEnricher.ClauseRequirement inputClause1 = inputClauseRequirements.get(0);
+        final DecisionTableEditorDefinitionEnricher.ClauseRequirement inputClause2 = inputClauseRequirements.get(1);
 
         assertEquals("InputData.name", inputClause1.text);
         assertEquals(STRING.getName(), inputClause1.typeRef.getLocalPart());
@@ -666,7 +666,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final ItemDefinition tPerson = mock(ItemDefinition.class);
         final String inputData = "InputData";
-        final List<DecisionTableEditorDefinitionEnricher.InputClauseRequirement> inputClauseRequirements = new ArrayList<>();
+        final List<DecisionTableEditorDefinitionEnricher.ClauseRequirement> inputClauseRequirements = new ArrayList<>();
         final ItemDefinitionUtils itemDefinitionUtils = new ItemDefinitionUtils(mock(DMNGraphUtils.class));
         final DecisionTableEditorDefinitionEnricher enricher = new DecisionTableEditorDefinitionEnricher(null, null, itemDefinitionUtils);
 
@@ -674,7 +674,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         when(tPerson.getTypeRef()).thenReturn(null);
         when(tPerson.getItemComponent()).thenReturn(emptyList());
 
-        enricher.addInputClauseRequirement(tPerson, inputClauseRequirements, inputData);
+        enricher.addClauseRequirement(tPerson, inputClauseRequirements, inputData);
 
         assertEquals(1, inputClauseRequirements.size());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -828,4 +828,44 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertEquals("InputData", inputClauseRequirements.get(0).text);
         assertEquals(TYPE_PERSON, inputClauseRequirements.get(0).typeRef.getLocalPart());
     }
+
+    @Test
+    public void testComputingClauseNameWithoutModelRef() {
+        final ItemDefinition itemComponent = new ItemDefinition();
+        itemComponent.setName(new Name("model.age"));
+        itemComponent.setAllowOnlyVisualChange(true);
+
+        assertEquals("age", new DecisionTableEditorDefinitionEnricher(null, null, null)
+                .computeClauseName(itemComponent));
+    }
+
+    @Test
+    public void testComputingClauseNameWithoutModelRefWhenModelRefHasMultipleLevels() {
+        final ItemDefinition itemComponent = new ItemDefinition();
+        itemComponent.setName(new Name("a.b.c.age"));
+        itemComponent.setAllowOnlyVisualChange(true);
+
+        assertEquals("age", new DecisionTableEditorDefinitionEnricher(null, null, null)
+                .computeClauseName(itemComponent));
+    }
+
+    @Test
+    public void testComputingClauseNameWithoutModelRefWhenModelRefAlreadyMissing() {
+        final ItemDefinition itemComponent = new ItemDefinition();
+        itemComponent.setName(new Name("age"));
+        itemComponent.setAllowOnlyVisualChange(true);
+
+        assertEquals("age", new DecisionTableEditorDefinitionEnricher(null, null, null)
+                .computeClauseName(itemComponent));
+    }
+
+    @Test
+    public void testComputingClauseNameWithoutModelRefWhenLocalPartEndsWithDot() {
+        final ItemDefinition itemComponent = new ItemDefinition();
+        itemComponent.setName(new Name("age."));
+        itemComponent.setAllowOnlyVisualChange(true);
+
+        assertEquals("age.", new DecisionTableEditorDefinitionEnricher(null, null, null)
+                .computeClauseName(itemComponent));
+    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -498,6 +498,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     @Test
     public void testModelEnrichmentWhenParentIsContextEntry() {
+        final Decision decision = mock(Decision.class);
         final String name = "context-entry";
         final Context context = new Context();
         final ContextEntry contextEntry = new ContextEntry();
@@ -508,6 +509,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         oModel.get().setParent(contextEntry);
         contextEntry.setParent(context);
         context.setParent(decision);
+        when(decision.asDMNModelInstrumentedBase()).thenReturn(contextEntry);
 
         definition.enrich(Optional.empty(), decision, oModel);
 
@@ -517,7 +519,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final List<OutputClause> output = model.getOutput();
         assertThat(output.size()).isEqualTo(1);
-        assertThat(output.get(0).getName()).isEqualTo(name);
+        assertThat(output.get(0).getName()).isEqualTo(DEFAULT_OUTPUT_NAME);
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
         assertStandardDecisionRuleEnrichment(model);
@@ -548,7 +550,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final List<OutputClause> output = model.getOutput();
         assertThat(output.size()).isEqualTo(1);
-        assertThat(output.get(0).getName()).isEqualTo(name);
+        assertThat(output.get(0).getName()).isEqualTo(DEFAULT_OUTPUT_NAME);
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
         assertStandardDecisionRuleEnrichment(model);
@@ -557,8 +559,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     @Test
     public void testModelEnrichmentWhenParentIsNestedContextEntryDefaultResult() {
+        final Decision decision = mock(Decision.class);
         final String name = "context-entry";
-
         final Context innerContext = new Context();
         final ContextEntry innerContextEntry = new ContextEntry();
         innerContext.getContextEntry().add(innerContextEntry);
@@ -572,6 +574,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         outerContext.setParent(decision);
 
         outerContextEntry.setVariable(new InformationItem(new Id(), new Description(), new Name(name), OUTPUT_DATA_QNAME));
+        when(decision.asDMNModelInstrumentedBase()).thenReturn(outerContextEntry);
 
         final Optional<DecisionTable> oModel = definition.getModelClass();
         oModel.get().setParent(innerContextEntry);
@@ -584,7 +587,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final List<OutputClause> output = model.getOutput();
         assertThat(output.size()).isEqualTo(1);
-        assertThat(output.get(0).getName()).isEqualTo(name);
+        assertThat(output.get(0).getName()).isEqualTo(DEFAULT_OUTPUT_NAME);
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
         assertStandardDecisionRuleEnrichment(model);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -80,6 +80,10 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
     private static final String DECISION_NAME_1 = "b-decision1";
 
+    private static final String DEFAULT_OUTPUT_NAME = "output-1";
+
+    private static final String TYPE_PERSON = "tPerson";
+
     private static final QName DECISION_QNAME_1 = STRING.asQName();
 
     private static final QName OUTPUT_DATA_QNAME = BuiltInType.DATE.asQName();
@@ -595,7 +599,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final List<OutputClause> output = model.getOutput();
         assertThat(output.size()).isEqualTo(1);
-        assertThat(output.get(0).getName()).isEqualTo("output-1");
+        assertThat(output.get(0).getName()).isEqualTo(DEFAULT_OUTPUT_NAME);
         assertThat(output.get(0).getTypeRef()).isEqualTo(OUTPUT_DATA_QNAME);
 
         assertStandardDecisionRuleEnrichment(model);
@@ -614,7 +618,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final List<OutputClause> output = model.getOutput();
         assertThat(output.size()).isEqualTo(1);
-        assertThat(output.get(0).getName()).isEqualTo("output-1");
+        assertThat(output.get(0).getName()).isEqualTo(DEFAULT_OUTPUT_NAME);
         assertThat(output.get(0).getTypeRef()).isEqualTo(BuiltInType.UNDEFINED.asQName());
 
         assertStandardDecisionRuleEnrichment(model);
@@ -635,7 +639,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         when(definitions.getItemDefinition()).thenReturn(Collections.singletonList(tPerson));
         when(hasExpression.asDMNModelInstrumentedBase()).thenReturn(decision);
         when(decision.getVariable()).thenReturn(informationItemPrimary);
-        when(informationItemPrimary.getTypeRef()).thenReturn(new QName("", "tPerson"));
+        when(informationItemPrimary.getTypeRef()).thenReturn(new QName("", TYPE_PERSON));
 
         final DecisionTableEditorDefinitionEnricher enricher = new DecisionTableEditorDefinitionEnricher(null, dmnGraphUtils, itemDefinitionUtils);
         final Optional<DecisionTable> oModel = definition.getModelClass();
@@ -664,9 +668,9 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         final Decision decision = mock(Decision.class);
         final InformationItemPrimary informationItemPrimary = mock(InformationItemPrimary.class);
         final ItemDefinition tPerson = mock(ItemDefinition.class);
-        final QName tPersonTypeRef = new QName("", "tPerson");
+        final QName tPersonTypeRef = new QName("", TYPE_PERSON);
 
-        when(tPerson.getName()).thenReturn(new Name("tPerson"));
+        when(tPerson.getName()).thenReturn(new Name(TYPE_PERSON));
         when(tPerson.getTypeRef()).thenReturn(tPersonTypeRef);
 
         when(dmnGraphUtils.getDefinitions()).thenReturn(definitions);
@@ -685,7 +689,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final OutputClause outputClause = outputClauses.get(0);
 
-        assertEquals("output-1", outputClause.getName());
+        assertEquals(DEFAULT_OUTPUT_NAME, outputClause.getName());
         assertEquals(tPersonTypeRef, outputClause.getTypeRef());
     }
 
@@ -731,7 +735,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         when(age.getTypeRef()).thenReturn(NUMBER.asQName());
         when(age.getItemComponent()).thenReturn(emptyList());
 
-        when(tPerson.getName()).thenReturn(new Name("tPerson"));
+        when(tPerson.getName()).thenReturn(new Name(TYPE_PERSON));
         when(tPerson.getTypeRef()).thenReturn(null);
         when(tPerson.getItemComponent()).thenReturn(asList(name, age));
         return tPerson;
@@ -746,7 +750,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         final ItemDefinitionUtils itemDefinitionUtils = new ItemDefinitionUtils(mock(DMNGraphUtils.class));
         final DecisionTableEditorDefinitionEnricher enricher = new DecisionTableEditorDefinitionEnricher(null, null, itemDefinitionUtils);
 
-        when(tPerson.getName()).thenReturn(new Name("tPerson"));
+        when(tPerson.getName()).thenReturn(new Name(TYPE_PERSON));
         when(tPerson.getTypeRef()).thenReturn(null);
         when(tPerson.getItemComponent()).thenReturn(emptyList());
 
@@ -755,6 +759,6 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         assertEquals(1, inputClauseRequirements.size());
 
         assertEquals("InputData", inputClauseRequirements.get(0).text);
-        assertEquals("tPerson", inputClauseRequirements.get(0).typeRef.getLocalPart());
+        assertEquals(TYPE_PERSON, inputClauseRequirements.get(0).typeRef.getLocalPart());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/DataTypeManagerTest.java
@@ -389,7 +389,7 @@ public class DataTypeManagerTest {
         when(itemDefinition.getName()).thenReturn(name);
         when(itemDefinition.getItemComponent()).thenReturn(new ArrayList<>());
         when(itemDefinition.getTypeRef()).thenReturn(typeRefMock);
-        when(itemDefinition.isAllowOnlyVisualChange()).thenReturn(true);
+        when(itemDefinition.isImported()).thenReturn(true);
         when(itemDefinitionUtils.getConstraintText(any())).thenCallRealMethod();
         when(itemDefinitionUtils.findByName(any())).thenReturn(Optional.empty());
 


### PR DESCRIPTION
*Please refer to:* https://issues.redhat.com/browse/DROOLS-3685

*Improvement description:* Creating Decision Table, sub-columns should be auto-created for structured type

*Proposed solution:* Changing `DecisionTableEditorDefinitionEnricher.java` in order to consider Decision's type for the output columns creation

*Outcome:*

Custom data type:
![image](https://user-images.githubusercontent.com/22591802/83349900-6cf96080-a338-11ea-8d44-143485655c2b.png)
Decision type:
![image](https://user-images.githubusercontent.com/22591802/83258972-8b841e00-a1b7-11ea-9b28-13bc0bf886c0.png)
Decision table:
![image](https://user-images.githubusercontent.com/22591802/83349903-7682c880-a338-11ea-8392-c84d8e6b1a1e.png)