### PR TITLE
AF-2452 : Making LRUCache configurable to avoid large memory retention

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/core/LRUBuilderCacheTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/core/LRUBuilderCacheTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.backend.builder.core;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LRUBuilderCacheTest {
+
+    @Test
+    public void testValidateCacheSize() {
+        assertEquals(LRUBuilderCache.validateCacheSize("10"), "10");
+        assertEquals(LRUBuilderCache.validateCacheSize("-10"), LRUBuilderCache.DEFAULT_BUILDER_CACHE_SIZE);
+        assertEquals(LRUBuilderCache.validateCacheSize(""), LRUBuilderCache.DEFAULT_BUILDER_CACHE_SIZE);
+        assertEquals(LRUBuilderCache.validateCacheSize("ab"), LRUBuilderCache.DEFAULT_BUILDER_CACHE_SIZE);
+        assertEquals(LRUBuilderCache.validateCacheSize(null), LRUBuilderCache.DEFAULT_BUILDER_CACHE_SIZE);
+    }
+
+}


### PR DESCRIPTION
**Description** :
 * Introducing new property 'org.kie.builder.cache.size' to configure LRUBuilderCache size

**JIRA**: 

- [AF-2452](https://issues.redhat.com/browse/AF-2452)

- [RHPAM-2808](https://issues.redhat.com/browse/RHPAM-2808)

**referenced Pull Requests**: 

* https://github.com/kiegroup/appformer/pull/1032

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
