### PR TITLE
KOGITO-513 - Do not open editor when .bpmn file can't be loaded

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -345,7 +345,9 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
     }
 
     void flush() {
-        ClientSession session = getSessionPresenter().getInstance();
-        formsFlushManager.flush(session, formElementUUID);
+        if (getSessionPresenter() != null) {
+            ClientSession session = getSessionPresenter().getInstance();
+            formsFlushManager.flush(session, formElementUUID);
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/webapp/index.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/webapp/index.html
@@ -37,9 +37,10 @@
 <script src="org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor/ace/ace.js" type="text/javascript" charset="utf-8"></script>
 <!-- Get .js files for any needed ACE modes and themes -->
 <script src="org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor/ace/theme-chrome.js" type="text/javascript" charset="utf-8"></script>
+<script src="org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor/ace/mode-xml.js" type="text/javascript" charset="utf-8"></script>
+<script src="org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor/ace/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
 
 </body>
 </html>
 
 
-<script src="org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor/ace/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramService.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.DiagramImpl;
+import org.kie.workbench.common.stunner.core.diagram.DiagramParsingException;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.diagram.MetadataImpl;
 import org.kie.workbench.common.stunner.core.graph.Graph;
@@ -121,7 +122,7 @@ public class BPMNClientDiagramService extends AbstractKogitoClientDiagramService
                     return promises.resolve();
                 })
                 .catch_((Promise.CatchOnRejectedCallbackFn<Collection<WorkItemDefinition>>) error -> {
-                    callback.onError(new ClientRuntimeError(error.toString()));
+                    callback.onError(new ClientRuntimeError(new DiagramParsingException(metadata, xml)));
                     return promises.resolve();
                 });
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientDiagramServiceTest.java
@@ -57,6 +57,7 @@ import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.DiagramImpl;
+import org.kie.workbench.common.stunner.core.diagram.DiagramParsingException;
 import org.kie.workbench.common.stunner.core.diagram.MetadataImpl;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -412,7 +413,7 @@ public class BPMNClientDiagramServiceTest {
         verify(callback, times(1)).onError(errorArgumentCaptor.capture());
         ClientRuntimeError error = errorArgumentCaptor.getValue();
 
-        assertTrue(error.getMessage().endsWith(BPMNClientDiagramService.NO_DIAGRAM_MESSAGE));
+        assertTrue(error.getThrowable() instanceof DiagramParsingException);
     }
 
     @Test


### PR DESCRIPTION
Hi @romartin, @domhanak,

To test this PR just put `&` sign inside of any XML attribute value. Only Kogito code was modified so no need to test Business Central. 

![Screenshot from 2020-06-16 14-23-15](https://user-images.githubusercontent.com/1477262/84776325-76452700-afe0-11ea-910f-997dc93754b2.png)
![Screenshot from 2020-06-16 14-25-27](https://user-images.githubusercontent.com/1477262/84776332-780eea80-afe0-11ea-9bc0-f096416ac9dd.png)


VSIX can be downloaded here: https://drive.google.com/drive/u/0/folders/1UzvsBmC4PVaxaIFdmnetQjwRizJJuOjl

PR is ready for review, thank you!

<details>
  <summary>Technical details</summary>
  <pre>There are two parts fixed: BPMN Editor itself and HTML where editor is embedded. 
* Kogito-Stunner has generic AbstractEditor which already support ACE Editor but only for `DiagramParsingException`, so I fixed it in BPMN Editor and ACE editor was called.
* Second issue was that we need to link ACE editor in HTML separately from the editor itself, that's why there is HTML fix as well.

Also, looks like there are two different ways how ACE Editor injected to the HTML. For Kogito Showcase it is `index.html` from `kie-wb-common-stunner-bpmn-kogito-runtime` module but for VS Code/Github ACE editor configureed here: https://github.com/kiegroup/kogito-tooling/blob/master/packages/kie-bc-editors/src/GwtEditorRoutes.ts#L58

I fixed showcase one, and it was already good on VS Code plugin side. </pre>
</details>