### PR TITLE
RHPAM-2910: BPMN Editor - Rule Flow Group should show from which project ruleflow group is loaded 

### DIFF
--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/main/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQuery.java
@@ -134,10 +134,10 @@ public class FindRuleFlowNamesQuery extends AbstractFindQuery implements NamedQu
             final List<RefactoringPageRow> result = new ArrayList(kObjects.size());
 
             for (final KObject kObject : kObjects) {
-                final Map<String, Map<String, String>> ruleFlowGroupNames = getRuleFlowGroupNamesNamesFromKObject(kObject);
-                for (String rkey : ruleFlowGroupNames.keySet()) {
+                final List<Map<String, String>> ruleFlowGroups = getRuleFlowGroupsFromKObject(kObject);
+                for (Map<String, String> group : ruleFlowGroups) {
                     RefactoringMapPageRow row = new RefactoringMapPageRow();
-                    row.setValue(ruleFlowGroupNames.get(rkey));
+                    row.setValue(group);
                     result.add(row);
                 }
             }
@@ -145,24 +145,25 @@ public class FindRuleFlowNamesQuery extends AbstractFindQuery implements NamedQu
             return result;
         }
 
-        private Map<String, Map<String, String>> getRuleFlowGroupNamesNamesFromKObject(final KObject kObject) {
-            final Map<String, Map<String, String>> ruleFlowGroupNames = new HashMap<>();
+        private List<Map<String, String>> getRuleFlowGroupsFromKObject(final KObject kObject) {
+            final List<Map<String, String>> ruleFlowGroups = new ArrayList<>();
             if (kObject == null) {
-                return ruleFlowGroupNames;
+                return ruleFlowGroups;
             }
             for (KProperty<?> property : kObject.getProperties()) {
                 if (SHARED_TERM.equals(property.getName())) {
                     Path path = getPath(kObject);
                     if (path != null) {
-                        ruleFlowGroupNames.put(property.getValue().toString(), new HashMap<>());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("name", property.getValue().toString());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("filename", path.getFileName());
-                        ruleFlowGroupNames.get(property.getValue().toString()).put("pathuri", path.toURI());
+                        Map<String, String> group = new HashMap<>();
+                        group.put("name", property.getValue().toString());
+                        group.put("filename", path.getFileName());
+                        group.put("pathuri", path.toURI());
+                        ruleFlowGroups.add(group);
                     }
                 }
             }
 
-            return ruleFlowGroupNames;
+            return ruleFlowGroups;
         }
 
         private Path getPath(KObject kObject) {

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/query/standard/FindRuleFlowNamesQueryTest.java
@@ -121,7 +121,7 @@ public class FindRuleFlowNamesQueryTest {
     }
 
     @Test
-    public void testExistentGroupUpdated() {
+    public void testExistentGroup() {
         properties.add(property);
         properties.add(property);
 
@@ -129,9 +129,15 @@ public class FindRuleFlowNamesQueryTest {
         when(kObject.getKey()).thenReturn(FILE_PATH);
 
         List<RefactoringPageRow> list = testedBuilder.buildResponse(kObjects);
+        assertEquals(2, list.size());
+
         RefactoringMapPageRow row = (RefactoringMapPageRow) list.get(0);
-        assertEquals(1, list.size());
-        Map<?, ?> map = row.getValue();
+        assertMapPageRow(row.getValue());
+        row = (RefactoringMapPageRow) list.get(1);
+        assertMapPageRow(row.getValue());
+    }
+
+    private void assertMapPageRow(Map<?, ?> map) {
         assertEquals(3, map.size());
         assertEquals(FILE_NAME, map.get("filename"));
         assertEquals(path.toUri().toString(), map.get("pathuri"));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/RuleFlowGroup.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/RuleFlowGroup.java
@@ -15,6 +15,8 @@
  */
 package org.kie.workbench.common.stunner.bpmn.definition.property.task;
 
+import java.util.Objects;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
@@ -32,34 +34,55 @@ public class RuleFlowGroup implements BPMNProperty {
 
     @Value
     @FieldValue
-    private String value;
+    private String name;
+
+    private String fileName;
+
+    private String pathUri;
 
     public RuleFlowGroup() {
         this("");
     }
 
-    public RuleFlowGroup(final String value) {
-        this.value = value;
+    public RuleFlowGroup(final String name) {
+        this.name = name;
     }
 
-    public String getValue() {
-        return value;
+    public String getName() {
+        return name;
     }
 
-    public void setValue(final String value) {
-        this.value = value;
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(final String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getPathUri() {
+        return pathUri;
+    }
+
+    public void setPathUri(final String pathUri) {
+        this.pathUri = pathUri;
     }
 
     @Override
     public int hashCode() {
-        return (null != value) ? value.hashCode() : 0;
+        return (null != name) ? name.hashCode() : 0;
     }
 
     @Override
+    // Group is the same if it has the same name, other data are just for information
     public boolean equals(Object o) {
         if (o instanceof RuleFlowGroup) {
             RuleFlowGroup other = (RuleFlowGroup) o;
-            return (null != value) ? value.equals(other.value) : null == other.value;
+            return Objects.equals(name, other.name);
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/dataproviders/RuleFlowGroupDataEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/forms/dataproviders/RuleFlowGroupDataEvent.java
@@ -18,17 +18,18 @@ package org.kie.workbench.common.stunner.bpmn.forms.dataproviders;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 
 @Portable
 public class RuleFlowGroupDataEvent {
 
-    private final String[] groupNames;
+    private final RuleFlowGroup[] groups;
 
-    public RuleFlowGroupDataEvent(final @MapsTo("groupNames") String[] groupNames) {
-        this.groupNames = groupNames;
+    public RuleFlowGroupDataEvent(final @MapsTo("groupNames") RuleFlowGroup[] groups) {
+        this.groups = groups;
     }
 
-    public String[] getGroupNames() {
-        return groupNames;
+    public RuleFlowGroup[] getGroups() {
+        return groups;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -665,13 +665,15 @@ reassignment.delete=Delete
 MultipleInstanceVariableValidator.InvalidVariableNameError=Invalid characters in the variable name. The variable name must be an alphanumeric value like myVariable, variable1, etc
 MultipleInstanceVariableValidator.InputAssignmentAlreadyExistsError=An input assignment with the name {0} already exists, please use a different name
 MultipleInstanceVariableValidator.OutputAssignmentAlreadyExistsError=An output assignment with the name {0} already exists, please use a different name
-
 #########################
 # BaseCancellingEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseCancellingEventExecutionSet.label=Implementation/Execution
-
 #########################
 # StartEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseStartEventExecutionSet.label=Implementation/Execution
+#########################
+# Combobox Widget
+#########################
+combobox.edit=Edit

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants_es.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants_es.properties
@@ -644,13 +644,15 @@ reassignment.delete=Eliminar
 MultipleInstanceVariableValidator.InvalidVariableNameError=Caracteres no válidos en el nombre de la variable. El nombre de la variable debe ser un valor alfanumérico como myVariable, variable1, etc.
 MultipleInstanceVariableValidator.InputAssignmentAlreadyExistsError=Ya existe una asignación de entrada con el nombre {0}, use un nombre diferente
 MultipleInstanceVariableValidator.OutputAssignmentAlreadyExistsError=Ya existe una asignación de salida con el nombre {0}, use un nombre diferente
-
 #########################
 # BaseCancellingEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseCancellingEventExecutionSet.label=Implementación/Ejecución
-
 #########################
 # StartEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseStartEventExecutionSet.label=Implementación/Ejecución
+#########################
+# Combobox Widget
+#########################
+combobox.edit=Edit

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants_fr.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants_fr.properties
@@ -644,13 +644,15 @@ reassignment.delete=Supprimer
 MultipleInstanceVariableValidator.InvalidVariableNameError=Caractères non valides dans le nom de la variable. Le nom de la variable doit être une valeur alphanumérique comme myVariable, variable1, etc.
 MultipleInstanceVariableValidator.InputAssignmentAlreadyExistsError=Il existe déjà une affectation d’entrée nommée {0}. Veuillez utiliser un autre nom.
 MultipleInstanceVariableValidator.OutputAssignmentAlreadyExistsError=Il existe déjà une affectation de sortie nommée {0}. Veuillez utiliser un autre nom.
-
 #########################
 # BaseCancellingEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseCancellingEventExecutionSet.label=Implémentation/Exécution
-
 #########################
 # StartEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseStartEventExecutionSet.label=Implémentation/Exécution
+#########################
+# Combobox Widget
+#########################
+combobox.edit=Edit

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants_ja.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants_ja.properties
@@ -642,13 +642,15 @@ reassignment.delete=削除
 MultipleInstanceVariableValidator.InvalidVariableNameError=変数名に無効な文字が含まれています。変数名は、myVariable や variable1 などの英数字値を使用してください。
 MultipleInstanceVariableValidator.InputAssignmentAlreadyExistsError={0} という名前の入力割り当てがすでに存在します。別の名前にしてください
 MultipleInstanceVariableValidator.OutputAssignmentAlreadyExistsError={0} という名前の出力割り当てがすでに存在します。別の名前にしてください
-
 #########################
 # BaseCancellingEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseCancellingEventExecutionSet.label=実装/実行
-
 #########################
 # StartEventExecutionSet
 #########################
 org.kie.workbench.common.stunner.bpmn.definition.property.event.BaseStartEventExecutionSet.label=実装/実行
+#########################
+# Combobox Widget
+#########################
+combobox.edit=Edit

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/BusinessRuleTaskPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/BusinessRuleTaskPropertyWriter.java
@@ -55,7 +55,7 @@ public class BusinessRuleTaskPropertyWriter extends ActivityPropertyWriter {
     }
 
     public void setRuleFlowGroup(RuleFlowGroup ruleFlowGroup) {
-        CustomAttribute.ruleFlowGroup.of(baseElement).set(ruleFlowGroup.getValue());
+        CustomAttribute.ruleFlowGroup.of(baseElement).set(ruleFlowGroup.getName());
     }
 
     public void setNamespace(Namespace namespace) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -1735,7 +1735,7 @@ public class BPMNDirectDiagramMarshallerTest {
         assertEquals("my business rule task",
                      businessRuleTask.getGeneral().getName().getValue());
         assertEquals("my-ruleflow-group",
-                     businessRuleTask.getExecutionSet().getRuleFlowGroup().getValue());
+                     businessRuleTask.getExecutionSet().getRuleFlowGroup().getName());
         assertEquals("true",
                      businessRuleTask.getExecutionSet().getIsAsync().getValue().toString());
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/marshalling/tasks/BusinessRuleTaskTest.java
@@ -932,7 +932,7 @@ public class BusinessRuleTaskTest extends TaskTest<BusinessRuleTask> {
         assertNotNull(onExitScriptTypeValues.get(0));
 
         assertEquals(ruleLanguage, executionSet.getRuleLanguage().getValue());
-        assertEquals(ruleFlowGroup, executionSet.getRuleFlowGroup().getValue());
+        assertEquals(ruleFlowGroup, executionSet.getRuleFlowGroup().getName());
         assertEquals(namespace, executionSet.getNamespace().getValue());
         assertEquals(decisionName, executionSet.getDecisionName().getValue());
         assertEquals(dmnModelName, executionSet.getDmnModelName().getValue());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupDataProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupDataProvider.java
@@ -25,6 +25,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RuleFlowGroupDataEvent;
 import org.kie.workbench.common.stunner.forms.client.session.StunnerFormsHandler;
 
@@ -34,7 +35,7 @@ import static java.util.Arrays.stream;
 public class RuleFlowGroupDataProvider {
 
     private final StunnerFormsHandler formsHandler;
-    final List<String> groupNames;
+    final List<RuleFlowGroup> groups;
 
     // CDI proxy.
     public RuleFlowGroupDataProvider() {
@@ -44,26 +45,26 @@ public class RuleFlowGroupDataProvider {
     @Inject
     public RuleFlowGroupDataProvider(final StunnerFormsHandler formsHandler) {
         this.formsHandler = formsHandler;
-        this.groupNames = new LinkedList<>();
+        this.groups = new LinkedList<>();
     }
 
-    public List<String> getRuleFlowGroupNames() {
-        return groupNames;
+    public List<RuleFlowGroup> getRuleFlowGroupNames() {
+        return groups;
     }
 
     void onRuleFlowGroupDataChanged(final @Observes RuleFlowGroupDataEvent event) {
-        setRuleFlowGroupNames(toList(event.getGroupNames()));
+        setRuleFlowGroupNames(toList(event.getGroups()));
     }
 
-    private void setRuleFlowGroupNames(final List<String> names) {
-        if (!groupNames.equals(names)) {
-            groupNames.clear();
-            groupNames.addAll(names);
+    private void setRuleFlowGroupNames(final List<RuleFlowGroup> groups) {
+        if (!this.groups.equals(groups)) {
+            this.groups.clear();
+            this.groups.addAll(groups);
             formsHandler.refreshCurrentSessionForms(BPMNDefinitionSet.class);
         }
     }
 
-    private static List<String> toList(final String[] s) {
+    private static List<RuleFlowGroup> toList(final RuleFlowGroup[] s) {
         return stream(s).collect(Collectors.toList());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRenderer.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.comboBoxEditor;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -28,8 +27,10 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.d
 import org.kie.workbench.common.forms.dynamic.client.rendering.renderers.selectors.SelectorFieldRenderer;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.selectors.StringSelectorOption;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerBPMNConstants;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 
 @Dependent
 public abstract class AbstractComboBoxFieldRenderer<T extends ComboBoxFieldDefinition>
@@ -37,27 +38,39 @@ public abstract class AbstractComboBoxFieldRenderer<T extends ComboBoxFieldDefin
 
     private ComboBoxWidgetView view;
 
+    private ClientTranslationService translationService;
+
     private ListBoxValues valueListBoxValues;
 
     @Inject
-    public AbstractComboBoxFieldRenderer(final ComboBoxWidgetView comboBoxEditor) {
+    public AbstractComboBoxFieldRenderer(final ComboBoxWidgetView comboBoxEditor, final ClientTranslationService translationService) {
         this.view = comboBoxEditor;
+        this.translationService = translationService;
     }
 
     @Override
     protected void refreshInput(Map<String, String> optionsValues,
                                 String defaultValue) {
-        List<String> values = new ArrayList<String>(optionsValues.keySet());
-        java.util.Collections.sort(values);
-        setComboBoxValues(values);
+        setComboBoxValues(optionsValues);
     }
 
     protected void setComboBoxValues(final List<String> values) {
-        valueListBoxValues = new ListBoxValues(ComboBoxWidgetView.CUSTOM_PROMPT,
-                                               "Edit" + " ",
-                                               null);
+        valueListBoxValues = createDefaultListBoxValues();
         valueListBoxValues.addValues(values);
         view.setComboBoxValues(valueListBoxValues);
+    }
+
+    protected void setComboBoxValues(final Map<String, String> values) {
+        valueListBoxValues = createDefaultListBoxValues();
+
+        valueListBoxValues.addValues(values);
+        view.setComboBoxValues(valueListBoxValues);
+    }
+
+    private ListBoxValues createDefaultListBoxValues() {
+        return new ListBoxValues(ComboBoxWidgetView.CUSTOM_PROMPT,
+                                 translationService.getValue(StunnerBPMNConstants.EDIT) + " ",
+                                 null);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRenderer.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 
 import org.kie.workbench.common.forms.adf.rendering.Renderer;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 
 @Dependent
 @Renderer(fieldDefinition = ComboBoxFieldDefinition.class)
@@ -30,8 +31,8 @@ public class ComboBoxFieldRenderer
     public static final String TYPE_NAME = ComboBoxFieldDefinition.FIELD_TYPE.getTypeName();
 
     @Inject
-    public ComboBoxFieldRenderer(final ComboBoxWidgetView comboBoxEditor) {
-        super(comboBoxEditor);
+    public ComboBoxFieldRenderer(final ComboBoxWidgetView comboBoxEditor, final ClientTranslationService translationService) {
+        super(comboBoxEditor, translationService);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxWidgetViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxWidgetViewImpl.java
@@ -47,13 +47,9 @@ public class ComboBoxWidgetViewImpl extends Composite implements ComboBoxWidgetV
     protected TextBox customValueField;
 
     @DataField
-    protected ValueListBox<String> valueField = new ValueListBox<String>(new Renderer<String>() {
+    protected ValueListBox<String> valueField = new ValueListBox<>(new Renderer<String>() {
         public String render(final String object) {
-            String s = "";
-            if (object != null) {
-                s = object.toString();
-            }
-            return s;
+            return (object != null) ? object : "";
         }
 
         public void render(final String object,
@@ -120,7 +116,7 @@ public class ComboBoxWidgetViewImpl extends Composite implements ComboBoxWidgetV
     public void setValue(final String newValue,
                          final boolean fireEvents) {
         String oldValue = currentValue;
-        currentValue = newValue;
+        currentValue = listBoxValues.getValueForDisplayValue(newValue);
         initView();
         if (fireEvents) {
             ValueChangeEvent.fireIfNotEqual(this,
@@ -142,7 +138,7 @@ public class ComboBoxWidgetViewImpl extends Composite implements ComboBoxWidgetV
     }
 
     protected void initView() {
-        dataModel.setModelValue(currentValue);
+        dataModel.setModelValue(listBoxValues.getDisplayNameForValue(currentValue));
         if (dataModel.customValue != null) {
             customValueField.setValue(dataModel.customValue);
             valueField.setValue(dataModel.customValue);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRenderer.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.BPMNPropertySet;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldDefinition;
 import org.kie.workbench.common.stunner.bpmn.util.MultipleFieldStringSerializer;
 import org.kie.workbench.common.stunner.core.client.definition.adapter.binding.ClientBindingUtils;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 
 /**
@@ -48,8 +49,9 @@ public class ConditionalComboBoxFieldRenderer extends AbstractComboBoxFieldRende
 
     @Inject
     public ConditionalComboBoxFieldRenderer(@FixedValues final ComboBoxFixedValuesWidgetView comboBoxEditor,
-                                            AdapterManager adapterManager) {
-        super(comboBoxEditor);
+                                            final ClientTranslationService translationService,
+                                            final AdapterManager adapterManager) {
+        super(comboBoxEditor, translationService);
         this.adapterManager = adapterManager;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerBPMNConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerBPMNConstants.java
@@ -97,4 +97,7 @@ public interface StunnerBPMNConstants {
 
     @TranslationKey(defaultValue = "Time period")
     String NOTIFICATION_EXPIRATION_TIMEPERIOD_LABEL = "notification.expiration.timeperiod.label";
+
+    @TranslationKey(defaultValue = "Edit")
+    String EDIT = "combobox.edit";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
@@ -100,6 +100,24 @@ public class ListBoxValues {
         }
     }
 
+    public void addValues(final Map<String, String> acceptableValues) {
+        clear();
+        if (acceptableValues == null) {
+            return;
+        }
+        List<String> keys = new ArrayList<>(acceptableValues.keySet());
+        java.util.Collections.sort(keys);
+
+        acceptableValuesWithCustomValues.add("");
+        acceptableValuesWithCustomValues.add(customPrompt);
+        for (String groupName : keys) {
+            String displayName = acceptableValues.get(groupName);
+            mapDisplayValuesToValues.put(displayName, groupName);
+            acceptableValuesWithoutCustomValues.add(displayName);
+            acceptableValuesWithCustomValues.add(displayName);
+        }
+    }
+
     public String addCustomValue(final String newValue,
                                  final String oldValue) {
         if (oldValue != null && !oldValue.isEmpty()) {
@@ -164,7 +182,7 @@ public class ListBoxValues {
         if (value == null || value.isEmpty()) {
             return false;
         } else {
-            return customValues.contains(value);
+            return customValues.contains(getValueForDisplayValue(value));
         }
     }
 
@@ -268,6 +286,14 @@ public class ListBoxValues {
             return mapDisplayValuesToValues.get(key);
         }
         return key;
+    }
+
+    public String getDisplayNameForValue(final String value) {
+        return mapDisplayValuesToValues.entrySet().stream()
+                .filter(v -> v.getValue().equals(value))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(value);
     }
 
     public String getNonCustomValueForUserString(final String userValue) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/ComboBoxViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/ComboBoxViewImpl.java
@@ -18,12 +18,7 @@ package org.kie.workbench.common.stunner.bpmn.client.forms.widgets;
 
 import java.util.List;
 
-import com.google.gwt.event.dom.client.BlurEvent;
-import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.FocusEvent;
-import com.google.gwt.event.dom.client.FocusHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.ValueListBox;
 
@@ -49,31 +44,13 @@ public class ComboBoxViewImpl implements ComboBoxView {
         this.textBox = textBox;
         this.textBox.setPlaceholder(placeholder);
         textBox.setVisible(false);
-        listBox.addValueChangeHandler(new ValueChangeHandler<String>() {
-            @Override
-            public void onValueChange(final ValueChangeEvent<String> valueChangeEvent) {
-                presenter.listBoxValueChanged(valueChangeEvent.getValue());
-            }
-        });
-        listBox.addDomHandler(new FocusHandler() {
-                                  @Override
-                                  public void onFocus(final FocusEvent focusEvent) {
-                                      listBoxGotFocus();
-                                  }
-                              },
+        listBox.addValueChangeHandler(valueChangeEvent -> presenter.listBoxValueChanged(valueChangeEvent.getValue()));
+        listBox.addDomHandler(focusEvent -> listBoxGotFocus(),
                               FocusEvent.getType());
-        textBox.addFocusHandler(new FocusHandler() {
-            @Override
-            public void onFocus(final FocusEvent focusEvent) {
-                textBoxGotFocus();
-            }
-        });
-        textBox.addBlurHandler(new BlurHandler() {
-            @Override
-            public void onBlur(final BlurEvent blurEvent) {
-                // Update ListBoxValues and set model values when textBox loses focus
-                textBoxLostFocus();
-            }
+        textBox.addFocusHandler(focusEvent -> textBoxGotFocus());
+        textBox.addBlurHandler(blurEvent -> {
+            // Update ListBoxValues and set model values when textBox loses focus
+            textBoxLostFocus();
         });
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupDataProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupDataProviderTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RuleFlowGroupDataEvent;
 import org.kie.workbench.common.stunner.forms.client.session.StunnerFormsHandler;
 import org.mockito.Mock;
@@ -29,7 +30,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -53,23 +53,27 @@ public class RuleFlowGroupDataProviderTest {
 
     @Test
     public void testOnRuleFlowGroupDataChanged() {
+        RuleFlowGroup group1 = new RuleFlowGroup("g1");
+        RuleFlowGroup group2 = new RuleFlowGroup("g2");
         RuleFlowGroupDataEvent event = mock(RuleFlowGroupDataEvent.class);
-        when(event.getGroupNames()).thenReturn(new String[]{"g1", "g2"});
+        when(event.getGroups()).thenReturn(new RuleFlowGroup[]{group1, group2});
         tested.onRuleFlowGroupDataChanged(event);
         verify(formsHandler, times(1)).refreshCurrentSessionForms(eq(BPMNDefinitionSet.class));
-        List<String> values = tested.getRuleFlowGroupNames();
+        List<RuleFlowGroup> values = tested.getRuleFlowGroupNames();
         assertNotNull(values);
         assertEquals(2, values.size());
-        assertTrue(values.contains("g1"));
-        assertTrue(values.contains("g2"));
+        assertEquals("g1", values.get(0).getName());
+        assertEquals("g2", values.get(1).getName());
     }
 
     @Test
     public void testOnRuleFlowGroupDataNotChanged() {
-        tested.groupNames.add("g1");
-        tested.groupNames.add("g2");
+        RuleFlowGroup group1 = new RuleFlowGroup("g1");
+        RuleFlowGroup group2 = new RuleFlowGroup("g2");
+        tested.groups.add(group1);
+        tested.groups.add(group2);
         RuleFlowGroupDataEvent event = mock(RuleFlowGroupDataEvent.class);
-        when(event.getGroupNames()).thenReturn(new String[]{"g1", "g2"});
+        when(event.getGroups()).thenReturn(new RuleFlowGroup[]{group1, group2});
         tested.onRuleFlowGroupDataChanged(event);
         verify(formsHandler, never()).refreshCurrentSessionForms(any(Class.class));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/dataproviders/RuleFlowGroupFormProviderTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.dynamic.model.config.SelectorData;
 import org.kie.workbench.common.forms.dynamic.service.shared.FormRenderingContext;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestRuleFlowGroupDataEvent;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,7 +33,6 @@ import org.uberfire.mocks.EventSourceMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -63,17 +63,42 @@ public class RuleFlowGroupFormProviderTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetSelectorData() {
-        List<String> names = Arrays.asList("g1", "g2", "g3");
-        when(dataProvider.getRuleFlowGroupNames()).thenReturn(names);
+        RuleFlowGroup group1 = new RuleFlowGroup("g1");
+        group1.setPathUri("default://master@MySpace/Project1/src/main/resources/com/myspace/project1/RulesFile.rdrl");
+        RuleFlowGroup group2 = new RuleFlowGroup("g2");
+        group2.setPathUri("default://master@MySpace/Project1/src/main/resources/com/myspace/RulesFile2.rdrl".replace('/', '\\'));
+        RuleFlowGroup group3 = new RuleFlowGroup("g1");
+        group3.setPathUri("default://master@MySpace/Project2/src/main/resources/com/myspace/project1/RulesFile.rdrl");
+        List<RuleFlowGroup> groups = Arrays.asList(group1, group2, group3);
+        when(dataProvider.getRuleFlowGroupNames()).thenReturn(groups);
         FormRenderingContext context = mock(FormRenderingContext.class);
         SelectorData data = tested.getSelectorData(context);
-        Map values = data.getValues();
+        Map<String, String> values = data.getValues();
         assertNotNull(values);
-        assertEquals(3, values.size());
-        assertTrue(values.containsKey("g1"));
-        assertTrue(values.containsKey("g2"));
-        assertTrue(values.containsKey("g3"));
+        assertEquals(2, values.size());
+        assertEquals("g2 [Project1]", values.get(group2.getName()));
+        assertEquals("g1 [Project1, Project2]", values.get(group1.getName()));
+        verify(requestRuleFlowGroupDataEvent, times(1)).fire(any(RequestRuleFlowGroupDataEvent.class));
+    }
+
+    @Test
+    public void testGroupWithSameProject() {
+        RuleFlowGroup group1 = new RuleFlowGroup("g1");
+        group1.setPathUri("default://master@MySpace/Project1/src/main/resources/com/myspace/project1/RulesFile.rdrl");
+        RuleFlowGroup group2 = new RuleFlowGroup("g1");
+        group2.setPathUri("default://master@MySpace/Project1/src/main/resources/com/myspace/RulesFile2.rdrl".replace('/', '\\'));
+        RuleFlowGroup group3 = new RuleFlowGroup("g1");
+        group3.setPathUri("default://master@MySpace/Project2/src/main/resources/com/myspace/project1/RulesFile.rdrl");
+        List<RuleFlowGroup> groups = Arrays.asList(group1, group2, group3);
+        when(dataProvider.getRuleFlowGroupNames()).thenReturn(groups);
+        FormRenderingContext context = mock(FormRenderingContext.class);
+        SelectorData<String> data = tested.getSelectorData(context);
+        Map<String, String> values = data.getValues();
+        assertNotNull(values);
+        assertEquals(1, values.size());
+        assertEquals("g1 [Project1, Project2]", values.get(group1.getName()));
         verify(requestRuleFlowGroupDataEvent, times(1)).fire(any(RequestRuleFlowGroupDataEvent.class));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/AbstractComboBoxFieldRendererTest.java
@@ -24,8 +24,10 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.i18n.StunnerBPMNConstants;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.ListBoxValues;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -34,6 +36,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractComboBoxFieldRendererTest {
@@ -42,11 +45,14 @@ public class AbstractComboBoxFieldRendererTest {
     private ComboBoxWidgetView comboBoxWidgetView;
 
     @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
     private ComboBoxFieldDefinition comboBoxFieldDefinition;
 
     @Spy
     @InjectMocks
-    private AbstractComboBoxFieldRenderer comboBoxFieldRenderer = new ComboBoxFieldRenderer(comboBoxWidgetView);
+    private AbstractComboBoxFieldRenderer comboBoxFieldRenderer = new ComboBoxFieldRenderer(comboBoxWidgetView, translationService);
 
     private Map<String, String> options;
 
@@ -59,6 +65,8 @@ public class AbstractComboBoxFieldRendererTest {
                     "1.77");
         options.put("gender",
                     "male");
+
+        when(translationService.getValue(StunnerBPMNConstants.EDIT)).thenReturn("Edit");
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxFieldRendererTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldDefinition;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ComboBoxFieldType;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -35,9 +36,12 @@ public class ComboBoxFieldRendererTest {
     @Mock
     private ComboBoxFieldDefinition comboBoxFieldDefinition;
 
+    @Mock
+    private ClientTranslationService translationService;
+
     @Spy
     @InjectMocks
-    private ComboBoxFieldRenderer comboBoxFieldRenderer = new ComboBoxFieldRenderer(comboBoxWidgetView);
+    private ComboBoxFieldRenderer comboBoxFieldRenderer = new ComboBoxFieldRenderer(comboBoxWidgetView, translationService);
 
     @Test
     public void getName() throws Exception {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxWidgetViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ComboBoxWidgetViewImplTest.java
@@ -52,7 +52,7 @@ public class ComboBoxWidgetViewImplTest {
         dataModel = mock(ComboBoxWidgetViewImpl.DataModel.class);
         view = mock(ComboBoxWidgetViewImpl.class);
         view.customValueField = customValueField;
-        ;
+
         view.valueComboBox = valueComboBox;
         view.dataModel = dataModel;
         doCallRealMethod().when(view).init();
@@ -79,6 +79,10 @@ public class ComboBoxWidgetViewImplTest {
 
     @Test
     public void testSetValue() {
+        ListBoxValues listBoxValues = new ListBoxValues(null,
+                                                        null,
+                                                        null);
+        view.setComboBoxValues(listBoxValues);
         String value = "test";
         view.setValue(value);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/comboBoxEditor/ConditionalComboBoxFieldRendererTest.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.task.OnExitActi
 import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldDefinition;
 import org.kie.workbench.common.stunner.bpmn.forms.model.ConditionalComboBoxFieldType;
 import org.kie.workbench.common.stunner.core.client.definition.adapter.binding.ClientBindingUtils;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.definition.adapter.AdapterManager;
 import org.kie.workbench.common.stunner.core.definition.adapter.PropertyAdapter;
 import org.mockito.BDDMockito;
@@ -67,9 +68,13 @@ public class ConditionalComboBoxFieldRendererTest {
     @Mock
     private FormRenderingContext renderingContextParent;
 
+    @Mock
+    private ClientTranslationService translationService;
+
     @Spy
     @InjectMocks
     private ConditionalComboBoxFieldRenderer conditionalComboBoxFieldRenderer = new ConditionalComboBoxFieldRenderer(comboBoxFixedValuesWidgetView,
+                                                                                                                     translationService,
                                                                                                                      adapterManager);
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
@@ -17,12 +17,17 @@
 package org.kie.workbench.common.stunner.bpmn.client.forms.util;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.assignmentsEditor.ActivityDataIOEditorViewImpl;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentData;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ListBoxValuesTest {
 
@@ -344,17 +349,75 @@ public class ListBoxValuesTest {
         // Copy custom values as well as non-custom
         ListBoxValues copy1 = new ListBoxValues(listBoxValues,
                                                 true);
-        Assert.assertTrue(copy1.getAcceptableValuesWithCustomValues().size() == 8);
-        Assert.assertTrue(copy1.getAcceptableValuesWithoutCustomValues().size() == 4);
-        Assert.assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"abc\""));
-        Assert.assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"def\""));
+        assertTrue(copy1.getAcceptableValuesWithCustomValues().size() == 8);
+        assertTrue(copy1.getAcceptableValuesWithoutCustomValues().size() == 4);
+        assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"abc\""));
+        assertTrue(copy1.getAcceptableValuesWithCustomValues().contains("\"def\""));
 
         // Don't copy custom values as well as non-custom
         ListBoxValues copy2 = new ListBoxValues(listBoxValues,
                                                 false);
-        Assert.assertTrue(copy2.getAcceptableValuesWithCustomValues().size() == 6);
-        Assert.assertTrue(copy2.getAcceptableValuesWithoutCustomValues().size() == 4);
+        assertTrue(copy2.getAcceptableValuesWithCustomValues().size() == 6);
+        assertTrue(copy2.getAcceptableValuesWithoutCustomValues().size() == 4);
         Assert.assertFalse(copy2.getAcceptableValuesWithCustomValues().contains("\"abc\""));
         Assert.assertFalse(copy2.getAcceptableValuesWithCustomValues().contains("\"def\""));
+    }
+
+    @Test
+    public void testAddNullValuesAsMap() {
+        ListBoxValues values = new ListBoxValues("Constant ...",
+                                                 "Edit ",
+                                                 null);
+        Map<String, String> testNull = null;
+        values.addValues(testNull);
+        assertTrue(values.getAcceptableValuesWithCustomValues().isEmpty());
+    }
+
+    @Test
+    public void testAddEmptyValuesAsMap() {
+        ListBoxValues values = new ListBoxValues("Constant ...",
+                                                 "Edit ",
+                                                 null);
+        Map<String, String> testEmpty = new HashMap<>();
+        values.addValues(testEmpty);
+        assertEquals(2, values.getAcceptableValuesWithCustomValues().size());
+        assertTrue(values.getAcceptableValuesWithoutCustomValues().isEmpty());
+        assertTrue(values.mapDisplayValuesToValues.isEmpty());
+    }
+
+    @Test
+    public void testAddValueWithDifferentKeysValues() {
+        ListBoxValues values = new ListBoxValues("Constant ...",
+                                                 "Edit ",
+                                                 null);
+        Map<String, String> testMap = new HashMap<>();
+        String displayName1 = "firstDisplayName";
+        String displayName2 = "secondDisplayName";
+        String valueName1 = "02firstKey";
+        String valueName2 = "01secondKey";
+        testMap.put(valueName1, displayName1);
+        testMap.put(valueName2, displayName2);
+        values.addValues(testMap);
+
+        assertEquals(4, values.getAcceptableValuesWithCustomValues().size());
+        assertEquals(2, values.getAcceptableValuesWithoutCustomValues().size());
+        assertEquals(2, values.mapDisplayValuesToValues.size());
+        assertEquals(displayName1, values.getDisplayNameForValue(valueName1));
+        assertEquals(displayName2, values.getDisplayNameForValue(valueName2));
+        assertEquals(valueName1, values.getValueForDisplayValue(displayName1));
+        assertEquals(valueName2, values.getValueForDisplayValue(displayName2));
+
+        String nonMappedValue = "nonMappedValue";
+        assertEquals(nonMappedValue, values.getDisplayNameForValue(nonMappedValue));
+    }
+
+    @Test
+    public void testEmptyValueDisplayNameMap() {
+        ListBoxValues values = new ListBoxValues("Constant ...",
+                                                 "Edit ",
+                                                 null);
+
+        String nonMappedValue = "nonMappedValue";
+        assertEquals(nonMappedValue, values.getDisplayNameForValue(nonMappedValue));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/ComboBoxAllTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/widgets/ComboBoxAllTest.java
@@ -32,6 +32,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -263,13 +264,12 @@ public class ComboBoxAllTest {
                 contains(StringUtils.createQuotedStringIfNotNumeric(customStringValue1)));
         assertTrue(getListBoxValues().getAcceptableValuesWithCustomValues().
                 contains(customNumericValue1));
-        assertTrue(!getListBoxValues().getAcceptableValuesWithCustomValues().
+        assertFalse(getListBoxValues().getAcceptableValuesWithCustomValues().
                 contains(customNumericValue2));
         assertTrue(getListBoxValues().getAcceptableValuesWithCustomValues().
                 contains(customNumericValue3));
         assertTrue(getListBoxValues().getAcceptableValuesWithCustomValues().
                 contains(StringUtils.createQuotedStringIfNotNumeric(customStringValue2)));
-//        System.out.println(comboBox.getListBoxValues().toString());
     }
 
     @Test
@@ -296,24 +296,19 @@ public class ComboBoxAllTest {
         setCustomValue(customDataType2);
         setNonCustomValue(customDataType1,
                           3);
-//        System.out.println(comboBox.getListBoxValues().toString());
     }
 
     private void setCustomValue(String value) {
         comboBox.view.listBoxGotFocus();
         comboBox.listBoxValueChanged(this.customPrompt);
-        assertEquals(listBox.isVisible(),
-                     false);
-        assertEquals(textBox.isVisible(),
-                     true);
+        assertFalse(listBox.isVisible());
+        assertTrue(textBox.isVisible());
         comboBox.view.textBoxGotFocus();
         textBox.setValue(value);
         comboBox.view.textBoxLostFocus();
         comboBox.view.listBoxGotFocus();
-        assertEquals(listBox.isVisible(),
-                     true);
-        assertEquals(textBox.isVisible(),
-                     false);
+        assertTrue(listBox.isVisible());
+        assertFalse(textBox.isVisible());
         String listBoxValue = this.quoteStringValues ? StringUtils.createQuotedStringIfNotNumeric(value) : value;
         verify(modelPresenter).setTextBoxModelValue(textBox,
                                                     value);
@@ -325,10 +320,8 @@ public class ComboBoxAllTest {
                                    int times) {
         comboBox.view.listBoxGotFocus();
         comboBox.listBoxValueChanged(value);
-        assertEquals(listBox.isVisible(),
-                     true);
-        assertEquals(textBox.isVisible(),
-                     false);
+        assertTrue(listBox.isVisible());
+        assertFalse(textBox.isVisible());
         verify(modelPresenter,
                times(times)).setListBoxModelValue(listBox,
                                                   value);
@@ -340,10 +333,8 @@ public class ComboBoxAllTest {
                                         int times) {
         comboBox.view.listBoxGotFocus();
         comboBox.listBoxValueChanged(this.editPrefix + value + this.editSuffix);
-        assertEquals(listBox.isVisible(),
-                     false);
-        assertEquals(textBox.isVisible(),
-                     true);
+        assertFalse(listBox.isVisible());
+        assertTrue(textBox.isVisible());
         verify(modelPresenter,
                times(times)).setTextBoxModelValue(textBox,
                                                   value);
@@ -356,10 +347,8 @@ public class ComboBoxAllTest {
         textBox.setValue(value);
         comboBox.view.textBoxLostFocus();
         comboBox.view.listBoxGotFocus();
-        assertEquals(listBox.isVisible(),
-                     true);
-        assertEquals(textBox.isVisible(),
-                     false);
+        assertTrue(listBox.isVisible());
+        assertFalse(textBox.isVisible());
         String listBoxValue = this.quoteStringValues ? StringUtils.createQuotedStringIfNotNumeric(value) : value;
         verify(modelPresenter).setTextBoxModelValue(textBox,
                                                     listBoxValue);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/BusinessRuleTaskPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/BusinessRuleTaskPropertyWriter.java
@@ -55,7 +55,7 @@ public class BusinessRuleTaskPropertyWriter extends ActivityPropertyWriter {
     }
 
     public void setRuleFlowGroup(RuleFlowGroup ruleFlowGroup) {
-        CustomAttribute.ruleFlowGroup.of(baseElement).set(ruleFlowGroup.getValue());
+        CustomAttribute.ruleFlowGroup.of(baseElement).set(ruleFlowGroup.getName());
     }
 
     public void setNamespace(Namespace namespace) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupDataService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupDataService.java
@@ -23,6 +23,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestRuleFlowGroupDataEvent;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RuleFlowGroupDataEvent;
 
@@ -39,7 +40,7 @@ public class RuleFlowGroupDataService {
         this.dataChangedEvent = dataChangedEvent;
     }
 
-    public List<String> getRuleFlowGroupNames() {
+    public List<RuleFlowGroup> getRuleFlowGroupNames() {
         return queryService.getRuleFlowGroupNames();
     }
 
@@ -48,7 +49,7 @@ public class RuleFlowGroupDataService {
     }
 
     void fireData() {
-        final List<String> groupNames = getRuleFlowGroupNames();
-        dataChangedEvent.fire(new RuleFlowGroupDataEvent(groupNames.toArray(new String[groupNames.size()])));
+        final RuleFlowGroup[] groupNames = getRuleFlowGroupNames().toArray(new RuleFlowGroup[0]);
+        dataChangedEvent.fire(new RuleFlowGroupDataEvent(groupNames));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/BPMNDiagramProjectServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/BPMNDiagramProjectServiceTest.java
@@ -33,6 +33,7 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -83,13 +84,13 @@ public class BPMNDiagramProjectServiceTest {
     @Test
     public void getProjectTypeCase() {
         final ProjectType projectType = tested.getProjectType(projectPath);
-        assertEquals(projectType, ProjectType.CASE);
+        assertEquals(ProjectType.CASE, projectType);
     }
 
     @Test
     public void getProjectTypeNull() {
         when(directoryStream.spliterator()).thenReturn(Collections.<Path>emptyList().spliterator());
         final ProjectType projectType = tested.getProjectType(projectPath);
-        assertEquals(projectType, null);
+        assertNull(projectType);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupDataServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupDataServiceTest.java
@@ -24,6 +24,7 @@ import javax.enterprise.event.Event;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RequestRuleFlowGroupDataEvent;
 import org.kie.workbench.common.stunner.bpmn.forms.dataproviders.RuleFlowGroupDataEvent;
 import org.mockito.ArgumentCaptor;
@@ -51,13 +52,15 @@ public class RuleFlowGroupDataServiceTest {
 
     @Before
     public void setUp() {
-        when(queryService.getRuleFlowGroupNames()).thenReturn(Arrays.asList("g1", "g2"));
+        RuleFlowGroup group1 = new RuleFlowGroup("g1");
+        RuleFlowGroup group2 = new RuleFlowGroup("g2");
+        when(queryService.getRuleFlowGroupNames()).thenReturn(Arrays.asList(group1, group2));
         tested = new RuleFlowGroupDataService(queryService, dataChangedEvent);
     }
 
     @Test
     public void testGetRuleFlowGroupNames() {
-        List<String> names = tested.getRuleFlowGroupNames();
+        List<RuleFlowGroup> names = tested.getRuleFlowGroupNames();
         assertRightRuleFlowGroupNames(names);
     }
 
@@ -67,7 +70,7 @@ public class RuleFlowGroupDataServiceTest {
         ArgumentCaptor<RuleFlowGroupDataEvent> ec = ArgumentCaptor.forClass(RuleFlowGroupDataEvent.class);
         verify(dataChangedEvent, times(1)).fire(ec.capture());
         RuleFlowGroupDataEvent event = ec.getValue();
-        assertRightRuleFlowGroupNames(event.getGroupNames());
+        assertRightRuleFlowGroups(event.getGroups());
     }
 
 
@@ -78,17 +81,17 @@ public class RuleFlowGroupDataServiceTest {
         verify(tested).fireData();
     }
 
-    private static void assertRightRuleFlowGroupNames(String[] names) {
+    private static void assertRightRuleFlowGroups(RuleFlowGroup[] names) {
         assertNotNull(names);
         assertEquals(2, names.length);
-        assertEquals("g1", names[0]);
-        assertEquals("g2", names[1]);
+        assertEquals("g1", names[0].getName());
+        assertEquals("g2", names[1].getName());
     }
 
-    private static void assertRightRuleFlowGroupNames(List<String> names) {
+    private static void assertRightRuleFlowGroupNames(List<RuleFlowGroup> names) {
         assertNotNull(names);
         assertEquals(2, names.size());
-        assertTrue(names.contains("g1"));
-        assertTrue(names.contains("g2"));
+        assertTrue(names.contains(new RuleFlowGroup("g1")));
+        assertTrue(names.contains(new RuleFlowGroup("g2")));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupQueryServiceTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/RuleFlowGroupQueryServiceTest.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueSharedPartIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
 import org.kie.workbench.common.services.refactoring.service.PartType;
+import org.kie.workbench.common.stunner.bpmn.definition.property.task.RuleFlowGroup;
 import org.uberfire.io.IOService;
 
 import static org.junit.Assert.assertEquals;
@@ -107,12 +108,16 @@ public class RuleFlowGroupQueryServiceTest {
         RefactoringPageRow emptyRow2 = mock(RefactoringPageRow.class);
         when(emptyRow2.getValue()).thenReturn(asMap(""));
         List<RefactoringPageRow> rows = Arrays.asList(row1, row2, row3, row4, row4_2, emptyRow1, emptyRow2);
-        List<String> result = RuleFlowGroupQueryService.DEFAULT_RESULT_CONVERTER.apply(rows);
-        assertEquals(4, result.size());
-        assertTrue(result.contains("row1"));
-        assertTrue(result.contains("row2"));
-        assertTrue(result.contains("row3"));
-        assertTrue(result.contains("row4"));
+        List<RuleFlowGroup> result = RuleFlowGroupQueryService.DEFAULT_RESULT_CONVERTER.apply(rows);
+        assertEquals(5, result.size());
+        RuleFlowGroup group1 = new RuleFlowGroup("row1");
+        RuleFlowGroup group2 = new RuleFlowGroup("row2");
+        RuleFlowGroup group3 = new RuleFlowGroup("row3");
+        RuleFlowGroup group4 = new RuleFlowGroup("row4");
+        assertTrue(result.contains(group1));
+        assertTrue(result.contains(group2));
+        assertTrue(result.contains(group3));
+        assertTrue(result.contains(group4));
     }
 
     private static Map<String, String> asMap(String s) {


### PR DESCRIPTION
This is just a cherry-pick.

**JIRA**:

[RHPAM-2910](https://issues.redhat.com/browse/RHPAM-2910 )

**referenced Pull Requests**: 
* https://github.com/kiegroup/kie-wb-common/pull/3325

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
