### PR TITLE
KOGITO-3517: Stunner: InlineEditor Keyboard events are triggering shortcuts in VSCode

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
@@ -239,6 +239,11 @@ public class WiresConnectorViewExt<T>
     }
 
     @Override
+    public void batch() {
+        label.ifPresent(l -> l.configure(Shape::batch));
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public T moveTitleToTop() {
         label.ifPresent(l -> l.configure(Shape::moveToTop));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExt.java
@@ -278,6 +278,11 @@ public class WiresShapeViewExt<T extends WiresShapeViewExt>
     }
 
     @Override
+    public void batch() {
+        textViewDecorator.getView().batch();
+    }
+
+    @Override
     public void refresh() {
         getTextViewDecorator().update();
         super.refresh();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecorator.java
@@ -293,6 +293,11 @@ public class WiresTextDecorator implements HasTitle<WiresTextDecorator> {
                 .name();
     }
 
+    @Override
+    public void batch() {
+        text.batch();
+    }
+
     public WiresTextDecorator setTitleStrokeAlpha(final double strokeAlpha) {
         text.setStrokeAlpha(strokeAlpha);
         return this;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExtTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExtTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -112,6 +113,8 @@ public class WiresConnectorViewExtTest {
         verify(labelText, times(1)).setFontSize(eq(0.3d));
         tested.moveTitleToTop();
         verify(labelText, times(1)).moveToTop();
+        tested.batch();
+        verify(labelText, times(1)).batch();
         assertNull(tested.getTitlePosition());
         assertNull(tested.getOrientation());
         assertEquals(0.0, tested.getMarginX(), 0.0001);
@@ -124,5 +127,23 @@ public class WiresConnectorViewExtTest {
         verify(label, times(1)).destroy();
         assertFalse(tested.label.isPresent());
         verify(connectorControl, times(1)).destroy();
+    }
+
+    @Test
+    public void testLabelNotPresent() {
+        tested = spy(new WiresConnectorViewExt(ShapeViewSupportedEvents.DESKTOP_CONNECTOR_EVENT_TYPES,
+                                               line,
+                                               HEAD_DECORATOR,
+                                               TAIL_DECORATOR) {
+            @Override
+            protected Optional<WiresConnectorLabel> createLabel(String title) {
+                return Optional.empty();
+            }
+        });
+
+        assertNotNull(tested.label);
+        assertFalse(tested.label.isPresent());
+        tested.batch();
+        verify(labelText, never()).batch();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresShapeViewExtTest.java
@@ -68,6 +68,13 @@ public class WiresShapeViewExtTest extends AbstractWiresShapeViewText {
     }
 
     @Test
+    public void testBatch() {
+        tested.getTextViewDecorator().batch();
+
+        verify(textDecorator).batch();
+    }
+
+    @Test
     public void testSetTextWrapperBounds() {
         testSetTextWrapperStrategy(TextWrapperStrategy.BOUNDS);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecoratorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresTextDecoratorTest.java
@@ -236,4 +236,14 @@ public class WiresTextDecoratorTest {
     public void testGetFontAlignment() {
         assertEquals("MIDDLE", decorator.getFontAlignment());
     }
+
+    @Test
+    public void testBatch() {
+        Text text = spy(new Text(""));
+        Whitebox.setInternalState(decorator, "text", text);
+
+        decorator.batch();
+
+        verify(text).batch();
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
@@ -160,19 +160,18 @@ public class InlineTextEditorBoxViewImpl
     }
 
     @EventHandler("nameField")
-    @SinkNative(Event.ONKEYDOWN | Event.ONBLUR)
+    @SinkNative(Event.ONKEYDOWN | Event.ONKEYUP | Event.ONKEYPRESS | Event.ONBLUR)
     void onChangeName(Event e) {
         if (isVisible()) {
+            e.stopPropagation();
             if (e.getTypeInt() == Event.ONBLUR) {
                 saveChanges();
             } else if (e.getTypeInt() == Event.ONKEYDOWN) {
                 if (e.getKeyCode() == KeyCodes.KEY_ENTER && !e.getShiftKey()) {
-                    e.stopPropagation();
                     e.preventDefault();
                     saveChanges();
                 } else if ((!isMultiline && e.getKeyCode() == KeyCodes.KEY_ENTER && e.getShiftKey()) ||
                         e.getKeyCode() == KeyCodes.KEY_TAB) {
-                    e.stopPropagation();
                     e.preventDefault();
                 } else if (e.getKeyCode() == KeyCodes.KEY_ESCAPE) {
                     rollback();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
@@ -181,8 +181,8 @@ public class InlineTextEditorBoxViewImpl
     }
 
     private void saveChanges() {
-        scheduleDeferredCommand(() -> presenter.onChangeName(getTextContent()));
-        scheduleDeferredCommand(() -> presenter.onSave());
+        presenter.onChangeName(getTextContent());
+        presenter.onSave();
     }
 
     private String getTextContent() {
@@ -200,6 +200,6 @@ public class InlineTextEditorBoxViewImpl
 
     @Override
     public void rollback() {
-        scheduleDeferredCommand(() -> presenter.onSave());
+        presenter.onClose();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
@@ -123,7 +123,7 @@ public class InlineTextEditorBoxViewImplTest {
         tested.onChangeName(event);
 
         verify(presenter,
-               never()).onClose();
+               never()).onSave();
     }
 
     @Test
@@ -135,7 +135,7 @@ public class InlineTextEditorBoxViewImplTest {
         tested.onChangeName(event);
 
         verify(presenter,
-               times(1)).onSave();
+               times(1)).onClose();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
@@ -150,6 +150,45 @@ public class InlineTextEditorBoxViewImplTest {
     }
 
     @Test
+    public void testNonKeyDownEventPropagation() {
+        when(event.getTypeInt()).thenReturn(Event.ONKEYDOWN);
+        when(event.getKeyCode()).thenReturn(KeyCodes.KEY_A);
+        when(event.getShiftKey()).thenReturn(false);
+        when(nameField.getInnerHTML()).thenReturn(NAME);
+        doAnswer(i -> true).when(tested).isVisible();
+        tested.onChangeName(event);
+
+        verify(event,
+               times(1)).stopPropagation();
+    }
+
+    @Test
+    public void testNonKeyUpEventPropagation() {
+        when(event.getTypeInt()).thenReturn(Event.ONKEYUP);
+        when(event.getKeyCode()).thenReturn(KeyCodes.KEY_A);
+        when(event.getShiftKey()).thenReturn(false);
+        when(nameField.getInnerHTML()).thenReturn(NAME);
+        doAnswer(i -> true).when(tested).isVisible();
+        tested.onChangeName(event);
+
+        verify(event,
+               times(1)).stopPropagation();
+    }
+
+    @Test
+    public void testNonKeyPressEventPropagation() {
+        when(event.getTypeInt()).thenReturn(Event.ONKEYPRESS);
+        when(event.getKeyCode()).thenReturn(KeyCodes.KEY_A);
+        when(event.getShiftKey()).thenReturn(false);
+        when(nameField.getInnerHTML()).thenReturn(NAME);
+        doAnswer(i -> true).when(tested).isVisible();
+        tested.onChangeName(event);
+
+        verify(event,
+               times(1)).stopPropagation();
+    }
+
+    @Test
     public void testOnKeyDownEnterEvent() {
         when(event.getTypeInt()).thenReturn(Event.ONKEYDOWN);
         when(event.getKeyCode()).thenReturn(KeyCodes.KEY_ENTER);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/shape/view/HasTitle.java
@@ -136,6 +136,8 @@ public interface HasTitle<T> {
 
     String getFontAlignment();
 
+    void batch();
+
     default T setTitleStrokeAlpha(final double alpha) {
         return (T) this;
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
 
-import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.touch.client.Point;
@@ -117,7 +116,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
     protected void doInit() {
         super.doInit();
         getTextEditorBox().initialize(canvasHandler,
-                                      () -> scheduleDeferredCommand(() -> AbstractCanvasInlineTextEditorControl.this.hide()));
+                                      AbstractCanvasInlineTextEditorControl.this::hide);
 
         getFloatingView()
                 .hide()
@@ -160,7 +159,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
         final TextDoubleClickHandler clickHandler = new TextDoubleClickHandler() {
             @Override
             public void handle(final TextDoubleClickEvent event) {
-                scheduleDeferredCommand(() -> AbstractCanvasInlineTextEditorControl.this.show(element));
+                AbstractCanvasInlineTextEditorControl.this.show(element);
             }
         };
         hasEventHandlers.addHandler(ViewEventType.TEXT_DBL_CLICK,
@@ -529,6 +528,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
             final double titleAlpha = editMode ? TITLE_EDIT_ALPHA : NOT_EDIT_ALPHA;
             shape.getShapeView().setFillAlpha(alpha);
             hasTitle.setTitleAlpha(titleAlpha);
+            hasTitle.batch();
             return true;
         }
         return false;
@@ -592,9 +592,5 @@ public abstract class AbstractCanvasInlineTextEditorControl
             getFloatingView().hide();
         }
         return this;
-    }
-
-    public void scheduleDeferredCommand(final Scheduler.ScheduledCommand command) {
-        Scheduler.get().scheduleDeferred(command);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
@@ -29,12 +29,10 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AbstractCanvasHandlerRegistrationControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.CanvasInlineTextEditorControl;
-import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl.KogitoKeyPress;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeysMatcher;
 import org.kie.workbench.common.stunner.core.client.components.views.FloatingView;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent.Key;
-import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.shape.view.HasEventHandlers;
@@ -79,7 +77,6 @@ public abstract class AbstractCanvasInlineTextEditorControl
     private double zoomFactor;
     private BoxType boxType;
     private HandlerRegistration mouseWheelHandler;
-    private KeyboardControl<AbstractCanvas, ClientSession> keyboardControl;
     private String fontFamily;
     private double fontSize;
     private double marginX;
@@ -112,9 +109,8 @@ public abstract class AbstractCanvasInlineTextEditorControl
 
     @Override
     public void bind(final EditorSession session) {
-        keyboardControl = session.getKeyboardControl();
-        keyboardControl.addKeyShortcutCallback(new KogitoKeyPress(new Key[]{ESC}, "Edit | Hide", this::hide));
-        keyboardControl.addKeyShortcutCallback(this::onKeyDownEvent);
+        session.getKeyboardControl().addKeyShortcutCallback(new KogitoKeyPress(new Key[]{ESC}, "Edit | Hide", this::hide));
+        session.getKeyboardControl().addKeyShortcutCallback(this::onKeyDownEvent);
     }
 
     @Override
@@ -263,9 +259,6 @@ public abstract class AbstractCanvasInlineTextEditorControl
                                     fixBoundaryX(editorBoxWidth, floatingViewPositionX),
                                     fixBoundaryY(editorBoxHeight, floatingViewPositionY));
             getFloatingView().show();
-
-            // Disable canvas shortcuts while typing
-            keyboardControl.setKeyEventHandlerEnabled(false);
         }
 
         return this;
@@ -587,10 +580,6 @@ public abstract class AbstractCanvasInlineTextEditorControl
         if (isVisible()) {
             getTextEditorBox().rollback();
         }
-
-        // Enable canvas shortcuts again after closing
-        keyboardControl.setKeyEventHandlerEnabled(true);
-
         return this;
     }
 
@@ -602,9 +591,6 @@ public abstract class AbstractCanvasInlineTextEditorControl
             getTextEditorBox().hide();
             getFloatingView().hide();
         }
-
-        // Enable canvas shortcuts again after closing
-        keyboardControl.setKeyEventHandlerEnabled(true);
         return this;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
@@ -15,7 +15,6 @@
  */
 package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
 
-import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.junit.Before;
@@ -202,11 +201,6 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
         when(session.getKeyboardControl()).thenReturn(keyboardControl);
 
         this.control = spy(getControl());
-
-        doAnswer(i -> {
-            ((Scheduler.ScheduledCommand) i.getArguments()[0]).execute();
-            return null;
-        }).when(control).scheduleDeferredCommand(any(Scheduler.ScheduledCommand.class));
 
         doReturn(textEditBoxWidget).when(control).wrapTextEditorBoxElement(eq(textEditBoxElement));
         doAnswer(i -> abstractCanvas).when(control).getAbstractCanvas();
@@ -497,6 +491,8 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
     }
 
     private void assertShow(final boolean multiline, final String textBoxAlignment, final String position) {
+        final HasTitle hasTitle = (HasTitle) testShapeView;
+
         verify(testShapeView).setFillAlpha(eq(AbstractCanvasInlineTextEditorControl.SHAPE_EDIT_ALPHA));
         verify(testShapeView).setTitleAlpha(eq(AbstractCanvasInlineTextEditorControl.TITLE_EDIT_ALPHA));
         verify(textEditorBox).show(eq(element), anyDouble(), anyDouble());
@@ -521,6 +517,9 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
             verify(floatingView).setX(eq(25d));
             verify(floatingView).setY(eq(350d));
         }
+
+        // Update Shape UI
+        verify(hasTitle).batch();
     }
 
     private void assertHide(final int t) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/shape/ShapeViewExtStub.java
@@ -177,6 +177,10 @@ public class ShapeViewExtStub
     }
 
     @Override
+    public void batch() {
+    }
+
+    @Override
     public Object moveTitleToTop() {
         return this;
     }


### PR DESCRIPTION
Hey @romartin: Please, could you review this PR?

This PR fixes the following related issues:
**JIRA**: [KOGITO-3517](https://issues.redhat.com/browse/KOGITO-3517)
**JIRA**: [RHPAM-3197](https://issues.redhat.com/browse/RHPAM-3197)

**Referenced Pull Requests**:
* [kogito-tooling](https://github.com/kiegroup/kogito-tooling/pull/290)

**VS Code**: [plugin](https://drive.google.com/file/d/1DnnlIF-z3NaTLSHxnDG_W67t5hqWOX-s/view?usp=sharing)

Thanks!