### PR TITLE
KOGITO-3022: [DMN Designer] Multiple DRDs support - Context menu - When multiple nodes are selected, showing context menu with right click

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControl.java
@@ -30,9 +30,8 @@ import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import elemental2.dom.DomGlobal;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
-import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
+import org.kie.workbench.common.dmn.client.editors.drd.DRDContextMenu;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.controls.LienzoMultipleSelectionControl;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.SelectionControl;
@@ -41,7 +40,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.event.selection.Canva
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
-import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -51,11 +49,6 @@ import org.kie.workbench.common.stunner.core.graph.content.definition.Definition
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
-import static org.kie.workbench.common.dmn.client.canvas.controls.toolbox.DMNEditDRDToolboxAction.DRDACTIONS_CONTEXT_MENU_ACTIONS_ADD_TO;
-import static org.kie.workbench.common.dmn.client.canvas.controls.toolbox.DMNEditDRDToolboxAction.DRDACTIONS_CONTEXT_MENU_ACTIONS_CREATE;
-import static org.kie.workbench.common.dmn.client.canvas.controls.toolbox.DMNEditDRDToolboxAction.DRDACTIONS_CONTEXT_MENU_ACTIONS_REMOVE;
-import static org.kie.workbench.common.dmn.client.canvas.controls.toolbox.DMNEditDRDToolboxAction.DRDACTIONS_CONTEXT_MENU_TITLE;
-import static org.kie.workbench.common.dmn.client.canvas.controls.toolbox.DMNEditDRDToolboxAction.HEADER_MENU_ICON_CLASS;
 import static org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities.getRelativeXOfEvent;
 import static org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities.getRelativeYOfEvent;
 
@@ -71,23 +64,20 @@ import static org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities.
 public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractCanvasHandler> extends LienzoMultipleSelectionControl<H> {
 
     private Optional<DomainObject> selectedDomainObject = Optional.empty();
-    private final ContextMenu drdContextMenu;
-    private final ClientTranslationService translationService;
+    private final DRDContextMenu drdContextMenu;
     private HandlerRegistration handlerRegistration;
 
     @Inject
     public DomainObjectAwareLienzoMultipleSelectionControl(final Event<CanvasSelectionEvent> canvasSelectionEvent,
                                                            final Event<CanvasClearSelectionEvent> clearSelectionEvent,
-                                                           final ContextMenu drdContextMenu,
-                                                           final ClientTranslationService translationService) {
+                                                           final DRDContextMenu drdContextMenu) {
         super(canvasSelectionEvent,
               clearSelectionEvent);
         this.drdContextMenu = drdContextMenu;
-        this.translationService = translationService;
     }
 
     @Override
-    protected void onEnable(H canvasHandler) {
+    protected void onEnable(final H canvasHandler) {
         super.onEnable(canvasHandler);
 
         handlerRegistration = canvasHandler
@@ -103,7 +93,7 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
 
                     if (selectionIsMultiple && aSelectedShapeHasBeenClicked) {
                         drdContextMenu.appendContextMenuToTheDOM(event.getNativeEvent().getClientX(), event.getNativeEvent().getClientY());
-                        drdContextMenu.show(self -> contextMenuHandler(self, getSelectedNodes(canvasHandler)));
+                        drdContextMenu.show(getSelectedNodes(canvasHandler));
                     }
                 }, ContextMenuEvent.getType());
     }
@@ -129,20 +119,6 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
         return getSelectedItems().stream()
                 .map(uuid -> CanvasLayoutUtils.getElement(canvasHandler, uuid))
                 .filter(element -> element instanceof Node);
-    }
-
-    void contextMenuHandler(final ContextMenu contextMenu, final List<Node<? extends Definition<?>, Edge>> selectedNodes) {
-        contextMenu.hide();
-        contextMenu.setHeaderMenu(translationService.getValue(DRDACTIONS_CONTEXT_MENU_TITLE), HEADER_MENU_ICON_CLASS);
-        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_CREATE),
-                                    true,
-                                    () -> DomGlobal.console.log("A", selectedNodes));
-        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_ADD_TO),
-                                    true,
-                                    () -> DomGlobal.console.log("B", selectedNodes));
-        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_REMOVE),
-                                    true,
-                                    () -> DomGlobal.console.log("C", selectedNodes));
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControl.java
@@ -98,7 +98,7 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
                 }, ContextMenuEvent.getType());
     }
 
-    private boolean isClickedOnShape(final H canvasHandler, final int canvasX, final int canvasY) {
+    protected boolean isClickedOnShape(final H canvasHandler, final int canvasX, final int canvasY) {
         return getSelectedNodesStream(canvasHandler)
                 .map(Element::getContent)
                 .filter(content -> content instanceof View)
@@ -109,13 +109,13 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
                 });
     }
 
-    private List<Node<? extends Definition<?>, Edge>> getSelectedNodes(final H canvasHandler) {
+    protected List<Node<? extends Definition<?>, Edge>> getSelectedNodes(final H canvasHandler) {
         return getSelectedNodesStream(canvasHandler)
                 .map(Element::asNode)
                 .collect(Collectors.toList());
     }
 
-    private Stream<? extends Element<? extends Definition<?>>> getSelectedNodesStream(final H canvasHandler) {
+    protected Stream<? extends Element<? extends Definition<?>>> getSelectedNodesStream(final H canvasHandler) {
         return getSelectedItems().stream()
                 .map(uuid -> CanvasLayoutUtils.getElement(canvasHandler, uuid))
                 .filter(element -> element instanceof Node);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControl.java
@@ -29,6 +29,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
 import elemental2.dom.DomGlobal;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
@@ -72,6 +73,7 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
     private Optional<DomainObject> selectedDomainObject = Optional.empty();
     private final ContextMenu drdContextMenu;
     private final ClientTranslationService translationService;
+    private HandlerRegistration handlerRegistration;
 
     @Inject
     public DomainObjectAwareLienzoMultipleSelectionControl(final Event<CanvasSelectionEvent> canvasSelectionEvent,
@@ -88,7 +90,7 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
     protected void onEnable(H canvasHandler) {
         super.onEnable(canvasHandler);
 
-        canvasHandler
+        handlerRegistration = canvasHandler
                 .getAbstractCanvas()
                 .getView()
                 .asWidget()
@@ -103,8 +105,7 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
                         drdContextMenu.appendContextMenuToTheDOM(event.getNativeEvent().getClientX(), event.getNativeEvent().getClientY());
                         drdContextMenu.show(self -> contextMenuHandler(self, getSelectedNodes(canvasHandler)));
                     }
-
-        }, ContextMenuEvent.getType());
+                }, ContextMenuEvent.getType());
     }
 
     private boolean isClickedOnShape(final H canvasHandler, final int canvasX, final int canvasY) {
@@ -186,6 +187,7 @@ public class DomainObjectAwareLienzoMultipleSelectionControl<H extends AbstractC
     @Override
     protected void onDestroy() {
         selectedDomainObject = Optional.empty();
+        handlerRegistration.removeHandler();
         super.onDestroy();
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxAction.java
@@ -19,34 +19,28 @@ package org.kie.workbench.common.dmn.client.canvas.controls.toolbox;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import elemental2.dom.DomGlobal;
-import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
+import org.kie.workbench.common.dmn.client.editors.drd.DRDContextMenu;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ToolboxAction;
-import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.resources.StunnerCommonImageResources;
 import org.kie.workbench.common.stunner.core.client.shape.ImageDataUriGlyph;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseClickEvent;
 import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+
+import static java.util.Collections.singletonList;
 
 @Dependent
 public class DMNEditDRDToolboxAction implements ToolboxAction<AbstractCanvasHandler> {
 
-    public static final String DRDACTIONS_CONTEXT_MENU_TITLE = "DRDActions.ContextMenu.Title";
-    public static final String DRDACTIONS_CONTEXT_MENU_ACTIONS_CREATE = "DRDActions.ContextMenu.Actions.Create";
-    public static final String DRDACTIONS_CONTEXT_MENU_ACTIONS_ADD_TO = "DRDActions.ContextMenu.Actions.AddTo";
-    public static final String DRDACTIONS_CONTEXT_MENU_ACTIONS_REMOVE = "DRDActions.ContextMenu.Actions.Remove";
-    public static final String HEADER_MENU_ICON_CLASS = "fa fa-share-alt";
-    private final ContextMenu drdContextMenu;
-    private final ClientTranslationService translationService;
+    private final DRDContextMenu drdContextMenu;
 
     @Inject
-    public DMNEditDRDToolboxAction(final ContextMenu drdContextMenu, final ClientTranslationService translationService) {
+    public DMNEditDRDToolboxAction(final DRDContextMenu drdContextMenu) {
         this.drdContextMenu = drdContextMenu;
-        this.translationService = translationService;
     }
 
     @Override
@@ -56,27 +50,18 @@ public class DMNEditDRDToolboxAction implements ToolboxAction<AbstractCanvasHand
 
     @Override
     public String getTitle(final AbstractCanvasHandler canvasHandler, final String uuid) {
-        return translationService.getValue(DRDACTIONS_CONTEXT_MENU_TITLE);
+        return drdContextMenu.getTitle();
     }
 
     @Override
     public ToolboxAction<AbstractCanvasHandler> onMouseClick(final AbstractCanvasHandler canvasHandler, final String uuid, final MouseClickEvent event) {
         drdContextMenu.appendContextMenuToTheDOM(event.getClientX(), event.getClientY());
 
-        drdContextMenu.show(self -> contextMenuHandler(self, CanvasLayoutUtils.getElement(canvasHandler, uuid)));
+        final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(canvasHandler, uuid);
+        if (element instanceof Node) {
+            drdContextMenu.show(singletonList(element.asNode()));
+        }
         return this;
     }
 
-    void contextMenuHandler(final ContextMenu contextMenu, final Element<? extends Definition<?>> element) {
-        contextMenu.setHeaderMenu(translationService.getValue(DRDACTIONS_CONTEXT_MENU_TITLE).toUpperCase(), HEADER_MENU_ICON_CLASS);
-        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_CREATE),
-                                    true,
-                                    () -> DomGlobal.console.log("A", element));
-        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_ADD_TO),
-                                    true,
-                                    () -> DomGlobal.console.log("B", element));
-        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_REMOVE),
-                                    true,
-                                    () -> DomGlobal.console.log("C", element));
-    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxAction.java
@@ -20,7 +20,6 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import elemental2.dom.DomGlobal;
-import elemental2.dom.HTMLElement;
 import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
@@ -62,16 +61,9 @@ public class DMNEditDRDToolboxAction implements ToolboxAction<AbstractCanvasHand
 
     @Override
     public ToolboxAction<AbstractCanvasHandler> onMouseClick(final AbstractCanvasHandler canvasHandler, final String uuid, final MouseClickEvent event) {
-        final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(canvasHandler, uuid);
+        drdContextMenu.appendContextMenuToTheDOM(event.getClientX(), event.getClientY());
 
-        final HTMLElement contextMenuElement = drdContextMenu.getElement();
-        contextMenuElement.style.position = "absolute";
-        contextMenuElement.style.left = event.getClientX() + "px";
-        contextMenuElement.style.top = event.getClientY() + "px";
-        DomGlobal.document.body.appendChild(contextMenuElement);
-
-        drdContextMenu.show(self -> contextMenuHandler(self, element));
-
+        drdContextMenu.show(self -> contextMenuHandler(self, CanvasLayoutUtils.getElement(canvasHandler, uuid)));
         return this;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenu.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenu.java
@@ -24,6 +24,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl.ListSelectorHeaderItem;
@@ -82,6 +83,14 @@ public class ContextMenu {
 
     public void addTextMenuItem(final String itemName, final boolean isEnabled, final Command command) {
         menuItems.add(ListSelectorTextItem.build(itemName, isEnabled, command));
+    }
+
+    public void appendContextMenuToTheDOM(final double x, final double y) {
+        final HTMLElement contextMenuElement = this.getElement();
+        contextMenuElement.style.position = "absolute";
+        contextMenuElement.style.left = x + "px";
+        contextMenuElement.style.top = y + "px";
+        DomGlobal.document.body.appendChild(contextMenuElement);
     }
 
     public interface View extends UberElemental<ContextMenu>, IsElement {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenu.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/contextmenu/ContextMenu.java
@@ -24,7 +24,6 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.dmn.client.widgets.grid.controls.list.HasListSelectorControl.ListSelectorHeaderItem;
@@ -83,14 +82,6 @@ public class ContextMenu {
 
     public void addTextMenuItem(final String itemName, final boolean isEnabled, final Command command) {
         menuItems.add(ListSelectorTextItem.build(itemName, isEnabled, command));
-    }
-
-    public void appendContextMenuToTheDOM(final double x, final double y) {
-        final HTMLElement contextMenuElement = this.getElement();
-        contextMenuElement.style.position = "absolute";
-        contextMenuElement.style.left = x + "px";
-        contextMenuElement.style.top = y + "px";
-        DomGlobal.document.body.appendChild(contextMenuElement);
     }
 
     public interface View extends UberElemental<ContextMenu>, IsElement {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDContextMenu.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDContextMenu.java
@@ -63,7 +63,7 @@ public class DRDContextMenu {
         contextMenu.show(self -> setDRDContextMenuHandler(self, selectedNodes));
     }
 
-    public void setDRDContextMenuHandler(final ContextMenu contextMenu, final Collection<Node<? extends Definition<?>, Edge>> selectedNodes) {
+    protected void setDRDContextMenuHandler(final ContextMenu contextMenu, final Collection<Node<? extends Definition<?>, Edge>> selectedNodes) {
         contextMenu.hide();
         contextMenu.setHeaderMenu(translationService.getValue(DRDACTIONS_CONTEXT_MENU_TITLE).toUpperCase(), HEADER_MENU_ICON_CLASS);
         contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_CREATE),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDContextMenu.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/drd/DRDContextMenu.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.drd;
+
+import java.util.Collection;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLElement;
+import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+
+@ApplicationScoped
+public class DRDContextMenu {
+
+    public static final String DRDACTIONS_CONTEXT_MENU_TITLE = "DRDActions.ContextMenu.Title";
+    public static final String DRDACTIONS_CONTEXT_MENU_ACTIONS_CREATE = "DRDActions.ContextMenu.Actions.Create";
+    public static final String DRDACTIONS_CONTEXT_MENU_ACTIONS_ADD_TO = "DRDActions.ContextMenu.Actions.AddTo";
+    public static final String DRDACTIONS_CONTEXT_MENU_ACTIONS_REMOVE = "DRDActions.ContextMenu.Actions.Remove";
+    public static final String HEADER_MENU_ICON_CLASS = "fa fa-share-alt";
+
+    private final ClientTranslationService translationService;
+    private final ContextMenu contextMenu;
+
+    @Inject
+    public DRDContextMenu(final ContextMenu contextMenu, final ClientTranslationService translationService) {
+        this.contextMenu = contextMenu;
+        this.translationService = translationService;
+    }
+
+    public String getTitle() {
+        return translationService.getValue(DRDACTIONS_CONTEXT_MENU_TITLE);
+    }
+
+    public void appendContextMenuToTheDOM(final double x, final double y) {
+        final HTMLElement contextMenuElement = contextMenu.getElement();
+        contextMenuElement.style.position = "absolute";
+        contextMenuElement.style.left = x + "px";
+        contextMenuElement.style.top = y + "px";
+        DomGlobal.document.body.appendChild(contextMenuElement);
+    }
+
+    public void show(final Collection<Node<? extends Definition<?>, Edge>> selectedNodes) {
+        contextMenu.show(self -> setDRDContextMenuHandler(self, selectedNodes));
+    }
+
+    public void setDRDContextMenuHandler(final ContextMenu contextMenu, final Collection<Node<? extends Definition<?>, Edge>> selectedNodes) {
+        contextMenu.hide();
+        contextMenu.setHeaderMenu(translationService.getValue(DRDACTIONS_CONTEXT_MENU_TITLE).toUpperCase(), HEADER_MENU_ICON_CLASS);
+        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_CREATE),
+                                    true,
+                                    () -> DomGlobal.console.log("A", selectedNodes));
+        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_ADD_TO),
+                                    true,
+                                    () -> DomGlobal.console.log("B", selectedNodes));
+        contextMenu.addTextMenuItem(translationService.getValue(DRDACTIONS_CONTEXT_MENU_ACTIONS_REMOVE),
+                                    true,
+                                    () -> DomGlobal.console.log("C", selectedNodes));
+    }
+
+    public HTMLElement getElement() {
+        return contextMenu.getElement();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControlTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControlTest.java
@@ -23,14 +23,18 @@ import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.shape.wires.SelectionManager;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.user.client.ui.Widget;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
+import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvasView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
@@ -98,6 +102,18 @@ public class DomainObjectAwareLienzoMultipleSelectionControlTest {
     @Mock
     private EventSourceMock<CanvasClearSelectionEvent> clearSelectionEvent;
 
+    @Mock
+    private ContextMenu drdContextMenu;
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private WiresCanvasView wiresCanvasView;
+
+    @Mock
+    private Widget canvasWidget;
+
     private DomainObjectAwareLienzoMultipleSelectionControl control;
 
     @Before
@@ -110,10 +126,14 @@ public class DomainObjectAwareLienzoMultipleSelectionControlTest {
         final WiresManager wiresManager = spy(WiresManager.get(lienzoLayer));
 
         this.control = new DomainObjectAwareLienzoMultipleSelectionControl(canvasSelectionEvent,
-                                                                           clearSelectionEvent);
+                                                                           clearSelectionEvent,
+                                                                           drdContextMenu,
+                                                                           translationService);
 
         when(canvasHandler.getCanvas()).thenReturn(canvas);
         when(canvasHandler.getAbstractCanvas()).thenReturn(canvas);
+        when(canvas.getView()).thenReturn(wiresCanvasView);
+        when(wiresCanvasView.asWidget()).thenReturn(canvasWidget);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
         when(diagram.getMetadata()).thenReturn(diagramMetadata);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControlTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControlTest.java
@@ -23,18 +23,18 @@ import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.shape.wires.SelectionManager;
 import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
+import org.kie.workbench.common.dmn.client.editors.drd.DRDContextMenu;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvas;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvasView;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
-import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
@@ -46,6 +46,7 @@ import org.mockito.Mock;
 import org.uberfire.mocks.EventSourceMock;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -103,16 +104,16 @@ public class DomainObjectAwareLienzoMultipleSelectionControlTest {
     private EventSourceMock<CanvasClearSelectionEvent> clearSelectionEvent;
 
     @Mock
-    private ContextMenu drdContextMenu;
-
-    @Mock
-    private ClientTranslationService translationService;
+    private DRDContextMenu drdContextMenu;
 
     @Mock
     private WiresCanvasView wiresCanvasView;
 
     @Mock
     private Widget canvasWidget;
+
+    @Mock
+    private HandlerRegistration handlerRegistration;
 
     private DomainObjectAwareLienzoMultipleSelectionControl control;
 
@@ -127,13 +128,13 @@ public class DomainObjectAwareLienzoMultipleSelectionControlTest {
 
         this.control = new DomainObjectAwareLienzoMultipleSelectionControl(canvasSelectionEvent,
                                                                            clearSelectionEvent,
-                                                                           drdContextMenu,
-                                                                           translationService);
+                                                                           drdContextMenu);
 
         when(canvasHandler.getCanvas()).thenReturn(canvas);
         when(canvasHandler.getAbstractCanvas()).thenReturn(canvas);
         when(canvas.getView()).thenReturn(wiresCanvasView);
         when(wiresCanvasView.asWidget()).thenReturn(canvasWidget);
+        when(canvasWidget.addDomHandler(any(), any())).thenReturn(handlerRegistration);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
         when(diagram.getMetadata()).thenReturn(diagramMetadata);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControlTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/selection/DomainObjectAwareLienzoMultipleSelectionControlTest.java
@@ -16,7 +16,9 @@
 
 package org.kie.workbench.common.dmn.client.canvas.controls.selection;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import com.ait.lienzo.client.core.event.OnEventHandlers;
 import com.ait.lienzo.client.core.shape.Viewport;
@@ -39,7 +41,9 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.Bound;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.mockito.Mock;
@@ -48,6 +52,7 @@ import org.uberfire.mocks.EventSourceMock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -247,5 +252,38 @@ public class DomainObjectAwareLienzoMultipleSelectionControlTest {
         control.destroy();
 
         assertThat(control.getSelectedItemDefinition()).isNotPresent();
+    }
+
+    @Test
+    public void testIsClickedOnShapeWhenShapeIsClicked() {
+        final DomainObjectAwareLienzoMultipleSelectionControl partiallyMockedControl = mock(DomainObjectAwareLienzoMultipleSelectionControl.class);
+        final View view = mock(View.class);
+
+        when(partiallyMockedControl.getSelectedNodesStream(canvasHandler)).thenReturn(Stream.of(element));
+        when(element.getContent()).thenReturn(view);
+        when(view.getBounds()).thenReturn(new Bounds(
+                new Bound(10d, 5d),
+                new Bound(30d, 20d)
+        ));
+        when(partiallyMockedControl.isClickedOnShape(canvasHandler, 25, 15)).thenCallRealMethod();
+
+        assertThat(partiallyMockedControl.isClickedOnShape(canvasHandler, 25, 15)).isTrue();
+    }
+
+    @Test
+    public void testIsClickedOnShapeWhenShapeIsNotClicked() {
+        assertThat(control.isClickedOnShape(canvasHandler, 0, 0)).isFalse();
+    }
+
+    @Test
+    public void testWhenGettingSelectedNodes() {
+        final DomainObjectAwareLienzoMultipleSelectionControl partiallyMockedControl = mock(DomainObjectAwareLienzoMultipleSelectionControl.class);
+
+        when(partiallyMockedControl.getSelectedNodesStream(canvasHandler)).thenReturn(Stream.of(element));
+        when(partiallyMockedControl.getSelectedNodes(canvasHandler)).thenCallRealMethod();
+
+        final List selectedNodes = partiallyMockedControl.getSelectedNodes(canvasHandler);
+        assertThat(selectedNodes).isNotEmpty();
+        assertThat(selectedNodes).hasSize(1);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxActionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxActionTest.java
@@ -16,7 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.canvas.controls.toolbox;
 
-import java.util.function.Consumer;
+import java.util.Collection;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.CSSStyleDeclaration;
@@ -24,13 +24,11 @@ import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLBodyElement;
 import elemental2.dom.HTMLDocument;
 import elemental2.dom.HTMLElement;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
+import org.kie.workbench.common.dmn.client.editors.drd.DRDContextMenu;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
-import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.shape.ImageDataUriGlyph;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseClickEvent;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -38,13 +36,9 @@ import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.mockito.Mock;
 import org.powermock.reflect.Whitebox;
-import org.uberfire.mvp.Command;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kie.workbench.common.dmn.client.canvas.controls.toolbox.DMNEditDRDToolboxAction.DRDACTIONS_CONTEXT_MENU_TITLE;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -66,10 +60,7 @@ public class DMNEditDRDToolboxActionTest {
     private Index<?, ?> graphIndex;
 
     @Mock
-    private ContextMenu drdContextMenu;
-
-    @Mock
-    private ClientTranslationService translationService;
+    private DRDContextMenu drdContextMenu;
 
     @Mock
     private MouseClickEvent mouseClickEvent;
@@ -80,7 +71,7 @@ public class DMNEditDRDToolboxActionTest {
         when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
         when(graphIndex.get(eq(UUID))).thenReturn(node);
 
-        dmnEditDRDToolboxAction = new DMNEditDRDToolboxAction(drdContextMenu, translationService);
+        dmnEditDRDToolboxAction = new DMNEditDRDToolboxAction(drdContextMenu);
     }
 
     @Test
@@ -89,13 +80,13 @@ public class DMNEditDRDToolboxActionTest {
         assertThat(dmnEditDRDToolboxAction.getGlyph(canvasHandler, UUID)).isInstanceOf(ImageDataUriGlyph.class);
     }
 
-    @Test
-    public void testGetTitle() {
-        dmnEditDRDToolboxAction.getTitle(canvasHandler, UUID);
-
-        verify(translationService,
-               times(1)).getValue(eq(DRDACTIONS_CONTEXT_MENU_TITLE));
-    }
+//    @Test
+//    public void testGetTitle() {
+//        dmnEditDRDToolboxAction.getTitle(canvasHandler, UUID);
+//
+//        verify(translationService,
+//               times(1)).getValue(eq(DRDACTIONS_CONTEXT_MENU_TITLE));
+//    }
 
     @Test
     public void testOnMouseClick() {
@@ -108,15 +99,15 @@ public class DMNEditDRDToolboxActionTest {
 
         dmnEditDRDToolboxAction.onMouseClick(canvasHandler, UUID, mouseClickEvent);
 
-        verify(drdContextMenu, times(1)).show(any(Consumer.class));
+        verify(drdContextMenu, times(1)).show(any(Collection.class));
     }
 
-    @Test
-    public void testContextMenuHandler() {
-        when(translationService.getValue(anyString())).thenReturn(StringUtils.EMPTY);
-        dmnEditDRDToolboxAction.contextMenuHandler(drdContextMenu, node);
-
-        verify(drdContextMenu, times(1)).setHeaderMenu(anyString(), anyString());
-        verify(drdContextMenu, times(3)).addTextMenuItem(anyString(), anyBoolean(), any(Command.class));
-    }
+//    @Test
+//    public void testContextMenuHandler() {
+//        when(translationService.getValue(anyString())).thenReturn(StringUtils.EMPTY);
+//        dmnEditDRDToolboxAction.contextMenuHandler(drdContextMenu, node);
+//
+//        verify(drdContextMenu, times(1)).setHeaderMenu(anyString(), anyString());
+//        verify(drdContextMenu, times(3)).addTextMenuItem(anyString(), anyBoolean(), any(Command.class));
+//    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxActionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDRDToolboxActionTest.java
@@ -80,13 +80,14 @@ public class DMNEditDRDToolboxActionTest {
         assertThat(dmnEditDRDToolboxAction.getGlyph(canvasHandler, UUID)).isInstanceOf(ImageDataUriGlyph.class);
     }
 
-//    @Test
-//    public void testGetTitle() {
-//        dmnEditDRDToolboxAction.getTitle(canvasHandler, UUID);
-//
-//        verify(translationService,
-//               times(1)).getValue(eq(DRDACTIONS_CONTEXT_MENU_TITLE));
-//    }
+    @Test
+    public void testGetTitle() {
+        final String title = "TITLE";
+
+        when(drdContextMenu.getTitle()).thenReturn(title);
+
+        assertThat(dmnEditDRDToolboxAction.getTitle(canvasHandler, UUID)).isEqualTo(title);
+    }
 
     @Test
     public void testOnMouseClick() {
@@ -102,12 +103,4 @@ public class DMNEditDRDToolboxActionTest {
         verify(drdContextMenu, times(1)).show(any(Collection.class));
     }
 
-//    @Test
-//    public void testContextMenuHandler() {
-//        when(translationService.getValue(anyString())).thenReturn(StringUtils.EMPTY);
-//        dmnEditDRDToolboxAction.contextMenuHandler(drdContextMenu, node);
-//
-//        verify(drdContextMenu, times(1)).setHeaderMenu(anyString(), anyString());
-//        verify(drdContextMenu, times(3)).addTextMenuItem(anyString(), anyBoolean(), any(Command.class));
-//    }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/drd/DRDContextMenuTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/drd/DRDContextMenuTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.drd;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.function.Consumer;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.CSSStyleDeclaration;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLBodyElement;
+import elemental2.dom.HTMLDocument;
+import elemental2.dom.HTMLElement;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.editors.contextmenu.ContextMenu;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.mockito.Mock;
+import org.powermock.reflect.Whitebox;
+import org.uberfire.mvp.Command;
+
+import static org.kie.workbench.common.dmn.client.editors.drd.DRDContextMenu.DRDACTIONS_CONTEXT_MENU_TITLE;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DRDContextMenuTest {
+
+    private DRDContextMenu drdContextMenu;
+
+    @Mock
+    private ContextMenu contextMenu;
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private Node<? extends Definition<?>, Edge> node;
+
+    @Mock
+    private HTMLElement element;
+
+    @Mock
+    private CSSStyleDeclaration styleDeclaration;
+
+    @Mock
+    private HTMLDocument htmlDocument;
+
+    @Mock
+    private HTMLBodyElement body;
+
+    @Before
+    public void setUp() {
+        drdContextMenu = new DRDContextMenu(contextMenu, translationService);
+    }
+
+    @Test
+    public void testGetTitle() {
+        drdContextMenu.getTitle();
+
+        verify(translationService,
+               times(1)).getValue(eq(DRDACTIONS_CONTEXT_MENU_TITLE));
+    }
+
+    @Test
+    public void testGetElement() {
+        drdContextMenu.getElement();
+
+        verify(contextMenu,
+               times(1)).getElement();
+    }
+
+    @Test
+    public void testShow() {
+        drdContextMenu.show(new ArrayList<>());
+
+        verify(contextMenu,
+               times(1)).show(any(Consumer.class));
+    }
+
+    @Test
+    public void testContextMenuHandler() {
+        when(translationService.getValue(anyString())).thenReturn(StringUtils.EMPTY);
+
+        drdContextMenu.setDRDContextMenuHandler(contextMenu, Collections.singletonList(node));
+
+        verify(contextMenu, times(1)).setHeaderMenu(anyString(), anyString());
+        verify(contextMenu, times(3)).addTextMenuItem(anyString(), anyBoolean(), any(Command.class));
+    }
+
+    @Test
+    public void testAppendContextMenuToTheDOM() {
+        when(contextMenu.getElement()).thenReturn(element);
+        Whitebox.setInternalState(element, "style", styleDeclaration);
+        Whitebox.setInternalState(DomGlobal.class, "document", htmlDocument);
+        Whitebox.setInternalState(htmlDocument, "body", body);
+
+        drdContextMenu.appendContextMenuToTheDOM(10, 10);
+
+        verify(body, times(1)).appendChild(any(HTMLElement.class));
+    }
+}


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-3022

**Task description:** When multiple nodes are selected, it should be possible to add/remove them from an existing DRD or to create a new one with them.

**Proposed solution:** the DRD context menu widget will be displayed when more than one node is selected, right clicking on one of them.

![multiple-selection-drd](https://user-images.githubusercontent.com/22591802/90395747-57711880-e095-11ea-9065-9244f73b63fa.gif)

**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
