### PR TITLE
KOGITO-2651 : Allow expressions in output assignments

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
@@ -50,7 +50,6 @@ import org.kie.workbench.common.stunner.bpmn.client.forms.widgets.VariableNameTe
 import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable.VariableType.OUTPUT;
-import static org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils.EXPRESSION;
 import static org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils.isEmpty;
 import static org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils.nonEmpty;
 
@@ -281,11 +280,7 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
 
     @Override
     public void setExpression(final String expression) {
-            getModel().setExpression(expression);
-    }
-
-    private static boolean isConstant(String expression) {
-        return !isEmpty(expression) && !EXPRESSION.test(expression);
+        getModel().setExpression(expression);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImpl.java
@@ -281,13 +281,7 @@ public class AssignmentListItemWidgetViewImpl extends Composite implements Assig
 
     @Override
     public void setExpression(final String expression) {
-        if (getModel().getVariableType() == OUTPUT && isConstant(expression)) {
-            notification.fire(new NotificationEvent(StunnerFormsClientFieldsConstants.CONSTANTS.Only_expressions_allowed_for_output(),
-                                                    NotificationEvent.NotificationType.ERROR));
-            processVarComboBox.textBoxValueChanged("");
-        } else {
             getModel().setExpression(expression);
-        }
     }
 
     private static boolean isConstant(String expression) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.java
@@ -75,8 +75,6 @@ public interface StunnerFormsClientFieldsConstants extends Messages {
 
     String Only_single_entry_allowed();
 
-    String Only_expressions_allowed_for_output();
-
     String Ok();
 
     String Source();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.properties
@@ -32,7 +32,6 @@ Data_Outputs_and_Assignments=Data Outputs and Assignments
 Data_IO=Data I/O
 Edit=Edit
 Enter_expression=Enter expression
-Only_expressions_allowed_for_output=Constant is not allowed for the Data Output
 Enter_type=Enter type
 Error_retrieving_datatypes=Error retrieving datatypes
 Invalid_character_in_name=Invalid character in name

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
@@ -361,9 +361,8 @@ public class AssignmentListItemWidgetViewImplTest {
     public void testSetConstantToOutput() {
         AssignmentRow row = new AssignmentRow(null, OUTPUT, null, null, null, null);
         when(view.getModel()).thenReturn(row);
-        view.setExpression("hello");
-
-        assertNull(view.getModel().getExpression());
+        view.setExpression("{hello}");
+        assertEquals(view.getModel().getExpression(), "{hello}");
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetViewImplTest.java
@@ -361,8 +361,8 @@ public class AssignmentListItemWidgetViewImplTest {
     public void testSetConstantToOutput() {
         AssignmentRow row = new AssignmentRow(null, OUTPUT, null, null, null, null);
         when(view.getModel()).thenReturn(row);
-        view.setExpression("{hello}");
-        assertEquals(view.getModel().getExpression(), "{hello}");
+        view.setExpression("hello");
+        assertEquals(view.getModel().getExpression(), "hello");
     }
 
     @Test


### PR DESCRIPTION
Hi @romartin @handreyrc can you review this PR? Change is simple, there was a check before to show a warning if the variable is output and expression. I removed the custom message and constants and updated test code. Let me know