### PR TITLE
JBPM-9176 remove Powermock dependency from designer and stunner framework

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -279,6 +279,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
@@ -243,6 +243,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/pom.xml
@@ -166,18 +166,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -192,16 +192,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.spec.javax.xml.bind</groupId>
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommandTest.java
@@ -40,8 +40,8 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RedoSessionCommandTest extends BaseSessionCommandKeyboardTest {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/integration/backend/service/IntegrationServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/integration/backend/service/IntegrationServiceImplTest.java
@@ -72,7 +72,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IntegrationServiceImplTest {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/pom.xml
@@ -144,18 +144,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/ProjectDiagramServiceControllerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/src/test/java/org/kie/workbench/common/stunner/project/backend/service/ProjectDiagramServiceControllerTest.java
@@ -27,6 +27,7 @@ import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.backend.service.KieServiceOverviewLoader;
 import org.kie.workbench.common.services.shared.project.KieModule;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
@@ -38,6 +39,7 @@ import org.kie.workbench.common.stunner.project.diagram.ProjectDiagram;
 import org.kie.workbench.common.stunner.project.diagram.ProjectMetadata;
 import org.kie.workbench.common.stunner.project.diagram.impl.ProjectDiagramImpl;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.java.nio.base.options.CommentedOption;
@@ -54,6 +56,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ProjectDiagramServiceControllerTest
         extends AbstractVFSDiagramServiceTest<ProjectMetadata, ProjectDiagram> {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/DataObjectTypeEditorFieldProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/DataObjectTypeEditorFieldProviderTest.java
@@ -18,21 +18,16 @@ package org.kie.workbench.common.stunner.bpmn.forms.service.fieldProviders;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.kie.workbench.common.forms.model.TypeInfo;
 import org.kie.workbench.common.stunner.bpmn.forms.model.DataObjectTypeFieldDefinition;
 import org.kie.workbench.common.stunner.bpmn.forms.model.DataObjectTypeFieldType;
-import org.mockito.Mock;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.spy;
 
 public class DataObjectTypeEditorFieldProviderTest {
 
     private DataObjectTypeEditorFieldProvider dataObjectTypeEditorFieldProvider;
-
-    @Mock
-    private TypeInfo typeInfo;
 
     @Before
     public void setUp() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/GenericServiceTaskEditorFieldProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/GenericServiceTaskEditorFieldProviderTest.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.stunner.bpmn.forms.model.GenericServiceTaskEdito
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.spy;
 
 public class GenericServiceTaskEditorFieldProviderTest {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/MetaDataEditorFieldProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/MetaDataEditorFieldProviderTest.java
@@ -23,7 +23,7 @@ import org.kie.workbench.common.stunner.bpmn.forms.model.MetaDataEditorFieldType
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.spy;
 
 public class MetaDataEditorFieldProviderTest {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/NotificationsEditorFieldProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/NotificationsEditorFieldProviderTest.java
@@ -26,7 +26,7 @@ import org.mockito.Mock;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.spy;
 
 public class NotificationsEditorFieldProviderTest {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/ProcessTypeProviderFieldProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/ProcessTypeProviderFieldProviderTest.java
@@ -23,7 +23,7 @@ import org.kie.workbench.common.stunner.bpmn.forms.model.ProcessTypeEditorFieldT
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.spy;
 
 public class ProcessTypeProviderFieldProviderTest {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/ReassignmentsEditorFieldProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/forms/service/fieldProviders/ReassignmentsEditorFieldProviderTest.java
@@ -24,7 +24,7 @@ import org.kie.workbench.common.stunner.bpmn.forms.model.ReassignmentsEditorFiel
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.spy;
 
 public class ReassignmentsEditorFieldProviderTest {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
@@ -345,18 +345,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/arifacts/ArtifactsConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/arifacts/ArtifactsConverterTest.java
@@ -59,10 +59,6 @@ public class ArtifactsConverterTest {
     @Mock
     private View<DataObject> dataObjectView;
 
-    private TextAnnotation textAnnotation;
-
-    private DataObject dataObject;
-
     @Mock
     private TextAnnotationPropertyWriter textAnnotationWriter;
 
@@ -71,7 +67,7 @@ public class ArtifactsConverterTest {
 
     @Test
     public void toTextAnnotationElement() {
-        textAnnotation = new TextAnnotation();
+        TextAnnotation textAnnotation = new TextAnnotation();
         textAnnotation.getGeneral().getDocumentation().setValue(DOC);
         textAnnotation.getGeneral().getName().setValue(NAME);
 
@@ -80,7 +76,6 @@ public class ArtifactsConverterTest {
 
         when(textAnnotationView.getDefinition()).thenReturn(textAnnotation);
         when(propertyWriterFactory.of(any(org.eclipse.bpmn2.TextAnnotation.class))).thenReturn(textAnnotationWriter);
-
 
         artifactsConverter = new ArtifactsConverter(propertyWriterFactory);
 
@@ -93,7 +88,7 @@ public class ArtifactsConverterTest {
 
     @Test
     public void toDataObjectElement() {
-        dataObject = new DataObject();
+        DataObject dataObject = new DataObject();
         dataObject.getGeneral().getDocumentation().setValue(DOC);
         dataObject.setName(new Name(NAME));
         dataObject.setType(new DataObjectType(new DataObjectTypeValue(NAME)));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/DataObjectPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/DataObjectPropertyWriterTest.java
@@ -31,7 +31,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DataObjectPropertyWriterTest {
@@ -40,7 +40,7 @@ public class DataObjectPropertyWriterTest {
 
     private DataObjectPropertyWriter tested;
 
-    private DataObjectReference reference = bpmn2.createDataObjectReference();
+    private final DataObjectReference reference = bpmn2.createDataObjectReference();
 
     @Mock
     private VariableScope variableScope;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/artifacts/ArtifactsConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/artifacts/ArtifactsConverterTest.java
@@ -38,7 +38,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ArtifactsConverterTest {
@@ -83,7 +83,6 @@ public class ArtifactsConverterTest {
     @Test
     public void convertTextAnnotation() {
         TextAnnotation element = Bpmn2Factory.eINSTANCE.createTextAnnotation();
-
 
         when(typedFactoryManager.newNode(anyString(),
                                          eq(org.kie.workbench.common.stunner.bpmn.definition.TextAnnotation.class))).thenReturn(nodeTextAnnotation);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/AssociationPropertyReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/AssociationPropertyReaderTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties;
 
-import java.util.List;
-
 import org.eclipse.bpmn2.Association;
 import org.eclipse.bpmn2.AssociationDirection;
 import org.eclipse.bpmn2.BaseElement;
@@ -28,23 +26,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.DefinitionResolver;
-import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.properties.util.PropertyReaderUtils;
 import org.kie.workbench.common.stunner.bpmn.definition.DirectionalAssociation;
 import org.kie.workbench.common.stunner.bpmn.definition.NonDirectionalAssociation;
-import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(PropertyReaderUtils.class)
+@RunWith(MockitoJUnitRunner.class)
 public class AssociationPropertyReaderTest {
 
     private static String SOURCE_ID = "SOURCE_ID";
@@ -104,30 +95,6 @@ public class AssociationPropertyReaderTest {
     }
 
     @Test
-    public void testGetSourceConnection() {
-        mockStatic(PropertyReaderUtils.class);
-        PowerMockito.when(PropertyReaderUtils.getSourcePosition(definitionResolver, ASSOCIATION_ID, SOURCE_ID)).thenReturn(position);
-        boolean arbitraryBoolean = true;
-        PowerMockito.when(PropertyReaderUtils.isAutoConnectionSource(association)).thenReturn(arbitraryBoolean);
-
-        Connection result = propertyReader.getSourceConnection();
-        assertEquals(X, result.getLocation().getX(), 0);
-        assertEquals(Y, result.getLocation().getY(), 0);
-    }
-
-    @Test
-    public void testGetTargetConnection() {
-        mockStatic(PropertyReaderUtils.class);
-        PowerMockito.when(PropertyReaderUtils.getTargetPosition(definitionResolver, ASSOCIATION_ID, TARGET_ID)).thenReturn(position);
-        boolean arbitraryBoolean = true;
-        PowerMockito.when(PropertyReaderUtils.isAutoConnectionSource(association)).thenReturn(arbitraryBoolean);
-
-        Connection result = propertyReader.getTargetConnection();
-        assertEquals(X, result.getLocation().getX(), 0);
-        assertEquals(Y, result.getLocation().getY(), 0);
-    }
-
-    @Test
     public void testGetAssociationByDirection() {
         final Association association = Bpmn2Factory.eINSTANCE.createAssociation();
 
@@ -143,14 +110,5 @@ public class AssociationPropertyReaderTest {
         //one direction
         association.setAssociationDirection(AssociationDirection.ONE);
         assertEquals(DirectionalAssociation.class, propertyReader.getAssociationByDirection());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testGetControlPoints() {
-        List<Point2D> controlPoints = mock(List.class);
-        mockStatic(PropertyReaderUtils.class);
-        PowerMockito.when(PropertyReaderUtils.getControlPoints(definitionResolver, ASSOCIATION_ID)).thenReturn(controlPoints);
-        assertEquals(controlPoints, propertyReader.getControlPoints());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/DataObjectPropertyReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/DataObjectPropertyReaderTest.java
@@ -37,7 +37,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
 import static org.mockito.Mockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DataObjectPropertyReaderTest {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -325,6 +325,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <!-- BPMN requires additional Monaco editor language libraries. -->

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/widget/ReassignmentEditorWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/widget/ReassignmentEditorWidgetViewImpl.java
@@ -132,7 +132,7 @@ public class ReassignmentEditorWidgetViewImpl extends Composite implements Reass
         this.multipleSelectorInputGroups.init(groupsLiveSearchService, multipleLiveSearchSelectionHandlerGroups);
     }
 
-    void initTypeSelector() {
+    protected void initTypeSelector() {
         notStarted.setValue(ReassignmentType.NotStartedReassign.getAlias());
         notStarted.setText(ReassignmentType.NotStartedReassign.getType());
         notCompleted.setText(ReassignmentType.NotCompletedReassign.getType());
@@ -201,7 +201,7 @@ public class ReassignmentEditorWidgetViewImpl extends Composite implements Reass
         okButton.disabled = readOnly;
     }
 
-    void ok() {
+    protected void ok() {
         // TODO looks like errai data binder doenst support liststore widgets.
         current.setUsers(multipleLiveSearchSelectionHandlerUsers.getSelectedValues());
         current.setGroups(multipleLiveSearchSelectionHandlerGroups.getSelectedValues());
@@ -226,7 +226,7 @@ public class ReassignmentEditorWidgetViewImpl extends Composite implements Reass
         hide();
     }
 
-    void hide() {
+    protected void hide() {
         //clear widgets and set default values
         multipleSelectorInputUsers.setValue(Collections.EMPTY_LIST);
         multipleSelectorInputGroups.setValue(Collections.EMPTY_LIST);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/URL.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/URL.java
@@ -18,7 +18,7 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.util;
 
 /**
  * This class is a proxy for a GWT static class {@link com.google.gwt.http.client.URL()} with native method to make it
- * testable without PowerMock dependency.
+ * testable without static mocking dependency.
  */
 public class URL {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariableProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/VariableProviderTest.java
@@ -48,8 +48,8 @@ import static org.jgroups.util.Util.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
 public class VariableProviderTest
         extends AbstractProcessFilteredNodeProviderBaseTest {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidgetTest.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Assignmen
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentData;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentParser;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDefinition;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
@@ -65,7 +66,8 @@ import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.uberfire.commons.data.Pair;
 
 import static org.junit.Assert.assertEquals;
@@ -79,7 +81,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(StringUtils.class)
 public class AssignmentsEditorWidgetTest extends AssignmentBaseTest {
 
     private static final String TASK_NAME = "Get Address";
@@ -94,8 +97,8 @@ public class AssignmentsEditorWidgetTest extends AssignmentBaseTest {
     public static final String ASSIGNMENTS_SINGLE_OUTPUT = "[dout]output1->employee";
     public static final String ASSIGNMENTS_MULTIPLE = "[din]employee->input1,[din]input2=ab%7Ccd%7Cef,[din]input3=yes,[din]input4=%22Hello%22+then+%22Goodbye%22,[dout]output1->employee,[dout]output2->reason";
     public static final List<String> DATATYPES = new ArrayList<>(Arrays.asList("myorg.myproject1.Cardboard",
-                                                                               "yourorg.materials.Paper",
-                                                                               "org.documents.Articles"));
+                                                                                     "yourorg.materials.Paper",
+                                                                                     "org.documents.Articles"));
     public static final String FORMATTED_DATATYPES = "Articles [org.documents]:org.documents.Articles,Cardboard [myorg.myproject1]:myorg.myproject1.Cardboard,Paper [yourorg.materials]:yourorg.materials.Paper";
 
     public static final String SIMPLE_DATA_TYPES = "Boolean:Boolean,Float:Float,Integer:Integer,Object:Object,String:String";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentsEditorWidgetTest.java
@@ -34,7 +34,6 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Assignmen
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentData;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentParser;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
-import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDefinition;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BusinessRuleTask;
@@ -66,8 +65,7 @@ import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.commons.data.Pair;
 
 import static org.junit.Assert.assertEquals;
@@ -81,8 +79,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(StringUtils.class)
+@RunWith(MockitoJUnitRunner.class)
 public class AssignmentsEditorWidgetTest extends AssignmentBaseTest {
 
     private static final String TASK_NAME = "Get Address";
@@ -96,9 +93,9 @@ public class AssignmentsEditorWidgetTest extends AssignmentBaseTest {
     public static final String ASSIGNMENTS_SINGLE_INPUT = "[din]employee->input1";
     public static final String ASSIGNMENTS_SINGLE_OUTPUT = "[dout]output1->employee";
     public static final String ASSIGNMENTS_MULTIPLE = "[din]employee->input1,[din]input2=ab%7Ccd%7Cef,[din]input3=yes,[din]input4=%22Hello%22+then+%22Goodbye%22,[dout]output1->employee,[dout]output2->reason";
-    public static final List<String> DATATYPES = new ArrayList<String>(Arrays.asList("myorg.myproject1.Cardboard",
-                                                                                     "yourorg.materials.Paper",
-                                                                                     "org.documents.Articles"));
+    public static final List<String> DATATYPES = new ArrayList<>(Arrays.asList("myorg.myproject1.Cardboard",
+                                                                               "yourorg.materials.Paper",
+                                                                               "org.documents.Articles"));
     public static final String FORMATTED_DATATYPES = "Articles [org.documents]:org.documents.Articles,Cardboard [myorg.myproject1]:myorg.myproject1.Cardboard,Paper [yourorg.materials]:yourorg.materials.Paper";
 
     public static final String SIMPLE_DATA_TYPES = "Boolean:Boolean,Float:Float,Integer:Integer,Object:Object,String:String";

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
@@ -94,7 +94,7 @@ public class ConditionalComboBoxFieldRendererTest {
     }
 
     @Test
-    public void init() throws Exception {
+    public void init() {
         resetMocks();
 
         EmbeddedSubprocess embeddedSubprocess = new EmbeddedSubprocess();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentBaseTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentBaseTest.java
@@ -62,7 +62,7 @@ public class AssignmentBaseTest {
     }
 
     /**
-     * Implementation of urlEncode for PowerMocked StringUtils
+     * Implementation of urlEncode for client side StringUtils
      * @param s
      * @return
      */
@@ -79,7 +79,7 @@ public class AssignmentBaseTest {
     }
 
     /**
-     * Implementation of urlDecode for PowerMocked StringUtils
+     * Implementation of urlDecode for client side StringUtils
      * @param s
      * @return
      */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/NotificationRowTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/NotificationRowTest.java
@@ -25,8 +25,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NotificationRowTest {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/ReassignmentRowTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/ReassignmentRowTest.java
@@ -25,8 +25,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReassignmentRowTest {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetTest.java
@@ -45,7 +45,7 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Notificat
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.notificationsEditor.event.NotificationEvent;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ReflectionUtilsTest;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.dropdown.LiveSearchDropDown;
 import org.uberfire.ext.widgets.common.client.dropdown.LiveSearchDropDownView;
@@ -60,14 +60,14 @@ import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.No
 import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.notificationsEditor.validation.ExpirationTypeOracle.PERIOD;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class NotificationEditorWidgetTest extends ReflectionUtilsTest {
 
     private NotificationEditorWidget presenter;
@@ -140,9 +140,7 @@ public class NotificationEditorWidgetTest extends ReflectionUtilsTest {
         multipleLiveSearchSelectionHandlerGroups = mock(MultipleLiveSearchSelectionHandler.class);
         notCompletedInput = mock(HTMLInputElement.class);
         notStartedInput = mock(HTMLInputElement.class);
-        incorrectEmail = mock(ParagraphElement.class);
 
-        doNothing().when(view).markEmailsAsCorrect();
         doNothing().when(modal).hide();
         doNothing().when(modal).show();
 
@@ -195,6 +193,7 @@ public class NotificationEditorWidgetTest extends ReflectionUtilsTest {
         doCallRealMethod().when(view).init(any(NotificationEditorWidgetView.Presenter.class));
 
         when(translationService.getValue(any(String.class))).thenReturn("Notification");
+
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetTest.java
@@ -45,7 +45,7 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Notificat
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.notificationsEditor.event.NotificationEvent;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ReflectionUtilsTest;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.dropdown.LiveSearchDropDown;
 import org.uberfire.ext.widgets.common.client.dropdown.LiveSearchDropDownView;
@@ -60,14 +60,14 @@ import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.No
 import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.notificationsEditor.validation.ExpirationTypeOracle.PERIOD;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.mock;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
 public class NotificationEditorWidgetTest extends ReflectionUtilsTest {
 
     private NotificationEditorWidget presenter;
@@ -140,7 +140,9 @@ public class NotificationEditorWidgetTest extends ReflectionUtilsTest {
         multipleLiveSearchSelectionHandlerGroups = mock(MultipleLiveSearchSelectionHandler.class);
         notCompletedInput = mock(HTMLInputElement.class);
         notStartedInput = mock(HTMLInputElement.class);
+        incorrectEmail = mock(ParagraphElement.class);
 
+        doNothing().when(view).markEmailsAsCorrect();
         doNothing().when(modal).hide();
         doNothing().when(modal).show();
 
@@ -193,7 +195,6 @@ public class NotificationEditorWidgetTest extends ReflectionUtilsTest {
         doCallRealMethod().when(view).init(any(NotificationEditorWidgetView.Presenter.class));
 
         when(translationService.getValue(any(String.class))).thenReturn("Notification");
-
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetViewImplTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Expiration;
 
-import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
+import static org.mockito.Mockito.doCallRealMethod;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class NotificationEditorWidgetViewImplTest extends GWTTestCase {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/widget/ReassignmentEditorWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/reassignmentsEditor/widget/ReassignmentEditorWidgetTest.java
@@ -39,18 +39,18 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Reassignm
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.reassignmentsEditor.event.ReassignmentEvent;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ReflectionUtilsTest;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.dropdown.LiveSearchDropDownView;
 import org.uberfire.ext.widgets.common.client.dropdown.MultipleLiveSearchSelectionHandler;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ReassignmentEditorWidgetTest extends ReflectionUtilsTest {
 
     @GwtMock

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorFieldRendererTest.java
@@ -29,10 +29,10 @@ import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GenericServiceTaskEditorFieldRendererTest extends ReflectionUtilsTest {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/serviceEditor/GenericServiceTaskEditorWidgetTest.java
@@ -38,10 +38,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @WithClassesToStub({Select.class, OptionsCollection.class})
 @RunWith(GwtMockitoTestRunner.class)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -123,16 +123,6 @@
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-client-common</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.powermock</groupId>
-          <artifactId>powermock-api-mockito</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.powermock</groupId>
-          <artifactId>powermock-module-junit4</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
@@ -224,18 +224,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/TestUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/TestUtils.java
@@ -43,7 +43,7 @@ import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 public class TestUtils {
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/DataObjectPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/DataObjectPropertyWriterTest.java
@@ -31,7 +31,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories.bpmn2;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DataObjectPropertyWriterTest {
@@ -40,7 +40,7 @@ public class DataObjectPropertyWriterTest {
 
     private DataObjectPropertyWriter tested;
 
-    private DataObjectReference reference = bpmn2.createDataObjectReference();
+    private final DataObjectReference reference = bpmn2.createDataObjectReference();
 
     @Mock
     private VariableScope variableScope;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/SubProcessConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/SubProcessConverterTest.java
@@ -39,7 +39,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories.bpmn2;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 // TODO: Kogito
 @Ignore

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/AssociationPropertyReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/AssociationPropertyReaderTest.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.properties;
 
-import java.util.List;
-
 import org.eclipse.bpmn2.Association;
 import org.eclipse.bpmn2.AssociationDirection;
 import org.eclipse.bpmn2.BaseElement;
@@ -28,34 +26,26 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.DefinitionResolver;
-import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.properties.util.PropertyReaderUtils;
 import org.kie.workbench.common.stunner.bpmn.definition.DirectionalAssociation;
 import org.kie.workbench.common.stunner.bpmn.definition.NonDirectionalAssociation;
-import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
-import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(PropertyReaderUtils.class)
+@RunWith(MockitoJUnitRunner.class)
 public class AssociationPropertyReaderTest {
 
-    private static String SOURCE_ID = "SOURCE_ID";
+    private final static String SOURCE_ID = "SOURCE_ID";
 
-    private static String TARGET_ID = "TARGET_ID";
+    private final static String TARGET_ID = "TARGET_ID";
 
-    private static String ASSOCIATION_ID = "ASSOCIATION_ID";
+    private final static String ASSOCIATION_ID = "ASSOCIATION_ID";
 
-    private static double X = 1;
+    private final static double X = 1;
 
-    private static double Y = 2;
+    private final static double Y = 2;
 
     @Mock
     private DefinitionResolver definitionResolver;
@@ -75,14 +65,11 @@ public class AssociationPropertyReaderTest {
     @Mock
     private BPMNPlane bpmnLane;
 
-    private Point2D position;
-
     @Mock
     private AssociationPropertyReader propertyReader;
 
     @Before
     public void setUp() {
-        position = Point2D.create(X, Y);
         when(bpmnDiagram.getPlane()).thenReturn(bpmnLane);
         when(association.getId()).thenReturn(ASSOCIATION_ID);
         when(sourceRef.getId()).thenReturn(SOURCE_ID);
@@ -104,30 +91,6 @@ public class AssociationPropertyReaderTest {
     }
 
     @Test
-    public void testGetSourceConnection() {
-        mockStatic(PropertyReaderUtils.class);
-        PowerMockito.when(PropertyReaderUtils.getSourcePosition(definitionResolver, ASSOCIATION_ID, SOURCE_ID)).thenReturn(position);
-        boolean arbitraryBoolean = true;
-        PowerMockito.when(PropertyReaderUtils.isAutoConnectionSource(association)).thenReturn(arbitraryBoolean);
-
-        Connection result = propertyReader.getSourceConnection();
-        assertEquals(X, result.getLocation().getX(), 0);
-        assertEquals(Y, result.getLocation().getY(), 0);
-    }
-
-    @Test
-    public void testGetTargetConnection() {
-        mockStatic(PropertyReaderUtils.class);
-        PowerMockito.when(PropertyReaderUtils.getTargetPosition(definitionResolver, ASSOCIATION_ID, TARGET_ID)).thenReturn(position);
-        boolean arbitraryBoolean = true;
-        PowerMockito.when(PropertyReaderUtils.isAutoConnectionSource(association)).thenReturn(arbitraryBoolean);
-
-        Connection result = propertyReader.getTargetConnection();
-        assertEquals(X, result.getLocation().getX(), 0);
-        assertEquals(Y, result.getLocation().getY(), 0);
-    }
-
-    @Test
     public void testGetAssociationByDirection() {
         final Association association = Bpmn2Factory.eINSTANCE.createAssociation();
 
@@ -143,14 +106,5 @@ public class AssociationPropertyReaderTest {
         //one direction
         association.setAssociationDirection(AssociationDirection.ONE);
         assertEquals(DirectionalAssociation.class, propertyReader.getAssociationByDirection());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testGetControlPoints() {
-        List<Point2D> controlPoints = mock(List.class);
-        mockStatic(PropertyReaderUtils.class);
-        PowerMockito.when(PropertyReaderUtils.getControlPoints(definitionResolver, ASSOCIATION_ID)).thenReturn(controlPoints);
-        assertEquals(controlPoints, propertyReader.getControlPoints());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/sequenceflows/SequenceFlowConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/sequenceflows/SequenceFlowConverterTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SequenceFlowConverterTest {


### PR DESCRIPTION
Hi @romartin, @LuboTerifaj, @domhanak,

there are changes with Powermock removals. I tried to do it as gentle as possible, but still think it is OK to postpone merge of this PR after closest release cut.

But it is ready for review from code point of view. Full Downstream Build binaries can wait because we have only 10 builds allowed now for kie-wb-common Full Downstream and there are more urgent PRs available now (see [BXMSPROD-803](https://issues.redhat.com/browse/BXMSPROD-803) for more details).

Anyway let's check my changes on the code level and fix all your suggestions before start Full Downstream.

Thank you!