### PR TITLE
KOGITO-1660 Fire multiple times type property dropdown is too small

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldEditorView.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldEditorView.html
@@ -34,7 +34,7 @@
                 </div>
 
                 <div class="row" data-field="multiple-timer-params">
-                    <div class="col-md-3">
+                    <div class="col-md-3" style="padding-right: 0">
                         <select class="form-control" data-field="time-cycle-language"></select>
                     </div>
                     <div class="col-md-9">


### PR DESCRIPTION
Hi @romartin, @domhanak, @tomasdavidorg,

it is a quick fix, but I think it is good enough, since we will fully rework forms in near future.

![image](https://user-images.githubusercontent.com/1477262/86477111-11136480-bd48-11ea-8388-7b221ed920fc.png)

VSIX for tests can be downloaded here: https://drive.google.com/file/d/1AVtusv1reXlrGELES-HPUS8wN0DXogeY/view?usp=sharing

There how it is looks like now in the Business Central:
![image](https://user-images.githubusercontent.com/1477262/86477277-5c2d7780-bd48-11ea-9498-207973e15022.png)
I didn't build it locally just tricked css styles directly on running instance.