### PR TITLE
RHPAM-2802 - Save and Rename of DMN/BPMN leads to Unexpected error

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -297,6 +297,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                    errorPopupPresenter,
                                                    diagramClientErrorHandler,
                                                    translationService));
+                this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilderMock;
                 return presenterCore;
             }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -75,6 +75,7 @@ import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
 import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.ace.AceEditorMode;
 import org.uberfire.ext.widgets.common.client.common.popups.YesNoCancelPopup;
@@ -595,6 +596,8 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
     public void open(final ProjectDiagram diagram,
                      final Viewer.Callback callback) {
         editor.open(diagram, callback);
+        SaveAndRenameCommandBuilder saveAndRenameCommandBuilder = getSaveAndRenameCommandBuilder();
+        saveAndRenameCommandBuilder.addContentSupplier(editor.getEditorProxy().getContentSupplier());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -99,6 +99,7 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
 import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.ace.AceEditorMode;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
@@ -252,6 +253,9 @@ public class AbstractProjectDiagramEditorTest {
     @Mock
     protected AbstractProjectDiagramEditorCore<ProjectMetadata, ProjectDiagram, ProjectDiagramResource, ProjectDiagramEditorProxy<ProjectDiagramResource>> presenterCore;
 
+    @Mock
+    protected SaveAndRenameCommandBuilder saveAndRenameCommandBuilderMock;
+
     protected boolean isReadOnly = false;
 
     protected Promises promises = new SyncPromises();
@@ -381,6 +385,7 @@ public class AbstractProjectDiagramEditorTest {
                                                    errorPopupPresenter,
                                                    diagramClientErrorHandler,
                                                    translationService));
+                this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilderMock;
                 return presenterCore;
             }
 
@@ -472,6 +477,8 @@ public class AbstractProjectDiagramEditorTest {
         verify(kieView).addMainEditorPage(eq(view));
         verify(kieView).addOverviewPage(eq(overviewWidget),
                                         any(com.google.gwt.user.client.Command.class));
+
+        verify(saveAndRenameCommandBuilderMock).addContentSupplier(any());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/ProjectDiagramEditorTest.java
@@ -81,6 +81,7 @@ import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
@@ -236,6 +237,10 @@ public class ProjectDiagramEditorTest {
     @Mock
     private Caller<ProjectDiagramResourceService> projectDiagramResourceServiceCaller;
 
+    @Mock
+    private SaveAndRenameCommandBuilder saveAndRenameCommandBuilderMock;
+
+
     private ProjectDiagramEditorStub presenter;
 
     private AbstractProjectDiagramEditorCore<ProjectMetadata, ProjectDiagram, ProjectDiagramResource, ProjectDiagramEditorProxy<ProjectDiagramResource>> presenterCore;
@@ -336,6 +341,11 @@ public class ProjectDiagramEditorTest {
                                                    diagramClientErrorHandler,
                                                    translationService));
                 return presenterCore;
+            }
+
+            @Override
+            protected SaveAndRenameCommandBuilder<ProjectDiagramResource, Metadata> getSaveAndRenameCommandBuilder() {
+                return saveAndRenameCommandBuilderMock;
             }
         };
         presenter.init();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/editor/BPMNDiagramEditorTest.java
@@ -189,6 +189,7 @@ public class BPMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                    errorPopupPresenter,
                                                    diagramClientErrorHandler,
                                                    translationService));
+                this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilderMock;
                 return presenterCore;
             }
 


### PR DESCRIPTION
SaveAndRenameCommandBuilder where supplying the wrong action when saving trying to save the file.
This fixes the problem by setting the right action as soon as that action is defined.

**JIRA**: [RHPAM-2802](https://issues.redhat.com/browse/RHPAM-2802)

**Business Central**: [WAR file](https://drive.google.com/file/d/1FZSRGjoQkeDOWpt5U1Bszuy1_iM247Xw/view?usp=sharing)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
