### PR TITLE
JBPM-9254 Stunner - BPMN Editor freezes in business central

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/dataio/AssignmentsInfo.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/dataio/AssignmentsInfo.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.definition.property.dataio;
 
+import java.util.Objects;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.jboss.errai.databinding.client.api.Bindable;
 import org.kie.workbench.common.forms.adf.definitions.annotations.metaModel.FieldDefinition;
@@ -63,14 +65,14 @@ public class AssignmentsInfo implements BPMNProperty {
 
     @Override
     public int hashCode() {
-        return (null != value) ? value.hashCode() : 0;
+        return Objects.hashCode(value);
     }
 
     @Override
     public boolean equals(Object o) {
         if (o instanceof AssignmentsInfo) {
             AssignmentsInfo other = (AssignmentsInfo) o;
-            return (null != value) ? value.equals(other.value) : null == other.value;
+            return Objects.equals(value, other.value);
         }
         return false;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/AssociationDeclaration.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/AssociationDeclaration.java
@@ -80,6 +80,25 @@ public class AssociationDeclaration {
                         : (source + type.op() + target));
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof AssociationDeclaration)) {
+            return false;
+        }
+
+        AssociationDeclaration otherDeclaration = (AssociationDeclaration) other;
+
+        return Objects.equals(type, otherDeclaration.type)
+                && Objects.equals(source, otherDeclaration.source)
+                && Objects.equals(target, otherDeclaration.target)
+                && Objects.equals(direction, otherDeclaration.direction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, source, target, direction);
+    }
+
     public enum Direction {
         Input("[din]"),
         Output("[dout]");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/DeclarationList.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/DeclarationList.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
+import org.kie.workbench.common.stunner.core.util.StringUtils;
+
 public class DeclarationList {
 
     private final List<VariableDeclaration> declarations;
@@ -38,7 +40,7 @@ public class DeclarationList {
     public static DeclarationList fromString(String encoded) {
         return new DeclarationList(
                 Arrays.stream(encoded.split(","))
-                        .filter(s -> !s.isEmpty()) // "" makes no sense
+                        .filter(StringUtils::nonEmpty) // "" makes no sense
                         .map(VariableDeclaration::fromString)
                         .collect(Collectors.toList()));
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/AssociationDeclarationTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/customproperties/AssociationDeclarationTest.java
@@ -19,8 +19,10 @@ package org.kie.workbench.common.stunner.bpmn.backend.converters.custompropertie
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Direction.Input;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Direction.Output;
+import static org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Type.FromTo;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.customproperties.AssociationDeclaration.Type.SourceTarget;
 
 public class AssociationDeclarationTest {
@@ -74,5 +76,34 @@ public class AssociationDeclarationTest {
         assertEquals(associationDeclaration.getTarget(), "");
         assertEquals(associationDeclaration.getType(), SourceTarget);
         assertEquals(associationDeclaration.getDirection(), Output);
+    }
+
+    @Test
+    public void testEquals() {
+        String source = "source";
+        String target = "target";
+        AssociationDeclaration declaration = new AssociationDeclaration(Input, FromTo, source, target);
+        assertFalse(declaration.equals(source));
+
+        AssociationDeclaration declaration2 = new AssociationDeclaration(Input, FromTo, source, target);
+        assertEquals(declaration, declaration2);
+
+        declaration2.setDirection(Output);
+        assertFalse(declaration.equals(declaration2));
+
+        declaration2.setDirection(Input);
+        assertEquals(declaration, declaration2);
+        declaration2.setType(SourceTarget);
+        assertFalse(declaration.equals(declaration2));
+
+        declaration2.setType(FromTo);
+        assertEquals(declaration, declaration2);
+        declaration2.setTarget(source);
+        assertFalse(declaration.equals(declaration2));
+
+        declaration2.setTarget(target);
+        assertEquals(declaration, declaration2);
+        declaration2.setSource(target);
+        assertFalse(declaration.equals(declaration2));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/ActivityPropertyWriterTest.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.bpmn2.InputSet;
+import org.eclipse.bpmn2.OutputSet;
 import org.eclipse.bpmn2.Task;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
@@ -79,5 +80,17 @@ public class ActivityPropertyWriterTest {
         ));
         List<InputSet> inputSets = task.getIoSpecification().getInputSets();
         assertEquals(1, inputSets.size());
+    }
+
+    @Test
+    public void testDuplicatedOutputsShouldBeRemoved() {
+        Task task = bpmn2.createTask();
+        ActivityPropertyWriter activityPropertyWriter =
+                new ActivityPropertyWriter(task, new FlatVariableScope(), new HashSet<>());
+        activityPropertyWriter.setAssignmentsInfo(new AssignmentsInfo(
+                "|NotCompletedNotify:Object,Skippable:Object||outcome_:String,outcome_:String,outcome_:String,outcome_:String,assignedUser_:String,email_:String,emailBody_:String|[dout]outcome_->outcome,[dout]outcome_->firResult,[dout]outcome_->outcome,[dout]outcome_->firResult,[dout]assignedUser_->assignedUser,[dout]email_->email,[dout]emailBody_->emailBody"
+        ));
+        List<OutputSet> outputSets = task.getIoSpecification().getOutputSets();
+        assertEquals(5, outputSets.get(0).getDataOutputRefs().size());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ParsedAssignmentsInfoTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/tostunner/properties/ParsedAssignmentsInfoTest.java
@@ -123,24 +123,24 @@ public class ParsedAssignmentsInfoTest {
         InitializedVariable.InitializedOutputVariable initializedOutputVariable =
                 initializedOutputVariables.get(0);
 
-        DataOutput dataOuput = initializedOutputVariable.getDataOutput();
+        DataOutput dataOutput = initializedOutputVariable.getDataOutput();
 
         DataOutputAssociation dataOutputAssociation = initializedOutputVariable.getDataOutputAssociation();
         List<ItemAwareElement> sourceRef = dataOutputAssociation.getSourceRef();
         DataOutput source = (DataOutput) sourceRef.get(0);
         PropertyImpl target = (PropertyImpl) dataOutputAssociation.getTargetRef();
 
-        String dataOuputID = dataOuput.getId();
-        String dataOutputName = dataOuput.getName();
+        String dataOutputID = dataOutput.getId();
+        String dataOutputName = dataOutput.getName();
         String dataOutputAssociationID = source.getName();
-        String dataOutputAssocationValue = target.getId();
+        String dataOutputAssociationValue = target.getId();
         String initVarID = initializedOutputVariable.getIdentifier();
         String initVarType = initializedOutputVariable.getType();
 
-        assertEquals(dataOuputID, DATA_OUTPUT_ID);
+        assertEquals(dataOutputID, DATA_OUTPUT_ID);
         assertEquals(dataOutputName, DATA_OUTPUT_NAME);
         assertEquals(dataOutputAssociationID, DATA_OUTPUT_ASSOCIATION_ID);
-        assertEquals(dataOutputAssocationValue, DATA_OUTPUT_ASSOCIATION_VALUE);
+        assertEquals(dataOutputAssociationValue, DATA_OUTPUT_ASSOCIATION_VALUE);
         assertEquals(initVarID, INIT_OUTPUT_VAR_ID);
         assertEquals(initVarType, INIT_OUTPUT_VAR_TYPE);
     }
@@ -159,14 +159,14 @@ public class ParsedAssignmentsInfoTest {
 
         InitializedVariable.InitializedOutputVariable initializedOutputVariable =
                 initializedOutputVariables.get(0);
-        DataOutput dataOuput = initializedOutputVariable.getDataOutput();
+        DataOutput dataOutput = initializedOutputVariable.getDataOutput();
         DataOutputAssociation dataOutputAssociation = initializedOutputVariable.getDataOutputAssociation();
-        String dataOuputID = dataOuput.getId();
-        String dataOutputName = dataOuput.getName();
+        String dataOutputID = dataOutput.getId();
+        String dataOutputName = dataOutput.getName();
         String initVarID = initializedOutputVariable.getIdentifier();
 
         assertNull(dataOutputAssociation);
-        assertEquals(dataOuputID, DATA_OUTPUT_ID);
+        assertEquals(dataOutputID, DATA_OUTPUT_ID);
         assertEquals(dataOutputName, DATA_OUTPUT_NAME);
         assertEquals(initVarID, INIT_OUTPUT_VAR_ID);
     }
@@ -194,24 +194,24 @@ public class ParsedAssignmentsInfoTest {
         InitializedVariable.InitializedOutputVariable initializedOutputVariable1 =
                 initializedOutputVariables.get(0);
 
-        DataOutput dataOuput1 = initializedOutputVariable1.getDataOutput();
+        DataOutput dataOutput1 = initializedOutputVariable1.getDataOutput();
 
         DataOutputAssociation dataOutputAssociation1 = initializedOutputVariable1.getDataOutputAssociation();
         List<ItemAwareElement> sourceRef1 = dataOutputAssociation1.getSourceRef();
         DataOutput source1 = (DataOutput) sourceRef1.get(0);
         PropertyImpl target1 = (PropertyImpl) dataOutputAssociation1.getTargetRef();
 
-        String dataOuputID1 = dataOuput1.getId();
-        String dataOutputName1 = dataOuput1.getName();
+        String dataOutputID1 = dataOutput1.getId();
+        String dataOutputName1 = dataOutput1.getName();
         String dataOutputAssociationID1 = source1.getName();
-        String dataOutputAssocationValue1 = target1.getId();
+        String dataOutputAssociationValue1 = target1.getId();
         String initVarID1 = initializedOutputVariable1.getIdentifier();
         String initVarType1 = initializedOutputVariable1.getType();
 
-        assertEquals(dataOuputID1, DATA_OUTPUT_ID);
+        assertEquals(dataOutputID1, DATA_OUTPUT_ID);
         assertEquals(dataOutputName1, DATA_OUTPUT_NAME);
         assertEquals(dataOutputAssociationID1, DATA_OUTPUT_ASSOCIATION_ID);
-        assertEquals(dataOutputAssocationValue1, DATA_OUTPUT_ASSOCIATION_VALUE_1);
+        assertEquals(dataOutputAssociationValue1, DATA_OUTPUT_ASSOCIATION_VALUE_1);
         assertEquals(initVarID1, INIT_OUTPUT_VAR_ID);
         assertEquals(initVarType1, INIT_OUTPUT_VAR_TYPE);
 
@@ -219,43 +219,43 @@ public class ParsedAssignmentsInfoTest {
         InitializedVariable.InitializedOutputVariable initializedOutputVariable2 =
                 initializedOutputVariables.get(1);
 
-        DataOutput dataOuput2 = initializedOutputVariable2.getDataOutput();
+        DataOutput dataOutput2 = initializedOutputVariable2.getDataOutput();
 
         DataOutputAssociation dataOutputAssociation2 = initializedOutputVariable2.getDataOutputAssociation();
         List<ItemAwareElement> sourceRef2 = dataOutputAssociation2.getSourceRef();
         DataOutput source2 = (DataOutput) sourceRef2.get(0);
         PropertyImpl target2 = (PropertyImpl) dataOutputAssociation2.getTargetRef();
 
-        String dataOuputID2 = dataOuput2.getId();
-        String dataOutputName2 = dataOuput2.getName();
+        String dataOutputID2 = dataOutput2.getId();
+        String dataOutputName2 = dataOutput2.getName();
         String dataOutputAssociationID2 = source2.getName();
-        String dataOutputAssocationValue2 = target2.getId();
+        String dataOutputAssociationValue2 = target2.getId();
         String initVarID2 = initializedOutputVariable2.getIdentifier();
         String initVarType2 = initializedOutputVariable2.getType();
 
-        assertEquals(dataOuputID2, DATA_OUTPUT_ID);
+        assertEquals(dataOutputID2, DATA_OUTPUT_ID);
         assertEquals(dataOutputName2, DATA_OUTPUT_NAME);
         assertEquals(dataOutputAssociationID2, DATA_OUTPUT_ASSOCIATION_ID);
-        assertEquals(dataOutputAssocationValue2, DATA_OUTPUT_ASSOCIATION_VALUE_2);
+        assertEquals(dataOutputAssociationValue2, DATA_OUTPUT_ASSOCIATION_VALUE_2);
         assertEquals(initVarID2, INIT_OUTPUT_VAR_ID);
         assertEquals(initVarType2, INIT_OUTPUT_VAR_TYPE);
     }
 
     @Test
-    public void fromString() {
+    public void testFromString() {
         String original =
                 "|input1:String,input2:String||output1:String,output2:String|[din]pv1->input1,[din]pv2->input2,[dout]output1->pv2,[dout]output2->pv2";
-        assertParseUnparse(original);
+        testAssertParseUnparse(original);
     }
 
     @Test
-    public void fromString2() {
+    public void testFromString2() {
         String original =
                 "||IntermediateMessageEventCatchingOutputVar1:String||[dout]IntermediateMessageEventCatchingOutputVar1->var1";
-        assertParseUnparse(original);
+        testAssertParseUnparse(original);
     }
 
-    private void assertParseUnparse(String original) {
+    private void testAssertParseUnparse(String original) {
         ParsedAssignmentsInfo assignmentsInfo =
                 ParsedAssignmentsInfo.fromString(original);
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/multipleDefinitionsUserTask.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/multipleDefinitionsUserTask.bpmn
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_DUGD4Pf_Eeq3urtOTzOphw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_processVarItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_inputVarOutputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__3317203C-A341-4148-A113-95670EA83DED_inputVarOutputXItem" structureRef="String"/>
+  <bpmn2:process id="TestProject.TestProcess" drools:packageName="com.myspace.testproject" drools:version="1.0" drools:adHoc="false" name="TestProcess" isExecutable="true" processType="Public">
+    <bpmn2:property id="processVar" itemSubjectRef="_processVarItem" name="processVar"/>
+    <bpmn2:sequenceFlow id="_B4517705-CFCF-4847-84A0-5A5B756E0155" sourceRef="_3317203C-A341-4148-A113-95670EA83DED" targetRef="_A31AC68F-476A-4219-878E-680EA081CD4B">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_5669FEAD-0B26-4E23-9033-91EBED7FC8F1" sourceRef="_CB01B5ED-7C49-497C-8371-23600519D01B" targetRef="_3317203C-A341-4148-A113-95670EA83DED">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:startEvent id="_CB01B5ED-7C49-497C-8371-23600519D01B">
+      <bpmn2:outgoing>_5669FEAD-0B26-4E23-9033-91EBED7FC8F1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:endEvent id="_A31AC68F-476A-4219-878E-680EA081CD4B">
+      <bpmn2:incoming>_B4517705-CFCF-4847-84A0-5A5B756E0155</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:userTask id="_3317203C-A341-4148-A113-95670EA83DED" name="Task">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5669FEAD-0B26-4E23-9033-91EBED7FC8F1</bpmn2:incoming>
+      <bpmn2:outgoing>_B4517705-CFCF-4847-84A0-5A5B756E0155</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_DUGD4ff_Eeq3urtOTzOphw">
+        <bpmn2:dataInput id="_3317203C-A341-4148-A113-95670EA83DED_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__3317203C-A341-4148-A113-95670EA83DED_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_3317203C-A341-4148-A113-95670EA83DED_SkippableInputX" drools:dtype="Object" itemSubjectRef="__3317203C-A341-4148-A113-95670EA83DED_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:dataOutput id="_3317203C-A341-4148-A113-95670EA83DED_inputVarOutputX" drools:dtype="String" itemSubjectRef="__3317203C-A341-4148-A113-95670EA83DED_inputVarOutputXItem" name="inputVar"/>
+        <bpmn2:dataOutput id="_3317203C-A341-4148-A113-95670EA83DED_inputVarOutputX" drools:dtype="String" itemSubjectRef="__3317203C-A341-4148-A113-95670EA83DED_inputVarOutputXItem" name="inputVar"/>
+        <bpmn2:inputSet id="_DUGD4vf_Eeq3urtOTzOphw">
+          <bpmn2:dataInputRefs>_3317203C-A341-4148-A113-95670EA83DED_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_3317203C-A341-4148-A113-95670EA83DED_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_DUGD4_f_Eeq3urtOTzOphw">
+          <bpmn2:dataOutputRefs>_3317203C-A341-4148-A113-95670EA83DED_inputVarOutputX</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>_3317203C-A341-4148-A113-95670EA83DED_inputVarOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_DUGD5Pf_Eeq3urtOTzOphw">
+        <bpmn2:targetRef>_3317203C-A341-4148-A113-95670EA83DED_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_DUGD5ff_Eeq3urtOTzOphw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DUGD5vf_Eeq3urtOTzOphw"><![CDATA[Task]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DUGD5_f_Eeq3urtOTzOphw">_3317203C-A341-4148-A113-95670EA83DED_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_DUGD6Pf_Eeq3urtOTzOphw">
+        <bpmn2:targetRef>_3317203C-A341-4148-A113-95670EA83DED_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_DUGD6ff_Eeq3urtOTzOphw">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DUGD6vf_Eeq3urtOTzOphw"><![CDATA[false]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DUGD6_f_Eeq3urtOTzOphw">_3317203C-A341-4148-A113-95670EA83DED_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_DUGD7Pf_Eeq3urtOTzOphw">
+        <bpmn2:sourceRef>_3317203C-A341-4148-A113-95670EA83DED_inputVarOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>processVar</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:dataOutputAssociation id="_DUGD7ff_Eeq3urtOTzOphw">
+        <bpmn2:sourceRef>_3317203C-A341-4148-A113-95670EA83DED_inputVarOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>processVar</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:userTask>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_DUGq8Pf_Eeq3urtOTzOphw">
+    <bpmndi:BPMNPlane id="_DUGq8ff_Eeq3urtOTzOphw" bpmnElement="TestProject.TestProcess">
+      <bpmndi:BPMNShape id="shape__3317203C-A341-4148-A113-95670EA83DED" bpmnElement="_3317203C-A341-4148-A113-95670EA83DED">
+        <dc:Bounds height="102.0" width="154.0" x="461.0" y="220.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__A31AC68F-476A-4219-878E-680EA081CD4B" bpmnElement="_A31AC68F-476A-4219-878E-680EA081CD4B">
+        <dc:Bounds height="56.0" width="56.0" x="733.0" y="243.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__CB01B5ED-7C49-497C-8371-23600519D01B" bpmnElement="_CB01B5ED-7C49-497C-8371-23600519D01B">
+        <dc:Bounds height="56.0" width="56.0" x="325.0" y="243.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__CB01B5ED-7C49-497C-8371-23600519D01B_to_shape__3317203C-A341-4148-A113-95670EA83DED" bpmnElement="_5669FEAD-0B26-4E23-9033-91EBED7FC8F1">
+        <di:waypoint xsi:type="dc:Point" x="381.0" y="271.0"/>
+        <di:waypoint xsi:type="dc:Point" x="461.0" y="271.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__3317203C-A341-4148-A113-95670EA83DED_to_shape__A31AC68F-476A-4219-878E-680EA081CD4B" bpmnElement="_B4517705-CFCF-4847-84A0-5A5B756E0155">
+        <di:waypoint xsi:type="dc:Point" x="615.0" y="271.0"/>
+        <di:waypoint xsi:type="dc:Point" x="733.0" y="271.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_DUGq8vf_Eeq3urtOTzOphw" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_3317203C-A341-4148-A113-95670EA83DED" id="_DUGq8_f_Eeq3urtOTzOphw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_CB01B5ED-7C49-497C-8371-23600519D01B" id="_DUGq9Pf_Eeq3urtOTzOphw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_DUGD4Pf_Eeq3urtOTzOphw</bpmn2:source>
+    <bpmn2:target>_DUGD4Pf_Eeq3urtOTzOphw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/AssociationDeclaration.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/AssociationDeclaration.java
@@ -80,6 +80,25 @@ public class AssociationDeclaration {
                         : (source + type.op() + target));
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof AssociationDeclaration)) {
+            return false;
+        }
+
+        AssociationDeclaration otherDeclaration = (AssociationDeclaration) other;
+
+        return Objects.equals(type, otherDeclaration.type)
+                && Objects.equals(source, otherDeclaration.source)
+                && Objects.equals(target, otherDeclaration.target)
+                && Objects.equals(direction, otherDeclaration.direction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, source, target, direction);
+    }
+
     public enum Direction {
         Input("[din]"),
         Output("[dout]");

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/ParsedAssignmentsInfo.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/ParsedAssignmentsInfo.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -196,31 +197,48 @@ public class ParsedAssignmentsInfo {
 
     public List<InitializedOutputVariable> createInitializedOutputVariables(String parentId, VariableScope variableScope, Set<DataObject> dataObjects) {
         List<InitializedOutputVariable> initializedOutputVariables = new ArrayList<>();
-
+        Set<String> processedVariables = new HashSet<>();
         getOutputs()
                 .getDeclarations()
                 .forEach(varDecl -> {
-                    if (associations.lookupOutputs(varDecl.getTypedIdentifier().getName()).isEmpty()) {
-                        initializedOutputVariables.add(InitializedVariable.outputOf(
-                                parentId,
-                                variableScope,
-                                varDecl,
-                                null,
-                                dataObjects));
+                    String varName = varDecl.getTypedIdentifier().getName();
+
+                    if (processedVariables.contains(varName)) {
+                        return;
+                    }
+                    processedVariables.add(varName);
+
+                    List<AssociationDeclaration> associationDeclarations = associations.lookupOutputs(varName);
+                    if (associationDeclarations.isEmpty()) {
+                        addUnassociatedVariable(parentId, variableScope, dataObjects, initializedOutputVariables, varDecl);
                     } else {
-                        initializedOutputVariables.addAll(associations.lookupOutputs(varDecl.getTypedIdentifier().getName())
-                                                                  .stream()
-                                                                  .map(outputDec -> InitializedVariable.outputOf(
-                                                                          parentId,
-                                                                          variableScope,
-                                                                          getOutputs().lookup(outputDec.getSource().replace(" ", "-")),
-                                                                          outputDec,
-                                                                          dataObjects))
-                                                                  .collect(Collectors.toList()));
+                        addVariable(parentId, variableScope, dataObjects, initializedOutputVariables, associationDeclarations);
                     }
                 });
 
         return initializedOutputVariables;
+    }
+
+    private void addVariable(String parentId, VariableScope variableScope, Set<DataObject> dataObjects, List<InitializedOutputVariable> initializedOutputVariables, List<AssociationDeclaration> declarations) {
+        initializedOutputVariables.addAll(declarations
+                                                  .stream()
+                                                  .distinct()
+                                                  .map(outputDec -> InitializedVariable.outputOf(
+                                                          parentId,
+                                                          variableScope,
+                                                          getOutputs().lookup(outputDec.getSource().replace(" ", "-")),
+                                                          outputDec,
+                                                          dataObjects))
+                                                  .collect(Collectors.toList()));
+    }
+
+    private void addUnassociatedVariable(String parentId, VariableScope variableScope, Set<DataObject> dataObjects, List<InitializedOutputVariable> initializedOutputVariables, VariableDeclaration varDecl) {
+        initializedOutputVariables.add(InitializedVariable.outputOf(
+                parentId,
+                variableScope,
+                varDecl,
+                null,
+                dataObjects));
     }
 
     public boolean isEmpty() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/AssociationDeclarationTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/AssociationDeclarationTest.java
@@ -19,8 +19,10 @@ package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customp
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.AssociationDeclaration.Direction.Input;
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.AssociationDeclaration.Direction.Output;
+import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.AssociationDeclaration.Type.FromTo;
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.AssociationDeclaration.Type.SourceTarget;
 
 public class AssociationDeclarationTest {
@@ -74,5 +76,34 @@ public class AssociationDeclarationTest {
         assertEquals(associationDeclaration.getTarget(), "");
         assertEquals(associationDeclaration.getType(), SourceTarget);
         assertEquals(associationDeclaration.getDirection(), Output);
+    }
+
+    @Test
+    public void testEquals() {
+        String source = "source";
+        String target = "target";
+        AssociationDeclaration declaration = new AssociationDeclaration(Input, FromTo, source, target);
+        assertFalse(declaration.equals(source));
+
+        AssociationDeclaration declaration2 = new AssociationDeclaration(Input, FromTo, source, target);
+        assertEquals(declaration, declaration2);
+
+        declaration2.setDirection(Output);
+        assertFalse(declaration.equals(declaration2));
+
+        declaration2.setDirection(Input);
+        assertEquals(declaration, declaration2);
+        declaration2.setType(SourceTarget);
+        assertFalse(declaration.equals(declaration2));
+
+        declaration2.setType(FromTo);
+        assertEquals(declaration, declaration2);
+        declaration2.setTarget(source);
+        assertFalse(declaration.equals(declaration2));
+
+        declaration2.setTarget(target);
+        assertEquals(declaration, declaration2);
+        declaration2.setSource(target);
+        assertFalse(declaration.equals(declaration2));
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ActivityPropertyReaderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/ActivityPropertyReaderTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunn
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.bpmn2.Activity;
@@ -30,7 +31,9 @@ import org.eclipse.bpmn2.ExtensionAttributeValue;
 import org.eclipse.bpmn2.InputOutputSpecification;
 import org.eclipse.bpmn2.ItemAwareElement;
 import org.eclipse.bpmn2.ItemDefinition;
+import org.eclipse.bpmn2.OutputSet;
 import org.eclipse.bpmn2.Property;
+import org.eclipse.bpmn2.Task;
 import org.eclipse.bpmn2.di.BPMNDiagram;
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
@@ -42,6 +45,9 @@ import org.jboss.drools.OnExitScriptType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories;
+import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.properties.ActivityPropertyWriter;
+import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.properties.FlatVariableScope;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.DefinitionResolver;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.ScriptTypeListValue;
@@ -157,6 +163,19 @@ public class ActivityPropertyReaderTest {
 
         AssignmentsInfo result = reader.getAssignmentsInfo();
         assertEquals("||||", result.getValue());
+    }
+
+
+    @Test
+    public void testDuplicatedOutputsShouldBeRemoved() {
+        Task task = Factories.bpmn2.createTask();
+        ActivityPropertyWriter activityPropertyWriter =
+                new ActivityPropertyWriter(task, new FlatVariableScope(), new HashSet<>());
+        activityPropertyWriter.setAssignmentsInfo(new AssignmentsInfo(
+                "|NotCompletedNotify:Object,Skippable:Object||outcome_:String,outcome_:String,outcome_:String,outcome_:String,assignedUser_:String,email_:String,emailBody_:String|[dout]outcome_->outcome,[dout]outcome_->firResult,[dout]outcome_->outcome,[dout]outcome_->firResult,[dout]assignedUser_->assignedUser,[dout]email_->email,[dout]emailBody_->emailBody"
+        ));
+        List<OutputSet> outputSets = task.getIoSpecification().getOutputSets();
+        assertEquals(5, outputSets.get(0).getDataOutputRefs().size());
     }
 
     private static void assertScript(String expectedLanguage, String expectedScript, ScriptTypeListValue value) {


### PR DESCRIPTION
**JIRA**: [JBPM-9254](https://issues.redhat.com/browse/JBPM-9254)

**Business Central**: [here](https://drive.google.com/file/d/1jH__H8IhyHAhXlLWnqtqmL55wJ-omdU2/view?usp=sharing)

**VS Code**: [here](https://drive.google.com/file/d/1l292hIuhDJQwMdv-DIzm9d0_nZUBbHjD/view?usp=sharing)

<details>
<summary>
Hi @romartin, there is a fix for the jira, I tested it with business central and I can't reproduce it anymore. See details under the cut.
</summary>

<br>

<b>A side effect</b>: now if user will manually declare twice the same variable like `userVar[String]->processVar` all duplicates will be removed. But it won't remove variables if only one or two of tree parts (variable name, variable type, variable association) are the same, like `userVar[String]->processVar1` and `userVar[String]->processVar2` will be preserved.

Fix can be more elegant than adding addition `Set` to keep names of processed variables but it will need a bit more deep rework of marshallers due to missing overriding of `equals` method in EMF library. Since we are planning to replace marshallers by new one, I think this rework is unnecessary and this tmp `Set` should be enough. WDYT? If you agree with this solution I will duplicate solution for Kogito version of marshallers and attach Binaries for further testing. Thank you!

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
