### PR TITLE
DROOLS-5656: [DMN Designer] Multiple DRDs support - Editor shows duplicated file extension on BC

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNClientProjectDiagramService.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNClientProjectDiagramService.java
@@ -35,7 +35,9 @@ import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.session.event.SessionDiagramSavedEvent;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.service.DiagramLookupService;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
 import org.kie.workbench.common.stunner.project.client.service.ClientProjectDiagramService;
 import org.kie.workbench.common.stunner.project.diagram.ProjectDiagram;
 import org.kie.workbench.common.stunner.project.diagram.ProjectMetadata;
@@ -88,9 +90,7 @@ public class DMNClientProjectDiagramService extends ClientProjectDiagramService 
 
             @Override
             public void onSuccess(final Diagram diagram) {
-                callback.onSuccess(new ProjectDiagramImpl(diagram.getName(),
-                                                          diagram.getGraph(),
-                                                          (ProjectMetadata) resource.getMetadata()));
+                callback.onSuccess(asProjectDiagramImpl(diagram, resource));
             }
 
             @Override
@@ -98,6 +98,14 @@ public class DMNClientProjectDiagramService extends ClientProjectDiagramService 
                 callback.onError(error);
             }
         };
+    }
+
+    ProjectDiagramImpl asProjectDiagramImpl(final Diagram diagram,
+                                            final DMNContentResource resource) {
+        final String name = removeExtension(diagram.getName());
+        final Graph graph = diagram.getGraph();
+        final ProjectMetadata metadata = (ProjectMetadata) resource.getMetadata();
+        return new ProjectDiagramImpl(name, graph, metadata);
     }
 
     @Override
@@ -136,5 +144,19 @@ public class DMNClientProjectDiagramService extends ClientProjectDiagramService 
                 DomGlobal.console.error(e.getMessage(), e);
             }
         };
+    }
+
+    private String removeExtension(final String filename) {
+
+        if (StringUtils.isEmpty(filename)) {
+            return "";
+        }
+
+        final int index = filename.lastIndexOf(".");
+        if (index == -1) {
+            return filename;
+        }
+
+        return filename.substring(0, index);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNClientProjectDiagramServiceTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNClientProjectDiagramServiceTest.java
@@ -186,4 +186,23 @@ public class DMNClientProjectDiagramServiceTest {
 
         verify(service).saveAsXml(path, xml, metadata, comment, stringCallback);
     }
+
+    @Test
+    public void testAsProjectDiagramImpl() {
+
+        final Graph graph = mock(Graph.class);
+        final Diagram diagram = mock(Diagram.class);
+        final DMNContentResource resource = mock(DMNContentResource.class);
+        final ProjectMetadata metadata = mock(ProjectMetadata.class);
+
+        when(diagram.getName()).thenReturn("Traffic Violation.dmn");
+        when(diagram.getGraph()).thenReturn(graph);
+        when(resource.getMetadata()).thenReturn(metadata);
+
+        final ProjectDiagramImpl projectDiagram = service.asProjectDiagramImpl(diagram, resource);
+
+        assertEquals("Traffic Violation", projectDiagram.getName());
+        assertEquals(graph, projectDiagram.getGraph());
+        assertEquals(metadata, projectDiagram.getMetadata());
+    }
 }


### PR DESCRIPTION
**JIRA**: [DROOLS-5656](https://issues.redhat.com/browse/DROOLS-5656): [DMN Designer] Multiple DRDs support - Editor shows duplicated file extension on BC

**Artifact (it happens on Business Central only)**: [WAR file](https://www.dropbox.com/s/lf5xpgebox3lxth/after.war?dl=0)

**Before:**
<img width="1684" alt="Screen Shot 2020-09-22 at 23 15 30" src="https://user-images.githubusercontent.com/1079279/93957209-2934c780-fd2a-11ea-8189-62cc1ab19559.png">

**After:**
<img width="1684" alt="Screen Shot 2020-09-22 at 22 59 29" src="https://user-images.githubusercontent.com/1079279/93957193-23d77d00-fd2a-11ea-9019-2b6c3e92825c.png">

---

<pre>
To retest a PR or trigger a specific build please add a comment:

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</pre>
