### PR TITLE
RHPAM-3134 : UI issue (in business-central) when more than one kie-server (with different ID) is connected

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenter.java
@@ -75,10 +75,8 @@ public class ContainerRemoteStatusPresenter {
         if ( serverInstanceUpdated != null &&
                 serverInstanceUpdated.getServerInstance() != null ) {
             final String updatedServerInstanceKey = serverInstanceUpdated.getServerInstance().getServerInstanceId();
-            if ( index.containsKey( updatedServerInstanceKey ) || index.isEmpty() ) {
-                final Map<String, ContainerCardPresenter> oldIndex = index.isEmpty() ?
-                        new HashMap<String, ContainerCardPresenter>() :
-                        new HashMap<String, ContainerCardPresenter>( index.remove( updatedServerInstanceKey ) );
+            if ( index.containsKey( updatedServerInstanceKey )) {
+                final Map<String, ContainerCardPresenter> oldIndex = new HashMap<String, ContainerCardPresenter>( index.remove( updatedServerInstanceKey ) );
                 final Map<String, ContainerCardPresenter> newIndexIndex = new HashMap<String, ContainerCardPresenter>( serverInstanceUpdated.getServerInstance().getContainers().size() );
                 index.put( updatedServerInstanceKey, newIndexIndex );
                 for ( final Container container : serverInstanceUpdated.getServerInstance().getContainers() ) {
@@ -98,7 +96,8 @@ public class ContainerRemoteStatusPresenter {
                 }
             } else {
                 for ( final Container container : serverInstanceUpdated.getServerInstance().getContainers() ) {
-                    if ( container.getServerTemplateId().equals( containerSpec.getServerTemplateKey().getId() ) &&
+                    if ( containerSpec != null &&
+                            container.getServerTemplateId().equals( containerSpec.getServerTemplateKey().getId() ) &&
                             container.getContainerSpecId().equals( containerSpec.getId() ) ) {
                         buildAndIndexContainer( container );
                     }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/status/ContainerRemoteStatusPresenterTest.java
@@ -158,6 +158,11 @@ public class ContainerRemoteStatusPresenterTest {
         newContainer.setStatus( KieContainerStatus.STARTED );
         newServerInstance.addContainer( newContainer );
 
+        // To check when ContainerSpec not available
+        presenter.onServerInstanceUpdated( new ServerInstanceUpdated( newServerInstance ) );
+
+        verify( cardPresenter , times(0)).setup( toKey( newServerInstance ), newContainer );
+
         presenter.setup( new ContainerSpec( "containerSpecId", "containerName", new ServerTemplateKey( "templateId", "templateId" ), new ReleaseId(), KieContainerStatus.STARTED, Collections.<Capability, ContainerConfig>emptyMap() ), Arrays.asList( existingContainer ) );
 
         verify( cardPresenter ).setup( toKey( serverInstance ), existingContainer );


### PR DESCRIPTION


 - Added ContainerSpec check
 - clean up

**JIRA**:  [RHPAM-3134](https://issues.redhat.com/browse/RHPAM-3134)

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
