### PR TITLE
AF-2608: Fix comment card style

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/changerequest/review/comment/CommentItemView.css
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/changerequest/review/comment/CommentItemView.css
@@ -46,3 +46,11 @@
     margin: 0 0 0 5px;
     padding: 0;
 }
+
+.comment-container .comment-actions .dropdown-kebab-pf {
+    margin-left: 1em !important;
+}
+
+.comment-container .comment-actions .dropdown-kebab-pf .dropdown-menu-right {
+    right: -15px !important;
+}


### PR DESCRIPTION
JIRA: [AF-2608 ](https://issues.redhat.com/browse/AF-2608)

Fixed style since the inherited one no longer applies.

Before:
![bug](https://user-images.githubusercontent.com/638737/91592830-85781780-e935-11ea-8c8f-66d3e99540f9.png)


After:
![fixed](https://user-images.githubusercontent.com/638737/91592835-8741db00-e935-11ea-9c94-ea5adb2c12e0.png)

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
