### PR TITLE
KOGITO-3571: [DMN Designer] Multiple DRDs support - Information requirements are duplicated into the DMN XML

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshaller.java
@@ -61,16 +61,13 @@ import org.kie.workbench.common.dmn.client.marshaller.converters.dd.PointUtils;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.MainJs;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.di.JSIDiagramElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITAssociation;
-import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITAuthorityRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITBusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDMNElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDRGElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDecision;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDecisionService;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDefinitions;
-import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITInformationRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITInputData;
-import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITKnowledgeRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITKnowledgeSource;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITTextAnnotation;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNDiagram;
@@ -355,30 +352,55 @@ public class DMNMarshaller {
             final JSITBusinessKnowledgeModel existingBkm = Js.uncheckedCast(existingDRGElement);
             final JSITBusinessKnowledgeModel nodeBkm = Js.uncheckedCast(node);
 
-            final List<JSITAuthorityRequirement> authorityRequirement = nodeBkm.getAuthorityRequirement();
-            final List<JSITKnowledgeRequirement> knowledgeRequirement = nodeBkm.getKnowledgeRequirement();
+            forEach(nodeBkm.getAuthorityRequirement(),
+                    authorityRequirement -> {
+                        if (!existingBkm.getAuthorityRequirement().contains(authorityRequirement)) {
+                            existingBkm.addAuthorityRequirement(authorityRequirement);
+                        }
+                    });
 
-            existingBkm.addAllAuthorityRequirement(authorityRequirement.toArray(new JSITAuthorityRequirement[0]));
-            existingBkm.addAllKnowledgeRequirement(knowledgeRequirement.toArray(new JSITKnowledgeRequirement[0]));
+            forEach(nodeBkm.getKnowledgeRequirement(),
+                    knowledgeRequirement -> {
+                        if (!existingBkm.getKnowledgeRequirement().contains(knowledgeRequirement)) {
+                            existingBkm.addKnowledgeRequirement(knowledgeRequirement);
+                        }
+                    });
         } else if (instanceOfDecision(node)) {
 
             final JSITDecision existingDecision = Js.uncheckedCast(existingDRGElement);
             final JSITDecision nodeDecision = Js.uncheckedCast(node);
 
-            final List<JSITAuthorityRequirement> authorityRequirement = nodeDecision.getAuthorityRequirement();
-            final List<JSITInformationRequirement> informationRequirement = nodeDecision.getInformationRequirement();
-            final List<JSITKnowledgeRequirement> knowledgeRequirement = nodeDecision.getKnowledgeRequirement();
+            forEach(nodeDecision.getAuthorityRequirement(),
+                    authorityRequirement -> {
+                        if (!existingDecision.getAuthorityRequirement().contains(authorityRequirement)) {
+                            existingDecision.addAuthorityRequirement(authorityRequirement);
+                        }
+                    });
 
-            existingDecision.addAllAuthorityRequirement(authorityRequirement.toArray(new JSITAuthorityRequirement[0]));
-            existingDecision.addAllInformationRequirement(informationRequirement.toArray(new JSITInformationRequirement[0]));
-            existingDecision.addAllKnowledgeRequirement(knowledgeRequirement.toArray(new JSITKnowledgeRequirement[0]));
+            forEach(nodeDecision.getInformationRequirement(),
+                    informationRequirement -> {
+                        if (!existingDecision.getInformationRequirement().contains(informationRequirement)) {
+                            existingDecision.addInformationRequirement(informationRequirement);
+                        }
+                    });
+
+            forEach(nodeDecision.getKnowledgeRequirement(),
+                    knowledgeRequirement -> {
+                        if (!existingDecision.getKnowledgeRequirement().contains(knowledgeRequirement)) {
+                            existingDecision.addKnowledgeRequirement(knowledgeRequirement);
+                        }
+                    });
         } else if (instanceOfKnowledgeSource(node)) {
 
             final JSITKnowledgeSource existingKnowledgeSource = Js.uncheckedCast(existingDRGElement);
             final JSITKnowledgeSource nodeKnowledgeSource = Js.uncheckedCast(node);
 
-            final List<JSITAuthorityRequirement> authorityRequirement = nodeKnowledgeSource.getAuthorityRequirement();
-            existingKnowledgeSource.addAllAuthorityRequirement(authorityRequirement.toArray(new JSITAuthorityRequirement[0]));
+            forEach(nodeKnowledgeSource.getAuthorityRequirement(),
+                    authorityRequirement -> {
+                        if (!existingKnowledgeSource.getAuthorityRequirement().contains(authorityRequirement)) {
+                            existingKnowledgeSource.addAuthorityRequirement(authorityRequirement);
+                        }
+                    });
         }
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshallerTest.java
@@ -59,63 +59,95 @@ public class DMNMarshallerTest {
     public void testMergeOrAddNodeToDefinitions() {
 
         final JSITDecision existingNode1 = makeDecision("id1");
+        final JSITBusinessKnowledgeModel existingNode2 = makeBusinessKnowledgeModel("id2");
+        final JSITKnowledgeSource existingNode3 = makeKnowledgeSource("id3");
+
         final JSITDecision node1 = makeDecision("id1");
         final JSITBusinessKnowledgeModel node2 = makeBusinessKnowledgeModel("id2");
         final JSITKnowledgeSource node3 = makeKnowledgeSource("id3");
-        final DMNMarshaller dmnMarshaller = spy(new DMNMarshaller());
+        final JSITBusinessKnowledgeModel node4 = makeBusinessKnowledgeModel("id4");
+        final JSITKnowledgeSource node5 = makeKnowledgeSource("id5");
 
+        final DMNMarshaller dmnMarshaller = spy(new DMNMarshaller());
         final JSITDefinitions definitions = spy(new JSITDefinitions());
-        final List<JSITDRGElement> definitionsDRGElements = new ArrayList<>(singletonList(existingNode1));
-        final JSITAuthorityRequirement authorityRequirement = new JSITAuthorityRequirement();
-        final JSITInformationRequirement informationRequirement = new JSITInformationRequirement();
-        final JSITKnowledgeRequirement knowledgeRequirement = new JSITKnowledgeRequirement();
-        final List<JSITAuthorityRequirement> existingAuthorityRequirement = new ArrayList<>();
-        final List<JSITInformationRequirement> existingInformationRequirement = new ArrayList<>();
-        final List<JSITKnowledgeRequirement> existingKnowledgeRequirement = new ArrayList<>();
+        final List<JSITDRGElement> definitionsDRGElements = new ArrayList<>(asList(existingNode1, existingNode2, existingNode3));
+
+        final JSITAuthorityRequirement node1AuthorityRequirement = new JSITAuthorityRequirement();
+        final JSITInformationRequirement node1InformationRequirement = new JSITInformationRequirement();
+        final JSITKnowledgeRequirement node1KnowledgeRequirement = new JSITKnowledgeRequirement();
+        final JSITAuthorityRequirement node2AuthorityRequirement = new JSITAuthorityRequirement();
+        final JSITKnowledgeRequirement node2KnowledgeRequirement = new JSITKnowledgeRequirement();
+        final JSITAuthorityRequirement node3AuthorityRequirement = new JSITAuthorityRequirement();
+
+        final List<JSITAuthorityRequirement> node1ExistingAuthorityRequirement = new ArrayList<>();
+        final List<JSITInformationRequirement> node1ExistingInformationRequirement = new ArrayList<>();
+        final List<JSITKnowledgeRequirement> node1ExistingKnowledgeRequirement = new ArrayList<>();
+        final List<JSITAuthorityRequirement> node2ExistingAuthorityRequirement = new ArrayList<>();
+        final List<JSITKnowledgeRequirement> node2ExistingKnowledgeRequirement = new ArrayList<>();
+        final List<JSITAuthorityRequirement> node3ExistingAuthorityRequirement = new ArrayList<>();
 
         doReturn(node1).when(dmnMarshaller).getWrappedJSITDRGElement(eq(node1), any());
         doReturn(node2).when(dmnMarshaller).getWrappedJSITDRGElement(eq(node2), any());
         doReturn(node3).when(dmnMarshaller).getWrappedJSITDRGElement(eq(node3), any());
+        doReturn(node4).when(dmnMarshaller).getWrappedJSITDRGElement(eq(node4), any());
+        doReturn(node5).when(dmnMarshaller).getWrappedJSITDRGElement(eq(node5), any());
+
         doReturn(true).when(dmnMarshaller).instanceOfDecision(eq(node1));
         doReturn(true).when(dmnMarshaller).instanceOfBusinessKnowledgeModel(eq(node2));
         doReturn(true).when(dmnMarshaller).instanceOfKnowledgeSource(eq(node3));
+        doReturn(true).when(dmnMarshaller).instanceOfBusinessKnowledgeModel(eq(node4));
+        doReturn(true).when(dmnMarshaller).instanceOfKnowledgeSource(eq(node5));
 
         // Mock native arrays
         doReturn(definitionsDRGElements).when(definitions).getDrgElement();
-        doReturn(existingAuthorityRequirement).when(existingNode1).getAuthorityRequirement();
-        doReturn(existingInformationRequirement).when(existingNode1).getInformationRequirement();
-        doReturn(existingKnowledgeRequirement).when(existingNode1).getKnowledgeRequirement();
+        doReturn(node1ExistingAuthorityRequirement).when(existingNode1).getAuthorityRequirement();
+        doReturn(node1ExistingInformationRequirement).when(existingNode1).getInformationRequirement();
+        doReturn(node1ExistingKnowledgeRequirement).when(existingNode1).getKnowledgeRequirement();
+        doReturn(node2ExistingAuthorityRequirement).when(existingNode2).getAuthorityRequirement();
+        doReturn(node2ExistingKnowledgeRequirement).when(existingNode2).getKnowledgeRequirement();
+        doReturn(node3ExistingAuthorityRequirement).when(existingNode3).getAuthorityRequirement();
 
         // Mock native arrays addition
         doAnswer((e) -> definitionsDRGElements.add((JSITDRGElement) e.getArguments()[0])).when(definitions).addDrgElement(any());
-        doAnswer((e) -> existingAuthorityRequirement.add((JSITAuthorityRequirement) e.getArguments()[0])).when(existingNode1).addAuthorityRequirement(any());
-        doAnswer((e) -> existingInformationRequirement.add((JSITInformationRequirement) e.getArguments()[0])).when(existingNode1).addInformationRequirement(any());
-        doAnswer((e) -> existingKnowledgeRequirement.add((JSITKnowledgeRequirement) e.getArguments()[0])).when(existingNode1).addKnowledgeRequirement(any());
+        doAnswer((e) -> node1ExistingAuthorityRequirement.add((JSITAuthorityRequirement) e.getArguments()[0])).when(existingNode1).addAuthorityRequirement(any());
+        doAnswer((e) -> node1ExistingInformationRequirement.add((JSITInformationRequirement) e.getArguments()[0])).when(existingNode1).addInformationRequirement(any());
+        doAnswer((e) -> node1ExistingKnowledgeRequirement.add((JSITKnowledgeRequirement) e.getArguments()[0])).when(existingNode1).addKnowledgeRequirement(any());
+        doAnswer((e) -> node2ExistingAuthorityRequirement.add((JSITAuthorityRequirement) e.getArguments()[0])).when(existingNode2).addAuthorityRequirement(any());
+        doAnswer((e) -> node2ExistingKnowledgeRequirement.add((JSITKnowledgeRequirement) e.getArguments()[0])).when(existingNode2).addKnowledgeRequirement(any());
+        doAnswer((e) -> node3ExistingAuthorityRequirement.add((JSITAuthorityRequirement) e.getArguments()[0])).when(existingNode3).addAuthorityRequirement(any());
 
-        final List<JSITAuthorityRequirement> authorityRequirements = new ArrayList<>(singletonList(authorityRequirement));
-        final List<JSITInformationRequirement> informationRequirements = new ArrayList<>(singletonList(informationRequirement));
-        final List<JSITKnowledgeRequirement> knowledgeRequirements = new ArrayList<>(singletonList(knowledgeRequirement));
-
-        doReturn(authorityRequirements).when(node1).getAuthorityRequirement();
-        doReturn(informationRequirements).when(node1).getInformationRequirement();
-        doReturn(knowledgeRequirements).when(node1).getKnowledgeRequirement();
+        doReturn(new ArrayList<>(singletonList(node1AuthorityRequirement))).when(node1).getAuthorityRequirement();
+        doReturn(new ArrayList<>(singletonList(node1KnowledgeRequirement))).when(node1).getKnowledgeRequirement();
+        doReturn(new ArrayList<>(singletonList(node1InformationRequirement))).when(node1).getInformationRequirement();
+        doReturn(new ArrayList<>(singletonList(node2AuthorityRequirement))).when(node2).getAuthorityRequirement();
+        doReturn(new ArrayList<>(singletonList(node2KnowledgeRequirement))).when(node2).getKnowledgeRequirement();
+        doReturn(new ArrayList<>(singletonList(node3AuthorityRequirement))).when(node3).getAuthorityRequirement();
 
         dmnMarshaller.mergeOrAddNodeToDefinitions(node1, definitions);
         dmnMarshaller.mergeOrAddNodeToDefinitions(node2, definitions);
         dmnMarshaller.mergeOrAddNodeToDefinitions(node3, definitions);
+        dmnMarshaller.mergeOrAddNodeToDefinitions(node4, definitions);
+        dmnMarshaller.mergeOrAddNodeToDefinitions(node5, definitions);
 
         // Merge twice. But the values must be added once.
         dmnMarshaller.mergeOrAddNodeToDefinitions(node1, definitions);
         dmnMarshaller.mergeOrAddNodeToDefinitions(node2, definitions);
         dmnMarshaller.mergeOrAddNodeToDefinitions(node3, definitions);
+        dmnMarshaller.mergeOrAddNodeToDefinitions(node4, definitions);
+        dmnMarshaller.mergeOrAddNodeToDefinitions(node5, definitions);
 
         verify(definitions, never()).addDrgElement(node1);
-        verify(definitions).addDrgElement(node2);
-        verify(definitions).addDrgElement(node3);
+        verify(definitions, never()).addDrgElement(node2);
+        verify(definitions, never()).addDrgElement(node3);
+        verify(definitions).addDrgElement(node4);
+        verify(definitions).addDrgElement(node5);
 
-        verify(existingNode1).addAuthorityRequirement(authorityRequirement);
-        verify(existingNode1).addInformationRequirement(informationRequirement);
-        verify(existingNode1).addKnowledgeRequirement(knowledgeRequirement);
+        verify(existingNode1).addAuthorityRequirement(node1AuthorityRequirement);
+        verify(existingNode1).addInformationRequirement(node1InformationRequirement);
+        verify(existingNode1).addKnowledgeRequirement(node1KnowledgeRequirement);
+        verify(existingNode2).addAuthorityRequirement(node2AuthorityRequirement);
+        verify(existingNode2).addKnowledgeRequirement(node2KnowledgeRequirement);
+        verify(existingNode3).addAuthorityRequirement(node3AuthorityRequirement);
     }
 
     @Test


### PR DESCRIPTION
**JIRA**: [KOGITO-3571](https://issues.redhat.com/browse/KOGITO-3571): [DMN Designer] Multiple DRDs support - Information requirements are duplicated into the DMN XML

Before:
![2020-10-08 23 01 49](https://user-images.githubusercontent.com/1079279/95534571-913b0d00-09bc-11eb-9846-b2b5327111f2.gif)

After:
![2020-10-08 23 03 32](https://user-images.githubusercontent.com/1079279/95534596-a2841980-09bc-11eb-8652-35074f50a004.gif)

Here's the [DMN model](https://gist.github.com/karreiro/dd00ffc17138865fb44c9ae600630c31) used in the GIFs.

**Business Central**: [WAR file](https://www.dropbox.com/s/3l081n8gxugaduf/business-central-KOGITO-3571.war?dl=0)
**VS Code**: [plugin](https://www.dropbox.com/s/v60khlm3lrur0m4/vscode-plugin-KOGITO-3571.vsix?dl=0)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
