### PR TITLE
JBPM-9352: Stunner - Warning when getContent is called while the model is invalid

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -15,9 +15,6 @@
  */
 package org.kie.workbench.common.stunner.kogito.client.editor;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -33,7 +30,6 @@ import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerVie
 import org.kie.workbench.common.stunner.client.widgets.presenters.Viewer;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
-import org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants;
 import org.kie.workbench.common.stunner.core.client.annotation.DiagramEditor;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
@@ -47,13 +43,9 @@ import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasDiagramValidator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
-import org.kie.workbench.common.stunner.core.rule.RuleViolation;
-import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
-import org.kie.workbench.common.stunner.core.validation.DomainViolation;
 import org.kie.workbench.common.stunner.forms.client.event.FormPropertiesOpened;
 import org.kie.workbench.common.stunner.forms.client.widgets.FormsFlushManager;
 import org.kie.workbench.common.stunner.kogito.client.docks.DiagramEditorPreviewAndExplorerDock;
@@ -104,7 +96,6 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
     protected final FormsFlushManager formsFlushManager;
     private final CanvasFileExport canvasFileExport;
     private final Promises promises;
-    private final CanvasDiagramValidator<AbstractCanvasHandler> validator;
 
     protected String formElementUUID;
 
@@ -131,8 +122,7 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
                              final AbstractKogitoClientDiagramService diagramServices,
                              final FormsFlushManager formsFlushManager,
                              final CanvasFileExport canvasFileExport,
-                             final Promises promises,
-                             final CanvasDiagramValidator<AbstractCanvasHandler> validator) {
+                             final Promises promises) {
         super(view,
               fileMenuBuilder,
               placeManager,
@@ -156,7 +146,6 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
         this.canvasFileExport = canvasFileExport;
         this.formsFlushManager = formsFlushManager;
         this.promises = promises;
-        this.validator = validator;
     }
 
     @OnStartup
@@ -274,26 +263,7 @@ public class BPMNDiagramEditor extends AbstractDiagramEditor {
     @Override
     public Promise getContent() {
         flush();
-        validateDiagram(getCanvasHandler());
         return diagramServices.transform(getEditor().getEditorProxy().getContentSupplier().get());
-    }
-
-    private void validateDiagram(CanvasHandler canvasHandler) {
-        getSessionPresenter().displayNotifications(t -> false);
-
-        validator.validate((AbstractCanvasHandler) canvasHandler, violations -> {
-            String errorMessage = getTranslationService().getValue(StunnerWidgetsConstants.MarshallingResponsePopup_ErrorMessageLabel);
-
-            if (!violations.isEmpty()) {
-                List<String> violationMessages = new ArrayList<>();
-                for (DiagramElementViolation<RuleViolation> next : violations) {
-                    final Collection<DomainViolation> domainViolations = next.getDomainViolations();
-                    domainViolations.forEach(item -> violationMessages.add(errorMessage + ": " + item.getUUID() + " - " + item.getMessage() + " - " + item.getViolationType()));
-                }
-                getEditor().getSessionPresenter().getView().showWarning(errorMessage + "(s): " + violationMessages);
-            }
-        });
-        getSessionPresenter().displayNotifications(t -> true);
     }
 
     @GetPreview

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
@@ -25,7 +25,6 @@ import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerVie
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
-import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
@@ -34,7 +33,6 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
-import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasDiagramValidator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
@@ -146,9 +144,6 @@ public class BPMNDiagramEditorTest {
     @Mock
     private ClientSession clientSession;
 
-    @Mock
-    private CanvasDiagramValidator<AbstractCanvasHandler> validator;
-
     private Promises promises = new SyncPromises();
 
     @SuppressWarnings("unchecked")
@@ -176,7 +171,7 @@ public class BPMNDiagramEditorTest {
                                            diagramServices,
                                            formsFlushManager,
                                            canvasFileExport,
-                                           promises, validator));
+                                           promises));
 
         when(editor.getSessionPresenter()).thenReturn(sessionPresenter);
         when(sessionPresenter.getInstance()).thenReturn(clientSession);


### PR DESCRIPTION
Hey @paulovmr @ederign 

As discussed with @porcelli , fixing the actual blocker issue by completely disabling validation in the bpmn editor.

See comments in https://issues.redhat.com/browse/JBPM-9352

BTW You know who should be the QE tester for this, if any? Can't see anyone on the ticket yet.

Thanks!

