### PR TITLE
Allow Secure Web Socket connections to standalone controllers

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerStandaloneControllerProducer.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerStandaloneControllerProducer.java
@@ -60,8 +60,8 @@ public class KieServerStandaloneControllerProducer {
     }
 
     protected static void validateProtocol(final String controllerURL){
-        if(controllerURL.startsWith("ws:") == false){
-            throw new RuntimeException("Invalid protocol for connecting with remote standalone controller, only Web Socket connections are supported");
+        if(controllerURL.startsWith("ws:") == false && controllerURL.startsWith("wss:") == false){
+            throw new RuntimeException("Invalid protocol for connecting with remote standalone controller, only Web Socket or Secure Web Socket connections are supported");
         }
     }
 

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/KieServerStandaloneControllerProducerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/KieServerStandaloneControllerProducerTest.java
@@ -29,12 +29,17 @@ public class KieServerStandaloneControllerProducerTest {
     }
 
     @Test
+    public void testSecureWebSocketProtocol() {
+        validateProtocol("wss://localhost:8443/controller");
+    }
+
+    @Test
     public void testUnsupportedProtocol() {
         try {
             validateProtocol("http://localhost:8080/controller");
             fail("Unsupported protocol should throw exception");
         } catch (Exception ex) {
-            assertEquals("Invalid protocol for connecting with remote standalone controller, only Web Socket connections are supported",
+            assertEquals("Invalid protocol for connecting with remote standalone controller, only Web Socket or Secure Web Socket connections are supported",
                          ex.getMessage());
         }
     }


### PR DESCRIPTION
This allows wss:// as well as ws:// connections

**Thank you for submitting this pull request**

**JIRA**: [JBPM-0000](https://issues.redhat.com/browse/JBPM-0000)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
