### PR TITLE
[DROOLS-5783] Make droolsjbpm-integration repo independent from appformer

### DIFF
--- a/kie-identity-session-provider/pom.xml
+++ b/kie-identity-session-provider/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.workbench</groupId>
+    <artifactId>kie-wb-common</artifactId>
+    <version>7.46.0-SNAPSHOT</version>
+  </parent>
+  
+  <groupId>org.kie</groupId>
+  <artifactId>kie-identity-session-provider</artifactId>
+  <name>KIE Identity And Session Provider</name>
+
+  <properties>
+    <java.module.name>org.kie.identity.session.provider</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-internal</artifactId>
+    </dependency> 
+    <dependency>
+     <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+     <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- specs -->
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+    </dependency> 
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/kie-identity-session-provider/src/main/java/org/kie/provider/SessionInfoProvider.java
+++ b/kie-identity-session-provider/src/main/java/org/kie/provider/SessionInfoProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.provider;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.uberfire.rpc.SessionInfo;
+
+public interface SessionInfoProvider {
+    
+    public static final String UNKNOWN_SESSION_ID = "--";
+
+    String getId();
+
+    User getIdentity();
+    
+    SessionInfo getSessionInfo();
+    
+}

--- a/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeIdentityProvider.java
+++ b/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeIdentityProvider.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import javax.enterprise.context.RequestScoped;
 import javax.enterprise.context.SessionScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -71,7 +70,7 @@ public class SafeIdentityProvider implements IdentityProvider, Serializable {
     
     @Override
     public List<String> getRoles() {
-        List<String> roles = new ArrayList<String>();
+        List<String> roles = new ArrayList<>();
         if( identityInstance.isUnsatisfied() ) { 
             // TODO: retrieve roles via info in servlet request and JAAS?
             return roles;

--- a/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeIdentityProvider.java
+++ b/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeIdentityProvider.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.provider.impl;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.kie.internal.identity.IdentityProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SessionScoped
+public class SafeIdentityProvider implements IdentityProvider, Serializable {
+
+    private static final Logger logger = LoggerFactory.getLogger( SafeIdentityProvider.class );
+
+    /** generated serial version UID */
+    private static final long serialVersionUID = 7709094889603436905L;
+
+    @Inject
+    private Instance<User> identityInstance;
+    
+    @Inject
+    private Instance<HttpServletRequest> request;
+    
+    @Override
+    public String getName() {
+        if( identityInstance.isUnsatisfied() ) { 
+            return getIdentityFromRequest();
+        }
+          
+        // default
+        try {
+            return identityInstance.get().getIdentifier();
+        } catch (Exception e) {
+            logger.debug( "Error on getting identity from User bean: " + e.getMessage(), e );
+            return getIdentityFromRequest();
+        }
+    }
+
+    private String getIdentityFromRequest() { 
+        if (!request.isUnsatisfied() && request.get().getUserPrincipal() != null) {
+            return request.get().getUserPrincipal().getName();
+        }
+        return UNKNOWN_USER_IDENTITY;
+    }
+    
+    @Override
+    public List<String> getRoles() {
+        List<String> roles = new ArrayList<String>();
+        if( identityInstance.isUnsatisfied() ) { 
+            // TODO: retrieve roles via info in servlet request and JAAS?
+            return roles;
+        }
+        
+        // default
+        User identity = identityInstance.get();
+        final Set<Role> ufRoles = identity.getRoles();
+        for (Role role : ufRoles) {
+            roles.add(role.getName());
+        }
+
+        final Set<Group> ufGroups = identity.getGroups();
+        for (Group group : ufGroups) {
+            roles.add(group.getName());
+        }
+
+        return roles;
+    }
+
+    @Override
+    public boolean hasRole(String role) {
+        if (request.isUnsatisfied()) {
+            return request.get().isUserInRole(role);
+        }
+        return getRoles().contains(role);
+    }
+
+}

--- a/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeSessionInfoProvider.java
+++ b/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeSessionInfoProvider.java
@@ -40,7 +40,7 @@ public class SafeSessionInfoProvider implements SessionInfoProvider, Serializabl
     /** Generated serial version UID */
     private static final long serialVersionUID = 8510219062936244657L;
 
-    private static final Logger logger = LoggerFactory.getLogger( SafeIdentityProvider.class );
+    private static final Logger logger = LoggerFactory.getLogger( SafeSessionInfoProvider.class );
             
     @Inject
     private Instance<SessionInfo> delegate;
@@ -79,7 +79,7 @@ public class SafeSessionInfoProvider implements SessionInfoProvider, Serializabl
     
     private User getUserFromIdentityProvider() { 
         List<String> roleStrList = identityProvider.getRoles();
-        List<Role> roles = new ArrayList<Role>(roleStrList.size());
+        List<Role> roles = new ArrayList<>(roleStrList.size());
         for( String roleStr : roleStrList ) { 
             roles.add( new RoleImpl(roleStr));
         }

--- a/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeSessionInfoProvider.java
+++ b/kie-identity-session-provider/src/main/java/org/kie/provider/impl/SafeSessionInfoProvider.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.provider.impl;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
+import org.kie.internal.identity.IdentityProvider;
+import org.kie.provider.SessionInfoProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.rpc.SessionInfo;
+import org.uberfire.rpc.impl.SessionInfoImpl;
+
+@SessionScoped
+public class SafeSessionInfoProvider implements SessionInfoProvider, Serializable  {
+
+    /** Generated serial version UID */
+    private static final long serialVersionUID = 8510219062936244657L;
+
+    private static final Logger logger = LoggerFactory.getLogger( SafeIdentityProvider.class );
+            
+    @Inject
+    private Instance<SessionInfo> delegate;
+
+    @Inject 
+    private IdentityProvider identityProvider; 
+    
+    @Override
+    public String getId() {
+        if( delegate.isUnsatisfied() ) { 
+            return UNKNOWN_SESSION_ID;
+        }
+        
+        // default
+        try {
+            return delegate.get().getId();
+        } catch ( Exception e ) {
+            return UNKNOWN_SESSION_ID;
+        }
+    }
+
+    @Override
+    public User getIdentity() {
+        if( delegate.isUnsatisfied() ) { 
+           return getUserFromIdentityProvider(); 
+        } 
+       
+        // default
+        try {
+            return delegate.get().getIdentity(); 
+        } catch ( Exception e ) {
+            logger.debug("SessionInfo bean was available but could not return identity: " + e.getMessage(), e );
+            return getUserFromIdentityProvider();
+        }
+    }
+    
+    private User getUserFromIdentityProvider() { 
+        List<String> roleStrList = identityProvider.getRoles();
+        List<Role> roles = new ArrayList<Role>(roleStrList.size());
+        for( String roleStr : roleStrList ) { 
+            roles.add( new RoleImpl(roleStr));
+        }
+        return new UserImpl( identityProvider.getName(), roles ); 
+    }
+
+    @Override
+    public SessionInfo getSessionInfo() {
+        if( delegate.isUnsatisfied() ) { 
+            return createSessionInfo();
+        }
+        
+        try { 
+            SessionInfo sessionInfo = delegate.get();
+            sessionInfo.getId();
+            return sessionInfo;
+        } catch( Exception e ) { 
+            logger.debug("SessionInfo bean was available but could not be retrieved: " + e.getMessage(), e );
+            return createSessionInfo();
+        }
+    }
+        
+    private SessionInfo createSessionInfo() { 
+        String id = getId();
+        User identity = getUserFromIdentityProvider();
+        return new SessionInfoImpl(id, identity);
+    }
+}

--- a/kie-identity-session-provider/src/main/resources/META-INF/ErraiApp.properties
+++ b/kie-identity-session-provider/src/main/resources/META-INF/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2012 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   <description>Kie Workbench - Common</description>
 
   <modules>
+    <module>kie-identity-session-provider</module>
     <module>kie-wb-common-profile</module>
     <module>kie-wb-common-widgets</module>
     <module>kie-wb-testing-utils</module>


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5783

Description:
The goal of this PR is to cleanup `droolsjbpm-integration` repo from unnecessary relation with other repos (in this case `appformer`). It is a sort of followup of this PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1505 that tries to do the same but it has been partially reverted because of some remaining usages

Details of this part of the PR:
- moving `kie-identity-session-provider` from `droolsjbpm-integration` repo to here because it is used by some -wb repos but it uses kie-internal so this is the first repo in common we can use

NOTE: I preserved same group and artifact of `kie-identity-session-provider` to preserve downstream usages. If we don't like to have a different naming I can change it + all downstreaming repos

@mareknovotny @Ginxo @lucamolteni @mariofusco @ederign 

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1517
* https://github.com/kiegroup/kie-soup/pull/163
* https://github.com/kiegroup/appformer/pull/1073
* https://github.com/kiegroup/droolsjbpm-integration/pull/2306
* https://github.com/kiegroup/kie-wb-common/pull/3472

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
