### PR TITLE
JBPM-9290 - Stunner - make body field of Notification resizable

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetViewImpl.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/notificationsEditor/widget/NotificationEditorWidgetViewImpl.html
@@ -128,7 +128,7 @@
         <input data-field="subject" type="text" class="form-control" max="99" style="width:500px; margin-top: 20px;">
     </div>
     <div class="row">
-        <textarea data-field="body" class="form-control" rows="5" id="comment" style="width:500px; resize: none;   margin-top: 20px;"></textarea>
+        <textarea data-field="body" class="form-control" rows="5" id="comment" style="width:500px; resize: vertical; margin-top: 20px;"></textarea>
     </div>
     <div class="row" data-field="errorDivPanel" style="width: 500px; margin-top:10px; color:red;">
     </div>


### PR DESCRIPTION
**JIRA**: [JBPM-9290](https://issues.redhat.com/browse/JBPM-9290)

Hi @romartin this is a small fix we talked about. Thank you!

<img width="820" alt="image" src="https://user-images.githubusercontent.com/1477262/90106186-595e7300-dd47-11ea-9aca-871cc87051d1.png">

Hi @domhanak, @LuboTerifaj, will check this PR or we can reassign it to another developer?

## Business Central
### Full resize
https://drive.google.com/file/d/1t8EUEcpsY3MHfjbXclrwA11C3d9VfDFA/view?usp=sharing
### Vertical resize only
https://drive.google.com/file/d/1CIN4DT3bgEQWX-HxH7yf0NFUJQMnYufp/view?usp=sharing

## VS Code extension
### Full resize
https://drive.google.com/file/d/10jwlCy7fd4YVpEVAl7BRAKwGSEdtn_vv/view?usp=sharing
### Vertical resize only
https://drive.google.com/file/d/1XPXcgjLi3Nrd0_SGf6-RMxPuypjBJSIa/view?usp=sharing