### PR TITLE
JBPM-9275 - Stunner - '^' character in Notification subject in User task breaks the process

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/notification/NotificationValue.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/notification/NotificationValue.java
@@ -152,9 +152,19 @@ public class NotificationValue {
                 "|togroups:" + join(",", groups) +
                 "|toemails:" + emails +
                 "|replyTo:" + replyTo +
-                "|subject:" + (subject != null ? subject.replaceAll("\\|", "&#124;") : "") +
-                "|body:" + (body != null ? body.replaceAll("\\|", "&#124;") : "") +
+                "|subject:" + replaceAsciiSymbols(subject) +
+                "|body:" + replaceAsciiSymbols(body) +
                 "]@[" + expiresAt + "]";
+    }
+
+    private static String replaceAsciiSymbols(String str) {
+        if (str == null) {
+            return "";
+        }
+
+        return str
+                .replaceAll("\\|", "&#124;")
+                .replaceAll("\\^", "&#94;");
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/NotificationValueTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/NotificationValueTest.java
@@ -150,15 +150,15 @@ public class NotificationValueTest {
 
     @Test
     public void testNotificationPartialVerticalBar() {
-        NotificationValue test = new NotificationValue("a||||||dssf||sdf|Sdf|sdf|Sdf|SDf",
+        NotificationValue test = new NotificationValue("a||||||dssf||sdf|Sdf|sdf|Sdf|SDf^",
                               "1h",
-                              "z|asd|ASd||asd|Asd|asd|",
+                              "^z|asd|ASd||asd|Asd|asd|",
                               "me",
                               "NotStartedNotify",
                               "me",
                               EMPTY_LIST,
                               EMPTY_LIST,
                               "");
-        assertEquals("[from:me|tousers:|togroups:|toemails:|replyTo:me|subject:z&#124;asd&#124;ASd&#124;&#124;asd&#124;Asd&#124;asd&#124;|body:a&#124;&#124;&#124;&#124;&#124;&#124;dssf&#124;&#124;sdf&#124;Sdf&#124;sdf&#124;Sdf&#124;SDf]@[1h]", test.toCDATAFormat());
+        assertEquals("[from:me|tousers:|togroups:|toemails:|replyTo:me|subject:&#94;z&#124;asd&#124;ASd&#124;&#124;asd&#124;Asd&#124;asd&#124;|body:a&#124;&#124;&#124;&#124;&#124;&#124;dssf&#124;&#124;sdf&#124;Sdf&#124;sdf&#124;Sdf&#124;SDf&#94;]@[1h]", test.toCDATAFormat());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/ParsedNotificationsInfos.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/ParsedNotificationsInfos.java
@@ -53,8 +53,8 @@ public class ParsedNotificationsInfos {
             notification.setGroups(parseGroup(tBody, "togroups"));
             notification.setEmails(join(",", parseGroup(tBody, "toemails")));
             notification.setReplyTo(parseElement(tBody, "replyTo"));
-            notification.setSubject(replaceVerticalBar(parseElement(tBody, "subject")));
-            notification.setBody(replaceVerticalBar(parseElement(tBody, "body")));
+            notification.setSubject(replaceAsciiSymbols(parseElement(tBody, "subject")));
+            notification.setBody(replaceAsciiSymbols(parseElement(tBody, "body")));
         }
 
         return notification;
@@ -88,8 +88,14 @@ public class ParsedNotificationsInfos {
         return new ParsedNotificationsInfos.CDATA(values, type).get();
     }
 
-    private static String replaceVerticalBar(String value) {
-        return value != null ? value.replaceAll("&#124;", "|") : null;
+    private static String replaceAsciiSymbols(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return value
+                .replaceAll("&#124;", "|")
+                .replaceAll("&#94;", "^");
     }
 
     private static class CDATA {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ParsedNotificationsInfosTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ParsedNotificationsInfosTest.java
@@ -34,13 +34,13 @@ public class ParsedNotificationsInfosTest {
 
     @Test
     public void testNotification() {
-        String body = "[from:director|tousers:director,jack,katy|togroups:Forms,IT|replyTo:guest|subject:asd|body:asd]@[11h]";
+        String body = "[from:director|tousers:director,jack,katy|togroups:Forms,IT|replyTo:guest|subject:&#94;asd|body:asd]@[11h]";
         NotificationValue actual = ParsedNotificationsInfos.of(AssociationType.NOT_COMPLETED_NOTIFY.getName(), body);
         NotificationValue expected = new NotificationValue();
         expected.setType(AssociationType.NOT_COMPLETED_NOTIFY.getName());
         expected.setFrom("director");
         expected.setReplyTo("guest");
-        expected.setSubject("asd");
+        expected.setSubject("^asd");
         expected.setBody("asd");
         expected.setExpiresAt("11h");
         expected.setGroups(new ArrayList<>(Arrays.asList("Forms", "IT")));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/ParsedNotificationsInfos.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/ParsedNotificationsInfos.java
@@ -53,8 +53,8 @@ public class ParsedNotificationsInfos {
             notification.setGroups(parseGroup(tBody, "togroups"));
             notification.setEmails(join(",", parseGroup(tBody, "toemails")));
             notification.setReplyTo(parseElement(tBody, "replyTo"));
-            notification.setSubject(replaceVerticalBar(parseElement(tBody, "subject")));
-            notification.setBody(replaceVerticalBar(parseElement(tBody, "body")));
+            notification.setSubject(replaceAsciiSymbols(parseElement(tBody, "subject")));
+            notification.setBody(replaceAsciiSymbols(parseElement(tBody, "body")));
         }
 
         return notification;
@@ -88,8 +88,14 @@ public class ParsedNotificationsInfos {
         return new ParsedNotificationsInfos.CDATA(values, type).get();
     }
 
-    private static String replaceVerticalBar(String value) {
-        return value != null ? value.replaceAll("&#124;", "|") : null;
+    private static String replaceAsciiSymbols(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return value
+                .replaceAll("&#124;", "|")
+                .replaceAll("&#94;", "^");
     }
 
     private static class CDATA {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ParsedNotificationsInfosTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ParsedNotificationsInfosTest.java
@@ -34,14 +34,14 @@ public class ParsedNotificationsInfosTest {
 
     @Test
     public void testNotification() {
-        String body = "[from:director|tousers:director,jack,katy|togroups:Forms,IT|replyTo:guest|subject:asd|body:asd]@[11h]";
+        String body = "[from:director|tousers:director,jack,katy|togroups:Forms,IT|replyTo:guest|subject:&#94;asd|body:asd&#94;]@[11h]";
         NotificationValue actual = ParsedNotificationsInfos.of(AssociationType.NOT_COMPLETED_NOTIFY.getName(), body);
         NotificationValue expected = new NotificationValue();
         expected.setType(AssociationType.NOT_COMPLETED_NOTIFY.getName());
         expected.setFrom("director");
         expected.setReplyTo("guest");
-        expected.setSubject("asd");
-        expected.setBody("asd");
+        expected.setSubject("^asd");
+        expected.setBody("asd^");
         expected.setExpiresAt("11h");
         expected.setGroups(new ArrayList<>(Arrays.asList("Forms", "IT")));
         expected.setUsers(new ArrayList<>(Arrays.asList("director", "jack", "katy")));


### PR DESCRIPTION
Hi @romartin,

I tested it locally and it works now, I can save and reload the process without issues, uploading a WAR (some connection issue, it takes time today), will attach it later.

@domhanak, @LuboTerifaj do we need your approve or we can assign second Software Engineer to a review?

Thank you!

## Business Central build
https://drive.google.com/file/d/16r5eNFShPjak1gsPmHq1XGBmzRHWBY8I/view?usp=sharing

## VS Code extension
https://drive.google.com/file/d/1IUKYH1Zvt-0HqiLdGm7rGTLPRaaHrAF0/view?usp=sharing