### PR TITLE
RHPAM-3178: Stunner - Monaco script editor scrollbars disappear

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorOptions.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorOptions.java
@@ -88,7 +88,7 @@ public class MonacoEditorOptions {
         properties.setUseTabStops(false);
         properties.setContextmenu(false);
         properties.setFolding(false);
-        properties.setMiniMapEnabled(false);
+        properties.setMiniMapEnabled(true);
         properties.setScrollbarUseShadows(false);
         properties.setAutomaticLayout(false);
         properties.setRenderWhitespace(true);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorPresenter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorPresenter.java
@@ -109,6 +109,7 @@ public class MonacoEditorPresenter {
                   () -> {
                       view.loadingEnds();
                       view.setLanguageReadOnly(readyOnly);
+                      view.attachListenerToPanelTitle();
                   });
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorView.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import jsinterop.base.Js;
 import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.Element;
 import org.jboss.errai.common.client.dom.Event;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.Node;
@@ -45,6 +46,9 @@ public class MonacoEditorView implements UberElement<MonacoEditorPresenter> {
 
     static final String DISPLAY = "display";
     static final String NONE = "none";
+    static final String PANEL_TITLE = "panel-title";
+    static final String EVENT_NAME = "click";
+    static final int DEPTH = 14;
 
     @Inject
     @DataField
@@ -107,6 +111,28 @@ public class MonacoEditorView implements UberElement<MonacoEditorPresenter> {
                      MonacoEditorOptions options,
                      Runnable callback) {
         load(new MonacoEditorInitializer(), modules, options, callback);
+    }
+
+    // Workaround for refreshing Monaco editor and get scrollbars visible when the accordion is expanded
+    void attachListenerToPanelTitle() {
+        final NodeList titleNodes = getParentInDepth(rootContainer, DEPTH).getElementsByClassName(PANEL_TITLE);
+        for (int i = 0; i < titleNodes.getLength(); i++) {
+            titleNodes.item(i)
+                    .addEventListener(EVENT_NAME,
+                                      event -> presenter.onLanguageChanged(languageSelector.getValue()),
+                                      false);
+        }
+    }
+
+    static Element getParentInDepth(final Element element, int depth) {
+        if (null != element && depth > 0) {
+            Element parent = element.getParentElement();
+            return null != parent ?
+                    getParentInDepth(parent, --depth)
+                    :
+                    element;
+        }
+        return element;
     }
 
     void load(MonacoEditorInitializer initializer,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorPresenterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorPresenterTest.java
@@ -113,6 +113,7 @@ public class MonacoEditorPresenterTest {
         callbackCaptor.getValue().run();
         verify(view, times(1)).loadingEnds();
         verify(view, times(1)).setLanguageReadOnly(eq(true));
+        verify(view, times(1)).attachListenerToPanelTitle();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/components/monaco_editor/MonacoEditorViewTest.java
@@ -20,7 +20,9 @@ import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.dom.CSSStyleDeclaration;
 import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.Element;
 import org.jboss.errai.common.client.dom.Event;
+import org.jboss.errai.common.client.dom.Node;
 import org.jboss.errai.common.client.dom.NodeList;
 import org.jboss.errai.common.client.dom.Select;
 import org.junit.Before;
@@ -33,6 +35,8 @@ import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoStandaloneCodeEdito
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -53,6 +57,18 @@ public class MonacoEditorViewTest {
 
     @Mock
     private Div rootContainer;
+
+    @Mock
+    private Div level1;
+
+    @Mock
+    private Div level2;
+
+    @Mock
+    private Div level3;
+
+    @Mock
+    private Node node;
 
     @Mock
     private Select languageSelector;
@@ -169,5 +185,54 @@ public class MonacoEditorViewTest {
         verify(monacoEditor, times(1)).getChildNodes();
         verify(rootContainer, times(1)).getChildNodes();
         assertNull(tested.editor);
+    }
+
+    @Test
+    public void testGetParentInDepth() {
+        setElementChain();
+        Element parentElementRecovered = tested.getParentInDepth(rootContainer, 3);
+        assertEquals(level1, parentElementRecovered);
+    }
+
+    @Test
+    public void testGetParentInDepthOutOfBounds() {
+        setElementChain();
+        Element parentElementRecovered = tested.getParentInDepth(rootContainer, 4);
+        assertEquals(level1, parentElementRecovered);
+    }
+
+    @Test
+    public void testGetParentInDepthNullElement() {
+        setElementChain();
+        Element parentElementRecovered = tested.getParentInDepth(null, 4);
+        assertNull(parentElementRecovered);
+    }
+
+    @Test
+    public void testAttachListenerToPanelTitle() {
+        setElementChain();
+        when(level1.getElementsByClassName(anyString())).thenReturn(getNodeList());
+        tested.attachListenerToPanelTitle();
+        verify(node, times(1)).addEventListener(anyString(), anyObject(), anyBoolean());
+    }
+
+    private void setElementChain() {
+        when(rootContainer.getParentElement()).thenReturn(level3);
+        when(level3.getParentElement()).thenReturn(level2);
+        when(level2.getParentElement()).thenReturn(level1);
+    }
+
+    private NodeList getNodeList() {
+        return new NodeList() {
+            @Override
+            public Node item(int i) {
+                return node;
+            }
+
+            @Override
+            public int getLength() {
+                return 1;
+            }
+        };
     }
 }


### PR DESCRIPTION
Hey @romartin, Please, could you review this PR?

Notice that I've enabled the miniMap(Preview) attending to requests. 
The editor looks broken once the miniMap space is not returned back to the editing area.

**JIRA**: [RHPAM-3178](https://issues.redhat.com/browse/RHPAM-3178)

**Business Central**: [WAR file](https://drive.google.com/file/d/1922TMxt848gN_MXx6PG1RHREP9OnD3uM/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1RH7i1tnC8hiIrTQ-rmjpwgMV5rIENr2m/view?usp=sharing)

Thanks!
