### PR TITLE
JBPM-9266 : Stunner - Called element in Reusable sub-process is not populated

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
@@ -22,6 +22,7 @@ import java.util.stream.StreamSupport;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import com.google.gwt.user.client.Timer;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorDataProvider;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
@@ -38,6 +39,19 @@ public class CalledElementFormProvider implements SelectorDataProvider {
     @Override
     public String getProviderName() {
         return getClass().getSimpleName();
+    }
+
+    public CalledElementFormProvider() {
+        scheduleServiceCall(() -> requestProcessDataEvent.fire(new RequestProcessDataEvent()));
+    }
+
+    protected void scheduleServiceCall(final com.google.gwt.user.client.Command command) {
+        new Timer() {
+            @Override
+            public void run() {
+                command.execute();
+            }
+        }.schedule(100);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
@@ -65,4 +65,8 @@ public class CalledElementFormProvider implements SelectorDataProvider {
             requestProcessDataEventSingleton.fire(new RequestProcessDataEvent());
         }
     }
+
+    public static Event<RequestProcessDataEvent> getRequestProcessDataEventSingleton() {
+        return requestProcessDataEventSingleton;
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
@@ -19,10 +19,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.Timer;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorDataProvider;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
@@ -41,17 +41,9 @@ public class CalledElementFormProvider implements SelectorDataProvider {
         return getClass().getSimpleName();
     }
 
-    public CalledElementFormProvider() {
-        scheduleServiceCall(() -> requestProcessDataEvent.fire(new RequestProcessDataEvent()));
-    }
-
-    protected void scheduleServiceCall(final com.google.gwt.user.client.Command command) {
-        new Timer() {
-            @Override
-            public void run() {
-                command.execute();
-            }
-        }.schedule(100);
+    @PostConstruct
+    public void populateData() {
+        requestProcessDataEvent.fire(new RequestProcessDataEvent());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProvider.java
@@ -36,6 +36,8 @@ public class CalledElementFormProvider implements SelectorDataProvider {
     @Inject
     Event<RequestProcessDataEvent> requestProcessDataEvent;
 
+    private static Event<RequestProcessDataEvent> requestProcessDataEventSingleton = null;
+
     @Override
     public String getProviderName() {
         return getClass().getSimpleName();
@@ -44,6 +46,7 @@ public class CalledElementFormProvider implements SelectorDataProvider {
     @PostConstruct
     public void populateData() {
         requestProcessDataEvent.fire(new RequestProcessDataEvent());
+        requestProcessDataEventSingleton = requestProcessDataEvent;
     }
 
     @Override
@@ -55,5 +58,11 @@ public class CalledElementFormProvider implements SelectorDataProvider {
 
     private static Map<Object, String> toMap(final Iterable<String> items) {
         return StreamSupport.stream(items.spliterator(), false).collect(Collectors.toMap(s -> s, s -> s));
+    }
+
+    public static void initServerData() {
+        if (requestProcessDataEventSingleton != null) {
+            requestProcessDataEventSingleton.fire(new RequestProcessDataEvent());
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializer.java
@@ -23,6 +23,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import elemental2.promise.Promise;
+import org.kie.workbench.common.stunner.bpmn.client.dataproviders.CalledElementFormProvider;
 import org.kie.workbench.common.stunner.bpmn.client.diagram.DiagramTypeClientService;
 import org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientService;
 import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
@@ -56,6 +57,7 @@ public class BPMNSessionInitializer implements SessionInitializer {
     public void init(final Metadata metadata,
                      final Command completeCallback) {
         diagramTypeService.loadDiagramType(metadata);
+        CalledElementFormProvider.initServerData();
         workItemDefinitionService
                 .call(metadata)
                 .then(workItemDefinitions -> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +27,7 @@ import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestProcessDataEvent;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
@@ -38,9 +38,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class CalledElementFormProviderTest {
 
     @Mock
@@ -53,7 +52,7 @@ public class CalledElementFormProviderTest {
 
     @Before
     public void setup() {
-        tested = spy(new CalledElementFormProvider());
+        tested = new CalledElementFormProvider();
         tested.dataProvider = dataProvider;
         tested.requestProcessDataEvent = event;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -57,10 +56,6 @@ public class CalledElementFormProviderTest {
         tested = spy(new CalledElementFormProvider());
         tested.dataProvider = dataProvider;
         tested.requestProcessDataEvent = event;
-        doAnswer(i -> {
-            ((com.google.gwt.user.client.Command) i.getArguments()[0]).execute();
-            return null;
-        }).when(tested).scheduleServiceCall(any());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
@@ -76,4 +76,11 @@ public class CalledElementFormProviderTest {
         assertTrue(values.containsKey("p3"));
         verify(event, times(1)).fire(any(RequestProcessDataEvent.class));
     }
+
+    @Test
+    public void testService() {
+        tested.populateData();
+        verify(event, times(1)).fire(any(RequestProcessDataEvent.class));
+        assertTrue(tested.requestProcessDataEvent.equals(tested.getRequestProcessDataEventSingleton()));
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/CalledElementFormProviderTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,19 +28,20 @@ import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestProcessDataEvent;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.spy;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class CalledElementFormProviderTest {
 
     @Mock
@@ -52,9 +54,13 @@ public class CalledElementFormProviderTest {
 
     @Before
     public void setup() {
-        tested = new CalledElementFormProvider();
+        tested = spy(new CalledElementFormProvider());
         tested.dataProvider = dataProvider;
         tested.requestProcessDataEvent = event;
+        doAnswer(i -> {
+            ((com.google.gwt.user.client.Command) i.getArguments()[0]).execute();
+            return null;
+        }).when(tested).scheduleServiceCall(any());
     }
 
     @Test


### PR DESCRIPTION
Hi @romartin @handreyrc can you review this PR? Basically every time the CalledElement for property was created and a call to get the contents it was firing up a Server event, but returned immediately so the data was not updated, if you previously selected and unselected the element it would get the right data. What I did is make the call upon the Form Provider creation so that the data is ready when the user clicked on the combo box.