### PR TITLE
JBPM-9432: Users and Groups reversed for Reassignment property

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/reassignment/ReassignmentValue.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/reassignment/ReassignmentValue.java
@@ -45,8 +45,8 @@ public class ReassignmentValue {
 
     public ReassignmentValue(@MapsTo("type") String type,
                              @MapsTo("duration") String duration,
-                             @MapsTo("users") List<String> groups,
-                             @MapsTo("groups") List<String> users) {
+                             @MapsTo("users") List<String> users,
+                             @MapsTo("groups") List<String> groups) {
         this.type = type;
         this.duration = duration;
         this.groups = groups;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ReassignmentValueTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ReassignmentValueTest.java
@@ -41,12 +41,12 @@ public class ReassignmentValueTest {
 
                 .addTrueCase(new ReassignmentValue("AAA",
                                                    "1h",
-                                                   Arrays.asList(new String[]{"foo", "bar", "baz"}),
-                                                   Collections.EMPTY_LIST),
+                                                   Collections.EMPTY_LIST,
+                                                   Arrays.asList(new String[]{"foo", "bar", "baz"})),
                              new ReassignmentValue("AAA",
                                                    "1h",
-                                                   Arrays.asList(new String[]{"foo", "bar", "baz"}),
-                                                   Collections.EMPTY_LIST))
+                                                   Collections.EMPTY_LIST,
+                                                   Arrays.asList(new String[]{"foo", "bar", "baz"})))
                 .addTrueCase(new ReassignmentValue("AAA",
                                                    "1h",
                                                    Arrays.asList(new String[]{"foo", "bar", "baz"}),
@@ -67,12 +67,12 @@ public class ReassignmentValueTest {
 
                 .addFalseCase(new ReassignmentValue("AAA",
                                                     "1h",
-                                                    Arrays.asList(new String[]{"foo1", "bar", "baz"}),
-                                                    Collections.EMPTY_LIST),
+                                                    Collections.EMPTY_LIST,
+                                                    Arrays.asList(new String[]{"foo1", "bar", "baz"})),
                               new ReassignmentValue("AAA",
                                                     "1h",
-                                                    Arrays.asList(new String[]{"foo", "bar", "baz"}),
-                                                    Collections.EMPTY_LIST))
+                                                    Collections.EMPTY_LIST,
+                                                    Arrays.asList(new String[]{"foo", "bar", "baz"})))
                 .addFalseCase(new ReassignmentValue("AAA",
                                                     "1h",
                                                     Arrays.asList(new String[]{"foo", "bar", "baz"}),


### PR DESCRIPTION
**JIRA**: [JBPM-9432](https://issues.redhat.com/browse/JBPM-9432)

**Business Central**: [WAR file](https://drive.google.com/file/d/1OAc5b5NH4W3re5MUDhADsv7nu612ZYI1/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1pdEBMzPv52dVcg48jUzV2pVti0aY2Fau/view?usp=sharing)

<details>
<summary>
Hi @romartin, there is a fix for JBPM-9432, I tested showcase and full downstream build (I uploaded it to drive as well, see link above) and I also tested and uploaded a VS code plugin and all works good now as well.

All important checks are green, PR is ready for review. Thank you!

@LuboTerifaj, @domhanak tester is not set, but I am not sure what is the procedure now, so I will add you both to the PR. Thank you!

How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
