### PR TITLE
RHPAM-3190: Stunner - Error is displayed when using BPMN designer editor

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
@@ -28,6 +28,7 @@ import org.appformer.client.context.Channel;
 import org.appformer.client.context.EditorContextProvider;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramsSession;
 import org.kie.workbench.common.dmn.client.docks.navigator.events.RefreshDecisionComponents;
 import org.kie.workbench.common.dmn.client.docks.navigator.included.components.DecisionComponents;
 import org.kie.workbench.common.dmn.client.docks.navigator.tree.DecisionNavigatorTreePresenter;
@@ -64,6 +65,8 @@ public class DecisionNavigatorPresenter {
 
     private DecisionNavigatorItemsProvider navigatorItemsProvider;
 
+    private DMNDiagramsSession dmnDiagramsSession;
+
     private boolean isRefreshHandlersEnabled = false;
 
     @Inject
@@ -73,7 +76,8 @@ public class DecisionNavigatorPresenter {
                                       final DecisionNavigatorObserver decisionNavigatorObserver,
                                       final TranslationService translationService,
                                       final EditorContextProvider context,
-                                      final DecisionNavigatorItemsProvider navigatorItemsProvider) {
+                                      final DecisionNavigatorItemsProvider navigatorItemsProvider,
+                                      final DMNDiagramsSession dmnDiagramsSession) {
         this.view = view;
         this.treePresenter = treePresenter;
         this.decisionComponents = decisionComponents;
@@ -81,6 +85,7 @@ public class DecisionNavigatorPresenter {
         this.translationService = translationService;
         this.context = context;
         this.navigatorItemsProvider = navigatorItemsProvider;
+        this.dmnDiagramsSession = dmnDiagramsSession;
     }
 
     @WorkbenchPartView
@@ -140,8 +145,10 @@ public class DecisionNavigatorPresenter {
     }
 
     public void refresh() {
-        refreshTreeView();
-        refreshComponentsView();
+        if (dmnDiagramsSession.isSessionStatePresent()) {
+            refreshTreeView();
+            refreshComponentsView();
+        }
     }
 
     public void refreshTreeView() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSession.java
@@ -92,6 +92,10 @@ public class DMNDiagramsSession implements GraphsProvider {
         return state;
     }
 
+    public boolean isSessionStatePresent() {
+        return getSessionState() != null;
+    }
+
     public DMNDiagramsSessionState getSessionState() {
         return dmnSessionStatesByPathURI.get(getCurrentSessionKey());
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
@@ -25,6 +25,7 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramsSession;
 import org.kie.workbench.common.dmn.client.docks.navigator.events.RefreshDecisionComponents;
 import org.kie.workbench.common.dmn.client.docks.navigator.included.components.DecisionComponents;
 import org.kie.workbench.common.dmn.client.docks.navigator.tree.DecisionNavigatorTreePresenter;
@@ -68,6 +69,9 @@ public class DecisionNavigatorPresenterTest {
     @Mock
     private DecisionNavigatorItemsProvider navigatorItemsProvider;
 
+    @Mock
+    private DMNDiagramsSession dmnDiagramsSession;
+
     private DecisionNavigatorPresenter presenter;
 
     @Before
@@ -78,7 +82,8 @@ public class DecisionNavigatorPresenterTest {
                                                        decisionNavigatorObserver,
                                                        translationService,
                                                        context,
-                                                       navigatorItemsProvider));
+                                                       navigatorItemsProvider,
+                                                       dmnDiagramsSession));
     }
 
     @Test
@@ -189,10 +194,22 @@ public class DecisionNavigatorPresenterTest {
 
     @Test
     public void testRefresh() {
+        doReturn(true).when(dmnDiagramsSession).isSessionStatePresent();
+
         presenter.refresh();
 
         verify(presenter).refreshTreeView();
         verify(presenter).refreshComponentsView();
+    }
+
+    @Test
+    public void testRefreshWhenSessionStateIsNotPresent() {
+        doReturn(false).when(dmnDiagramsSession).isSessionStatePresent();
+
+        presenter.refresh();
+
+        verify(presenter, never()).refreshTreeView();
+        verify(presenter, never()).refreshComponentsView();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSessionTest.java
@@ -93,7 +93,7 @@ public class DMNDiagramsSessionTest {
     public void setup() {
 
         dmnDiagramsSessionState = spy(new DMNDiagramsSessionState(dmnDiagramUtils));
-        dmnDiagramsSession = new DMNDiagramsSession(dmnDiagramsSessionStates, sessionManager, dmnDiagramUtils);
+        dmnDiagramsSession = spy(new DMNDiagramsSession(dmnDiagramsSessionStates, sessionManager, dmnDiagramUtils));
 
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(clientSession.getCanvasHandler()).thenReturn(canvasHandler);
@@ -287,5 +287,18 @@ public class DMNDiagramsSessionTest {
         final String actualId = dmnDiagramsSession.getCurrentDiagramId();
 
         assertEquals(expectedId, actualId);
+    }
+
+    @Test
+    public void testsSessionStatePresentWhenItReturnsTrue() {
+        final DMNDiagramsSessionState sessionState = mock(DMNDiagramsSessionState.class);
+        doReturn(sessionState).when(dmnDiagramsSession).getSessionState();
+        assertTrue(dmnDiagramsSession.isSessionStatePresent());
+    }
+
+    @Test
+    public void testsSessionStatePresentWhenItReturnsFalse() {
+        doReturn(null).when(dmnDiagramsSession).getSessionState();
+        assertFalse(dmnDiagramsSession.isSessionStatePresent());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommands.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommands.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNPerformAutomaticLayoutCommand;
 import org.kie.workbench.common.dmn.project.client.session.command.SaveDiagramSessionCommand;
+import org.kie.workbench.common.dmn.project.client.validation.DMNValidateSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.ManagedClientSessionCommands;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.CopySelectionSessionCommand;
@@ -58,7 +59,7 @@ public class DMNEditorSessionCommands extends EditorSessionCommands {
                 .register(DeleteSelectionSessionCommand.class)
                 .register(UndoSessionCommand.class)
                 .register(RedoSessionCommand.class)
-                .register(ValidateSessionCommand.class)
+                .register(DMNValidateSessionCommand.class)
                 .register(ExportToPngSessionCommand.class)
                 .register(ExportToJpgSessionCommand.class)
                 .register(ExportToPdfSessionCommand.class)
@@ -69,6 +70,11 @@ public class DMNEditorSessionCommands extends EditorSessionCommands {
                 .register(CutSelectionSessionCommand.class)
                 .register(SaveDiagramSessionCommand.class)
                 .register(DMNPerformAutomaticLayoutCommand.class);
+    }
+
+    @Override
+    public ValidateSessionCommand getValidateSessionCommand() {
+        return get(DMNValidateSessionCommand.class);
     }
 
     public PerformAutomaticLayoutCommand getPerformAutomaticLayoutCommand() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/validation/DMNCanvasDiagramValidator.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/validation/DMNCanvasDiagramValidator.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.dmn.project.client.validation;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
-import javax.enterprise.inject.Specializes;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
@@ -28,7 +27,7 @@ import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasVali
 import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasValidationSuccessEvent;
 
 @Dependent
-@Specializes
+@DMNEditor
 public class DMNCanvasDiagramValidator extends CanvasDiagramValidator<AbstractCanvasHandler> {
 
     @Inject

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/validation/DMNValidateSessionCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/validation/DMNValidateSessionCommand.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.project.client.validation;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
+
+@Dependent
+@DMNEditor
+public class DMNValidateSessionCommand extends ValidateSessionCommand {
+
+    @Inject
+    public DMNValidateSessionCommand(final @DMNEditor DMNCanvasDiagramValidator validator) {
+        super(validator);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommandsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/session/DMNEditorSessionCommandsTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNPerformAutomaticLayoutCommand;
 import org.kie.workbench.common.dmn.project.client.session.command.SaveDiagramSessionCommand;
+import org.kie.workbench.common.dmn.project.client.validation.DMNValidateSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.ClearSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.CopySelectionSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.CutSelectionSessionCommand;
@@ -33,14 +34,15 @@ import org.kie.workbench.common.stunner.core.client.session.command.impl.PasteSe
 import org.kie.workbench.common.stunner.core.client.session.command.impl.RedoSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.SwitchGridSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.UndoSessionCommand;
-import org.kie.workbench.common.stunner.core.client.session.command.impl.ValidateSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.impl.VisitGraphSessionCommand;
 import org.kie.workbench.common.stunner.kogito.client.session.EditorSessionCommands;
 import org.kie.workbench.common.stunner.kogito.client.session.EditorSessionCommandsTest;
 import org.mockito.InOrder;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DMNEditorSessionCommandsTest extends EditorSessionCommandsTest {
@@ -62,7 +64,7 @@ public class DMNEditorSessionCommandsTest extends EditorSessionCommandsTest {
         inOrder.verify(commands).register(DeleteSelectionSessionCommand.class);
         inOrder.verify(commands).register(UndoSessionCommand.class);
         inOrder.verify(commands).register(RedoSessionCommand.class);
-        inOrder.verify(commands).register(ValidateSessionCommand.class);
+        inOrder.verify(commands).register(DMNValidateSessionCommand.class);
         inOrder.verify(commands).register(ExportToPngSessionCommand.class);
         inOrder.verify(commands).register(ExportToJpgSessionCommand.class);
         inOrder.verify(commands).register(ExportToPdfSessionCommand.class);
@@ -73,5 +75,13 @@ public class DMNEditorSessionCommandsTest extends EditorSessionCommandsTest {
         inOrder.verify(commands).register(CutSelectionSessionCommand.class);
         inOrder.verify(commands).register(SaveDiagramSessionCommand.class);
         inOrder.verify(commands).register(DMNPerformAutomaticLayoutCommand.class);
+    }
+
+    @Test
+    @Override
+    public void testGetValidateSessionCommand() {
+        editorSessionCommands.getValidateSessionCommand();
+
+        verify(commands).get(eq(DMNValidateSessionCommand.class));
     }
 }


### PR DESCRIPTION
**JIRA**: [RHPAM-3190](https://issues.redhat.com/browse/RHPAM-3190): RHPAM-3190: Stunner - Error is displayed when using BPMN designer editor

**Artifact (it happens on Business Central only)**: [WAR file v2](https://www.dropbox.com/s/mllt9lkwfj8ydt6/business-central-RHPAM-3190-2.war?dl=0)

**Before:**
![2020-09-23 10 56 03](https://user-images.githubusercontent.com/1079279/94022931-00451e80-fd8c-11ea-9730-ea43d291fd33.gif)


**After:**
![2020-09-23 10 58 16](https://user-images.githubusercontent.com/1079279/94022908-f8857a00-fd8b-11ea-9f1f-f1ef0bfe2478.gif)


---

<pre>
To retest a PR or trigger a specific build please add a comment:

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</pre>
