### PR TITLE
KOGITO-3364: [DMN Designer] Multiple DRDs support - When a node is deleted in the DRG, undo/redo operations do not work properly

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommand.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteCanvasConnectorCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+
+import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.belongsToCurrentGraph;
+
+public class DMNDeleteCanvasConnectorNodeCommand extends DeleteCanvasConnectorCommand {
+
+    private final GraphsProvider graphsProvider;
+
+    public DMNDeleteCanvasConnectorNodeCommand(final Edge candidate, final GraphsProvider graphsProvider) {
+        super(candidate);
+        this.graphsProvider = graphsProvider;
+    }
+
+    @Override
+    public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
+        if (candidateNodeBelongsToCurrentGraph()) {
+            return superUndo(context);
+        } else {
+            return CanvasCommandResultBuilder.SUCCESS;
+        }
+    }
+
+    CommandResult<CanvasViolation> superUndo(final AbstractCanvasHandler context) {
+        return super.undo(context);
+    }
+
+    boolean candidateNodeBelongsToCurrentGraph() {
+        return belongsToCurrentGraph(getCandidate(), graphsProvider);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommand.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasCommand;
+import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteCanvasNodeCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Node;
+
+public class DMNDeleteCanvasNodeCommand extends DeleteCanvasNodeCommand {
+
+    private final GraphsProvider graphsProvider;
+
+    public DMNDeleteCanvasNodeCommand(final Node candidate,
+                                      final GraphsProvider graphsProvider) {
+        super(candidate);
+        this.graphsProvider = graphsProvider;
+    }
+
+    @Override
+    protected AbstractCanvasCommand createUndoCommand(final Node parent,
+                                                      final Node candidate,
+                                                      final String ssid) {
+
+        if (belongsToCurrentGraph(candidate)) {
+            return superCreateUndoCommand(parent, candidate, ssid);
+        } else {
+            return createEmptyCommand();
+        }
+    }
+
+    AbstractCanvasCommand createEmptyCommand() {
+        return new AbstractCanvasCommand() {
+            @Override
+            public CommandResult<CanvasViolation> execute(final AbstractCanvasHandler context) {
+                return CanvasCommandResultBuilder.SUCCESS;
+            }
+
+            @Override
+            public CommandResult<CanvasViolation> undo(final AbstractCanvasHandler context) {
+                return CanvasCommandResultBuilder.SUCCESS;
+            }
+        };
+    }
+
+    boolean belongsToCurrentGraph(final Node candidate) {
+        return ContentDefinitionIdUtils.belongsToCurrentGraph(candidate, graphsProvider);
+    }
+
+    AbstractCanvasCommand superCreateUndoCommand(final Node parent,
+                                                 final Node candidate,
+                                                 final String ssid) {
+        return super.createUndoCommand(parent, candidate, ssid);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteElementsCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteElementsCommand.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.impl.SafeDeleteNodeCommand;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 public class DMNDeleteElementsCommand extends DeleteElementsCommand {
@@ -44,7 +45,15 @@ public class DMNDeleteElementsCommand extends DeleteElementsCommand {
     @Override
     protected Command<GraphCommandExecutionContext, RuleViolation> newGraphCommand(final AbstractCanvasHandler context) {
         return new DMNDeleteElementsGraphCommand(() -> elements,
-                                                 new CanvasMultipleDeleteProcessor(),
+                                                 new DMNCanvasMultipleDeleteProcessor(),
                                                  getGraphsProvider());
+    }
+
+    private class DMNCanvasMultipleDeleteProcessor extends CanvasMultipleDeleteProcessor {
+
+        @Override
+        protected DMNDeleteNodeCommand.DMNCanvasDeleteProcessor createProcessor(SafeDeleteNodeCommand.Options options) {
+            return new DMNDeleteNodeCommand.DMNCanvasDeleteProcessor(options, getGraphsProvider());
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteNodeCommand.java
@@ -17,12 +17,15 @@
 package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteCanvasConnectorCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteNodeCommand;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.graph.command.impl.SafeDeleteNodeCommand;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 public class DMNDeleteNodeCommand extends DeleteNodeCommand {
@@ -33,7 +36,7 @@ public class DMNDeleteNodeCommand extends DeleteNodeCommand {
                                 final GraphsProvider graphsProvider) {
         super(candidate,
               SafeDeleteNodeCommand.Options.defaults(),
-              new CanvasDeleteProcessor(SafeDeleteNodeCommand.Options.defaults()));
+              new DMNCanvasDeleteProcessor(SafeDeleteNodeCommand.Options.defaults(), graphsProvider));
         this.graphsProvider = graphsProvider;
     }
 
@@ -47,5 +50,26 @@ public class DMNDeleteNodeCommand extends DeleteNodeCommand {
                                             deleteProcessor,
                                             options,
                                             getGraphsProvider());
+    }
+
+    public static class DMNCanvasDeleteProcessor extends CanvasDeleteProcessor {
+
+        private final GraphsProvider graphsProvider;
+
+        public DMNCanvasDeleteProcessor(final SafeDeleteNodeCommand.Options options,
+                                        final GraphsProvider graphsProvider) {
+            super(options);
+            this.graphsProvider = graphsProvider;
+        }
+
+        @Override
+        protected DeleteCanvasConnectorCommand createDeleteCanvasConnectorNodeCommand(final Edge<? extends View<?>, Node> connector) {
+            return new DMNDeleteCanvasConnectorNodeCommand(connector, graphsProvider);
+        }
+
+        @Override
+        protected DMNDeleteCanvasNodeCommand createDeleteCanvasNodeCommand(final Node<?, Edge> node) {
+            return new DMNDeleteCanvasNodeCommand(node, graphsProvider);
+        }
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNSafeDeleteNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNSafeDeleteNodeCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 
 import org.kie.workbench.common.dmn.api.definition.model.DecisionService;
+import org.kie.workbench.common.dmn.client.commands.factory.graph.DMNDeleteConnectorCommand;
 import org.kie.workbench.common.dmn.client.commands.factory.graph.DMNDeregisterNodeCommand;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
@@ -24,9 +25,11 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.impl.DeleteConnectorCommand;
 import org.kie.workbench.common.stunner.core.graph.command.impl.DeregisterNodeCommand;
 import org.kie.workbench.common.stunner.core.graph.command.impl.SafeDeleteNodeCommand;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.util.NodeDefinitionHelper;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
@@ -74,5 +77,10 @@ public class DMNSafeDeleteNodeCommand extends SafeDeleteNodeCommand {
     @Override
     protected DeregisterNodeCommand createDeregisterNodeCommand(final Node node) {
         return new DMNDeregisterNodeCommand(getGraph(node), node.getUUID());
+    }
+
+    @Override
+    protected DeleteConnectorCommand getDeleteConnectorCommand(final Edge<? extends View<?>, Node> edge) {
+        return new DMNDeleteConnectorCommand(edge, graphsProvider);
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.impl.DeleteConnectorCommand;
+import org.kie.workbench.common.stunner.core.graph.command.impl.SetConnectionSourceNodeCommand;
+import org.kie.workbench.common.stunner.core.graph.command.impl.SetConnectionTargetNodeCommand;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+
+public class DMNDeleteConnectorCommand extends DeleteConnectorCommand {
+
+    private final GraphsProvider graphsProvider;
+
+    public DMNDeleteConnectorCommand(final Edge<? extends View, Node> edge,
+                                     final GraphsProvider graphsProvider) {
+        super(edge);
+        this.graphsProvider = graphsProvider;
+    }
+
+    @Override
+    protected SetConnectionTargetNodeCommand getSetConnectionTargetCommand(final Edge<? extends ViewConnector, Node> edge) {
+        return new DMNSetConnectionTargetNodeCommand(null,
+                                                     edge,
+                                                     null,
+                                                     graphsProvider);
+    }
+
+    @Override
+    protected SetConnectionSourceNodeCommand getSetConnectionSourceCommand(final Edge<? extends ViewConnector, Node> edge) {
+        return new DMNSetConnectionSourceNodeCommand(null,
+                                                     edge,
+                                                     null,
+                                                     graphsProvider);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
@@ -97,6 +97,9 @@ public class DMNSetConnectionSourceNodeCommand extends SetConnectionSourceNodeCo
     }
 
     Graph getEdgesGraph() {
-        return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+        if (getDiagramId().isPresent()) {
+            return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+        }
+        throw new IllegalStateException("Unable to get the edges graph. The diagramId is not set.");
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import java.util.Optional;
+
+import org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.impl.SetConnectionSourceNodeCommand;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.getDiagramId;
+import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.isTheCurrentDiagram;
+
+public class DMNSetConnectionSourceNodeCommand extends SetConnectionSourceNodeCommand {
+
+    private final GraphsProvider graphsProvider;
+    private final Optional<String> diagramId;
+
+    public DMNSetConnectionSourceNodeCommand(final Node<? extends View<?>, Edge> sourceNode,
+                                             final Edge<? extends View, Node> edge,
+                                             final Connection connection,
+                                             final GraphsProvider graphsProvider) {
+        super(sourceNode, edge, connection);
+        this.graphsProvider = graphsProvider;
+        this.diagramId = ContentDefinitionIdUtils.getDiagramId(edge);
+    }
+
+    @Override
+    public Node<? extends View<?>, Edge> getSourceNode(final GraphCommandExecutionContext context) {
+        if (commandBelongsToAnotherGraph()) {
+            return getEdgesGraph().getNode(getSourceNodeUUID());
+        } else {
+            return superGetSourceNode(context);
+        }
+    }
+
+    Node<? extends View<?>, Edge> superGetSourceNode(final GraphCommandExecutionContext context) {
+        return super.getSourceNode(context);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
+        final DMNSetConnectionSourceNodeCommand undoCommand = new DMNSetConnectionSourceNodeCommand((Node<? extends View<?>, Edge>) getNode(context,
+                                                                                                                                            getLastSourceNodeUUID()),
+                                                                                                    getEdge(context),
+                                                                                                    getLastConnection(),
+                                                                                                    graphsProvider);
+        return undoCommand.execute(context);
+    }
+
+    public Optional<String> getDiagramId() {
+        return diagramId;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Node<?, Edge> getNode(final GraphCommandExecutionContext context,
+                                    final String uuid) {
+        if (commandBelongsToAnotherGraph()) {
+            return getEdgesGraph().getNode(uuid);
+        } else {
+            return superGetNode(context, uuid);
+        }
+    }
+
+    Node<?, Edge> superGetNode(final GraphCommandExecutionContext context,
+                               final String uuid) {
+        return super.getNode(context, uuid);
+    }
+
+    boolean commandBelongsToAnotherGraph() {
+        return getDiagramId().isPresent()
+                && !isTheCurrentDiagram(getDiagramId(), graphsProvider);
+    }
+
+    Graph getEdgesGraph() {
+        return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
@@ -30,7 +30,6 @@ import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.getDiagramId;
 import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.isTheCurrentDiagram;
 
 public class DMNSetConnectionSourceNodeCommand extends SetConnectionSourceNodeCommand {
@@ -93,13 +92,18 @@ public class DMNSetConnectionSourceNodeCommand extends SetConnectionSourceNodeCo
 
     boolean commandBelongsToAnotherGraph() {
         return getDiagramId().isPresent()
-                && !isTheCurrentDiagram(getDiagramId(), graphsProvider);
+                && !isTheCurrentDiagram(getDiagramId(), getGraphsProvider());
     }
 
     Graph getEdgesGraph() {
-        if (getDiagramId().isPresent()) {
-            return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+        final Optional<String> id = getDiagramId();
+        if (id.isPresent()) {
+            return getGraphsProvider().getDiagram(id.get()).getGraph();
         }
         throw new IllegalStateException("Unable to get the edges graph. The diagramId is not set.");
+    }
+
+    public GraphsProvider getGraphsProvider() {
+        return graphsProvider;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
@@ -96,6 +96,9 @@ public class DMNSetConnectionTargetNodeCommand extends SetConnectionTargetNodeCo
     }
 
     Graph getEdgesGraph() {
-        return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+        if (getDiagramId().isPresent()) {
+            return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+        }
+        throw new IllegalStateException("Unable to get the edges graph. The diagramId is not set.");
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
@@ -92,13 +92,18 @@ public class DMNSetConnectionTargetNodeCommand extends SetConnectionTargetNodeCo
 
     boolean commandBelongsToAnotherGraph() {
         return getDiagramId().isPresent()
-                && !isTheCurrentDiagram(getDiagramId(), graphsProvider);
+                && !isTheCurrentDiagram(getDiagramId(), getGraphsProvider());
     }
 
     Graph getEdgesGraph() {
-        if (getDiagramId().isPresent()) {
-            return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+        final Optional<String> id = getDiagramId();
+        if (id.isPresent()) {
+            return getGraphsProvider().getDiagram(id.get()).getGraph();
         }
         throw new IllegalStateException("Unable to get the edges graph. The diagramId is not set.");
+    }
+
+    GraphsProvider getGraphsProvider() {
+        return graphsProvider;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import java.util.Optional;
+
+import org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.command.impl.SetConnectionTargetNodeCommand;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+
+import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.isTheCurrentDiagram;
+
+public class DMNSetConnectionTargetNodeCommand extends SetConnectionTargetNodeCommand {
+
+    private final GraphsProvider graphsProvider;
+    private final Optional<String> diagramId;
+
+    public DMNSetConnectionTargetNodeCommand(final Node<? extends View<?>, Edge> targetNode,
+                                             final Edge<? extends View, Node> edge,
+                                             final Connection connection,
+                                             final GraphsProvider graphsProvider) {
+        super(targetNode, edge, connection);
+        this.graphsProvider = graphsProvider;
+        this.diagramId = ContentDefinitionIdUtils.getDiagramId(edge);
+    }
+
+    @Override
+    protected Node<? extends View<?>, Edge> getTargetNode(final GraphCommandExecutionContext context) {
+        if (commandBelongsToAnotherGraph()) {
+            return getEdgesGraph().getNode(getTargetNodeUUID());
+        } else {
+            return superGetTargetNode(context);
+        }
+    }
+
+    Node<? extends View<?>, Edge> superGetTargetNode(GraphCommandExecutionContext context) {
+        return super.getTargetNode(context);
+    }
+
+    public Optional<String> getDiagramId() {
+        return diagramId;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
+        final DMNSetConnectionTargetNodeCommand undoCommand = new DMNSetConnectionTargetNodeCommand((Node<? extends View<?>, Edge>) getNode(context,
+                                                                                                                                            getLastTargetNodeUUID()),
+                                                                                                    getEdge(context),
+                                                                                                    getLastConnection(),
+                                                                                                    graphsProvider);
+        return undoCommand.execute(context);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Node<?, Edge> getNode(final GraphCommandExecutionContext context,
+                                    final String uuid) {
+        if (commandBelongsToAnotherGraph()) {
+            return getEdgesGraph().getNode(uuid);
+        } else {
+            return superGetNode(context, uuid);
+        }
+    }
+
+    Node<?, Edge> superGetNode(final GraphCommandExecutionContext context,
+                               final String uuid) {
+        return super.getNode(context, uuid);
+    }
+
+    boolean commandBelongsToAnotherGraph() {
+        return getDiagramId().isPresent()
+                && !isTheCurrentDiagram(getDiagramId(), graphsProvider);
+    }
+
+    Graph getEdgesGraph() {
+        return graphsProvider.getDiagram(getDiagramId().get()).getGraph();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/ContentDefinitionIdUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/ContentDefinitionIdUtils.java
@@ -28,6 +28,9 @@ import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 public class ContentDefinitionIdUtils {
 
+    private ContentDefinitionIdUtils() {
+    }
+
     public static boolean belongsToCurrentGraph(final Node node,
                                                 final GraphsProvider graphsProvider) {
         return isTheCurrentDiagram(getDiagramId(node), graphsProvider);
@@ -39,7 +42,7 @@ public class ContentDefinitionIdUtils {
     }
 
     public static boolean isTheCurrentDiagram(final Optional<String> diagramId,
-                                               final GraphsProvider graphsProvider) {
+                                              final GraphsProvider graphsProvider) {
         return diagramId.isPresent() &&
                 Objects.equals(diagramId.get(), graphsProvider.getCurrentDiagramId());
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/ContentDefinitionIdUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/util/ContentDefinitionIdUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.util;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+public class ContentDefinitionIdUtils {
+
+    public static boolean belongsToCurrentGraph(final Node node,
+                                                final GraphsProvider graphsProvider) {
+        return isTheCurrentDiagram(getDiagramId(node), graphsProvider);
+    }
+
+    public static boolean belongsToCurrentGraph(final Edge<? extends View, Node> edge,
+                                                final GraphsProvider graphsProvider) {
+        return isTheCurrentDiagram(getDiagramId(edge), graphsProvider);
+    }
+
+    public static boolean isTheCurrentDiagram(final Optional<String> diagramId,
+                                               final GraphsProvider graphsProvider) {
+        return diagramId.isPresent() &&
+                Objects.equals(diagramId.get(), graphsProvider.getCurrentDiagramId());
+    }
+
+    public static Optional<String> getDiagramId(final Edge<? extends View, Node> edge) {
+        final Node node;
+        if (Objects.isNull(edge.getSourceNode())) {
+            node = edge.getTargetNode();
+        } else {
+            node = edge.getSourceNode();
+        }
+
+        return getDiagramId(node);
+    }
+
+    public static Optional<String> getDiagramId(final Node node) {
+
+        if (Objects.isNull(node)) {
+            return Optional.empty();
+        }
+
+        final Object content = node.getContent();
+        if (content instanceof Definition) {
+            final Object definition = ((Definition) content).getDefinition();
+            if (definition instanceof HasContentDefinitionId) {
+                return Optional.of(((HasContentDefinitionId) definition).getDiagramId());
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNCanvasHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNCanvasHandler.java
@@ -121,5 +121,7 @@ public class DMNCanvasHandler<D extends Diagram, C extends AbstractCanvas> exten
                        final Element child) {
         super.addChild(parent, child);
     }
+
+
 }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNCanvasHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNCanvasHandler.java
@@ -121,7 +121,4 @@ public class DMNCanvasHandler<D extends Diagram, C extends AbstractCanvas> exten
                        final Element child) {
         super.addChild(parent, child);
     }
-
-
 }
-

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommandTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
+import org.kie.workbench.common.stunner.core.command.CommandResult;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNDeleteCanvasConnectorNodeCommandTest {
+
+    @Mock
+    private GraphsProvider graphsProvider;
+
+    @Mock
+    private Edge candidate;
+
+    @Mock
+    private AbstractCanvasHandler context;
+
+    private DMNDeleteCanvasConnectorNodeCommand command;
+
+    @Before
+    public void setup() {
+        command = spy(new DMNDeleteCanvasConnectorNodeCommand(candidate, graphsProvider));
+    }
+
+    @Test
+    public void testUndoWhenCandidateDoesNotBelongsToCurrentGraph() {
+
+        doReturn(false).when(command).candidateNodeBelongsToCurrentGraph();
+
+        final CommandResult<CanvasViolation> commandResult = command.undo(context);
+
+        assertEquals(CanvasCommandResultBuilder.SUCCESS, commandResult);
+
+        verify(command, never()).superUndo(context);
+    }
+
+    @Test
+    public void testUndoWhenCandidateDoesBelongsToCurrentGraph() {
+
+        final CommandResult superCommandResult = mock(CommandResult.class);
+        doReturn(superCommandResult).when(command).superUndo(context);
+        doReturn(true).when(command).candidateNodeBelongsToCurrentGraph();
+
+        final CommandResult<CanvasViolation> commandResult = command.undo(context);
+
+        assertEquals(superCommandResult, commandResult);
+
+        verify(command).superUndo(context);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommandTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.canvas;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasCommand;
+import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNDeleteCanvasNodeCommandTest {
+
+    @Mock
+    private Node candidate;
+
+    @Mock
+    private GraphsProvider graphsProvide;
+
+    private DMNDeleteCanvasNodeCommand command;
+
+    @Before
+    public void setup() {
+
+        command = spy(new DMNDeleteCanvasNodeCommand(candidate, graphsProvide));
+    }
+
+    @Test
+    public void testCreateUndoCommandWhenBelongsToCurrentGraph() {
+
+        final AbstractCanvasCommand superCanvasCommand = mock(AbstractCanvasCommand.class);
+        final Node parent = mock(Node.class);
+        final String ssid = "ssid";
+
+        doReturn(true).when(command).belongsToCurrentGraph(candidate);
+        doReturn(superCanvasCommand).when(command).superCreateUndoCommand(parent, candidate, ssid);
+
+        final AbstractCanvasCommand actualUndoCommand = command.createUndoCommand(parent, candidate, ssid);
+
+        assertEquals(superCanvasCommand, actualUndoCommand);
+        verify(command, never()).createEmptyCommand();
+    }
+
+    @Test
+    public void testCreateUndoCommandWhenDoesNotBelongsToCurrentGraph() {
+
+        final Node parent = mock(Node.class);
+        final String ssid = "ssid";
+
+        doReturn(false).when(command).belongsToCurrentGraph(candidate);
+        final AbstractCanvasCommand emptyCommand = mock(AbstractCanvasCommand.class);
+        doReturn(emptyCommand).when(command).createEmptyCommand();
+
+        final AbstractCanvasCommand actualUndoCommand = command.createUndoCommand(parent, candidate, ssid);
+
+        assertEquals(emptyCommand, actualUndoCommand);
+        verify(command).createEmptyCommand();
+        verify(command, never()).superCreateUndoCommand(parent, candidate, ssid);
+    }
+
+    @Test
+    public void testEmptyCommand() {
+
+        final AbstractCanvasCommand emptyCommand = command.createEmptyCommand();
+        final AbstractCanvasHandler handler = mock(AbstractCanvasHandler.class);
+
+        assertEquals(CanvasCommandResultBuilder.SUCCESS, emptyCommand.execute(handler));
+        assertEquals(CanvasCommandResultBuilder.SUCCESS, emptyCommand.undo(handler));
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommandTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.impl.SetConnectionSourceNodeCommand;
+import org.kie.workbench.common.stunner.core.graph.command.impl.SetConnectionTargetNodeCommand;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNDeleteConnectorCommandTest {
+
+    @Mock
+    private Edge<? extends View, Node> edge;
+
+    @Mock
+    private GraphsProvider graphsProvider;
+
+    private Edge<? extends ViewConnector, Node> edgeParameter = mock(Edge.class);
+
+    private DMNDeleteConnectorCommand command;
+
+    @Before
+    public void setup() {
+
+        when(edgeParameter.getUUID()).thenReturn("uuid");
+        when(edge.getUUID()).thenReturn("uuid");
+        command = new DMNDeleteConnectorCommand(edge, graphsProvider);
+    }
+
+    @Test
+    public void testGetSetConnectionSourceCommand() {
+
+        final SetConnectionSourceNodeCommand setConnectionSourceCommand = command.getSetConnectionSourceCommand(edgeParameter);
+
+        assertTrue(setConnectionSourceCommand instanceof DMNSetConnectionSourceNodeCommand);
+    }
+
+    @Test
+    public void testGetSetConnectionTargetCommand() {
+
+        final SetConnectionTargetNodeCommand setConnectionTargetCommand = command.getSetConnectionTargetCommand(edgeParameter);
+
+        assertTrue(setConnectionTargetCommand instanceof DMNSetConnectionTargetNodeCommand);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommandTest.java
@@ -29,6 +29,8 @@ import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.mockito.Mock;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -60,6 +62,9 @@ public class DMNDeleteConnectorCommandTest {
         final SetConnectionSourceNodeCommand setConnectionSourceCommand = command.getSetConnectionSourceCommand(edgeParameter);
 
         assertTrue(setConnectionSourceCommand instanceof DMNSetConnectionSourceNodeCommand);
+        assertNull(setConnectionSourceCommand.getSourceNode());
+        assertEquals(edgeParameter, setConnectionSourceCommand.getEdge());
+        assertEquals(graphsProvider, ((DMNSetConnectionSourceNodeCommand) setConnectionSourceCommand).getGraphsProvider());
     }
 
     @Test
@@ -68,5 +73,8 @@ public class DMNDeleteConnectorCommandTest {
         final SetConnectionTargetNodeCommand setConnectionTargetCommand = command.getSetConnectionTargetCommand(edgeParameter);
 
         assertTrue(setConnectionTargetCommand instanceof DMNSetConnectionTargetNodeCommand);
+        assertNull(setConnectionTargetCommand.getSourceNode());
+        assertEquals(edgeParameter, setConnectionTargetCommand.getEdge());
+        assertEquals(graphsProvider, ((DMNSetConnectionTargetNodeCommand) setConnectionTargetCommand).getGraphsProvider());
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommandTest.java
@@ -196,6 +196,14 @@ public class DMNSetConnectionSourceNodeCommandTest {
         assertEquals(graph, actualGraph);
     }
 
+    @Test(expected=IllegalStateException.class)
+    public void testGetEdgesGraphWhenDiagramIdIsNotSet() {
+
+        doReturn(Optional.empty()).when(command).getDiagramId();
+
+        command.getEdgesGraph();
+    }
+
     private Node createNode(final String diagramId) {
 
         final Node node = mock(Node.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommandTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNSetConnectionSourceNodeCommandTest {
+
+    private static final String EDGE_UUID = "edge uuid";
+    private static final String NODE_DIAGRAM_UUID = "the id";
+    private static final String SOURCE_NODE_UUID = "source node uuid";
+
+    @Mock
+    private Node<? extends View<?>, Edge> sourceNode;
+
+    @Mock
+    private Edge<? extends View, Node> edge;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private GraphsProvider graphsProvider;
+
+    @Mock
+    private GraphCommandExecutionContext context;
+
+    private DMNSetConnectionSourceNodeCommand command;
+
+    @Before
+    public void setup() {
+
+        final Node edgeSourceNode = createNode(NODE_DIAGRAM_UUID);
+
+        when(sourceNode.getUUID()).thenReturn(SOURCE_NODE_UUID);
+        when(edge.getUUID()).thenReturn(EDGE_UUID);
+        when(edge.getSourceNode()).thenReturn(edgeSourceNode);
+
+        command = spy(new DMNSetConnectionSourceNodeCommand(sourceNode,
+                                                            edge,
+                                                            connection,
+                                                            graphsProvider));
+    }
+
+    @Test
+    public void testGetSourceNodeWhenCommandBelongsToAnotherGraph() {
+
+        final Node node = mock(Node.class);
+        final Graph graph = mock(Graph.class);
+
+        doReturn(true).when(command).commandBelongsToAnotherGraph();
+        doReturn(graph).when(command).getEdgesGraph();
+
+        when(graph.getNode(SOURCE_NODE_UUID)).thenReturn(node);
+
+        final Node currentSourceNode = command.getSourceNode(context);
+
+        assertEquals(node, currentSourceNode);
+        verify(command, never()).superGetSourceNode(context);
+    }
+
+    @Test
+    public void testGetSourceNodeWhenCommandBelongsToCurrentGraph() {
+
+        final Node node = mock(Node.class);
+
+        doReturn(false).when(command).commandBelongsToAnotherGraph();
+        doReturn(node).when(command).superGetSourceNode(context);
+
+        final Node currentSourceNode = command.getSourceNode(context);
+
+        assertEquals(node, currentSourceNode);
+        verify(command).superGetSourceNode(context);
+    }
+
+    @Test
+    public void testGetNodeWhenCommandBelongsToAnotherGraph() {
+
+        final String uuid = "uuid";
+        final Graph graph = mock(Graph.class);
+        final Node node = mock(Node.class);
+
+        doReturn(true).when(command).commandBelongsToAnotherGraph();
+        doReturn(graph).when(command).getEdgesGraph();
+        when(graph.getNode(uuid)).thenReturn(node);
+
+        final Node currentNode = command.getNode(context, uuid);
+
+        assertEquals(node, currentNode);
+    }
+
+    @Test
+    public void testGetNodeWhenCommandBelongsToCurrentGraph() {
+
+        final String uuid = "uuid";
+        final Node node = mock(Node.class);
+
+        doReturn(false).when(command).commandBelongsToAnotherGraph();
+        doReturn(node).when(command).superGetNode(context, uuid);
+
+        final Node currentNode = command.getNode(context, uuid);
+
+        assertEquals(node, currentNode);
+    }
+
+    @Test
+    public void testCommandBelongsToAnotherGraphWhenItIsNot() {
+
+        final String diagramId = "diagramId";
+        final Optional<String> commandDiagramId = Optional.of(diagramId);
+
+        when(graphsProvider.getCurrentDiagramId()).thenReturn(diagramId);
+        doReturn(commandDiagramId).when(command).getDiagramId();
+
+        assertFalse(command.commandBelongsToAnotherGraph());
+    }
+
+    @Test
+    public void testCommandBelongsToAnotherGraph() {
+
+        final String diagramId = "diagramId";
+        final String anotherDiagramId = "another diagram id";
+        final Optional<String> commandDiagramId = Optional.of(diagramId);
+
+        when(graphsProvider.getCurrentDiagramId()).thenReturn(anotherDiagramId);
+        doReturn(commandDiagramId).when(command).getDiagramId();
+
+        assertTrue(command.commandBelongsToAnotherGraph());
+    }
+
+    @Test
+    public void testCommandBelongsToAnotherGraphWhenDiagramIdIsNotPresent() {
+
+        final String anotherDiagramId = "another diagram id";
+
+        when(graphsProvider.getCurrentDiagramId()).thenReturn(anotherDiagramId);
+        doReturn(Optional.empty()).when(command).getDiagramId();
+
+        assertFalse(command.commandBelongsToAnotherGraph());
+    }
+
+    @Test
+    public void testGetEdgesGraph() {
+
+        final String diagramId = "diagram id";
+        final Diagram diagram = mock(Diagram.class);
+        final Graph graph = mock(Graph.class);
+
+        doReturn(Optional.of(diagramId)).when(command).getDiagramId();
+        when(diagram.getGraph()).thenReturn(graph);
+        when(graphsProvider.getDiagram(diagramId)).thenReturn(diagram);
+
+        final Graph actualGraph = command.getEdgesGraph();
+
+        assertEquals(graph, actualGraph);
+    }
+
+    private Node createNode(final String diagramId) {
+
+        final Node node = mock(Node.class);
+        final Definition definition = mock(Definition.class);
+        final HasContentDefinitionId hasContentDefinitionId = mock(HasContentDefinitionId.class);
+
+        when(node.getContent()).thenReturn(definition);
+        when(hasContentDefinitionId.getDiagramId()).thenReturn(diagramId);
+        when(definition.getDefinition()).thenReturn(hasContentDefinitionId);
+
+        return node;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommandTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.factory.graph;
+
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.view.Connection;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNSetConnectionTargetNodeCommandTest {
+
+    private static final String EDGE_UUID = "edge uuid";
+    private static final String NODE_DIAGRAM_UUID = "the id";
+    private static final String TARGET_NODE_UUID = "target node uuid";
+
+    @Mock
+    private Node<? extends View<?>, Edge> targetNode;
+
+    @Mock
+    private Edge<? extends View, Node> edge;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private GraphsProvider graphsProvider;
+
+    @Mock
+    private GraphCommandExecutionContext context;
+
+    private DMNSetConnectionTargetNodeCommand command;
+
+    @Before
+    public void setup() {
+
+        final Node edgeSourceNode = createNode(NODE_DIAGRAM_UUID);
+
+        when(targetNode.getUUID()).thenReturn(TARGET_NODE_UUID);
+        when(edge.getUUID()).thenReturn(EDGE_UUID);
+        when(edge.getSourceNode()).thenReturn(edgeSourceNode);
+
+        command = spy(new DMNSetConnectionTargetNodeCommand(targetNode,
+                                                            edge,
+                                                            connection,
+                                                            graphsProvider));
+    }
+
+    @Test
+    public void testGetTargetNodeWhenCommandBelongsToAnotherGraph() {
+
+        final Node node = mock(Node.class);
+        final Graph graph = mock(Graph.class);
+
+        doReturn(true).when(command).commandBelongsToAnotherGraph();
+        doReturn(graph).when(command).getEdgesGraph();
+
+        when(graph.getNode(TARGET_NODE_UUID)).thenReturn(node);
+
+        final Node currentTargetNode = command.getTargetNode(context);
+
+        assertEquals(node, currentTargetNode);
+        verify(command, never()).superGetTargetNode(context);
+    }
+
+    @Test
+    public void testGetTargetNodeWhenCommandBelongsToCurrentGraph() {
+
+        final Node node = mock(Node.class);
+
+        doReturn(false).when(command).commandBelongsToAnotherGraph();
+        doReturn(node).when(command).superGetTargetNode(context);
+
+        final Node currentTargetNode = command.getTargetNode(context);
+
+        assertEquals(node, currentTargetNode);
+        verify(command).superGetTargetNode(context);
+    }
+
+    @Test
+    public void testGetNodeWhenCommandBelongsToAnotherGraph() {
+
+        final String uuid = "uuid";
+        final Graph graph = mock(Graph.class);
+        final Node node = mock(Node.class);
+
+        doReturn(true).when(command).commandBelongsToAnotherGraph();
+        doReturn(graph).when(command).getEdgesGraph();
+        when(graph.getNode(uuid)).thenReturn(node);
+
+        final Node currentNode = command.getNode(context, uuid);
+
+        assertEquals(node, currentNode);
+    }
+
+    @Test
+    public void testGetNodeWhenCommandBelongsToCurrentGraph() {
+
+        final String uuid = "uuid";
+        final Node node = mock(Node.class);
+
+        doReturn(false).when(command).commandBelongsToAnotherGraph();
+        doReturn(node).when(command).superGetNode(context, uuid);
+
+        final Node currentNode = command.getNode(context, uuid);
+
+        assertEquals(node, currentNode);
+    }
+
+    @Test
+    public void testCommandBelongsToAnotherGraphWhenItIsNot() {
+
+        final String diagramId = "diagramId";
+        final Optional<String> commandDiagramId = Optional.of(diagramId);
+
+        when(graphsProvider.getCurrentDiagramId()).thenReturn(diagramId);
+        doReturn(commandDiagramId).when(command).getDiagramId();
+
+        assertFalse(command.commandBelongsToAnotherGraph());
+    }
+
+    @Test
+    public void testCommandBelongsToAnotherGraph() {
+
+        final String diagramId = "diagramId";
+        final String anotherDiagramId = "another diagram id";
+        final Optional<String> commandDiagramId = Optional.of(diagramId);
+
+        when(graphsProvider.getCurrentDiagramId()).thenReturn(anotherDiagramId);
+        doReturn(commandDiagramId).when(command).getDiagramId();
+
+        assertTrue(command.commandBelongsToAnotherGraph());
+    }
+
+    @Test
+    public void testCommandBelongsToAnotherGraphWhenDiagramIdIsNotPresent() {
+
+        final String anotherDiagramId = "another diagram id";
+
+        when(graphsProvider.getCurrentDiagramId()).thenReturn(anotherDiagramId);
+        doReturn(Optional.empty()).when(command).getDiagramId();
+
+        assertFalse(command.commandBelongsToAnotherGraph());
+    }
+
+    @Test
+    public void testGetEdgesGraph() {
+
+        final String diagramId = "diagram id";
+        final Diagram diagram = mock(Diagram.class);
+        final Graph graph = mock(Graph.class);
+
+        doReturn(Optional.of(diagramId)).when(command).getDiagramId();
+        when(diagram.getGraph()).thenReturn(graph);
+        when(graphsProvider.getDiagram(diagramId)).thenReturn(diagram);
+
+        final Graph actualGraph = command.getEdgesGraph();
+
+        assertEquals(graph, actualGraph);
+    }
+
+    private Node createNode(final String diagramId) {
+
+        final Node node = mock(Node.class);
+        final Definition definition = mock(Definition.class);
+        final HasContentDefinitionId hasContentDefinitionId = mock(HasContentDefinitionId.class);
+
+        when(node.getContent()).thenReturn(definition);
+        when(hasContentDefinitionId.getDiagramId()).thenReturn(diagramId);
+        when(definition.getDefinition()).thenReturn(hasContentDefinitionId);
+
+        return node;
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommandTest.java
@@ -196,6 +196,14 @@ public class DMNSetConnectionTargetNodeCommandTest {
         assertEquals(graph, actualGraph);
     }
 
+    @Test(expected=IllegalStateException.class)
+    public void testGetEdgesGraphWhenDiagramIdIsNotSet() {
+
+        doReturn(Optional.empty()).when(command).getDiagramId();
+
+        command.getEdgesGraph();
+    }
+
     private Node createNode(final String diagramId) {
 
         final Node node = mock(Node.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/ContentDefinitionIdUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/util/ContentDefinitionIdUtilsTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.commands.util;
+
+import java.util.Optional;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.belongsToCurrentGraph;
+import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils.getDiagramId;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ContentDefinitionIdUtilsTest {
+
+    @Test
+    public void testNodeBelongsToCurrentGraph() {
+
+        final String currentDiagramId = "currentDiagramId";
+        final Node node = createNode(currentDiagramId);
+        final GraphsProvider graphsProvider = createGraphsProvider(currentDiagramId);
+
+        assertTrue(belongsToCurrentGraph(node, graphsProvider));
+    }
+
+    @Test
+    public void testNodeBelongsToCurrentGraphWhenDoesNot() {
+
+        final String nodeDiagramId = "nodeDiagramId";
+        final String currentDiagramId = "currentDiagramId";
+        final Node node = createNode(nodeDiagramId);
+        final GraphsProvider graphsProvider = createGraphsProvider(currentDiagramId);
+
+        assertFalse(belongsToCurrentGraph(node, graphsProvider));
+    }
+
+    @Test
+    public void testEdgeBelongsToCurrentGraph() {
+
+        final String currentDiagramId = "currentDiagramId";
+        final Node node = createNode(currentDiagramId);
+        final Edge edge = createEdge(node, null);
+        final GraphsProvider graphsProvider = createGraphsProvider(currentDiagramId);
+
+        assertTrue(belongsToCurrentGraph(edge, graphsProvider));
+    }
+
+    @Test
+    public void testEdgeBelongsToCurrentGraphWhenDoesNot() {
+
+        final String nodeDiagramId = "nodeDiagramId";
+        final String currentDiagramId = "currentDiagramId";
+        final Node node = createNode(nodeDiagramId);
+        final Edge edge = createEdge(node, null);
+        final GraphsProvider graphsProvider = createGraphsProvider(currentDiagramId);
+
+        assertFalse(belongsToCurrentGraph(edge, graphsProvider));
+    }
+
+    @Test
+    public void testGetDiagramIdFromEdge() {
+
+        final String targetNodeDiagramId = "targetNodeId";
+        final String sourceNodeDiagramId = "sourceNodeId";
+        final Node target = createNode(targetNodeDiagramId);
+        final Node source = createNode(sourceNodeDiagramId);
+        final Edge edge = createEdge(source, target);
+
+        final Optional<String> actualId = getDiagramId(edge);
+
+        assertTrue(actualId.isPresent());
+        assertEquals(sourceNodeDiagramId, actualId.get());
+    }
+
+    @Test
+    public void testGetDiagramIdFromEdgeSourceNode() {
+
+        final String sourceNodeDiagramId = "diagram id";
+        final Node source = createNode(sourceNodeDiagramId);
+        final Edge edge = createEdge(source, null);
+
+        final Optional<String> actualId = getDiagramId(edge);
+
+        assertTrue(actualId.isPresent());
+        assertEquals(sourceNodeDiagramId, actualId.get());
+    }
+
+    @Test
+    public void testGetDiagramIdFromEdgeTargetNode() {
+
+        final String targetNodeDiagramId = "diagram id";
+        final Node target = createNode(targetNodeDiagramId);
+        final Edge edge = createEdge(null, target);
+
+        final Optional<String> actualId = getDiagramId(edge);
+
+        assertTrue(actualId.isPresent());
+        assertEquals(targetNodeDiagramId, actualId.get());
+    }
+
+    @Test
+    public void testGetDiagramIdFromNode() {
+
+        final String diagramId = "diagram Id";
+        final Node node = createNode(diagramId);
+
+        final Optional<String> actual = getDiagramId(node);
+
+        assertTrue(actual.isPresent());
+        assertEquals(diagramId, actual.get());
+    }
+
+    @Test
+    public void testGetDiagramIdFromNodeWhenNodeIsNull() {
+
+        final Optional<String> diagramId = getDiagramId((Node) null);
+        assertFalse(diagramId.isPresent());
+        assertNotNull(diagramId);
+    }
+
+    private Edge createEdge(final Node sourceNode, final Node targetNode) {
+
+        final Edge edge = mock(Edge.class);
+        when(edge.getSourceNode()).thenReturn(sourceNode);
+        when(edge.getTargetNode()).thenReturn(targetNode);
+        return edge;
+    }
+
+    private Node createNode(final String diagramId) {
+
+        final Node node = mock(Node.class);
+        final Definition definition = mock(Definition.class);
+        final HasContentDefinitionId hasContentDefinitionId = mock(HasContentDefinitionId.class);
+
+        when(node.getContent()).thenReturn(definition);
+        when(hasContentDefinitionId.getDiagramId()).thenReturn(diagramId);
+        when(definition.getDefinition()).thenReturn(hasContentDefinitionId);
+
+        return node;
+    }
+
+    private GraphsProvider createGraphsProvider(final String currentDiagramId) {
+
+        final GraphsProvider graphsProvider = mock(GraphsProvider.class);
+        when(graphsProvider.getCurrentDiagramId()).thenReturn(currentDiagramId);
+        return graphsProvider;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/DeleteNodeCommand.java
@@ -187,10 +187,14 @@ public class DeleteNodeCommand extends AbstractCanvasGraphCommand {
 
         private boolean doDeleteConnector(final Edge<? extends View<?>, Node> connector) {
             if (!options.getExclusions().contains(connector.getUUID())) {
-                getCommand().addCommand(new DeleteCanvasConnectorCommand(connector));
+                getCommand().addCommand(createDeleteCanvasConnectorNodeCommand(connector));
                 return true;
             }
             return false;
+        }
+
+        protected DeleteCanvasConnectorCommand createDeleteCanvasConnectorNodeCommand(final Edge<? extends View<?>, Node> connector) {
+            return new DeleteCanvasConnectorCommand(connector);
         }
 
         protected DeleteCanvasNodeCommand createDeleteCanvasNodeCommand(final Node<?, Edge> node) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/DeleteConnectorCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/DeleteConnectorCommand.java
@@ -31,7 +31,7 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
  * A Command to delete an edge from a graph
  */
 @Portable
-public final class DeleteConnectorCommand extends AbstractGraphCompositeCommand {
+public class DeleteConnectorCommand extends AbstractGraphCompositeCommand {
 
     private final String edgeUUID;
     private transient Edge<? extends View, Node> edge;
@@ -54,14 +54,22 @@ public final class DeleteConnectorCommand extends AbstractGraphCompositeCommand 
         final Node<View<?>, Edge> targetNode = edge.getTargetNode();
         final Node<View<?>, Edge> sourceNode = edge.getSourceNode();
         if (null != sourceNode) {
-            commands.add(new SetConnectionSourceNodeCommand(null,
-                                                            edge));
+            commands.add(getSetConnectionSourceCommand(edge));
         }
         if (null != targetNode) {
-            commands.add(new SetConnectionTargetNodeCommand(null,
-                                                            edge));
+            commands.add(getSetConnectionTargetCommand(edge));
         }
         return this;
+    }
+
+    protected SetConnectionTargetNodeCommand getSetConnectionTargetCommand(final Edge<? extends ViewConnector, Node> edge) {
+        return new SetConnectionTargetNodeCommand(null,
+                                                  edge);
+    }
+
+    protected SetConnectionSourceNodeCommand getSetConnectionSourceCommand(final Edge<? extends ViewConnector, Node> edge) {
+        return new SetConnectionSourceNodeCommand(null,
+                                                  edge);
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SafeDeleteNodeCommand.java
@@ -236,7 +236,7 @@ public class SafeDeleteNodeCommand extends AbstractGraphCompositeCommand {
                                   final Edge<? extends ViewConnector<?>, Node> out) {
                 final ViewConnector<?> outContent = out.getContent();
                 final Node targetNode = out.getTargetNode();
-                addCommand(new DeleteConnectorCommand(out));
+                addCommand(getDeleteConnectorCommand(out));
                 safeDeleteCallback.ifPresent(c -> c.deleteCandidateConnector(out));
                 addCommand(new SetConnectionTargetNodeCommand(targetNode,
                                                               in,
@@ -249,7 +249,7 @@ public class SafeDeleteNodeCommand extends AbstractGraphCompositeCommand {
 
             private boolean doDeleteConnector(final Edge<? extends View<?>, Node> edge) {
                 if (!isElementExcluded(edge) && !processedConnectors.contains(edge.getUUID())) {
-                    addCommand(new DeleteConnectorCommand(edge));
+                    addCommand(getDeleteConnectorCommand(edge));
                     safeDeleteCallback.ifPresent(c -> c.deleteConnector(edge));
                     processedConnectors.add(edge.getUUID());
                     return true;
@@ -257,6 +257,10 @@ public class SafeDeleteNodeCommand extends AbstractGraphCompositeCommand {
                 return false;
             }
         };
+    }
+
+    protected DeleteConnectorCommand getDeleteConnectorCommand(final Edge<? extends View<?>, Node> edge) {
+        return new DeleteConnectorCommand(edge);
     }
 
     void createChangeParentCommands(final Element<?> canvas,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetConnectionSourceNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetConnectionSourceNodeCommand.java
@@ -40,7 +40,7 @@ import org.kie.workbench.common.stunner.core.rule.context.EdgeCardinalityContext
  * - if connector is not view based, no need to provide magnet index.
  */
 @Portable
-public final class SetConnectionSourceNodeCommand extends AbstractGraphCommand {
+public class SetConnectionSourceNodeCommand extends AbstractGraphCommand {
 
     private final String sourceNodeUUID;
     private final String edgeUUID;
@@ -199,6 +199,18 @@ public final class SetConnectionSourceNodeCommand extends AbstractGraphCommand {
 
     public Connection getConnection() {
         return connection;
+    }
+
+    public String getSourceNodeUUID() {
+        return sourceNodeUUID;
+    }
+
+    public Connection getLastConnection() {
+        return lastConnection;
+    }
+
+    public String getLastSourceNodeUUID() {
+        return lastSourceNodeUUID;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetConnectionTargetNodeCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/impl/SetConnectionTargetNodeCommand.java
@@ -40,7 +40,7 @@ import org.kie.workbench.common.stunner.core.rule.context.EdgeCardinalityContext
  * - if connector is not view based, no need to provide magnet index.
  */
 @Portable
-public final class SetConnectionTargetNodeCommand extends AbstractGraphCommand {
+public class SetConnectionTargetNodeCommand extends AbstractGraphCommand {
 
     private final String targetNodeUUID;
     private final String edgeUUID;
@@ -160,7 +160,7 @@ public final class SetConnectionTargetNodeCommand extends AbstractGraphCommand {
         return undoCommand.execute(context);
     }
 
-    private Edge<? extends View, Node> getEdge(final GraphCommandExecutionContext context) {
+    protected Edge<? extends View, Node> getEdge(final GraphCommandExecutionContext context) {
         if (null == this.edge) {
             this.edge = getViewEdge(context,
                                     edgeUUID);
@@ -177,7 +177,7 @@ public final class SetConnectionTargetNodeCommand extends AbstractGraphCommand {
     }
 
     @SuppressWarnings("unchecked")
-    private Node<? extends View<?>, Edge> getTargetNode(final GraphCommandExecutionContext context) {
+    protected Node<? extends View<?>, Edge> getTargetNode(final GraphCommandExecutionContext context) {
         if (null == targetNode) {
             targetNode = (Node<? extends View<?>, Edge>) getNode(context,
                                                                  targetNodeUUID);
@@ -199,6 +199,18 @@ public final class SetConnectionTargetNodeCommand extends AbstractGraphCommand {
 
     public Node<? extends View<?>, Edge> getSourceNode() {
         return sourceNode;
+    }
+
+    public String getTargetNodeUUID(){
+        return targetNodeUUID;
+    }
+
+    public Connection getLastConnection() {
+        return lastConnection;
+    }
+
+    public String getLastTargetNodeUUID() {
+        return lastTargetNodeUUID;
     }
 
     @Override


### PR DESCRIPTION
**JIRA**: [KOGITO-3364](https://issues.redhat.com/browse/KOGITO-3364)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
