### PR TITLE
DROOLS-5516 : Date field in Guided rule template is not displaying correct date

### DIFF
--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCell.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCell.java
@@ -25,12 +25,9 @@ import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.text.shared.SafeHtmlRenderer;
 import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
-import org.kie.workbench.common.widgets.client.util.TimeZoneUtils;
 import org.uberfire.ext.widgets.common.client.common.DatePicker;
 
 import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.FORMATTER;
-import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.convertFromServerTimeZone;
-import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.formatWithServerTimeZone;
 
 /**
  * A Popup Date Editor.
@@ -49,25 +46,25 @@ public class PopupDateEditCell extends AbstractPopupEditCell<Date, Date> {
         // See https://issues.jboss.org/browse/GUVNOR-2322
         // The DatePicker was being closed, before the ValueChangeHandler invoked, in response to the
         // containing PopupPanel being automatically hidden when another Element received events.
-        datePicker.setContainer( vPanel );
-        panel.addAutoHidePartner( datePicker.getElement() );
+        datePicker.setContainer(vPanel);
+        panel.addAutoHidePartner(datePicker.getElement());
 
         // Hide the panel and call valueUpdater.update when a date is selected
-        datePicker.addValueChangeHandler( new ValueChangeHandler<Date>() {
+        datePicker.addValueChangeHandler(new ValueChangeHandler<Date>() {
             @Override
-            public void onValueChange( final ValueChangeEvent<Date> event ) {
+            public void onValueChange(final ValueChangeEvent<Date> event) {
                 Date date = datePicker.getValue();
-                setValue( lastContext,
-                          lastParent,
-                          date );
-                if ( valueUpdater != null ) {
-                    valueUpdater.update( date );
+                setValue(lastContext,
+                         lastParent,
+                         date);
+                if (valueUpdater != null) {
+                    valueUpdater.update(date);
                 }
                 panel.hide();
             }
-        } );
+        });
 
-        vPanel.add( datePicker );
+        vPanel.add(datePicker);
     }
 
     @Override
@@ -75,7 +72,7 @@ public class PopupDateEditCell extends AbstractPopupEditCell<Date, Date> {
                        Date value,
                        SafeHtmlBuilder sb) {
         if (value != null) {
-            sb.append(getRenderer().render(formatWithServerTimeZone(value)));
+            sb.append(getRenderer().render(FORMATTER.format(value)));
         }
     }
 
@@ -94,28 +91,28 @@ public class PopupDateEditCell extends AbstractPopupEditCell<Date, Date> {
     }
 
     Date convertToServerTimeZone(final Date value) {
-        return TimeZoneUtils.convertToServerTimeZone(value);
+        return value;
     }
 
     // Start editing the cell
     @Override
     @SuppressWarnings("deprecation")
-    protected void startEditing( final Context context,
-                                 final Element parent,
-                                 final Date value ) {
+    protected void startEditing(final Context context,
+                                final Element parent,
+                                final Date value) {
 
         // Default date
         Date date = value;
-        if ( value == null ) {
+        if (value == null) {
             Date d = new Date();
             int year = d.getYear();
             int month = d.getMonth();
             int dom = d.getDate();
-            date = new Date( year,
-                             month,
-                             dom );
+            date = new Date(year,
+                            month,
+                            dom);
         }
-        getDatePicker().setValue(convertFromServerTimeZone(date));
+        getDatePicker().setValue(date);
 
         panel.setPopupPositionAndShow(new PositionCallback() {
             public void setPosition(int offsetWidth,
@@ -125,8 +122,7 @@ public class PopupDateEditCell extends AbstractPopupEditCell<Date, Date> {
                                        parent.getAbsoluteTop()
                                                + offsetY);
             }
-        } );
-
+        });
     }
 
     String getPattern() {

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/test/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCellTest.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/test/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDateEditCellTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.cell.client.ValueUpdater;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.text.shared.SafeHtmlRenderer;
 import com.google.gwtmockito.GwtMock;
@@ -30,13 +29,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.kie.workbench.common.widgets.client.util.TimeZoneUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.uberfire.ext.widgets.common.client.common.DatePicker;
 
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.DATE_FORMAT;
-import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.KIE_TIMEZONE_OFFSET;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -50,7 +49,7 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class PopupDateEditCellTest {
 
-    private static final String TEST_DATE_FORMAT = "MM-dd-yyyy HH:mm:ss Z";
+    private static final String TEST_DATE_FORMAT = "MM-dd-yyyy";
 
     @GwtMock
     private DatePicker datePicker;
@@ -69,7 +68,6 @@ public class PopupDateEditCellTest {
     @Before
     public void setup() {
         ApplicationPreferences.setUp(new HashMap<String, String>() {{
-            put(KIE_TIMEZONE_OFFSET, "10800000");
             put(DATE_FORMAT, TEST_DATE_FORMAT);
         }});
 
@@ -104,7 +102,7 @@ public class PopupDateEditCellTest {
 
         final Cell.Context context = mock(Cell.Context.class);
         final Element parent = mock(Element.class);
-        final Date expectedDate = makeDate("04-01-2018 00:00:00 -0300");
+        final Date expectedDate = makeDate("04-01-2018");
 
         cell.startEditing(context, parent, expectedDate);
 
@@ -118,8 +116,8 @@ public class PopupDateEditCellTest {
     @Test
     public void testCommit() {
 
-        final Date clientDate = makeDate("04-01-2018 00:00:00 -0300");
-        final Date serverDate = makeDate("04-01-2018 06:00:00 +0300");
+        final Date clientDate = makeDate("04-01-2018");
+        final Date serverDate = makeDate("04-01-2018");
 
         when(datePicker.getValue()).thenReturn(clientDate);
         doReturn(serverDate).when(cell).convertToServerTimeZone(clientDate);
@@ -133,8 +131,8 @@ public class PopupDateEditCellTest {
     @Test
     public void testCommitWhenValueUpdaterIsNull() {
 
-        final Date clientDate = makeDate("04-01-2018 00:00:00 -0300");
-        final Date serverDate = makeDate("04-01-2018 06:00:00 +0300");
+        final Date clientDate = makeDate("04-01-2018");
+        final Date serverDate = makeDate("04-01-2018");
 
         when(datePicker.getValue()).thenReturn(clientDate);
         doReturn(null).when(cell).getValueUpdater();
@@ -151,12 +149,11 @@ public class PopupDateEditCellTest {
 
         final Cell.Context context = mock(Cell.Context.class);
         final SafeHtmlBuilder safeHtmlBuilder = mock(SafeHtmlBuilder.class);
-        final Date clientDate = makeDate("05-01-2018 18:00:00 -0300");
-        final String serverDate = "05-02-2018 00:00:00 +0300";
+        final Date clientDate = makeDate("05-01-2018");
 
         cell.render(context, clientDate, safeHtmlBuilder);
 
-        verify(renderer).render(eq(serverDate));
+        verify(renderer).render(eq("05-01-2018"));
     }
 
     @Test
@@ -176,10 +173,6 @@ public class PopupDateEditCellTest {
     }
 
     private Date makeDate(final String dateString) {
-        return format().parse(dateString);
-    }
-
-    private DateTimeFormat format() {
-        return DateTimeFormat.getFormat(TEST_DATE_FORMAT);
+        return TimeZoneUtils.FORMATTER.parse(dateString);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5516

Templated rules store the table data with Strings. For this reason you get what you see both in server and client side. The grid cell, as far as I know and could find, is only used by templated rules so removed the conversions.