### PR TITLE
Stunner - Reduce the hardware stress for GWT builds

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -732,7 +732,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
-          <extraJvmArgs>-Xmx4096m -Xms1024m -Xss1M -XX:CompileThreshold=7000 -Derrai.dynamic_validation.enabled=true</extraJvmArgs>
+          <extraJvmArgs>-Xmx4G -Xms1G -Xss1M -XX:CompileThreshold=7000 -Derrai.dynamic_validation.enabled=true</extraJvmArgs>
           <module>org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor</module>
           <localWorkers>8</localWorkers>
           <noServer>false</noServer>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -1304,10 +1304,12 @@
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
           <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
-          <extraJvmArgs>-Xmx16G -Xms2G -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.marshalling.server.classOutput=${project.build.outputDirectory} -Derrai.dynamic_validation.enabled=true</extraJvmArgs>
+          <extraJvmArgs>-Xmx6G -Xms1G -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.marshalling.server.classOutput=${project.build.outputDirectory} -Derrai.dynamic_validation.enabled=true</extraJvmArgs>
           <module>org.kie.workbench.common.stunner.project.StunnerProjectShowcase</module>
-          <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
+          <noServer>false</noServer>
+          <draftCompile>true</draftCompile>
+          <optimizationLevel>0</optimizationLevel>
           <disableCastChecking>true</disableCastChecking>
           <runTarget>stunner.html</runTarget>
           <hostedWebapp>src/main/webapp</hostedWebapp>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectShowcase.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectShowcase.gwt.xml
@@ -97,7 +97,7 @@
   <source path='client'/>
   <source path='bpmn'/>
 
-  <set-property name="user.agent" value="gecko1_8,safari"/>
+  <set-property name="user.agent" value="safari"/>
   <set-property name="locale" value="default"/>
 
 </module>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -723,16 +723,15 @@
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
           <strict>true</strict>
-          <localWorkers>8</localWorkers>
           <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
-          <draftCompile>true</draftCompile>
-          <extraJvmArgs>-Xmx4096m -Xms1024m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.dynamic_validation.enabled=true</extraJvmArgs>
+          <extraJvmArgs>-Xmx4G -Xms1G -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.dynamic_validation.enabled=true</extraJvmArgs>
           <module>org.kie.workbench.common.stunner.standalone.StunnerStandaloneShowcaseWithSourceMap</module>
-          <style>PRETTY</style>
-          <logLevel>INFO</logLevel>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
+          <logLevel>INFO</logLevel>
+          <draftCompile>true</draftCompile>
           <disableCastChecking>true</disableCastChecking>
+          <optimizationLevel>0</optimizationLevel>
           <runTarget>index.html</runTarget>
           <hostedWebapp>src/main/webapp</hostedWebapp>
           <gwtSdkFirstInClasspath>false</gwtSdkFirstInClasspath>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/FastCompiledStunnerStandaloneShowcase.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/FastCompiledStunnerStandaloneShowcase.gwt.xml
@@ -20,7 +20,7 @@
 
   <inherits name="org.kie.workbench.common.stunner.standalone.StunnerStandaloneShowcase"/>
 
-  <set-property name="user.agent" value="safari,gecko1_8"/>
+  <set-property name="user.agent" value="safari"/>
   <set-property name="locale" value="default"/>
 
   <collapse-all-properties/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/StunnerStandaloneShowcase.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/StunnerStandaloneShowcase.gwt.xml
@@ -59,7 +59,7 @@
 
   <!-- We don't need to support IE10 or older -->
   <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
-  <set-property name="user.agent" value="gecko1_8,safari"/>
+  <set-property name="user.agent" value="safari"/>
 
   <!-- To change the default logLevel -->
   <set-property name="gwt.logging.logLevel" value="SEVERE"/>


### PR DESCRIPTION
Hey @mbiarnes @mareknovotny 

I've created this PR trying to avoid issues on our CI builds, due to the wrong use of resources. So let's see how the builds work on this PR, and hopefully sooner than later we should have green full builds again for this repo :+1: 

I've done a few improvements for the gwt compiler on the differents apps, but the most important change is on the `stunner-showcase-project` app - gwt compiler was not properly configured and also I've reduced the stress during its compilation by decreasing the permutaions and optimization around it, anyway this app is jsut for our testing, nothing that gets delivered as part of any product, so we're good also this way.

Here is a quick profiling about the hardware stress on the gwt compiler process before and after these fixes:

**Before**

![gwt-compiler-profile-before-fix](https://user-images.githubusercontent.com/4602417/91777480-3d384e00-ebf0-11ea-8689-e53a0f8a6322.png)

**After**

![gwt-compiler-profile-after-fix](https://user-images.githubusercontent.com/4602417/91777488-42959880-ebf0-11ea-8e5d-e10a618d604d.png)

So both heap and cpu usage, and build times, have been reduced at least by 1/2

Thanks!