### PR TITLE
[7.44.x] DROOLS-5664 DMN editor reporting unsaved changes in DMN files after no changes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -274,6 +274,13 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
 
     @Override
     public void initialiseKieEditorForSession(final ProjectDiagram diagram) {
+        onDiagramLoad();
+
+        /*
+            Method below is doing a lot of things: title, documentation page, etc.
+            It also sets the original hash (used for detecting Diagram's changes)
+            It is recommended to set the original hash after onDiagramLoad, that may have modified the Diagram
+         */
         superInitialiseKieEditorForSession(diagram);
 
         kieView.getMultiPage().addPage(dataTypesPage);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -297,6 +297,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                    errorPopupPresenter,
                                                    diagramClientErrorHandler,
                                                    translationService));
+                this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilderMock;
                 return presenterCore;
             }
 
@@ -391,6 +392,17 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     }
 
     @Test
+    public void testInitialiseKieEditorForSessionWhenInitializingKieEditorForSessionThenDiagramAlreadyLoaded() {
+        doNothing().when(diagramEditor).superInitialiseKieEditorForSession(any());
+        final InOrder inOrder = inOrder(diagramEditor);
+
+        diagramEditor.initialiseKieEditorForSession(diagram);
+
+        inOrder.verify(diagramEditor).onDiagramLoad();
+        inOrder.verify(diagramEditor).superInitialiseKieEditorForSession(any());
+    }
+
+    @Test
     public void testSetupSearchComponent() {
 
         diagramEditor.setupSearchComponent();
@@ -407,12 +419,12 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
 
         open();
 
-        verify(decisionNavigatorDock).reload();
-        verify(expressionEditor).setToolbarStateHandler(any(DMNProjectToolbarStateHandler.class));
-        verify(dataTypesPage).reload();
+        verify(decisionNavigatorDock, atLeast(1)).reload();
+        verify(expressionEditor, atLeast(1)).setToolbarStateHandler(any(DMNProjectToolbarStateHandler.class));
+        verify(dataTypesPage, atLeast(1)).reload();
         verify(layoutHelper).applyLayout(diagram, layoutExecutor);
-        verify(includedModelsPage).reload();
-        verify(lazyCanvasFocusUtils).releaseFocus();
+        verify(includedModelsPage, atLeast(1)).reload();
+        verify(lazyCanvasFocusUtils, atLeast(1)).releaseFocus();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditorTest.java
@@ -99,6 +99,7 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
 import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.ace.AceEditorMode;
 import org.uberfire.ext.widgets.core.client.editors.texteditor.TextEditorView;
@@ -252,6 +253,9 @@ public class AbstractProjectDiagramEditorTest {
     @Mock
     protected AbstractProjectDiagramEditorCore<ProjectMetadata, ProjectDiagram, ProjectDiagramResource, ProjectDiagramEditorProxy<ProjectDiagramResource>> presenterCore;
 
+    @Mock
+    protected SaveAndRenameCommandBuilder saveAndRenameCommandBuilderMock;
+
     protected boolean isReadOnly = false;
 
     protected Promises promises = new SyncPromises();
@@ -381,6 +385,7 @@ public class AbstractProjectDiagramEditorTest {
                                                    errorPopupPresenter,
                                                    diagramClientErrorHandler,
                                                    translationService));
+                this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilderMock;
                 return presenterCore;
             }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-5664

*How it works*:

1. When the diagram is loaded (and the unmarshaller part already executed), this method gets called, in order to store the original diagram hash.
2. When closing the diagram session, this method checks if the session can be closed or not by comparing the original diagram hash, with the current one:
2.1. if they are different (the method super.mayClose(getCurrentDiagramHash()) returns false), the "unsaved changes" modal is displayed.

*Provided solution*:
Several operations may happen before the diagram is drawn (for example element wrapping, etc.), so it is recommended to compute and store che original diagram hash after the diagram gets loaded (inspired by [kie-wb-common-stunner-kogito-client](https://github.com/kiegroup/kie-wb-common/blob/5b73c1dda58ff2391aaee0de8c92321022ac7eb0/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditor.java#L312-L314))

*Recorded demo*:
![DROOLS-5664](https://user-images.githubusercontent.com/22591802/97461765-546c9100-193e-11eb-988a-e91fa8c4e301.gif)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
