### PR TITLE
RHPAM-3119 : [Data Modeler] Unsaved changes dialog appears after rename

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceImpl.java
@@ -568,8 +568,8 @@ public class DataModelerServiceImpl
             }
             
             /* Modify data object with updated fileName and packageName
-             * before resolving source to handle inconsistencies in
-             * source code and data object
+             * or by resolving from @path before resolving source to handle
+             * inconsistencies in source code and data object
              * */
             if  (dataObject  != null) {
                 dataObject.setName(targetName.replace(".java", ""));

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceImpl.java
@@ -545,10 +545,7 @@ public class DataModelerServiceImpl
         boolean onBatch = false;
 
         try {
-
-            GenerationResult result = resolveSaveSource(source,
-                                                        path,
-                                                        dataObject);
+            
 
             Package currentPackage = moduleService.resolvePackage(path);
             Package targetPackage = currentPackage;
@@ -569,6 +566,19 @@ public class DataModelerServiceImpl
                 targetName = newFileName + ".java";
                 nameChanged = true;
             }
+            
+            /* Modify data object with updated fileName and packageName
+             * before resolving source to handle inconsistencies in
+             * source code and data object
+             * */
+            if  (dataObject  != null) {
+                dataObject.setName(targetName.replace(".java", ""));
+                dataObject.setPackageName(targetPackage.getPackageName());
+            }
+            
+            GenerationResult result = resolveSaveSource(source,
+                                                        path,
+                                                        dataObject);
 
             ioService.startBatch(targetPath.getFileSystem());
             onBatch = true;

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceImpl.java
@@ -571,7 +571,7 @@ public class DataModelerServiceImpl
              * or by resolving from @path before resolving source to handle
              * inconsistencies in source code and data object
              * */
-            if  (dataObject  != null) {
+            if (dataObject != null) {
                 dataObject.setName(targetName.replace(".java", ""));
                 dataObject.setPackageName(targetPackage.getPackageName());
             }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceTest.java
@@ -167,6 +167,8 @@ public class DataModelerServiceTest {
                                            "file:///src");
         Package packageMock = mock(Package.class);
         when(packageMock.getPackageMainSrcPath()).thenReturn(srcPath);
+        when(moduleService.resolvePackage(dataObjectPath)).thenReturn(packageMock);
+        when(packageMock.getPackageName()).thenReturn("dataobjects");
         when(serviceHelper.ensurePackageStructure(any(Module.class),
                                                   anyString())).thenReturn(packageMock);
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceTest.java
@@ -138,29 +138,45 @@ public class DataModelerServiceTest {
     @Test
     public void saveSourcePackageNameChanged() {
         testSaveSource("newPackageName",
-                       null);
+                       null,
+                       new DataObjectImpl("dataobjects",
+                                          "TestDataObject"));
     }
 
     @Test
     public void saveSourceFileNameChanged() {
         testSaveSource(null,
-                       "newFileName");
+                       "newFileName",
+                       new DataObjectImpl("dataobjects",
+                                          "TestDataObject"));
     }
 
     @Test
     public void saveSourceBothPackageAndFileNameChanged() {
         testSaveSource("newPackageName",
-                       "newFileName");
+                       "newFileName",
+                       new DataObjectImpl("dataobjects",
+                                          "TestDataObject"));
+    }
+    
+    @Test
+    public void saveSourceBothPackageAndFileNameChangedNullDataObj() {
+        testSaveSource("newPackageName",
+                       "newFileName",
+                       null);
     }
 
     @Test
     public void saveSourceNoPackageAndFileNameChange() {
         testSaveSource(null,
-                       null);
+                       null,
+                       new DataObjectImpl("dataobjects",
+                                          "TestDataObject"));
     }
 
     private void testSaveSource(String newPackageName,
-                                String newFileName) {
+                                String newFileName,
+                                DataObject dataObject) {
         Path dataObjectPath = PathFactory.newPath("TestDataObject",
                                                   "file:///dataobjects/TestDataObject.java");
         Path srcPath = PathFactory.newPath("src",
@@ -175,9 +191,6 @@ public class DataModelerServiceTest {
         DataModelerSaveHelper saveHelper = mock(DataModelerSaveHelper.class);
         List<DataModelerSaveHelper> saveHelpers = Arrays.asList(saveHelper);
         when(saveHelperInstance.iterator()).thenReturn(saveHelpers.iterator());
-
-        DataObject dataObject = new DataObjectImpl("dataobjects",
-                                                   "TestDataObject");
 
         dataModelerService.saveSource("Source",
                                       dataObjectPath,

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
@@ -591,7 +591,7 @@ public class DataModelerScreenPresenter
                     /* when DataObject editor or source is changed we
                      * need to send the DataObject to the server  in order
                      *  to let the source to be updated prior to save.
-                    * */
+                     */
                     modifiedDataObject[0] = context.getDataObject();
                 }
                 view.showSaving();
@@ -619,7 +619,7 @@ public class DataModelerScreenPresenter
         };
     }
 
-    private RemoteCallback<GenerationResult> getSaveSuccessCallback( final Path currentPath) {
+    private RemoteCallback<GenerationResult> getSaveSuccessCallback(final Path currentPath) {
         return new RemoteCallback<GenerationResult>() {
 
             @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
@@ -588,23 +588,16 @@ public class DataModelerScreenPresenter
 
                 final DataObject[] modifiedDataObject = new DataObject[1];
                 if (isDirty()) {
-                    if (context.isEditorChanged()) {
-
-                        //at save time the source has always priority over the model.
-                        //If the source was properly parsed and the editor has changes, we need to send the DataObject
-                        //to the server in order to let the source to be updated prior to save.
-                        modifiedDataObject[0] = context.getDataObject();
-                    } else {
-                        //if the source has changes, no update form the UI to the source will be performed.
-                        //instead the parsed DataObject must be returned from the server.
-                        modifiedDataObject[0] = null;
-                    }
+                    /* when DataObject editor or source is changed we
+                     * need to send the DataObject to the server  in order
+                     *  to let the source to be updated prior to save.
+                    * */
+                    modifiedDataObject[0] = context.getDataObject();
                 }
                 view.showSaving();
 
                 if (newTypeInfo != null) {
-                    modelerService.call(getSaveSuccessCallback(newTypeInfo,
-                                                               path),
+                    modelerService.call(getSaveSuccessCallback(path),
                                         new DataModelerErrorCallback(Constants.INSTANCE.modelEditor_saving_error())).saveSource(
                             getSource(),
                             path,
@@ -614,8 +607,7 @@ public class DataModelerScreenPresenter
                             newTypeInfo.getPackageName(),
                             newTypeInfo.getName());
                 } else {
-                    modelerService.call(getSaveSuccessCallback(newTypeInfo,
-                                                               path),
+                    modelerService.call(getSaveSuccessCallback(path),
                                         new DataModelerErrorCallback(Constants.INSTANCE.modelEditor_saving_error())).saveSource(
                             getSource(),
                             path,
@@ -627,16 +619,13 @@ public class DataModelerScreenPresenter
         };
     }
 
-    private RemoteCallback<GenerationResult> getSaveSuccessCallback(final JavaTypeInfo newTypeInfo,
-                                                                    final Path currentPath) {
+    private RemoteCallback<GenerationResult> getSaveSuccessCallback( final Path currentPath) {
         return new RemoteCallback<GenerationResult>() {
 
             @Override
             public void callback(GenerationResult result) {
 
                 view.hideBusyIndicator();
-
-                if (newTypeInfo == null) {
 
                     Boolean oldDirtyStatus = isDirty();
 
@@ -678,14 +667,6 @@ public class DataModelerScreenPresenter
                                                              null));
 
                     versionRecordManager.reloadVersions(currentPath);
-                } else {
-                    notification.fire(new NotificationEvent(
-                            org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants.INSTANCE.ItemRenamedSuccessfully(),
-                            NotificationEvent.NotificationType.SUCCESS));
-                    //If the file was renamed as part of the file saving, don't do anything.
-                    //A rename event will arrive, the same as for the "Rename" case.
-                    //and the file will be automatically reloaded.
-                }
             }
         };
     }


### PR DESCRIPTION
**Issue**: When we change a package or fileName in the general properties of DataModeller and save it, the DataObject is reloaded. If we try to close the data object before reload is complete we see unsaved changes dialog. 

**Reason**: DataObject context and source are updated only during reloading.

**Solution**: The context and source hash are updated before reload. The DataObject is sent to the server after any change in DataModeller or the source to handle the inconsistencies in source and DataObject Model.

**JIRA**: [RHPAM-3119](https://issues.redhat.com/browse/RHPAM-3119)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
