### PR TITLE
JBPM-9267 : Stunner - Rule flow group is not populated

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
@@ -20,11 +20,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.Timer;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorDataProvider;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
@@ -43,17 +43,9 @@ public class RuleFlowGroupFormProvider implements SelectorDataProvider {
     @Inject
     RuleFlowGroupDataProvider dataProvider;
 
-    public RuleFlowGroupFormProvider() {
-        scheduleServiceCall(() -> requestRuleFlowGroupDataEvent.fire(new RequestRuleFlowGroupDataEvent()));
-    }
-
-    protected void scheduleServiceCall(final com.google.gwt.user.client.Command command) {
-        new Timer() {
-            @Override
-            public void run() {
-                command.execute();
-            }
-        }.schedule(100);
+    @PostConstruct
+    public void populateData() {
+        requestRuleFlowGroupDataEvent.fire(new RequestRuleFlowGroupDataEvent());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
@@ -40,12 +40,15 @@ public class RuleFlowGroupFormProvider implements SelectorDataProvider {
     @Inject
     Event<RequestRuleFlowGroupDataEvent> requestRuleFlowGroupDataEvent;
 
+    private static Event<RequestRuleFlowGroupDataEvent> requestRuleFlowGroupDataEventEventSingleton = null;
+
     @Inject
     RuleFlowGroupDataProvider dataProvider;
 
     @PostConstruct
     public void populateData() {
         requestRuleFlowGroupDataEvent.fire(new RequestRuleFlowGroupDataEvent());
+        requestRuleFlowGroupDataEventEventSingleton = requestRuleFlowGroupDataEvent;
     }
 
     @Override
@@ -93,5 +96,11 @@ public class RuleFlowGroupFormProvider implements SelectorDataProvider {
     private static int getIndexOfFileSeparator(String string) {
         int index = string.indexOf('/');
         return index == -1 ? string.indexOf('\\') : index;
+    }
+
+    public static void initServerData() {
+        if (requestRuleFlowGroupDataEventEventSingleton != null) {
+            requestRuleFlowGroupDataEventEventSingleton.fire(new RequestRuleFlowGroupDataEvent());
+        }
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
@@ -103,4 +103,9 @@ public class RuleFlowGroupFormProvider implements SelectorDataProvider {
             requestRuleFlowGroupDataEventEventSingleton.fire(new RequestRuleFlowGroupDataEvent());
         }
     }
+
+    public static Event<RequestRuleFlowGroupDataEvent> getRequestRuleFlowGroupDataEventEventSingleton() {
+        return requestRuleFlowGroupDataEventEventSingleton;
+    }
+
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProvider.java
@@ -24,6 +24,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import com.google.gwt.user.client.Timer;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorDataProvider;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
@@ -41,6 +42,19 @@ public class RuleFlowGroupFormProvider implements SelectorDataProvider {
 
     @Inject
     RuleFlowGroupDataProvider dataProvider;
+
+    public RuleFlowGroupFormProvider() {
+        scheduleServiceCall(() -> requestRuleFlowGroupDataEvent.fire(new RequestRuleFlowGroupDataEvent()));
+    }
+
+    protected void scheduleServiceCall(final com.google.gwt.user.client.Command command) {
+        new Timer() {
+            @Override
+            public void run() {
+                command.execute();
+            }
+        }.schedule(100);
+    }
 
     @Override
     public String getProviderName() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/session/BPMNSessionInitializer.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import elemental2.promise.Promise;
 import org.kie.workbench.common.stunner.bpmn.client.dataproviders.CalledElementFormProvider;
+import org.kie.workbench.common.stunner.bpmn.client.dataproviders.RuleFlowGroupFormProvider;
 import org.kie.workbench.common.stunner.bpmn.client.diagram.DiagramTypeClientService;
 import org.kie.workbench.common.stunner.bpmn.client.workitem.WorkItemDefinitionClientService;
 import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
@@ -58,6 +59,7 @@ public class BPMNSessionInitializer implements SessionInitializer {
                      final Command completeCallback) {
         diagramTypeService.loadDiagramType(metadata);
         CalledElementFormProvider.initServerData();
+        RuleFlowGroupFormProvider.initServerData();
         workItemDefinitionService
                 .call(metadata)
                 .then(workItemDefinitions -> {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 @RunWith(GwtMockitoTestRunner.class)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
@@ -57,11 +57,6 @@ public class RuleFlowGroupFormProviderTest {
         tested = spy(new RuleFlowGroupFormProvider());
         tested.dataProvider = dataProvider;
         tested.requestRuleFlowGroupDataEvent = requestRuleFlowGroupDataEvent;
-
-        doAnswer(i -> {
-            ((com.google.gwt.user.client.Command) i.getArguments()[0]).execute();
-            return null;
-        }).when(tested).scheduleServiceCall(any());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,10 +28,12 @@ import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContex
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestRuleFlowGroupDataEvent;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class RuleFlowGroupFormProviderTest {
 
     @Mock
@@ -101,5 +102,12 @@ public class RuleFlowGroupFormProviderTest {
         assertEquals(1, values.size());
         assertEquals("g1 [Project1, Project2]", values.get(group1.getName()));
         verify(requestRuleFlowGroupDataEvent, times(1)).fire(any(RequestRuleFlowGroupDataEvent.class));
+    }
+
+    @Test
+    public void serviceInitialized() {
+        tested.populateData();
+        verify(requestRuleFlowGroupDataEvent, times(1)).fire(any(RequestRuleFlowGroupDataEvent.class));
+        assertTrue(tested.requestRuleFlowGroupDataEvent.equals(tested.getRequestRuleFlowGroupDataEventEventSingleton()));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +29,6 @@ import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContex
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestRuleFlowGroupDataEvent;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
@@ -38,8 +38,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.spy;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
 public class RuleFlowGroupFormProviderTest {
 
     @Mock
@@ -52,9 +54,14 @@ public class RuleFlowGroupFormProviderTest {
 
     @Before
     public void setup() {
-        tested = new RuleFlowGroupFormProvider();
+        tested = spy(new RuleFlowGroupFormProvider());
         tested.dataProvider = dataProvider;
         tested.requestRuleFlowGroupDataEvent = requestRuleFlowGroupDataEvent;
+
+        doAnswer(i -> {
+            ((com.google.gwt.user.client.Command) i.getArguments()[0]).execute();
+            return null;
+        }).when(tested).scheduleServiceCall(any());
     }
 
     @Test


### PR DESCRIPTION
Hi @romartin @handreyrc can you review this PR? Basically the Ruleflow was not being populated because it called the server but returned results immediately before the event (back) was catched. Modified so that it initializes when the form provider gets called.