### PR TITLE
DROOLS-5749: [DMN Designer] Multiple DRDs support - When users open a DMN with duplicated information requirements, the marshaller doesn't fix it

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshaller.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
@@ -61,16 +62,13 @@ import org.kie.workbench.common.dmn.client.marshaller.converters.dd.PointUtils;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.MainJs;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.di.JSIDiagramElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITAssociation;
-import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITAuthorityRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITBusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDMNElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDRGElement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDecision;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDecisionService;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDefinitions;
-import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITInformationRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITInputData;
-import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITKnowledgeRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITKnowledgeSource;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITTextAnnotation;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNDiagram;
@@ -365,38 +363,35 @@ public class DMNMarshaller {
             final JSITBusinessKnowledgeModel existingBkm = Js.uncheckedCast(existingDRGElement);
             final JSITBusinessKnowledgeModel nodeBkm = Js.uncheckedCast(node);
 
-            existingBkm.addAllAuthorityRequirement(nodeBkm.getAuthorityRequirement().toArray(new JSITAuthorityRequirement[0]));
-            existingBkm.addAllKnowledgeRequirement(nodeBkm.getKnowledgeRequirement().toArray(new JSITKnowledgeRequirement[0]));
-
-            existingBkm.setAuthorityRequirement(distinct(existingBkm.getAuthorityRequirement()));
-            existingBkm.setKnowledgeRequirement(distinct(existingBkm.getKnowledgeRequirement()));
+            existingBkm.setAuthorityRequirement(distinct(nodeBkm.getAuthorityRequirement(), existingBkm.getAuthorityRequirement()));
+            existingBkm.setKnowledgeRequirement(distinct(nodeBkm.getKnowledgeRequirement(), existingBkm.getKnowledgeRequirement()));
         } else if (instanceOfDecision(node)) {
 
             final JSITDecision existingDecision = Js.uncheckedCast(existingDRGElement);
             final JSITDecision nodeDecision = Js.uncheckedCast(node);
 
-            existingDecision.addAllAuthorityRequirement(nodeDecision.getAuthorityRequirement().toArray(new JSITAuthorityRequirement[0]));
-            existingDecision.addAllInformationRequirement(nodeDecision.getInformationRequirement().toArray(new JSITInformationRequirement[0]));
-            existingDecision.addAllKnowledgeRequirement(nodeDecision.getKnowledgeRequirement().toArray(new JSITKnowledgeRequirement[0]));
-
-            existingDecision.setAuthorityRequirement(distinct(existingDecision.getAuthorityRequirement()));
-            existingDecision.setInformationRequirement(distinct(existingDecision.getInformationRequirement()));
-            existingDecision.setKnowledgeRequirement(distinct(existingDecision.getKnowledgeRequirement()));
+            existingDecision.setAuthorityRequirement(distinct(nodeDecision.getAuthorityRequirement(), existingDecision.getAuthorityRequirement()));
+            existingDecision.setInformationRequirement(distinct(nodeDecision.getInformationRequirement(), existingDecision.getInformationRequirement()));
+            existingDecision.setKnowledgeRequirement(distinct(nodeDecision.getKnowledgeRequirement(), existingDecision.getKnowledgeRequirement()));
         } else if (instanceOfKnowledgeSource(node)) {
 
             final JSITKnowledgeSource existingKnowledgeSource = Js.uncheckedCast(existingDRGElement);
             final JSITKnowledgeSource nodeKnowledgeSource = Js.uncheckedCast(node);
 
-            existingKnowledgeSource.addAllAuthorityRequirement(nodeKnowledgeSource.getAuthorityRequirement().toArray(new JSITAuthorityRequirement[0]));
-            existingKnowledgeSource.setAuthorityRequirement(distinct(existingKnowledgeSource.getAuthorityRequirement()));
+            existingKnowledgeSource.setAuthorityRequirement(distinct(nodeKnowledgeSource.getAuthorityRequirement(), existingKnowledgeSource.getAuthorityRequirement()));
         }
     }
 
-    private <T extends JSITDMNElement> List<T> distinct(final List<T> list) {
+    private <T extends JSITDMNElement> List<T> distinct(final List<T> list1,
+                                                        final List<T> list2) {
+
+        final List<T> combined = Stream.concat(list1.stream(), list2.stream()).collect(Collectors.toList());
         final Map<String, T> map = new HashMap<>();
-        forEach(list, item -> {
+
+        forEach(combined, item -> {
             map.putIfAbsent(item.getId(), Js.uncheckedCast(item));
         });
+
         return new ArrayList<>(map.values());
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshallerTest.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSIT
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITKnowledgeSource;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.mockito.invocation.InvocationOnMock;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -99,6 +100,9 @@ public class DMNMarshallerTest {
         doReturn(true).when(dmnMarshaller).instanceOfKnowledgeSource(eq(node5));
 
         // Mock native arrays
+
+        doAnswer((e) -> definitionsDRGElements.add((JSITDRGElement) e.getArguments()[0])).when(definitions).addDrgElement(any());
+
         doReturn(definitionsDRGElements).when(definitions).getDrgElement();
         doReturn(node1ExistingAuthorityRequirement).when(existingNode1).getAuthorityRequirement();
         doReturn(node1ExistingInformationRequirement).when(existingNode1).getInformationRequirement();
@@ -107,21 +111,26 @@ public class DMNMarshallerTest {
         doReturn(node2ExistingKnowledgeRequirement).when(existingNode2).getKnowledgeRequirement();
         doReturn(node3ExistingAuthorityRequirement).when(existingNode3).getAuthorityRequirement();
 
-        // Mock native arrays addition
-        doAnswer((e) -> definitionsDRGElements.add((JSITDRGElement) e.getArguments()[0])).when(definitions).addDrgElement(any());
-        doAnswer((e) -> node1ExistingAuthorityRequirement.add((JSITAuthorityRequirement) e.getArguments()[0])).when(existingNode1).addAuthorityRequirement(any());
-        doAnswer((e) -> node1ExistingInformationRequirement.add((JSITInformationRequirement) e.getArguments()[0])).when(existingNode1).addInformationRequirement(any());
-        doAnswer((e) -> node1ExistingKnowledgeRequirement.add((JSITKnowledgeRequirement) e.getArguments()[0])).when(existingNode1).addKnowledgeRequirement(any());
-        doAnswer((e) -> node2ExistingAuthorityRequirement.add((JSITAuthorityRequirement) e.getArguments()[0])).when(existingNode2).addAuthorityRequirement(any());
-        doAnswer((e) -> node2ExistingKnowledgeRequirement.add((JSITKnowledgeRequirement) e.getArguments()[0])).when(existingNode2).addKnowledgeRequirement(any());
-        doAnswer((e) -> node3ExistingAuthorityRequirement.add((JSITAuthorityRequirement) e.getArguments()[0])).when(existingNode3).addAuthorityRequirement(any());
-
         doReturn(new ArrayList<>(singletonList(node1AuthorityRequirement))).when(node1).getAuthorityRequirement();
         doReturn(new ArrayList<>(singletonList(node1KnowledgeRequirement))).when(node1).getKnowledgeRequirement();
         doReturn(new ArrayList<>(singletonList(node1InformationRequirement))).when(node1).getInformationRequirement();
         doReturn(new ArrayList<>(singletonList(node2AuthorityRequirement))).when(node2).getAuthorityRequirement();
         doReturn(new ArrayList<>(singletonList(node2KnowledgeRequirement))).when(node2).getKnowledgeRequirement();
         doReturn(new ArrayList<>(singletonList(node3AuthorityRequirement))).when(node3).getAuthorityRequirement();
+
+        doAnswer((e) -> setList(node1ExistingAuthorityRequirement, e)).when(existingNode1).setAuthorityRequirement(any());
+        doAnswer((e) -> setList(node1ExistingInformationRequirement, e)).when(existingNode1).setInformationRequirement(any());
+        doAnswer((e) -> setList(node1ExistingKnowledgeRequirement, e)).when(existingNode1).setKnowledgeRequirement(any());
+        doAnswer((e) -> setList(node2ExistingAuthorityRequirement, e)).when(existingNode2).setAuthorityRequirement(any());
+        doAnswer((e) -> setList(node2ExistingKnowledgeRequirement, e)).when(existingNode2).setKnowledgeRequirement(any());
+        doAnswer((e) -> setList(node3ExistingAuthorityRequirement, e)).when(existingNode3).setAuthorityRequirement(any());
+
+        doAnswer((e) -> addAll(node1ExistingAuthorityRequirement, e)).when(existingNode1).addAllAuthorityRequirement(any());
+        doAnswer((e) -> addAll(node1ExistingInformationRequirement, e)).when(existingNode1).addAllInformationRequirement(any());
+        doAnswer((e) -> addAll(node1ExistingKnowledgeRequirement, e)).when(existingNode1).addAllKnowledgeRequirement(any());
+        doAnswer((e) -> addAll(node2ExistingAuthorityRequirement, e)).when(existingNode2).addAllAuthorityRequirement(any());
+        doAnswer((e) -> addAll(node2ExistingKnowledgeRequirement, e)).when(existingNode2).addAllKnowledgeRequirement(any());
+        doAnswer((e) -> addAll(node3ExistingAuthorityRequirement, e)).when(existingNode3).addAllAuthorityRequirement(any());
 
         dmnMarshaller.mergeOrAddNodeToDefinitions(node1, definitions);
         dmnMarshaller.mergeOrAddNodeToDefinitions(node2, definitions);
@@ -142,12 +151,19 @@ public class DMNMarshallerTest {
         verify(definitions).addDrgElement(node4);
         verify(definitions).addDrgElement(node5);
 
-        verify(existingNode1).addAuthorityRequirement(node1AuthorityRequirement);
-        verify(existingNode1).addInformationRequirement(node1InformationRequirement);
-        verify(existingNode1).addKnowledgeRequirement(node1KnowledgeRequirement);
-        verify(existingNode2).addAuthorityRequirement(node2AuthorityRequirement);
-        verify(existingNode2).addKnowledgeRequirement(node2KnowledgeRequirement);
-        verify(existingNode3).addAuthorityRequirement(node3AuthorityRequirement);
+        assertEquals(1, node1ExistingAuthorityRequirement.size());
+        assertEquals(1, node1ExistingInformationRequirement.size());
+        assertEquals(1, node1ExistingKnowledgeRequirement.size());
+        assertEquals(1, node2ExistingAuthorityRequirement.size());
+        assertEquals(1, node2ExistingKnowledgeRequirement.size());
+        assertEquals(1, node3ExistingAuthorityRequirement.size());
+
+        assertEquals(node1AuthorityRequirement, node1ExistingAuthorityRequirement.get(0));
+        assertEquals(node1InformationRequirement, node1ExistingInformationRequirement.get(0));
+        assertEquals(node1KnowledgeRequirement, node1ExistingKnowledgeRequirement.get(0));
+        assertEquals(node2AuthorityRequirement, node2ExistingAuthorityRequirement.get(0));
+        assertEquals(node2KnowledgeRequirement, node2ExistingKnowledgeRequirement.get(0));
+        assertEquals(node3AuthorityRequirement, node3ExistingAuthorityRequirement.get(0));
     }
 
     @Test
@@ -271,5 +287,22 @@ public class DMNMarshallerTest {
         final JSITKnowledgeSource knowledgeSource = spy(new JSITKnowledgeSource());
         doReturn(id).when(knowledgeSource).getId();
         return knowledgeSource;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> boolean setList(final List<T> list,
+                                final InvocationOnMock e) {
+        final List<T> argument = new ArrayList<>((ArrayList<T>) e.getArguments()[0]);
+        list.clear();
+        list.addAll(argument);
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> boolean addAll(final List<T> list,
+                               final InvocationOnMock e) {
+        final Object argument = e.getArguments()[0];
+        list.add((T) argument);
+        return true;
     }
 }


### PR DESCRIPTION
**JIRA**: [DROOLS-5749](https://issues.redhat.com/browse/DROOLS-5749) - [DMN Designer] Multiple DRDs support - When users open a DMN with duplicated information requirements, the marshaller doesn't fix it

**Business Central**: [WAR file](https://www.dropbox.com/s/toe10dnah6sgduw/business-central-DROOLS-5749.war?dl=0)
**VS Code**: [plugin](https://www.dropbox.com/s/4auffyl3phrvvlb/vscode-plugin-DROOLS-5749.vsix?dl=0)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
