### PR TITLE
RHDM-1407 :Importing Git project doesn't show new branches

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/BaseProjectImportService.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/BaseProjectImportService.java
@@ -230,7 +230,7 @@ public abstract class BaseProjectImportService implements ImportService {
             put(SCHEME,
                 GitRepository.SCHEME.toString());
             put("replaceIfExists",
-                false);
+                true);
             put("username",
                 username);
             put("password",


### PR DESCRIPTION
- this will replace the cache entry in  /system/{fs-name}.git everytime project is reimported. This will allow BC to be aware of new changes in project repo after the last import.