### PR TITLE
KOGITO-3379: [DMN Designer] Multiple DRDs support - Warn users when more than one node will be cascaded deleted

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DRGElement.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DRGElement.java
@@ -29,11 +29,13 @@ import org.kie.workbench.common.forms.adf.definitions.DynamicReadOnly;
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
+import org.kie.workbench.common.stunner.core.graph.content.HasStringName;
 import org.kie.workbench.common.stunner.core.rule.annotation.RuleExtension;
 
 @RuleExtension(handler = NoInputNodesInImportedDecisionRule.class)
 public abstract class DRGElement extends NamedElement implements DynamicReadOnly,
-                                                                 HasContentDefinitionId {
+                                                                 HasContentDefinitionId,
+                                                                 HasStringName {
 
     private static final String[] READONLY_FIELDS = {
             "NameHolder",
@@ -122,5 +124,10 @@ public abstract class DRGElement extends NamedElement implements DynamicReadOnly
 
     public void setLinksHolder(final DocumentationLinksHolder linksHolder) {
         this.linksHolder = linksHolder;
+    }
+
+    @Override
+    public String getStringName() {
+        return getName().getValue();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DRGElementTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DRGElementTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.forms.adf.definitions.DynamicReadOnly;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -31,6 +32,7 @@ import static org.kie.workbench.common.forms.adf.definitions.DynamicReadOnly.Rea
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
@@ -56,6 +58,7 @@ public class DRGElementTest {
         doCallRealMethod().when(drgElement).isAllowOnlyVisualChange();
         doCallRealMethod().when(drgElement).isReadonlyField(anyString());
         doCallRealMethod().when(drgElement).getContentDefinitionId();
+        doCallRealMethod().when(drgElement).getStringName();
     }
 
     @Test
@@ -120,6 +123,21 @@ public class DRGElementTest {
         final String currentId = drgElement.getContentDefinitionId();
 
         assertEquals(contentDefinitionId, currentId);
+    }
+
+    @Test
+    public void testGetStringName() {
+
+        final Name name = mock(Name.class);
+        final String theName = "the name";
+
+        when(name.getValue()).thenReturn(theName);
+
+        doReturn(name).when(drgElement).getName();
+
+        final String stringName = drgElement.getStringName();
+
+        assertEquals(theName, stringName);
     }
 
     private void checkIfItIsNotReadOnly(final String property) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/DefaultCanvasCommandFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/DefaultCanvasCommandFactory.java
@@ -26,10 +26,10 @@ import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.factory.canvas.AddChildNodeCommand;
 import org.kie.workbench.common.dmn.client.commands.factory.canvas.DMNDeleteElementsCommand;
 import org.kie.workbench.common.dmn.client.commands.factory.canvas.DMNDeleteNodeCommand;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.command.LienzoCanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommand;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.ChildrenTraverseProcessor;
@@ -39,7 +39,7 @@ import org.kie.workbench.common.stunner.core.graph.processing.traverse.content.V
 @ApplicationScoped
 public class DefaultCanvasCommandFactory extends LienzoCanvasCommandFactory {
 
-    private GraphsProvider graphsProvider;
+    private DMNGraphsProvider graphsProvider;
 
     protected DefaultCanvasCommandFactory() {
         super();
@@ -48,7 +48,7 @@ public class DefaultCanvasCommandFactory extends LienzoCanvasCommandFactory {
     @Inject
     public DefaultCanvasCommandFactory(final ManagedInstance<ChildrenTraverseProcessor> childrenTraverseProcessors,
                                        final ManagedInstance<ViewTraverseProcessor> viewTraverseProcessors,
-                                       final GraphsProvider graphsProvider) {
+                                       final DMNGraphsProvider graphsProvider) {
         super(childrenTraverseProcessors,
               viewTraverseProcessors);
         this.graphsProvider = graphsProvider;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommand.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteCanvasConnectorCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
@@ -30,7 +31,8 @@ public class DMNDeleteCanvasConnectorNodeCommand extends DeleteCanvasConnectorCo
 
     private final GraphsProvider graphsProvider;
 
-    public DMNDeleteCanvasConnectorNodeCommand(final Edge candidate, final GraphsProvider graphsProvider) {
+    public DMNDeleteCanvasConnectorNodeCommand(final Edge candidate,
+                                               final DMNGraphsProvider graphsProvider) {
         super(candidate);
         this.graphsProvider = graphsProvider;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommand.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 
 import org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteCanvasNodeCommand;
@@ -31,7 +32,7 @@ public class DMNDeleteCanvasNodeCommand extends DeleteCanvasNodeCommand {
     private final GraphsProvider graphsProvider;
 
     public DMNDeleteCanvasNodeCommand(final Node candidate,
-                                      final GraphsProvider graphsProvider) {
+                                      final DMNGraphsProvider graphsProvider) {
         super(candidate);
         this.graphsProvider = graphsProvider;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteElementsCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteElementsCommand.java
@@ -19,10 +19,10 @@ package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 import java.util.Collection;
 
 import org.kie.workbench.common.dmn.client.commands.factory.graph.DMNDeleteElementsGraphCommand;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteElementsCommand;
 import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.graph.command.impl.SafeDeleteNodeCommand;
@@ -30,15 +30,15 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 public class DMNDeleteElementsCommand extends DeleteElementsCommand {
 
-    private final GraphsProvider graphsProvider;
+    private final DMNGraphsProvider graphsProvider;
 
     public DMNDeleteElementsCommand(final Collection<Element> elements,
-                                    final GraphsProvider graphsProvider) {
+                                    final DMNGraphsProvider graphsProvider) {
         super(elements);
         this.graphsProvider = graphsProvider;
     }
 
-    public GraphsProvider getGraphsProvider() {
+    public DMNGraphsProvider getGraphsProvider() {
         return graphsProvider;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteNodeCommand.java
@@ -16,11 +16,11 @@
 
 package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteCanvasConnectorCommand;
 import org.kie.workbench.common.stunner.core.client.canvas.command.DeleteNodeCommand;
 import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
@@ -30,17 +30,17 @@ import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 public class DMNDeleteNodeCommand extends DeleteNodeCommand {
 
-    private final GraphsProvider graphsProvider;
+    private final DMNGraphsProvider graphsProvider;
 
     public DMNDeleteNodeCommand(final Node candidate,
-                                final GraphsProvider graphsProvider) {
+                                final DMNGraphsProvider graphsProvider) {
         super(candidate,
               SafeDeleteNodeCommand.Options.defaults(),
               new DMNCanvasDeleteProcessor(SafeDeleteNodeCommand.Options.defaults(), graphsProvider));
         this.graphsProvider = graphsProvider;
     }
 
-    public GraphsProvider getGraphsProvider() {
+    public DMNGraphsProvider getGraphsProvider() {
         return graphsProvider;
     }
 
@@ -54,10 +54,10 @@ public class DMNDeleteNodeCommand extends DeleteNodeCommand {
 
     public static class DMNCanvasDeleteProcessor extends CanvasDeleteProcessor {
 
-        private final GraphsProvider graphsProvider;
+        private final DMNGraphsProvider graphsProvider;
 
         public DMNCanvasDeleteProcessor(final SafeDeleteNodeCommand.Options options,
-                                        final GraphsProvider graphsProvider) {
+                                        final DMNGraphsProvider graphsProvider) {
             super(options);
             this.graphsProvider = graphsProvider;
         }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNSafeDeleteNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNSafeDeleteNodeCommand.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionService;
 import org.kie.workbench.common.dmn.client.commands.factory.graph.DMNDeleteConnectorCommand;
 import org.kie.workbench.common.dmn.client.commands.factory.graph.DMNDeregisterNodeCommand;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -35,13 +36,13 @@ import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 
 public class DMNSafeDeleteNodeCommand extends SafeDeleteNodeCommand {
 
-    private final GraphsProvider graphsProvider;
+    private final DMNGraphsProvider graphsProvider;
     private final Node<?, Edge> node;
 
     public DMNSafeDeleteNodeCommand(final Node<?, Edge> node,
                                     final SafeDeleteNodeCommandCallback safeDeleteCallback,
                                     final Options options,
-                                    final GraphsProvider graphsProvider) {
+                                    final DMNGraphsProvider graphsProvider) {
         super(node, safeDeleteCallback, options);
         this.graphsProvider = graphsProvider;
         this.node = node;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommand.java
@@ -16,7 +16,7 @@
 
 package org.kie.workbench.common.dmn.client.commands.factory.graph;
 
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.impl.DeleteConnectorCommand;
@@ -27,10 +27,10 @@ import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 
 public class DMNDeleteConnectorCommand extends DeleteConnectorCommand {
 
-    private final GraphsProvider graphsProvider;
+    private final DMNGraphsProvider graphsProvider;
 
     public DMNDeleteConnectorCommand(final Edge<? extends View, Node> edge,
-                                     final GraphsProvider graphsProvider) {
+                                     final DMNGraphsProvider graphsProvider) {
         super(edge);
         this.graphsProvider = graphsProvider;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteElementsGraphCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteElementsGraphCommand.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.function.Supplier;
 
 import org.kie.workbench.common.dmn.client.commands.factory.canvas.DMNSafeDeleteNodeCommand;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -29,11 +29,11 @@ import org.kie.workbench.common.stunner.core.graph.command.impl.SafeDeleteNodeCo
 
 public class DMNDeleteElementsGraphCommand extends DeleteElementsCommand {
 
-    private GraphsProvider graphsProvider;
+    private DMNGraphsProvider graphsProvider;
 
     public DMNDeleteElementsGraphCommand(final Supplier<Collection<Element>> elements,
                                          final DeleteCallback callback,
-                                         final GraphsProvider graphsProvider) {
+                                         final DMNGraphsProvider graphsProvider) {
         super(elements, callback);
         this.graphsProvider = graphsProvider;
     }
@@ -48,7 +48,7 @@ public class DMNDeleteElementsGraphCommand extends DeleteElementsCommand {
                                             getGraphsProvider());
     }
 
-    public GraphsProvider getGraphsProvider() {
+    public DMNGraphsProvider getGraphsProvider() {
         return graphsProvider;
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommand.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.commands.factory.graph;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -34,13 +35,13 @@ import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitio
 
 public class DMNSetConnectionSourceNodeCommand extends SetConnectionSourceNodeCommand {
 
-    private final GraphsProvider graphsProvider;
+    private final DMNGraphsProvider graphsProvider;
     private final Optional<String> diagramId;
 
     public DMNSetConnectionSourceNodeCommand(final Node<? extends View<?>, Edge> sourceNode,
                                              final Edge<? extends View, Node> edge,
                                              final Connection connection,
-                                             final GraphsProvider graphsProvider) {
+                                             final DMNGraphsProvider graphsProvider) {
         super(sourceNode, edge, connection);
         this.graphsProvider = graphsProvider;
         this.diagramId = ContentDefinitionIdUtils.getDiagramId(edge);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommand.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.commands.factory.graph;
 import java.util.Optional;
 
 import org.kie.workbench.common.dmn.client.commands.util.ContentDefinitionIdUtils;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
@@ -34,13 +35,13 @@ import static org.kie.workbench.common.dmn.client.commands.util.ContentDefinitio
 
 public class DMNSetConnectionTargetNodeCommand extends SetConnectionTargetNodeCommand {
 
-    private final GraphsProvider graphsProvider;
+    private final DMNGraphsProvider graphsProvider;
     private final Optional<String> diagramId;
 
     public DMNSetConnectionTargetNodeCommand(final Node<? extends View<?>, Edge> targetNode,
                                              final Edge<? extends View, Node> edge,
                                              final Connection connection,
-                                             final GraphsProvider graphsProvider) {
+                                             final DMNGraphsProvider graphsProvider) {
         super(targetNode, edge, connection);
         this.graphsProvider = graphsProvider;
         this.diagramId = ContentDefinitionIdUtils.getDiagramId(edge);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSession.java
@@ -39,17 +39,17 @@ import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.uberfire.backend.vfs.Path;
 
 import static java.util.Collections.emptyList;
+import static org.kie.workbench.common.dmn.client.docks.navigator.drds.DRGDiagramUtils.isDRG;
 
 @ApplicationScoped
 @Default
-public class DMNDiagramsSession implements GraphsProvider {
+public class DMNDiagramsSession {
 
     private static Diagram NO_DIAGRAM = null;
 
@@ -128,12 +128,10 @@ public class DMNDiagramsSession implements GraphsProvider {
         getSessionState().getDMNDiagramsByDiagramId().remove(diagramId);
     }
 
-    @Override
     public Diagram getDiagram(final String dmnDiagramElementId) {
         return getSessionState().getDiagram(dmnDiagramElementId);
     }
 
-    @Override
     public String getCurrentDiagramId() {
         if (!Objects.isNull(getSessionState())) {
             final Optional<DMNDiagramElement> current = getCurrentDMNDiagramElement();
@@ -183,10 +181,6 @@ public class DMNDiagramsSession implements GraphsProvider {
         return Optional.ofNullable(getSessionState()).map(DMNDiagramsSessionState::getDRGDiagramElement).orElse(null);
     }
 
-    private DMNDiagramTuple getDRGDiagramTuple() {
-        return Optional.ofNullable(getSessionState()).map(DMNDiagramsSessionState::getDRGDiagramTuple).orElse(null);
-    }
-
     public void clear() {
         getSessionState().clear();
     }
@@ -199,12 +193,10 @@ public class DMNDiagramsSession implements GraphsProvider {
         return Optional.ofNullable(getSessionState()).map(DMNDiagramsSessionState::getModelImports).orElse(emptyList());
     }
 
-    @Override
     public boolean isGlobalGraphSelected() {
         return getCurrentDMNDiagramElement().map(DRGDiagramUtils::isDRG).orElse(false);
     }
 
-    @Override
     public List<Graph> getGraphs() {
         return getDMNDiagrams()
                 .stream()
@@ -229,6 +221,14 @@ public class DMNDiagramsSession implements GraphsProvider {
                             .orElse(NO_DIAGRAM);
                 })
                 .orElse(NO_DIAGRAM);
+    }
+
+    public List<Graph> getNonGlobalGraphs() {
+        return getDMNDiagrams()
+                .stream()
+                .filter(dmnDiagramTuple -> !isDRG(dmnDiagramTuple.getDMNDiagram()))
+                .map(tuple -> tuple.getStunnerDiagram().getGraph())
+                .collect(Collectors.toList());
     }
 
     private Optional<ClientSession> getCurrentSession() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNGraphsProvider.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNGraphsProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.docks.navigator.drds;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+
+@Alternative
+@ApplicationScoped
+@DMNEditor
+@Default
+public class DMNGraphsProvider implements GraphsProvider {
+
+    private final DMNDiagramsSession diagramsSession;
+
+    protected DMNGraphsProvider() {
+        // CDI proxy
+        this(null);
+    }
+
+    @Inject
+    public DMNGraphsProvider(final DMNDiagramsSession diagramsSession) {
+        this.diagramsSession = diagramsSession;
+    }
+
+    @Override
+    public boolean isGlobalGraphSelected() {
+        return diagramsSession.isGlobalGraphSelected();
+    }
+
+    @Override
+    public List<Graph> getGraphs() {
+        return diagramsSession.getGraphs();
+    }
+
+    @Override
+    public List<Graph> getNonGlobalGraphs() {
+        return diagramsSession.getNonGlobalGraphs();
+    }
+
+    @Override
+    public Diagram getDiagram(final String diagramId) {
+        return diagramsSession.getDiagram(diagramId);
+    }
+
+    @Override
+    public String getCurrentDiagramId() {
+        return diagramsSession.getCurrentDiagramId();
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNCanvasHandler.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/DMNCanvasHandler.java
@@ -70,7 +70,7 @@ public class DMNCanvasHandler<D extends Diagram, C extends AbstractCanvas> exten
                             final Event<CanvasElementUpdatedEvent> canvasElementUpdatedEvent,
                             final Event<CanvasElementsClearEvent> canvasElementsClearEvent,
                             final DMNElementsSynchronizer dmnElementsSynchronizer,
-                            final GraphsProvider graphsProvider) {
+                            final @DMNEditor GraphsProvider graphsProvider) {
         super(clientDefinitionManager, commandFactory, ruleManager, graphUtils, indexBuilder, shapeManager, textPropertyProviderFactory, canvasElementAddedEvent, canvasElementRemovedEvent, canvasElementUpdatedEvent, canvasElementsClearEvent);
         this.dmnElementsSynchronizer = dmnElementsSynchronizer;
         this.graphsProvider = graphsProvider;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/RegistryProvider.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/session/RegistryProvider.java
@@ -26,22 +26,22 @@ import javax.inject.Inject;
 import org.appformer.client.stateControl.registry.Registry;
 import org.appformer.client.stateControl.registry.RegistryChangeListener;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 
 @ApplicationScoped
 public class RegistryProvider {
 
     private final ManagedInstance<CommandRegistryHolder> registryHolders;
-    private final GraphsProvider graphsProvider;
+    private final DMNGraphsProvider graphsProvider;
     private final Map<String, Registry<Command<AbstractCanvasHandler, CanvasViolation>>> registryMap;
     private RegistryChangeListener registryChangeListener;
 
     @Inject
     public RegistryProvider(final ManagedInstance<CommandRegistryHolder> registryHolders,
-                            final GraphsProvider graphsProvider) {
+                            final DMNGraphsProvider graphsProvider) {
         this.registryHolders = registryHolders;
         this.graphsProvider = graphsProvider;
         this.registryMap = new HashMap<>();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/META-INF/ErraiApp.properties
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/resources/META-INF/ErraiApp.properties
@@ -29,5 +29,6 @@
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
 errai.ioc.enabled.alternatives=org.kie.workbench.common.dmn.client.commands.clone.DMNDeepCloneProcess \
-                               org.kie.workbench.common.dmn.client.api.ReadOnlyProviderImpl
+                               org.kie.workbench.common.dmn.client.api.ReadOnlyProviderImpl \
+                               org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider 
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNDeleteNodeToolboxActionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNDeleteNodeToolboxActionTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.canvas.controls.toolbox;
+
+import java.util.Collections;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.command.DefaultCanvasCommandFactory;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.DeleteNodeConfirmation;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
+import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseClickEvent;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.EventSourceMock;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNDeleteNodeToolboxActionTest {
+
+    private DMNDeleteNodeToolboxAction toolboxAction;
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    @Mock
+    private SessionCommandManager<AbstractCanvasHandler> sessionCommandManager;
+
+    @Mock
+    private ManagedInstance<DefaultCanvasCommandFactory> commandFactories;
+
+    @Mock
+    private DefinitionUtils definitionUtils;
+
+    @Mock
+    private EventSourceMock<CanvasClearSelectionEvent> clearSelectionEvent;
+
+    @Mock
+    private DeleteNodeConfirmation deleteNodeConfirmation;
+
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+
+    @Mock
+    private Index graphIndex;
+
+    @Before
+    public void setup() {
+        toolboxAction = spy(new DMNDeleteNodeToolboxAction(translationService,
+                                                           sessionCommandManager,
+                                                           commandFactories,
+                                                           definitionUtils,
+                                                           clearSelectionEvent,
+                                                           deleteNodeConfirmation));
+
+        doNothing().when(toolboxAction).superOnMouseClick(any(), any(), any());
+        when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
+    }
+
+    @Test
+    public void testOnMouseClickWhenNodeRequiresDeletionConfirmation() {
+
+        final String nodeUuid = "node uuid";
+        final Element element = mock(Element.class);
+        final Node node = mock(Node.class);
+        final MouseClickEvent event = new MouseClickEvent(0, 0, 0, 0);
+
+        when(element.asNode()).thenReturn(node);
+        when(graphIndex.get(nodeUuid)).thenReturn(element);
+        when(deleteNodeConfirmation.requiresDeletionConfirmation(Collections.singleton(node))).thenReturn(true);
+
+        toolboxAction.onMouseClick(canvasHandler, nodeUuid, event);
+
+        verify(deleteNodeConfirmation).confirmDeletion(any(), any(), any());
+        verify(toolboxAction, never()).superOnMouseClick(canvasHandler, nodeUuid, event);
+    }
+
+    @Test
+    public void testOnMouseClickWhenNodeDoesNotRequiresDeletionConfirmation() {
+
+        final String nodeUuid = "node uuid";
+        final Element element = mock(Element.class);
+        final Node node = mock(Node.class);
+        final MouseClickEvent event = new MouseClickEvent(0, 0, 0, 0);
+
+        when(element.asNode()).thenReturn(node);
+        when(graphIndex.get(nodeUuid)).thenReturn(element);
+        when(deleteNodeConfirmation.requiresDeletionConfirmation(Collections.singleton(node))).thenReturn(false);
+
+        toolboxAction.onMouseClick(canvasHandler, nodeUuid, event);
+
+        verify(deleteNodeConfirmation, never()).confirmDeletion(any(), any(), any());
+        verify(toolboxAction).superOnMouseClick(canvasHandler, nodeUuid, event);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasConnectorNodeCommandTest.java
@@ -20,11 +20,11 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
 import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.mockito.Mock;
 
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verify;
 public class DMNDeleteCanvasConnectorNodeCommandTest {
 
     @Mock
-    private GraphsProvider graphsProvider;
+    private DMNGraphsProvider graphsProvider;
 
     @Mock
     private Edge candidate;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteCanvasNodeCommandTest.java
@@ -20,10 +20,10 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.command.AbstractCanvasCommand;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.mockito.Mock;
 
@@ -41,7 +41,7 @@ public class DMNDeleteCanvasNodeCommandTest {
     private Node candidate;
 
     @Mock
-    private GraphsProvider graphsProvide;
+    private DMNGraphsProvider graphsProvide;
 
     private DMNDeleteCanvasNodeCommand command;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteElementsCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteElementsCommandTest.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.commands.factory.graph.DMNDeleteElementsGraphCommand;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
@@ -39,7 +39,7 @@ public class DMNDeleteElementsCommandTest {
     @Test
     public void testNewGraphCommand() {
 
-        final GraphsProvider selectedDiagramProvider = mock(GraphsProvider.class);
+        final DMNGraphsProvider selectedDiagramProvider = mock(DMNGraphsProvider.class);
         final ArrayList<Element> elements = new ArrayList<>();
         final Element element = mock(Element.class);
         when(element.getUUID()).thenReturn("uuid");

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/canvas/DMNDeleteNodeCommandTest.java
@@ -18,8 +18,8 @@ package org.kie.workbench.common.dmn.client.commands.factory.canvas;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.command.Command;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
@@ -36,7 +36,7 @@ public class DMNDeleteNodeCommandTest {
     @Test
     public void testNewGraphCommand() {
 
-        final GraphsProvider selectedDiagramProvider = mock(GraphsProvider.class);
+        final DMNGraphsProvider selectedDiagramProvider = mock(DMNGraphsProvider.class);
         final Node candidate = mock(Node.class);
         when(candidate.getUUID()).thenReturn("uuid");
         final DMNDeleteNodeCommand cmd = new DMNDeleteNodeCommand(candidate, selectedDiagramProvider);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteConnectorCommandTest.java
@@ -20,7 +20,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.impl.SetConnectionSourceNodeCommand;
@@ -42,7 +42,7 @@ public class DMNDeleteConnectorCommandTest {
     private Edge<? extends View, Node> edge;
 
     @Mock
-    private GraphsProvider graphsProvider;
+    private DMNGraphsProvider graphsProvider;
 
     private Edge<? extends ViewConnector, Node> edgeParameter = mock(Edge.class);
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteElementsGraphCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNDeleteElementsGraphCommandTest.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.dmn.client.commands.factory.graph;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.commands.factory.canvas.DMNSafeDeleteNodeCommand;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.command.impl.DeleteElementsCommand;
@@ -37,7 +37,7 @@ public class DMNDeleteElementsGraphCommandTest {
     @Test
     public void testCreateSafeDeleteNodeCommand() {
 
-        final GraphsProvider selectedDiagramProvider = mock(GraphsProvider.class);
+        final DMNGraphsProvider selectedDiagramProvider = mock(DMNGraphsProvider.class);
         final Node<?, Edge> node = mock(Node.class);
         final SafeDeleteNodeCommand.Options options = SafeDeleteNodeCommand.Options.defaults();
         final DeleteElementsCommand.DeleteCallback callback = mock(DeleteElementsCommand.DeleteCallback.class);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionSourceNodeCommandTest.java
@@ -22,8 +22,8 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -61,7 +61,7 @@ public class DMNSetConnectionSourceNodeCommandTest {
     private Connection connection;
 
     @Mock
-    private GraphsProvider graphsProvider;
+    private DMNGraphsProvider graphsProvider;
 
     @Mock
     private GraphCommandExecutionContext context;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/factory/graph/DMNSetConnectionTargetNodeCommandTest.java
@@ -22,8 +22,8 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -61,7 +61,7 @@ public class DMNSetConnectionTargetNodeCommandTest {
     private Connection connection;
 
     @Mock
-    private GraphsProvider graphsProvider;
+    private DMNGraphsProvider graphsProvider;
 
     @Mock
     private GraphCommandExecutionContext context;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNGraphsProviderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNGraphsProviderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.docks.navigator.drds;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNGraphsProviderTest {
+
+    private DMNGraphsProvider provider;
+
+    @Mock
+    private DMNDiagramsSession diagramsSession;
+
+    @Before
+    public void setup() {
+        provider = new DMNGraphsProvider(diagramsSession);
+    }
+
+    @Test
+    public void testIsGlobalGraphSelected() {
+
+        when(diagramsSession.isGlobalGraphSelected()).thenReturn(true);
+
+        final boolean isGlobalGraphSelected = provider.isGlobalGraphSelected();
+
+        verify(diagramsSession).isGlobalGraphSelected();
+        assertTrue(isGlobalGraphSelected);
+    }
+
+    @Test
+    public void testGetGraphs() {
+
+        final List<Graph> graphs = mock(List.class);
+
+        when(diagramsSession.getGraphs()).thenReturn(graphs);
+
+        final List<Graph> actual = provider.getGraphs();
+
+        assertEquals(graphs, actual);
+    }
+
+    @Test
+    public void testGetNonGlobalGraphs() {
+
+        final List<Graph> graphs = mock(List.class);
+
+        when(diagramsSession.getNonGlobalGraphs()).thenReturn(graphs);
+
+        final List<Graph> actual = provider.getNonGlobalGraphs();
+
+        assertEquals(graphs, actual);
+    }
+
+    @Test
+    public void testGetDiagram() {
+
+        final String diagramId = "diagram Id";
+        final Diagram diagram = mock(Diagram.class);
+        when(diagramsSession.getDiagram(diagramId)).thenReturn(diagram);
+
+        final Diagram actualDiagram = provider.getDiagram(diagramId);
+
+        assertEquals(diagram, actualDiagram);
+    }
+
+    @Test
+    public void testGetCurrentDiagramId() {
+
+        final String currentDiagramId = "currentDiagramId";
+        when(diagramsSession.getCurrentDiagramId()).thenReturn(currentDiagramId);
+
+        final String actual = provider.getCurrentDiagramId();
+        assertEquals(currentDiagramId, actual);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/RegistryProviderTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/session/RegistryProviderTest.java
@@ -23,7 +23,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNGraphsProvider;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
@@ -43,7 +43,7 @@ public class RegistryProviderTest {
     private ManagedInstance<CommandRegistryHolder> registryHolders;
 
     @Mock
-    private GraphsProvider graphsProvider;
+    private DMNGraphsProvider graphsProvider;
 
     private RegistryProvider provider;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.dialog;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.canvas.ConfirmationDialog;
+import org.uberfire.ext.editor.commons.client.file.popups.elemental2.Elemental2Modal;
+import org.uberfire.mvp.Command;
+
+@Dependent
+public class ConfirmationDialogImpl extends Elemental2Modal<ConfirmationDialogImpl.View> implements ConfirmationDialog {
+
+    static final String WIDTH = "500px";
+
+    @Inject
+    public ConfirmationDialogImpl(final View view) {
+        super(view);
+    }
+
+    @Override
+    public void show(final String title,
+                     final String boldDescription,
+                     final String question,
+                     final Command onYesAction,
+                     final Command onNoAction) {
+        getView().init(this);
+        getView().initialize(title, boldDescription, question, onYesAction, onNoAction);
+        superSetup();
+        setModalWidth();
+        show();
+    }
+
+    void setModalWidth() {
+        setWidth(WIDTH);
+    }
+
+    public interface View extends Elemental2Modal.View<ConfirmationDialogImpl> {
+
+        void initialize(final String title,
+                        final String boldDescription,
+                        final String question,
+                        final Command onConfirmAction,
+                        final Command onCancelAction);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplView.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplView.html
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    <div data-field="header" data-i18n-key="Header">
+    </div>
+
+    <div data-field="body" class="kie-confirmation-dialog-body">
+        <p data-field="bold-description"></p>
+        <br/>
+        <p data-field="question"></p>
+    </div>
+
+    <div data-field="footer" class="kie-confirmation-dialog-footer">
+        <button data-field="yes-button" class="btn btn-primary" data-i18n-key="Yes"></button>
+        <button data-field="no-button" class="btn btn-default" data-i18n-key="No"></button>
+    </div>
+</div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplView.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplView.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.dialog;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.HTMLParagraphElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.mvp.Command;
+
+@Dependent
+@Templated
+public class ConfirmationDialogImplView implements ConfirmationDialogImpl.View {
+
+    private Command onYesAction;
+
+    private Command onNoAction;
+
+    private ConfirmationDialogImpl presenter;
+
+    @DataField("header")
+    private final HTMLDivElement header;
+
+    @DataField("body")
+    private final HTMLDivElement body;
+
+    @DataField("footer")
+    private final HTMLDivElement footer;
+
+    @DataField("yes-button")
+    private final HTMLButtonElement yesButton;
+
+    @DataField("no-button")
+    private final HTMLButtonElement noButton;
+
+    @DataField("bold-description")
+    private final HTMLParagraphElement boldDescription;
+
+    @DataField("question")
+    private final HTMLParagraphElement question;
+
+    @Inject
+    public ConfirmationDialogImplView(final HTMLDivElement header,
+                                      final HTMLDivElement body,
+                                      final HTMLDivElement footer,
+                                      final HTMLButtonElement yesButton,
+                                      final HTMLButtonElement noButton,
+                                      final HTMLParagraphElement boldDescription,
+                                      final HTMLParagraphElement question) {
+        this.header = header;
+        this.body = body;
+        this.footer = footer;
+        this.yesButton = yesButton;
+        this.noButton = noButton;
+        this.boldDescription = boldDescription;
+        this.question = question;
+    }
+
+    @Override
+    public void initialize(final String title,
+                           final String boldDescription,
+                           final String question,
+                           final Command onYesAction,
+                           final Command onNoAction) {
+        this.onYesAction = onYesAction;
+        this.onNoAction = onNoAction;
+        this.header.textContent = title;
+        this.boldDescription.textContent = boldDescription;
+        this.question.textContent = question;
+    }
+
+    @Override
+    public String getHeader() {
+        return header.textContent;
+    }
+
+    @Override
+    public HTMLElement getBody() {
+        return body;
+    }
+
+    @Override
+    public HTMLElement getFooter() {
+        return footer;
+    }
+
+    @Override
+    public void init(final ConfirmationDialogImpl presenter) {
+        this.presenter = presenter;
+    }
+
+    @EventHandler("yes-button")
+    public void onYesButtonClick(final ClickEvent e) {
+        presenter.hide();
+        onYesAction.execute();
+    }
+
+    @EventHandler("no-button")
+    public void onNoButtonClick(final ClickEvent e) {
+        presenter.hide();
+        onNoAction.execute();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplView.less
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplView.less
@@ -1,11 +1,11 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,21 +14,25 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.diagram;
+.kie-confirmation-dialog-body {
 
-import java.util.List;
+  p {
+    margin: 0;
+  }
 
-import org.kie.workbench.common.stunner.core.graph.Graph;
+  label {
+    font-weight: 600;
+    color: #555;
+    margin: 15px 0 5px;
+  }
 
-public interface GraphsProvider {
+  [data-field="bold-description"] {
+    font-weight: bold;
+  }
+}
 
-    boolean isGlobalGraphSelected();
-
-    List<Graph> getGraphs();
-
-    List<Graph> getNonGlobalGraphs();
-
-    Diagram getDiagram(final String diagramId);
-
-    String getCurrentDiagramId();
+.kie-confirmation-dialog-footer {
+  .btn {
+    padding: 2px 15px;
+  }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
@@ -1,7 +1,7 @@
 ConfirmationDialogImplView.Yes=Yes
 ConfirmationDialogImplView.No=No
 
-DeleteNodeConfirmationDialogImpl.ConfirmationDescription=All {0} nodes will be removed from all decision requirements diagrams (DRDs).
+DeleteNodeConfirmationDialogImpl.ConfirmationDescription=All {0} nodes will be removed from all diagrams.
 DeleteNodeConfirmationDialogImpl.Question=Are you sure you want to continue?
 DeleteNodeConfirmationDialogImpl.Title=Are you sure you want to remove this?
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
@@ -1,3 +1,10 @@
+ConfirmationDialogImplView.Yes=Yes
+ConfirmationDialogImplView.No=No
+
+DeleteNodeConfirmationDialogImpl.ConfirmationDescription=All {0} nodes will be removed from all decision requirements diagrams (DRDs).
+DeleteNodeConfirmationDialogImpl.Question=Are you sure you want to continue?
+DeleteNodeConfirmationDialogImpl.Title=Are you sure you want to remove this?
+
 DefinitionPaletteGroupWidgetViewImpl.showMore=More
 DefinitionPaletteGroupWidgetViewImpl.showLess=Less
 NameEditBoxWidgetViewImpl.save=Save

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.dialog;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.uberfire.mvp.Command;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ConfirmationDialogImplTest {
+
+    @Mock
+    private ConfirmationDialogImpl.View view;
+
+    private ConfirmationDialogImpl confirmationDialog;
+
+    @Before
+    public void setup() {
+        confirmationDialog = spy(new ConfirmationDialogImpl(view));
+    }
+
+    @Test
+    public void testShow() {
+
+        final String title = "title";
+        final String boldDescription = "bold description";
+        final String question = "question";
+        final Command onYesAction = mock(Command.class);
+        final Command onNoAction = mock(Command.class);
+
+        doNothing().when(confirmationDialog).superSetup();
+        doNothing().when(confirmationDialog).show();
+        doNothing().when(confirmationDialog).setModalWidth();
+
+        final InOrder inOrder = Mockito.inOrder(confirmationDialog, view);
+
+        confirmationDialog.show(title,
+                                boldDescription,
+                                question,
+                                onYesAction,
+                                onNoAction);
+
+        inOrder.verify(view).init(confirmationDialog);
+        inOrder.verify(view).initialize(title, boldDescription, question, onYesAction, onNoAction);
+        inOrder.verify(confirmationDialog).superSetup();
+        inOrder.verify(confirmationDialog).show();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplViewTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/dialog/ConfirmationDialogImplViewTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.dialog;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.HTMLParagraphElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ConfirmationDialogImplViewTest {
+
+    private ConfirmationDialogImplView confirmationDialog;
+
+    @Mock
+    private HTMLDivElement header;
+
+    @Mock
+    private HTMLDivElement body;
+
+    @Mock
+    private HTMLDivElement footer;
+
+    @Mock
+    private HTMLButtonElement yesButton;
+
+    @Mock
+    private HTMLButtonElement noButton;
+
+    @Mock
+    private HTMLParagraphElement boldDescription;
+
+    @Mock
+    private HTMLParagraphElement question;
+
+    @Mock
+    private ConfirmationDialogImpl presenter;
+
+    private static final String TitleString = "title";
+
+    private static final String BoldDescriptionString = "description";
+
+    private static final String QuestionString = "question";
+
+    @Mock
+    private Command onConfirmAction;
+
+    @Mock
+    private Command onCancelAction;
+
+    @Before
+    public void setup() {
+        confirmationDialog = new ConfirmationDialogImplView(header,
+                                                            body,
+                                                            footer,
+                                                            yesButton,
+                                                            noButton,
+                                                            boldDescription,
+                                                            question);
+        confirmationDialog.init(presenter);
+        confirmationDialog.initialize(TitleString,
+                                      BoldDescriptionString,
+                                      QuestionString,
+                                      onConfirmAction,
+                                      onCancelAction);
+    }
+
+    @Test
+    public void testGetHeader() {
+
+        final String textContent = "some text";
+        header.textContent = textContent;
+
+        final String actualHeader = confirmationDialog.getHeader();
+
+        assertEquals(textContent, actualHeader);
+    }
+
+    @Test
+    public void testGetBody() {
+
+        final HTMLElement actualBody = confirmationDialog.getBody();
+
+        assertEquals(body, actualBody);
+    }
+
+    @Test
+    public void testGetFooter() {
+
+        final HTMLElement actualFooter = confirmationDialog.getFooter();
+
+        assertEquals(footer, actualFooter);
+    }
+
+    @Test
+    public void testOnYesButtonClick() {
+
+        final ClickEvent clickEvent = mock(ClickEvent.class);
+
+        confirmationDialog.onYesButtonClick(clickEvent);
+
+        verify(presenter).hide();
+        verify(onConfirmAction).execute();
+    }
+
+    @Test
+    public void testOnNoButtonClick() {
+
+        final ClickEvent clickEvent = mock(ClickEvent.class);
+
+        confirmationDialog.onNoButtonClick(clickEvent);
+
+        verify(presenter).hide();
+        verify(onCancelAction).execute();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/DeleteNodeConfirmation.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/DeleteNodeConfirmation.java
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.diagram;
+package org.kie.workbench.common.stunner.core.client.canvas.controls;
 
-import java.util.List;
+import java.util.Collection;
 
-import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.uberfire.mvp.Command;
 
-public interface GraphsProvider {
+public interface DeleteNodeConfirmation {
 
-    boolean isGlobalGraphSelected();
+    boolean requiresDeletionConfirmation(final Collection<Element> elements);
 
-    List<Graph> getGraphs();
-
-    List<Graph> getNonGlobalGraphs();
-
-    Diagram getDiagram(final String diagramId);
-
-    String getCurrentDiagramId();
+    void confirmDeletion(final Command onDeletionAccepted,
+                         final Command onDeletionRejected,
+                         final Collection<Element> elements);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/HasStringName.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/HasStringName.java
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.diagram;
+package org.kie.workbench.common.stunner.core.graph.content;
 
-import java.util.List;
+public interface HasStringName {
 
-import org.kie.workbench.common.stunner.core.graph.Graph;
-
-public interface GraphsProvider {
-
-    boolean isGlobalGraphSelected();
-
-    List<Graph> getGraphs();
-
-    List<Graph> getNonGlobalGraphs();
-
-    Diagram getDiagram(final String diagramId);
-
-    String getCurrentDiagramId();
+    String getStringName();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/DefaultGraphsProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/DefaultGraphsProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.api;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+
+@Default
+@ApplicationScoped
+public class DefaultGraphsProvider implements GraphsProvider {
+
+    protected DefaultGraphsProvider() {
+        // CDI proxy
+    }
+
+    @Override
+    public boolean isGlobalGraphSelected() {
+        return false;
+    }
+
+    @Override
+    public List<Graph> getGraphs() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Graph> getNonGlobalGraphs() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Diagram getDiagram(final String diagramId) {
+        return null;
+    }
+
+    @Override
+    public String getCurrentDiagramId() {
+        return null;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/ConfirmationDialog.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/ConfirmationDialog.java
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.core.diagram;
+package org.kie.workbench.common.stunner.core.client.canvas;
 
-import java.util.List;
+import org.uberfire.mvp.Command;
 
-import org.kie.workbench.common.stunner.core.graph.Graph;
+public interface ConfirmationDialog {
 
-public interface GraphsProvider {
-
-    boolean isGlobalGraphSelected();
-
-    List<Graph> getGraphs();
-
-    List<Graph> getNonGlobalGraphs();
-
-    Diagram getDiagram(final String diagramId);
-
-    String getCurrentDiagramId();
+    void show(final String title,
+              final String boldDescription,
+              final String question,
+              final Command onYesAction,
+              final Command onNoAction);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/DeleteNodeConfirmationImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/DeleteNodeConfirmationImpl.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.core.client.canvas.controls.DeleteNodeConfirmation;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
+import org.kie.workbench.common.stunner.core.graph.content.HasStringName;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
+import org.uberfire.mvp.Command;
+
+import static org.kie.workbench.common.stunner.core.client.canvas.resources.StunnerClientCommonConstants.DeleteNodeConfirmationImpl_ConfirmationDescription;
+import static org.kie.workbench.common.stunner.core.client.canvas.resources.StunnerClientCommonConstants.DeleteNodeConfirmationImpl_Question;
+import static org.kie.workbench.common.stunner.core.client.canvas.resources.StunnerClientCommonConstants.DeleteNodeConfirmationImpl_Title;
+import static org.kie.workbench.common.stunner.core.graph.util.NodeDefinitionHelper.getContentDefinitionId;
+
+@ApplicationScoped
+@Default
+public class DeleteNodeConfirmationImpl implements DeleteNodeConfirmation {
+
+    private ClientTranslationService translationService;
+    private ConfirmationDialog confirmationDialog;
+    private GraphsProvider graphsProvider;
+
+    static final String QUOTE = "\"";
+    static final String SEPARATOR = ", ";
+
+    protected DeleteNodeConfirmationImpl() {
+        // CDI proxy
+    }
+
+    @Inject
+    public DeleteNodeConfirmationImpl(@Default final GraphsProvider graphsProvider,
+                                      final ConfirmationDialog confirmationDialog,
+                                      final ClientTranslationService translationService) {
+        this.graphsProvider = graphsProvider;
+        this.confirmationDialog = confirmationDialog;
+        this.translationService = translationService;
+    }
+
+    @Override
+    public boolean requiresDeletionConfirmation(final Collection<Element> elements) {
+        return graphsProvider.isGlobalGraphSelected()
+                && !graphsProvider.getNonGlobalGraphs().isEmpty()
+                && isReferredInAnotherGraph(elements);
+    }
+
+    @Override
+    public void confirmDeletion(final Command onDeletionAccepted,
+                                final Command onDeletionRejected,
+                                final Collection<Element> elements) {
+
+        final String referredElementsName = getReferredElementsName(elements);
+        confirmationDialog.show(translationService.getValue(DeleteNodeConfirmationImpl_Title),
+                                translationService.getValue(DeleteNodeConfirmationImpl_ConfirmationDescription, referredElementsName),
+                                translationService.getValue(DeleteNodeConfirmationImpl_Question),
+                                onDeletionAccepted,
+                                onDeletionRejected);
+    }
+
+    String getReferredElementsName(final Collection<Element> elements) {
+        final StringBuilder builder = new StringBuilder();
+        for (final Element element : elements) {
+            if (isReferredInAnotherGraph(element)) {
+                final Optional<String> name = getElementName(element);
+                name.ifPresent(value -> {
+                    if (builder.length() > 0) {
+                        builder.append(SEPARATOR);
+                    }
+                    builder.append(QUOTE);
+                    builder.append(value);
+                    builder.append(QUOTE);
+                });
+            }
+        }
+        return builder.toString();
+    }
+
+    Optional<String> getElementName(final Element element) {
+        final Object content = element.getContent();
+        if (content instanceof Definition) {
+            final Object definition = ((Definition) content).getDefinition();
+            if (definition instanceof HasStringName) {
+                final String name = ((HasStringName) definition).getStringName();
+                if (StringUtils.isEmpty(name)) {
+                    return Optional.empty();
+                }
+                return Optional.of(name);
+            }
+        }
+        return Optional.empty();
+    }
+
+    boolean isReferredInAnotherGraph(final Collection<Element> elements) {
+        return elements.stream().anyMatch(this::isReferredInAnotherGraph);
+    }
+
+    boolean isReferredInAnotherGraph(final Element element) {
+        if (element.getContent() instanceof Definition) {
+            final Definition def = (Definition) element.getContent();
+            if (def.getDefinition() instanceof HasContentDefinitionId) {
+                final HasContentDefinitionId hasContentDefinitionId = (HasContentDefinitionId) def.getDefinition();
+                final String contentId = hasContentDefinitionId.getContentDefinitionId();
+                final List<Graph> graphs = graphsProvider.getNonGlobalGraphs();
+                return graphs.stream().anyMatch(graph -> containsNodeWithContentId(graph, contentId));
+            }
+        }
+        return false;
+    }
+
+    boolean containsNodeWithContentId(final Graph graph,
+                                      final String contentId) {
+        return StreamSupport.stream(graph.nodes().spliterator(), false)
+                .anyMatch(n -> Objects.equals(getContentDefinitionId((Node) n), contentId));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/resources/StunnerClientCommonConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/resources/StunnerClientCommonConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.resources;
+
+import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
+
+public class StunnerClientCommonConstants {
+
+    @TranslationKey(defaultValue = "")
+    public static final String DeleteNodeConfirmationImpl_ConfirmationDescription = "DeleteNodeConfirmationDialogImpl.ConfirmationDescription";
+
+    @TranslationKey(defaultValue = "")
+    public static final String DeleteNodeConfirmationImpl_Question = "DeleteNodeConfirmationDialogImpl.Question";
+
+    @TranslationKey(defaultValue = "")
+    public static final String DeleteNodeConfirmationImpl_Title = "DeleteNodeConfirmationDialogImpl.Title";
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactory.java
@@ -24,6 +24,7 @@ import javax.inject.Singleton;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.DeleteNodeConfirmation;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
@@ -87,11 +88,12 @@ public class SessionSingletonCommandsFactory {
             final ManagedInstance<CanvasCommandFactory<AbstractCanvasHandler>> canvasCommandFactoryInstance,
             final Event<CanvasClearSelectionEvent> clearSelectionEvent,
             final DefinitionUtils definitionUtils,
-            final SessionManager sessionManager) {
+            final SessionManager sessionManager,
+            final DeleteNodeConfirmation deleteNodeConfirmation) {
         final ClientSession currentSession = sessionManager.getCurrentSession();
 
         if (!deleteSessionInstances.containsKey(currentSession)) {
-            return new DeleteSelectionSessionCommand(sessionCommandManager, canvasCommandFactoryInstance, clearSelectionEvent, definitionUtils, sessionManager);
+            return new DeleteSelectionSessionCommand(sessionCommandManager, canvasCommandFactoryInstance, clearSelectionEvent, definitionUtils, sessionManager, deleteNodeConfirmation);
         }
 
         return deleteSessionInstances.get(currentSession);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/DeleteNodeConfirmationImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/DeleteNodeConfirmationImplTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.diagram.GraphsProvider;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
+import org.kie.workbench.common.stunner.core.graph.content.HasStringName;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.core.client.canvas.DeleteNodeConfirmationImpl.QUOTE;
+import static org.kie.workbench.common.stunner.core.client.canvas.DeleteNodeConfirmationImpl.SEPARATOR;
+import static org.kie.workbench.common.stunner.core.client.canvas.resources.StunnerClientCommonConstants.DeleteNodeConfirmationImpl_ConfirmationDescription;
+import static org.kie.workbench.common.stunner.core.client.canvas.resources.StunnerClientCommonConstants.DeleteNodeConfirmationImpl_Question;
+import static org.kie.workbench.common.stunner.core.client.canvas.resources.StunnerClientCommonConstants.DeleteNodeConfirmationImpl_Title;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeleteNodeConfirmationImplTest {
+
+    @Mock
+    private GraphsProvider graphsProvider;
+
+    @Mock
+    private ConfirmationDialog confirmationDialog;
+
+    @Mock
+    private ClientTranslationService translationService;
+
+    private DeleteNodeConfirmationImpl confirmation;
+
+    @Before
+    public void setup() {
+        confirmation = spy(new DeleteNodeConfirmationImpl(graphsProvider,
+                                                          confirmationDialog,
+                                                          translationService));
+    }
+
+    @Test
+    public void testRequiresDeleteConfirmationWhenAllConditionsMatch() {
+
+        final Collection<Element> elements = mock(Collection.class);
+        final List<Graph> list = mock(List.class);
+        when(list.isEmpty()).thenReturn(false);
+        when(graphsProvider.isGlobalGraphSelected()).thenReturn(true);
+        when(graphsProvider.getNonGlobalGraphs()).thenReturn(list);
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(elements);
+
+        assertTrue(confirmation.requiresDeletionConfirmation(elements));
+    }
+
+    @Test
+    public void testRequiresDeleteConfirmationWhenGlobalGraphItIsNotSelected() {
+
+        final Collection<Element> elements = mock(Collection.class);
+
+        when(graphsProvider.isGlobalGraphSelected()).thenReturn(false);
+
+        assertFalse(confirmation.requiresDeletionConfirmation(elements));
+    }
+
+    @Test
+    public void testRequiresDeleteConfirmationWhenThereIsNoNonGlobalGraphs() {
+
+        final Collection<Element> elements = mock(Collection.class);
+        final List<Graph> list = Collections.emptyList();
+        when(graphsProvider.isGlobalGraphSelected()).thenReturn(true);
+        when(graphsProvider.getNonGlobalGraphs()).thenReturn(list);
+
+        assertFalse(confirmation.requiresDeletionConfirmation(elements));
+    }
+
+    @Test
+    public void testRequiresDeleteConfirmationWhenThereIsNoElementReferredInAnotherGraph() {
+
+        final Collection<Element> elements = mock(Collection.class);
+        final List<Graph> list = mock(List.class);
+        when(list.isEmpty()).thenReturn(false);
+        when(graphsProvider.isGlobalGraphSelected()).thenReturn(true);
+        when(graphsProvider.getNonGlobalGraphs()).thenReturn(list);
+        doReturn(false).when(confirmation).isReferredInAnotherGraph(elements);
+
+        assertFalse(confirmation.requiresDeletionConfirmation(elements));
+    }
+
+    @Test
+    public void testConfirmDeletion() {
+
+        final Command onDeletionAccepted = mock(Command.class);
+        final Command onDeletionRejected = mock(Command.class);
+        final Collection<Element> elements = mock(Collection.class);
+        final String referredElementsName = "element-1, element-2";
+        final String confirmationDescription = "All " + referredElementsName;
+
+        doReturn(referredElementsName).when(confirmation).getReferredElementsName(elements);
+
+        when(translationService.getValue(DeleteNodeConfirmationImpl_ConfirmationDescription, referredElementsName))
+                .thenReturn(confirmationDescription);
+
+        final String title = "title";
+        when(translationService.getValue(DeleteNodeConfirmationImpl_Title)).thenReturn(title);
+        final String question = "question";
+        when(translationService.getValue(DeleteNodeConfirmationImpl_Question)).thenReturn(question);
+
+        confirmation.confirmDeletion(onDeletionAccepted, onDeletionRejected, elements);
+
+        verify(confirmationDialog).show(title,
+                                        confirmationDescription,
+                                        question,
+                                        onDeletionAccepted,
+                                        onDeletionRejected);
+    }
+
+    @Test
+    public void testGetReferredElementsName() {
+
+        final String name1 = "name1";
+        final String name2 = "name2";
+        final String name3 = "name3";
+        final String name7 = "name7";
+        final String nonReferredName = "nonReferredName";
+
+        final Element element1 = createElementMockWithName(name1);
+        final Element element2 = createElementMockWithName(name2);
+        final Element element3 = createElementMockWithName(name3);
+        final Element element4WithoutName = mock(Element.class);
+        final Element element5WithNullName = createElementMockWithName(null);
+        final Element element6WithEmptyName = createElementMockWithName("");
+        final Element element7 = createElementMockWithName(name7);
+        final Element elementNonReferred = createElementMockWithName(nonReferredName);
+        final String expected = buildExpected(name1, name2, name3, name7);
+
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(element1);
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(element2);
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(element3);
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(element4WithoutName);
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(element5WithNullName);
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(element6WithEmptyName);
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(element7);
+        doReturn(false).when(confirmation).isReferredInAnotherGraph(elementNonReferred);
+
+        final List<Element> list = Arrays.asList(element1,
+                                                 element2,
+                                                 element3,
+                                                 element4WithoutName,
+                                                 element5WithNullName,
+                                                 element6WithEmptyName,
+                                                 element7,
+                                                 elementNonReferred);
+        final String referredElements = confirmation.getReferredElementsName(list);
+
+        assertEquals(expected, referredElements);
+    }
+
+    @Test
+    public void testGetElementName() {
+
+        final String elementName = "name";
+        final Element element = createElementMockWithName(elementName);
+
+        final Optional<String> actualName = confirmation.getElementName(element);
+
+        assertTrue(actualName.isPresent());
+        assertEquals(elementName, actualName.get());
+    }
+
+    @Test
+    public void testGetElementNameWhenNameIsNull() {
+
+        final Element element = createElementMockWithName(null);
+
+        final Optional<String> actualName = confirmation.getElementName(element);
+
+        assertFalse(actualName.isPresent());
+    }
+
+    @Test
+    public void testIsReferredInAnotherGraph() {
+
+        final String contentId = "content id";
+        final Element element = createElementMockWithContentId(contentId);
+
+        final Graph graph1 = mock(Graph.class);
+        final Graph graph2 = mock(Graph.class);
+        final Graph graph3 = mock(Graph.class);
+        final List<Graph> graphs = Arrays.asList(graph1, graph2, graph3);
+        when(graphsProvider.getNonGlobalGraphs()).thenReturn(graphs);
+        doReturn(true).when(confirmation).containsNodeWithContentId(graph3, contentId);
+        doReturn(false).when(confirmation).containsNodeWithContentId(graph1, contentId);
+        doReturn(false).when(confirmation).containsNodeWithContentId(graph2, contentId);
+
+        final boolean isReferred = confirmation.isReferredInAnotherGraph(element);
+
+        verify(confirmation).containsNodeWithContentId(graph3, contentId);
+        verify(confirmation).containsNodeWithContentId(graph2, contentId);
+        verify(confirmation).containsNodeWithContentId(graph1, contentId);
+
+        assertTrue(isReferred);
+    }
+
+    @Test
+    public void testIsReferredInAnotherGraphWhenItIsNot() {
+
+        final String contentId = "content id";
+        final Element element = createElementMockWithContentId(contentId);
+
+        final Graph graph1 = mock(Graph.class);
+        final Graph graph2 = mock(Graph.class);
+        final Graph graph3 = mock(Graph.class);
+        final List<Graph> graphs = Arrays.asList(graph1, graph2, graph3);
+        when(graphsProvider.getNonGlobalGraphs()).thenReturn(graphs);
+        doReturn(false).when(confirmation).containsNodeWithContentId(graph3, contentId);
+        doReturn(false).when(confirmation).containsNodeWithContentId(graph1, contentId);
+        doReturn(false).when(confirmation).containsNodeWithContentId(graph2, contentId);
+
+        final boolean isReferred = confirmation.isReferredInAnotherGraph(element);
+
+        verify(confirmation).containsNodeWithContentId(graph3, contentId);
+        verify(confirmation).containsNodeWithContentId(graph2, contentId);
+        verify(confirmation).containsNodeWithContentId(graph1, contentId);
+
+        assertFalse(isReferred);
+    }
+
+    @Test
+    public void testIsReferredInAnotherGraphWhenElementContentIsNotDefinition() {
+
+        final String contentId = "content id";
+        final Element element = mock(Element.class);
+        final Object someContent = mock(Object.class);
+        when(element.getContent()).thenReturn(someContent);
+
+        final boolean isReferred = confirmation.isReferredInAnotherGraph(element);
+
+        assertFalse(isReferred);
+    }
+
+    @Test
+    public void testAnyElementOfCollectionIsReferredInAnotherGraph() {
+
+        final Element e1 = mock(Element.class);
+        final Element e2 = mock(Element.class);
+        final Element e3 = mock(Element.class);
+        final List<Element> collection = Arrays.asList(e1, e2, e3);
+
+        final boolean isReferred = confirmation.isReferredInAnotherGraph(collection);
+
+        assertFalse(isReferred);
+        verify(confirmation).isReferredInAnotherGraph(e1);
+        verify(confirmation).isReferredInAnotherGraph(e2);
+        verify(confirmation).isReferredInAnotherGraph(e3);
+    }
+
+    @Test
+    public void testContainsNodeWithContentId() {
+
+        final String contentId1 = "id1";
+        final String contentId2 = "id2";
+        final Node node1 = createNodeMockWithContentId(contentId1);
+        final Node node2 = createNodeMockWithContentId(contentId2);
+        final List<Node> nodes = Arrays.asList(node1, node2);
+        final Graph graph = mock(Graph.class);
+        final Iterable iterable = mock(Iterable.class);
+
+        when(iterable.spliterator()).thenReturn(nodes.spliterator());
+        when(graph.nodes()).thenReturn(iterable);
+
+        assertTrue(confirmation.containsNodeWithContentId(graph, contentId1));
+        assertTrue(confirmation.containsNodeWithContentId(graph, contentId2));
+        assertFalse(confirmation.containsNodeWithContentId(graph, "some random id"));
+    }
+
+    @Test
+    public void testAnyElementOfCollectionIsReferredInAnotherGraphWhenItIs() {
+
+        final Element e1 = mock(Element.class);
+        final Element e2 = mock(Element.class);
+        final Element e3 = mock(Element.class);
+        final List<Element> collection = Arrays.asList(e1, e2, e3);
+
+        doReturn(true).when(confirmation).isReferredInAnotherGraph(e3);
+
+        final boolean isReferred = confirmation.isReferredInAnotherGraph(collection);
+
+        assertTrue(isReferred);
+        verify(confirmation).isReferredInAnotherGraph(e1);
+        verify(confirmation).isReferredInAnotherGraph(e2);
+        verify(confirmation).isReferredInAnotherGraph(e3);
+    }
+
+    private String buildExpected(final String... names) {
+
+        final StringBuilder builder = new StringBuilder();
+        for (final String name : names) {
+            if (builder.length() > 0) {
+                builder.append(SEPARATOR);
+            }
+            builder.append(QUOTE);
+            builder.append(name);
+            builder.append(QUOTE);
+        }
+
+        return builder.toString();
+    }
+
+    private Element createElementMockWithName(final String name) {
+
+        final Element element = mock(Element.class);
+        final Definition definition = mock(Definition.class);
+        final HasStringName hasStringName = mock(HasStringName.class);
+
+        when(element.getContent()).thenReturn(definition);
+        when(definition.getDefinition()).thenReturn(hasStringName);
+        when(hasStringName.getStringName()).thenReturn(name);
+
+        return element;
+    }
+
+    private Element createElementMockWithContentId(final String contentId) {
+
+        final Element element = mock(Element.class);
+        final Definition definition = mock(Definition.class);
+        final HasContentDefinitionId contentDefinitionId = mock(HasContentDefinitionId.class);
+
+        when(element.getContent()).thenReturn(definition);
+        when(definition.getDefinition()).thenReturn(contentDefinitionId);
+        when(contentDefinitionId.getContentDefinitionId()).thenReturn(contentId);
+
+        return element;
+    }
+
+    private Node createNodeMockWithContentId(final String contentId) {
+
+        final Node element = mock(Node.class);
+        final Definition definition = mock(Definition.class);
+        final HasContentDefinitionId contentDefinitionId = mock(HasContentDefinitionId.class);
+
+        when(element.getContent()).thenReturn(definition);
+        when(definition.getDefinition()).thenReturn(contentDefinitionId);
+        when(contentDefinitionId.getContentDefinitionId()).thenReturn(contentId);
+
+        return element;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.DeleteNodeConfirmation;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandFactory;
 import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent;
@@ -65,6 +66,9 @@ public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboar
     @Mock
     private ManagedInstance<CanvasCommandFactory<AbstractCanvasHandler>> canvasCommandFactoryInstance;
 
+    @Mock
+    private DeleteNodeConfirmation deleteNodeConfirmation;
+
     @Override
     public void setup() {
         when(sessionManager.getCurrentSession()).thenReturn(session);
@@ -79,10 +83,13 @@ public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboar
 
     @Override
     protected AbstractClientSessionCommand<EditorSession> getCommand() {
+
         return DeleteSelectionSessionCommand.getInstance(sessionCommandManager,
                                                          canvasCommandFactoryInstance,
                                                          canvasClearSelectionEventEvent,
-                                                         definitionUtils, sessionManager);
+                                                         definitionUtils,
+                                                         sessionManager,
+                                                         deleteNodeConfirmation);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/DeleteSelectionSessionCommandTest.java
@@ -17,6 +17,8 @@
 package org.kie.workbench.common.stunner.core.client.session.command.impl;
 
 import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
 
 import javax.enterprise.event.Event;
 
@@ -32,6 +34,8 @@ import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent
 import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.command.ClientSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -39,6 +43,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -96,6 +101,13 @@ public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboar
     public void testClearSessionInvoked() {
         DeleteSelectionSessionCommand deleteCommand = (DeleteSelectionSessionCommand) this.command;
 
+        final String element = "element";
+        final Collection<String> elements = Collections.singleton(element);
+        final Index graphIndex = mock(Index.class);
+        final Element theElement = mock(Element.class);
+        when(graphIndex.get(element)).thenReturn(theElement);
+        when(canvasHandler.getGraphIndex()).thenReturn(graphIndex);
+        when(selectionControl.getSelectedItems()).thenReturn(elements);
         when(definitionUtils.getQualifier(anyString())).thenReturn(qualifier);
 
         deleteCommand.bind(session);
@@ -122,7 +134,7 @@ public class DeleteSelectionSessionCommandTest extends BaseSessionCommandKeyboar
 
     @Test
     public void testExecuteBackSpaceKeys() {
-       this.checkRespondsToExpectedKeysMatch(new KeyboardEvent.Key[]{KeyboardEvent.Key.KEY_BACKSPACE});
+        this.checkRespondsToExpectedKeysMatch(new KeyboardEvent.Key[]{KeyboardEvent.Key.KEY_BACKSPACE});
     }
 
     @Test(expected = IllegalStateException.class)

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/command/impl/SessionSingletonCommandsFactoryTest.java
@@ -100,35 +100,35 @@ public class SessionSingletonCommandsFactoryTest {
 
     @Test(expected = IllegalStateException.class)
     public void testOnlyOneInstancePerSessionDelete() {
-        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
-        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager, null);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager, null);
     }
 
     @Test
     public void testNewInstancesOndifferentSessionsDelete() {
-        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager, null);
         when(sessionManager.getCurrentSession()).thenReturn(session2);
-        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager, null);
         assertTrue(deleteSelectionSessionCommand.hashCode() != deleteSelectionSessionCommand2.hashCode());
     }
 
     @Test
     public void testGetInstancesDelete() {
-        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
-        final DeleteSelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager, null);
+        final DeleteSelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager, null);
 
         assertEquals(deleteSelectionSessionCommand, instanceCopy);
 
         when(sessionManager.getCurrentSession()).thenReturn(session2);
-        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
-        final DeleteSelectionSessionCommand instanceCopy2 = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand deleteSelectionSessionCommand2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager, null);
+        final DeleteSelectionSessionCommand instanceCopy2 = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager, null);
 
         assertEquals(deleteSelectionSessionCommand2, instanceCopy2);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testGetInstancesOnFetchDelete() {
-        final DeleteSelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager);
-        final DeleteSelectionSessionCommand instanceCopy2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager);
+        final DeleteSelectionSessionCommand instanceCopy = SessionSingletonCommandsFactory.getInstanceDelete(null, null, null, null, sessionManager, null);
+        final DeleteSelectionSessionCommand instanceCopy2 = new DeleteSelectionSessionCommand(null, null, null, null, sessionManager, null);
     }
 }


### PR DESCRIPTION
**JIRA**: [KOGITO-3379](https://issues.redhat.com/browse/KOGITO-3379)

**Business Central**: [WAR file](https://drive.google.com/file/d/1ddogQg-etL0O17Xc91IJIsCj1v6BvHNY/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1gt_QU0pB0WVIocQF8tJv_7zPlMAKbi9G/view?usp=sharing)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
