### PR TITLE
JBPM-9182 / JBPM-9199 - Variable related issues

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/elements/GlobalVariablesElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/elements/GlobalVariablesElement.java
@@ -49,7 +49,7 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
         setStringValue(element, value);
     }
 
-    protected Optional<String> getStringValue(BaseElement element) {
+    private Optional<String> getStringValue(BaseElement element) {
         List<ExtensionAttributeValue> extValues = element.getExtensionValues();
 
         List<FeatureMap> extElementsList = extValues.stream()
@@ -68,19 +68,19 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
         return Optional.ofNullable(globalVariables);
     }
 
-    protected void setStringValue(BaseElement element, String value) {
+    private void setStringValue(BaseElement element, String value) {
         Stream.of(value.split(","))
-                .map(this::extensionOf)
+                .map(GlobalVariablesElement::extensionOf)
                 .forEach(getExtensionElements(element)::add);
     }
 
-    protected FeatureMap.Entry extensionOf(String variable) {
+    static FeatureMap.Entry extensionOf(String variable) {
         return new EStructuralFeatureImpl.SimpleFeatureMapEntry(
                 (EStructuralFeature.Internal) DOCUMENT_ROOT__GLOBAL,
                 globalTypeDataOf(variable));
     }
 
-    protected GlobalType globalTypeDataOf(String variable) {
+    static GlobalType globalTypeDataOf(String variable) {
         GlobalType globalType = DroolsFactory.eINSTANCE.createGlobalType();
         String[] properties = variable.split(":", -1);
         globalType.setIdentifier(properties[0]);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/elements/GlobalVariablesElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/elements/GlobalVariablesElement.java
@@ -49,13 +49,7 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
         setStringValue(element, value);
     }
 
-    private void setStringValue(BaseElement element, String value) {
-        Stream.of(value.split(","))
-                .map(this::extensionOf)
-                .forEach(getExtensionElements(element)::add);
-    }
-
-    private Optional<String> getStringValue(BaseElement element) {
+    protected Optional<String> getStringValue(BaseElement element) {
         List<ExtensionAttributeValue> extValues = element.getExtensionValues();
 
         List<FeatureMap> extElementsList = extValues.stream()
@@ -68,14 +62,16 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
                 .collect(Collectors.toList());
 
         String globalVariables = globalExtensions.stream()
-                .filter(globalType -> globalType.getIdentifier() != null &&
-                        globalType.getIdentifier().length() > 0 &&
-                        globalType.getType() != null &&
-                        globalType.getType().length() > 0)
                 .map(globalType -> globalType.getIdentifier() + ":" + globalType.getType())
                 .collect(Collectors.joining(","));
 
         return Optional.ofNullable(globalVariables);
+    }
+
+    protected void setStringValue(BaseElement element, String value) {
+        Stream.of(value.split(","))
+                .map(this::extensionOf)
+                .forEach(getExtensionElements(element)::add);
     }
 
     protected FeatureMap.Entry extensionOf(String variable) {
@@ -86,7 +82,7 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
 
     protected GlobalType globalTypeDataOf(String variable) {
         GlobalType globalType = DroolsFactory.eINSTANCE.createGlobalType();
-        String[] properties = variable.split(":");
+        String[] properties = variable.split(":", -1);
         globalType.setIdentifier(properties[0]);
         globalType.setType(properties[1]);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils;
+
 public class Variable {
 
     static final String DIVIDER = ":";
@@ -195,15 +197,15 @@ public class Variable {
             return false;
         }
 
-        if (getName() != null && !getName().isEmpty() ? !getName().equals(variable.getName()) : variable.getName() != null && !variable.getName().isEmpty()) {
+        if (!StringUtils.isEmpty(getName()) ? !getName().equals(variable.getName()) : !StringUtils.isEmpty(variable.getName())) {
             return false;
         }
 
-        if (getDataType() != null && !getDataType().isEmpty() ? !getDataType().equals(variable.getDataType()) : variable.getDataType() != null && !variable.getDataType().isEmpty()) {
+        if (!StringUtils.isEmpty(getDataType()) ? !getDataType().equals(variable.getDataType()) : !StringUtils.isEmpty(variable.getDataType())) {
             return false;
         }
 
-        if (getCustomDataType() != null && !getCustomDataType().isEmpty() ? !getCustomDataType().equals(variable.getCustomDataType()) : variable.getCustomDataType() != null && !variable.getCustomDataType().isEmpty()) {
+        if (!StringUtils.isEmpty(getCustomDataType()) ? !getCustomDataType().equals(variable.getCustomDataType()) : !StringUtils.isEmpty(variable.getCustomDataType())) {
             return false;
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/Variable.java
@@ -143,29 +143,25 @@ public class Variable {
                                        final List<String> dataTypes) {
         Variable var = new Variable(variableType);
         String[] varParts = s.split(DIVIDER, -1);
-        if (varParts.length == 3) {
-            String name = varParts[0];
-            if (!name.isEmpty()) {
-                var.setName(name);
-                var.tags = new ArrayList<>();
 
-                String dataType = varParts[1];
-                if (!dataType.isEmpty()) {
-                    if (dataTypes != null && dataTypes.contains(dataType)) {
-                        var.setDataType(dataType);
-                    } else {
-                        var.setCustomDataType(dataType);
-                    }
-                }
+        String name = varParts[0];
+        var.setName(name);
 
-                final String strippedDownTags = varParts[2].replace("[", "").replace("]", "");
-                String[] elements = strippedDownTags.split(TAG_DIVIDER);
-
-                if (!strippedDownTags.isEmpty()) {
-                    var.tags.addAll(Arrays.asList(elements));
-                }
-            }
+        String dataType = varParts.length > 1 ? varParts[1] : null;
+        if (dataTypes != null && dataTypes.contains(dataType)) {
+            var.setDataType(dataType);
+        } else {
+            var.setCustomDataType(dataType);
         }
+
+        var.tags = new ArrayList<>();
+        String tags = varParts.length > 2 ? varParts[2] : "";
+        final String strippedDownTags = tags.replace("[", "").replace("]", "");
+        String[] elements = strippedDownTags.split(TAG_DIVIDER);
+        if (!strippedDownTags.isEmpty()) {
+            var.tags.addAll(Arrays.asList(elements));
+        }
+
         return var;
     }
 
@@ -185,27 +181,33 @@ public class Variable {
 
     @Override
     public boolean equals(final Object o) {
-
         if (this == o) {
             return true;
         }
+
         if (!(o instanceof Variable)) {
             return false;
         }
+
         Variable variable = (Variable) o;
+
         if (getVariableType() != variable.getVariableType()) {
             return false;
         }
-        if (getName() != null ? !getName().equals(variable.getName()) : variable.getName() != null) {
+
+        if (getName() != null && !getName().isEmpty() ? !getName().equals(variable.getName()) : variable.getName() != null && !variable.getName().isEmpty()) {
             return false;
         }
-        if (getDataType() != null ? !getDataType().equals(variable.getDataType()) : variable.getDataType() != null) {
+
+        if (getDataType() != null && !getDataType().isEmpty() ? !getDataType().equals(variable.getDataType()) : variable.getDataType() != null && !variable.getDataType().isEmpty()) {
             return false;
         }
-        if (tags != null && !tags.isEmpty() ? !tags.equals(variable.tags) : variable.getTags() != null && !variable.getTags().isEmpty()) {
+
+        if (getCustomDataType() != null && !getCustomDataType().isEmpty() ? !getCustomDataType().equals(variable.getCustomDataType()) : variable.getCustomDataType() != null && !variable.getCustomDataType().isEmpty()) {
             return false;
         }
-        return getCustomDataType() != null ? getCustomDataType().equals(variable.getCustomDataType()) : variable.getCustomDataType() == null;
+
+        return tags != null && !tags.isEmpty() ? tags.equals(variable.tags) : variable.getTags() == null || variable.getTags().isEmpty();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableTest.java
@@ -151,7 +151,7 @@ public class VariableTest {
 
         String test2 = DIVIDER + DIVIDER;
         Variable result2 = Variable.deserialize(test2, variableType);
-        Variable expected2 = new Variable(variableType);
+        Variable expected2 = new Variable("", variableType);
         assertEquals(expected2, result2);
 
         String test3 = NAME + DIVIDER + DIVIDER;
@@ -170,7 +170,6 @@ public class VariableTest {
         assertEquals(expected5, result5);
 
         String test6 = NAME + DIVIDER + CUSTOM_DATA_TYPE + DIVIDER;
-        ;
         Variable result6 = Variable.deserialize(test6, variableType, Arrays.asList(DATA_TYPE));
         Variable expected6 = new Variable(NAME, variableType, null, CUSTOM_DATA_TYPE);
         assertEquals(expected6, result6);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/VariableTest.java
@@ -213,27 +213,35 @@ public class VariableTest {
         Variable otherVariable7 = new Variable(null, null, DATA_TYPE, null);
         assertFalse(variable7.equals(otherVariable7));
 
-        //CUSTOM DATA TYPE
-        Variable variable8 = new Variable(null, null, null, CUSTOM_DATA_TYPE);
-        Variable otherVariable8 = new Variable(null, null, null, "Other Custom Data Type");
-        assertFalse(variable8.equals(otherVariable8));
+        Variable variable8 = new Variable(null, null, null, null);
+        Variable otherVariable8 = new Variable(null, null, "", null);
+        assertTrue(variable8.equals(otherVariable8));
 
-        Variable variable9 = new Variable(null, null, null, null);
-        Variable otherVariable9 = new Variable(null, null, null, CUSTOM_DATA_TYPE);
+        //CUSTOM DATA TYPE
+        Variable variable9 = new Variable(null, null, null, CUSTOM_DATA_TYPE);
+        Variable otherVariable9 = new Variable(null, null, null, "Other Custom Data Type");
         assertFalse(variable9.equals(otherVariable9));
 
-        //TAGS
-        Variable variable10 = new Variable(null, null, null, null, TAGS);
-        Variable otherVariable10 = new Variable(null, null, null, null, OTHER_TAGS);
+        Variable variable10 = new Variable(null, null, null, null);
+        Variable otherVariable10 = new Variable(null, null, null, CUSTOM_DATA_TYPE);
         assertFalse(variable10.equals(otherVariable10));
 
-        Variable variable11 = new Variable(null, null, null, null, null);
-        Variable otherVariable11 = new Variable(null, null, null, null, TAGS);
-        assertFalse(variable11.equals(otherVariable11));
+        Variable variable11 = new Variable(null, null, null, null);
+        Variable otherVariable11 = new Variable(null, null, null, "");
+        assertTrue(variable11.equals(otherVariable11));
 
-        Variable variable12 = new Variable(null, null, null, null, new ArrayList<>());
-        Variable otherVariable12 = new Variable(null, null, null, null, TAGS);
+        //TAGS
+        Variable variable12 = new Variable(null, null, null, null, TAGS);
+        Variable otherVariable12 = new Variable(null, null, null, null, OTHER_TAGS);
         assertFalse(variable12.equals(otherVariable12));
+
+        Variable variable13 = new Variable(null, null, null, null, null);
+        Variable otherVariable13 = new Variable(null, null, null, null, TAGS);
+        assertFalse(variable13.equals(otherVariable13));
+
+        Variable variable14 = new Variable(null, null, null, null, new ArrayList<>());
+        Variable otherVariable14 = new Variable(null, null, null, null, TAGS);
+        assertFalse(variable14.equals(otherVariable14));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElement.java
@@ -72,17 +72,17 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
     @Override
     protected void setStringValue(BaseElement element, String value) {
         Stream.of(value.split(","))
-                .map(this::extensionOf)
+                .map(GlobalVariablesElement::extensionOf)
                 .forEach(getExtensionElements(element)::add);
     }
 
-    protected FeatureMap.Entry extensionOf(String variable) {
+    static FeatureMap.Entry extensionOf(String variable) {
         return new EStructuralFeatureImpl.SimpleFeatureMapEntry(
                 (EStructuralFeature.Internal) DOCUMENT_ROOT__GLOBAL,
                 globalTypeDataOf(variable));
     }
 
-    protected GlobalType globalTypeDataOf(String variable) {
+    static GlobalType globalTypeDataOf(String variable) {
         GlobalType globalType = DroolsFactory.eINSTANCE.createGlobalType();
         String[] properties = variable.split(":", -1);
         globalType.setIdentifier(properties[0]);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElement.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElement.java
@@ -50,13 +50,6 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
     }
 
     @Override
-    protected void setStringValue(BaseElement element, String value) {
-        Stream.of(value.split(","))
-                .map(this::extensionOf)
-                .forEach(getExtensionElements(element)::add);
-    }
-
-    @Override
     protected Optional<String> getStringValue(BaseElement element) {
         List<ExtensionAttributeValue> extValues = element.getExtensionValues();
 
@@ -70,25 +63,28 @@ public class GlobalVariablesElement extends ElementDefinition<String> {
                 .collect(Collectors.toList());
 
         String globalVariables = globalExtensions.stream()
-                .filter(globalType -> globalType.getIdentifier() != null &&
-                        globalType.getIdentifier().length() > 0 &&
-                        globalType.getType() != null &&
-                        globalType.getType().length() > 0)
                 .map(globalType -> globalType.getIdentifier() + ":" + globalType.getType())
                 .collect(Collectors.joining(","));
 
         return Optional.ofNullable(globalVariables);
     }
 
-    private FeatureMap.Entry extensionOf(String variable) {
+    @Override
+    protected void setStringValue(BaseElement element, String value) {
+        Stream.of(value.split(","))
+                .map(this::extensionOf)
+                .forEach(getExtensionElements(element)::add);
+    }
+
+    protected FeatureMap.Entry extensionOf(String variable) {
         return new EStructuralFeatureImpl.SimpleFeatureMapEntry(
                 (EStructuralFeature.Internal) DOCUMENT_ROOT__GLOBAL,
                 globalTypeDataOf(variable));
     }
 
-    private GlobalType globalTypeDataOf(String variable) {
+    protected GlobalType globalTypeDataOf(String variable) {
         GlobalType globalType = DroolsFactory.eINSTANCE.createGlobalType();
-        String[] properties = variable.split(":");
+        String[] properties = variable.split(":", -1);
         globalType.setIdentifier(properties[0]);
         globalType.setType(properties[1]);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElementTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/elements/GlobalVariablesElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.elements;
+package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.elements;
 
 import org.eclipse.bpmn2.BaseElement;
 import org.eclipse.emf.ecore.impl.EStructuralFeatureImpl;
 import org.eclipse.emf.ecore.util.FeatureMap;
 import org.jboss.drools.GlobalType;
 import org.junit.Test;
-import org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.CustomElement;
+import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.CustomElement;
 
 import static org.jboss.drools.DroolsPackage.Literals.DOCUMENT_ROOT__GLOBAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
+import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories.bpmn2;
 
 public class GlobalVariablesElementTest {
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9182
Global Variables accept empty data type values without problems.

https://issues.redhat.com/browse/JBPM-9199
All other variable based fields now keep the data type after saving.

[Business Central](https://drive.google.com/file/d/196Mkj5Qa4OTN_X01aBvk3kUveCQ4iQKJ/view?usp=sharing)
[VSIX](https://drive.google.com/file/d/1RXcmBiA3YEHssE1Bj3ePkEVKhUre9bwR/view?usp=sharing)