### PR TITLE
RHPAM-2452 - Stunner - Migration from old designer to new one shows Warnings for the simplest processes

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/Match.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/Match.java
@@ -52,7 +52,8 @@ import org.kie.workbench.common.stunner.core.validation.Violation;
  *     // unwrap the result on success, raise an exception otherwise
  *     T2 t2 = result.value();
  * </pre>
- * @param <In> the input type of the match
+ *
+ * @param <In>  the input type of the match
  * @param <Out> the type of the result of the match
  */
 public class Match<In, Out> {
@@ -105,6 +106,16 @@ public class Match<In, Out> {
                         defaultValue, MarshallingMessage.builder().message("Ignored " + t).build());
     }
 
+    private <T> Function<T, Result<Out>> ignored(Class<?> expectedClass, Out outValue) {
+        return t ->
+                Result.ignored(
+                        "Ignored: " +
+                                Optional.ofNullable(t)
+                                        .map(o -> o.getClass().getCanonicalName())
+                                        .orElse("null -- expected " + expectedClass.getCanonicalName()),
+                        outValue, MarshallingMessage.builder().message("Ignored " + t).build());
+    }
+
     public <Sub> Match<In, Out> when(Class<Sub> type, Function<Sub, Out> then) {
         Function<Sub, Result<Out>> thenWrapped = sub -> Result.of(then.apply(sub));
         return when_(type, thenWrapped);
@@ -135,6 +146,10 @@ public class Match<In, Out> {
 
     public <Sub> Match<In, Out> ignore(Class<Sub> type) {
         return when_(type, ignored(type));
+    }
+
+    public <Sub> Match<In, Out> ignore(Class<Sub> type, Out outValue) {
+        return when_(type, ignored(type, outValue));
     }
 
     public Match<In, Out> orElse(Function<In, Out> then) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/FlowElementConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/FlowElementConverter.java
@@ -18,14 +18,15 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner;
 
 import org.eclipse.bpmn2.BoundaryEvent;
 import org.eclipse.bpmn2.CallActivity;
-import org.eclipse.bpmn2.DataObject;
 import org.eclipse.bpmn2.DataObjectReference;
+import org.eclipse.bpmn2.DataStore;
 import org.eclipse.bpmn2.DataStoreReference;
 import org.eclipse.bpmn2.EndEvent;
 import org.eclipse.bpmn2.FlowElement;
 import org.eclipse.bpmn2.Gateway;
 import org.eclipse.bpmn2.IntermediateCatchEvent;
 import org.eclipse.bpmn2.IntermediateThrowEvent;
+import org.eclipse.bpmn2.SequenceFlow;
 import org.eclipse.bpmn2.StartEvent;
 import org.eclipse.bpmn2.SubProcess;
 import org.eclipse.bpmn2.Task;
@@ -57,7 +58,8 @@ public class FlowElementConverter extends AbstractConverter {
                 .when(TextAnnotation.class, converterFactory.artifactsConverter()::convert)
                 .when(DataObjectReference.class, converterFactory.artifactsConverter()::convert)
                 .ignore(DataStoreReference.class)
-                .ignore(DataObject.class)
+                .ignore(DataStore.class)
+                .ignore(SequenceFlow.class, null)
                 .defaultValue(Result.ignored("FlowElement not found", getNotFoundMessage(flowElement)))
                 .inputDecorator(BPMNElementDecorators.flowElementDecorator())
                 .outputDecorator(BPMNElementDecorators.resultBpmnDecorator())

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/ProcessConverterDelegate.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/ProcessConverterDelegate.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 package org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.processes;
 
 import java.util.ArrayList;
@@ -71,7 +72,6 @@ final class ProcessConverterDelegate {
             List<FlowElement> flowElements,
             List<LaneSet> laneSets) {
 
-
         // Fixes id and name for Data Objects
         for (FlowElement element : flowElements) {
             element.setId(revertIllegalCharsAttribute(element.getId()));
@@ -114,9 +114,9 @@ final class ProcessConverterDelegate {
     }
 
     private Result<Map<String, BpmnNode>> convertFlowElements(List<FlowElement> flowElements) {
-        final List<Result<BpmnNode>> results = flowElements
-                .stream()
+        final List<Result<BpmnNode>> results = flowElements.stream()
                 .map(converterFactory.flowElementConverter()::convertNode)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         final Map<String, BpmnNode> resultMap = results.stream()

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/MatchTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/MatchTest.java
@@ -23,6 +23,7 @@ import org.eclipse.bpmn2.EventSubprocess;
 import org.eclipse.bpmn2.FlowElement;
 import org.eclipse.bpmn2.ManualTask;
 import org.eclipse.bpmn2.ReceiveTask;
+import org.eclipse.bpmn2.SequenceFlow;
 import org.eclipse.bpmn2.StartEvent;
 import org.eclipse.bpmn2.SubProcess;
 import org.eclipse.bpmn2.impl.UserTaskImpl;
@@ -47,6 +48,9 @@ public class MatchTest {
 
     @Mock
     private BpmnNode defaultValue;
+
+    @Mock
+    private BpmnNode outValue;
 
     @Mock
     private Function<UserTaskImpl, BpmnNode> assertUserTask;
@@ -96,33 +100,55 @@ public class MatchTest {
 
     @Test
     public void ignoreTestAuto() {
-        ManualTask element = Bpmn2Factory.eINSTANCE.createManualTask();
-        Result<BpmnNode> result = match().apply(element);
-        assertEquals(result.value(), defaultValue);
-        assertTrue(result.isIgnored());
-        assertFalse(result.isFailure());
+        ManualTask manualTask = Bpmn2Factory.eINSTANCE.createManualTask();
+        Result<BpmnNode> result1 = match().apply(manualTask);
+        assertEquals(result1.value(), defaultValue);
+        assertTrue(result1.isIgnored());
+        assertFalse(result1.isFailure());
+
+        SequenceFlow sequenceFlow = Bpmn2Factory.eINSTANCE.createSequenceFlow();
+        Result<BpmnNode> result2 = match().apply(sequenceFlow);
+        assertEquals(result2.value(), outValue);
+        assertTrue(result2.isIgnored());
+        assertFalse(result2.isFailure());
     }
 
     @Test
     public void ignoreTestIgnore() {
-        ManualTask element = Bpmn2Factory.eINSTANCE.createManualTask();
-        Result<BpmnNode> result = match()
+        ManualTask manualTask = Bpmn2Factory.eINSTANCE.createManualTask();
+        Result<BpmnNode> result1 = match()
                 .mode(MarshallingRequest.Mode.IGNORE)
-                .apply(element);
-        assertEquals(result.value(), defaultValue);
-        assertTrue(result.isIgnored());
-        assertFalse(result.isFailure());
+                .apply(manualTask);
+        assertEquals(result1.value(), defaultValue);
+        assertTrue(result1.isIgnored());
+        assertFalse(result1.isFailure());
+
+        SequenceFlow sequenceFlow = Bpmn2Factory.eINSTANCE.createSequenceFlow();
+        Result<BpmnNode> result2 = match()
+                .mode(MarshallingRequest.Mode.IGNORE)
+                .apply(sequenceFlow);
+        assertEquals(result2.value(), outValue);
+        assertTrue(result2.isIgnored());
+        assertFalse(result2.isFailure());
     }
 
     @Test
     public void ignoreTestError() {
-        ManualTask element = Bpmn2Factory.eINSTANCE.createManualTask();
-        Result<BpmnNode> result = match()
+        ManualTask manualTask = Bpmn2Factory.eINSTANCE.createManualTask();
+        Result<BpmnNode> result1 = match()
                 .mode(MarshallingRequest.Mode.ERROR)
-                .apply(element);
-        assertEquals(result.value(), defaultValue);
-        assertFalse(result.isIgnored());
-        assertTrue(result.isFailure());
+                .apply(manualTask);
+        assertEquals(result1.value(), defaultValue);
+        assertFalse(result1.isIgnored());
+        assertTrue(result1.isFailure());
+
+        SequenceFlow sequenceFlow = Bpmn2Factory.eINSTANCE.createSequenceFlow();
+        Result<BpmnNode> result2 = match()
+                .mode(MarshallingRequest.Mode.ERROR)
+                .apply(sequenceFlow);
+        assertEquals(result2.value(), defaultValue);
+        assertFalse(result2.isIgnored());
+        assertTrue(result2.isFailure());
     }
 
     @Test
@@ -138,6 +164,7 @@ public class MatchTest {
                 .whenExactly(UserTaskImpl.class, assertUserTask)
                 .when(SubProcess.class, assertSubProcess)
                 .ignore(ManualTask.class)
+                .ignore(SequenceFlow.class, outValue)
                 .missing(ReceiveTask.class)
                 .defaultValue(defaultValue)
                 .mode(MarshallingRequest.Mode.AUTO);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/FlowElementConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/FlowElementConverterTest.java
@@ -26,6 +26,7 @@ import org.eclipse.bpmn2.FlowElement;
 import org.eclipse.bpmn2.Gateway;
 import org.eclipse.bpmn2.IntermediateCatchEvent;
 import org.eclipse.bpmn2.IntermediateThrowEvent;
+import org.eclipse.bpmn2.SequenceFlow;
 import org.eclipse.bpmn2.StartEvent;
 import org.eclipse.bpmn2.SubProcess;
 import org.eclipse.bpmn2.Task;
@@ -47,6 +48,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -155,9 +157,20 @@ public class FlowElementConverterTest {
     }
 
     @Test
+    public void convertIgnored() {
+        assertIgnored(SequenceFlow.class);
+    }
+
+    @Test
     public void convertUnsupported() {
         assertUnsupported(DataStoreReference.class);
         assertUnsupported(DataObject.class);
+    }
+
+    private <T extends FlowElement> void assertIgnored(Class<T> type) {
+        T element = mock(type);
+        Result<BpmnNode> result = tested.convertNode(element);
+        assertNull(result);
     }
 
     private <T extends FlowElement> void assertUnsupported(Class<T> type) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/ProcessConverterDelegateTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/processes/ProcessConverterDelegateTest.java
@@ -183,6 +183,24 @@ public class ProcessConverterDelegateTest {
     }
 
     @Test
+    public void testConvertIgnoredFlowElements() {
+        List<LaneSet> laneSets = Collections.emptyList();
+        //adding 2 supported and 2 unsupported elements
+        List<FlowElement> flowElements = Arrays.asList(mockTask("1"),
+                                                       mockTask("2"),
+                                                       mockSequenceFlow("3", null, null),
+                                                       mockUnsupportedDataObject("4"));
+
+        Result<Map<String, BpmnNode>> result = converterDelegate.convertChildNodes(parentNode, flowElements, laneSets);
+        Map<String, BpmnNode> values = result.value();
+        List<MarshallingMessage> messages = result.messages();
+        //check one message per unsupported element
+        assertEquals(2, values.size());
+        assertEquals(1, messages.size());
+        assertTrue(messages.stream().map(MarshallingMessage::getViolationType).allMatch(Violation.Type.WARNING::equals));
+    }
+
+    @Test
     public void testConvertLanes() {
         Task task0_1 = mockTask("TASK0_1");
         Task task0_2 = mockTask("TASK0_2");


### PR DESCRIPTION
All nodes were processed as by FlowElementConverters. Edge nodes are processed by a different set of converters.
This fix intends to filter them accordingly and use the correct converters for processing.

**Thank you for submitting this pull request**

**JIRA**: [RHPAM-2452](https://issues.redhat.com/browse/RHPAM-2452)

**Business Central**: [WAR file](https://drive.google.com/file/d/1twxhguRF395vT2L-NwFaFWupsTXIzFGI/view?usp=sharing)

**VS Code**: [*Not reproducible in VS Code*]
