### PR TITLE
fixed real directory for Errai Wildfly distribution

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
@@ -30,7 +30,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
   </properties>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/pom.xml
@@ -30,7 +30,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
     <gwt.helper.includes>DMNClient,Marshaller</gwt.helper.includes>
     <gwt.helper.rootDirectories>${project.parent.basedir}/</gwt.helper.rootDirectories>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
@@ -30,7 +30,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
     <code.coverage.disabled>true</code.coverage.disabled>
     <sonar.skip>true</sonar.skip>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
   </properties>
 
   <dependencies>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -31,7 +31,7 @@
   <description>Kie Workbench - Common - Stunner - Standalone Showcase</description>
 
   <properties>
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
   </properties>
 


### PR DESCRIPTION
This is a change for having always directory for Errai Wildfly unpacked distribution to be on the same name as original wildfly distribution as Errai just repackaged it so naming directory to that version is not confusing