### PR TITLE
RHPAM-2859 :Number of assets displayed for a project doesn't matches the count displayed

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/PopulatedAssetsScreen.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/assets/PopulatedAssetsScreen.java
@@ -349,7 +349,7 @@ public class PopulatedAssetsScreen {
         this.getAssets(this.filter,
                        this.filterType,
                        getOffset(),
-                       this.currentPage * this.pageSize,
+                       this.pageSize,
                        this.addAssetsToView(runnable));
         this.view.setCurrentPage(this.currentPage);
         this.checkPaginationButtons();


### PR DESCRIPTION
**Thank you for submitting this pull request**

**RHPAM-2859**: https://issues.redhat.com/browse/RHPAM-2859

How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
