### PR TITLE
AF-2644 : Package list fails to populate default package for imported projects

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/project/KieModuleServiceImpl.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/project/KieModuleServiceImpl.java
@@ -135,15 +135,17 @@ public class KieModuleServiceImpl
                                      PackageItem.DEFAULT_PACKAGE_NAME));
 
         for (final String packageName : packageServiceLoader.find(activeModule.getRootPath())) {
-            final StringBuilder packageBuilder = new StringBuilder();
-            for (final String token : packageName.split("\\.")) {
-                if (packageBuilder.length() != 0) {
-                    packageBuilder.append(".");
-                }
-                packageBuilder.append(token);
+            if (!packageName.trim().isEmpty()) {
+                final StringBuilder packageBuilder = new StringBuilder();
+                for (final String token : packageName.split("\\.")) {
+                    if (packageBuilder.length() != 0) {
+                        packageBuilder.append(".");
+                    }
+                    packageBuilder.append(token);
 
-                packages.add(new PackageItem(packageBuilder.toString(),
-                                             packageBuilder.toString()));
+                    packages.add(new PackageItem(packageBuilder.toString(),
+                                                 packageBuilder.toString()));
+                }
             }
         }
 

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/project/KieModuleServiceImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/project/KieModuleServiceImplTest.java
@@ -114,6 +114,7 @@ public class KieModuleServiceImplTest {
     @Test
     public void testPackages() {
         final HashSet<Object> packages = new HashSet<>();
+        packages.add("");
         packages.add("org.test");
 
         doReturn(packages).when(packageServiceLoader).find(rootPath);


### PR DESCRIPTION
**JIRA**: [AF-2644](https://issues.redhat.com/browse/AF-2644)

Problem is that there are two empty packages. One shows up as "nothing selected" and the other as "<default>". Removing one of them.

