### PR TITLE
[7.44.x] KOGITO-3366: [DMN Designer] Boxed Expression - Decision Tables - Users lost constraints when they change the focus 

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/converters/InputClausePropertyConverter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/converters/InputClausePropertyConverter.java
@@ -35,7 +35,9 @@ public class InputClausePropertyConverter {
         final Id id = IdPropertyConverter.wbFromDMN(dmn.getId());
         final Description description = DescriptionPropertyConverter.wbFromDMN(dmn.getDescription());
         final InputClauseLiteralExpression inputExpression = InputClauseLiteralExpressionPropertyConverter.wbFromDMN(dmn.getInputExpression());
-        final InputClauseUnaryTests inputValues = InputClauseUnaryTestsPropertyConverter.wbFromDMN(dmn.getInputValues());
+        final InputClauseUnaryTests inputValues = Optional
+                .ofNullable(InputClauseUnaryTestsPropertyConverter.wbFromDMN(dmn.getInputValues()))
+                .orElse(new InputClauseUnaryTests());
 
         final InputClause result = new InputClause(id,
                                                    description,
@@ -45,9 +47,7 @@ public class InputClausePropertyConverter {
         if (Objects.nonNull(inputExpression)) {
             inputExpression.setParent(result);
         }
-        if (Objects.nonNull(inputValues)) {
-            inputValues.setParent(result);
-        }
+        inputValues.setParent(result);
 
         return result;
     }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-3366

![KOGITO-3366](https://user-images.githubusercontent.com/22591802/94444070-34fb1080-01a6-11eb-90c3-4c3b24c68229.gif)

<details>
<summary>
During DMN file unmarshalling, `inputValues`, in order to be editable, should not be null.
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
