### PR TITLE
KOGITO-3696: DMN Editor regression failing display edge when xml missing DMNDI

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/included/DMNMarshallerImportsService.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/included/DMNMarshallerImportsService.java
@@ -57,7 +57,7 @@ public class DMNMarshallerImportsService {
         final DMN12UnmarshallCallback jsCallback = dmn12 -> {
             final JSITDefinitions dmnDefinitions = Js.uncheckedCast(JsUtils.getUnwrappedElement(dmn12));
             callback.onSuccess(modelToStunnerConverter
-                                       .makeNodes(dmnDefinitions, new HashMap<>(), (a, b) -> {/* Nothing. */})
+                                       .makeNodes(dmnDefinitions, new HashMap<>(), false, (a, b) -> {/* Nothing. */})
                                        .stream()
                                        .map(e -> getDRGElement(e.getNode()))
                                        .filter(Optional::isPresent)

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/DMNUnmarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/DMNUnmarshaller.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -143,11 +144,12 @@ public class DMNUnmarshaller {
                 hasComponentWidthsMap.put(uuid, hcw);
             }
         };
+        final boolean isDMNDIPresent = Optional.ofNullable(dmnDefinitions.getDMNDI()).isPresent(); // Check before the DRG creation ('ensureDRGElementExists').
 
         ensureDRGElementExists(dmnDefinitions);
 
         final Definitions wbDefinitions = DefinitionsConverter.wbFromDMN(dmnDefinitions, importDefinitions, pmmlDocuments);
-        final List<NodeEntry> nodeEntries = modelToStunnerConverter.makeNodes(dmnDefinitions, importDefinitions, hasComponentWidthsConsumer);
+        final List<NodeEntry> nodeEntries = modelToStunnerConverter.makeNodes(dmnDefinitions, importDefinitions, isDMNDIPresent, hasComponentWidthsConsumer);
         final List<JSITDecisionService> dmnDecisionServices = getDecisionServices(nodeEntries);
 
         //Ensure all locations are updated to relative for Stunner

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeEntriesFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeEntriesFactory.java
@@ -63,6 +63,7 @@ public class NodeEntriesFactory {
 
     public List<NodeEntry> makeNodes(final JSITDefinitions definitions,
                                      final Map<JSITImport, JSITDefinitions> importDefinitions,
+                                     final boolean isDMNDIPresent,
                                      final BiConsumer<String, HasComponentWidths> componentWidthsConsumer) {
 
         final List<JSIDMNDiagram> dmnDiagrams = definitions.getDMNDI().getDMNDiagram();
@@ -85,7 +86,7 @@ public class NodeEntriesFactory {
                     .filter(n -> Objects.equals(n.getDiagramId(), diagramId))
                     .collect(Collectors.toList());
 
-            nodeConnector.connect(dmnDiagram, edges, associations, nodes);
+            nodeConnector.connect(dmnDiagram, edges, associations, nodes, isDMNDIPresent);
         });
 
         return nodeEntries;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnectorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnectorTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.marshaller.unmarshall.nodes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.model.InformationRequirement;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDMNElement;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDMNElementReference;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNEdge;
+import org.kie.workbench.common.stunner.core.api.FactoryManager;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+import org.mockito.Mock;
+
+import static java.util.Collections.singletonList;
+import static org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils.getDefinitionId;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NodeConnectorTest {
+
+    @Mock
+    private FactoryManager factoryManager;
+
+    @Mock
+    private JSITDMNElement jsiDMNElement;
+
+    @Mock
+    private JSITDMNElementReference jsiDMNElementReference;
+
+    @Mock
+    private NodeEntry nodeEntry;
+
+    @Mock
+    private Node currentNode;
+
+    @Mock
+    private Node requiredNode;
+
+    @Mock
+    private JSITDMNElement nodeEntryElement;
+
+    private NodeConnector nodeConnector;
+
+    private String connectorTypeId = getDefinitionId(InformationRequirement.class);
+
+    private Map<String, List<NodeEntry>> entriesById = new HashMap<>();
+
+    private List<JSIDMNEdge> edges = new ArrayList<>();
+
+    private String diagramId = "diagramId";
+
+    private boolean isDMNDIPresent = false;
+
+    @Before
+    public void setup() {
+        nodeConnector = spy(new NodeConnector(factoryManager));
+    }
+
+    @Test
+    public void testConnectEdgeToNodesWhenDMNDIIsNotPresent() {
+
+        final JSIDMNEdge newEdge = mock(JSIDMNEdge.class);
+
+        when(jsiDMNElementReference.getHref()).thenReturn("#123");
+        when(jsiDMNElement.getId()).thenReturn("789");
+        when(nodeEntry.getDmnElement()).thenReturn(nodeEntryElement);
+        when(nodeEntry.getNode()).thenReturn(requiredNode);
+        when(nodeEntryElement.getId()).thenReturn("456");
+        doReturn(newEdge).when(nodeConnector).newEdge();
+        doNothing().when(nodeConnector).connectWbEdge(any(), any(), any(), any(), any(), any());
+
+        entriesById.put("123", singletonList(nodeEntry));
+        isDMNDIPresent = false;
+
+        nodeConnector.connectEdgeToNodes(connectorTypeId, jsiDMNElement, jsiDMNElementReference, entriesById, diagramId, edges, isDMNDIPresent, currentNode);
+
+        verify(nodeConnector).connectWbEdge(eq(connectorTypeId), eq(diagramId), eq(currentNode), eq(requiredNode), eq(newEdge), eq("456"));
+    }
+
+    @Test
+    public void testConnectEdgeToNodesWhenDMNDIIsPresent() {
+
+        final JSIDMNEdge existingEdge = mock(JSIDMNEdge.class);
+
+        when(jsiDMNElementReference.getHref()).thenReturn("#123");
+        when(jsiDMNElement.getId()).thenReturn("789");
+        when(existingEdge.getDmnElementRef()).thenReturn(new QName("", "789"));
+        doReturn(requiredNode).when(nodeConnector).getNode(eq(existingEdge), any());
+        doNothing().when(nodeConnector).connectWbEdge(any(), any(), any(), any(), any(), any());
+
+        entriesById.put("123", singletonList(nodeEntry));
+        edges.add(existingEdge);
+        isDMNDIPresent = true;
+
+        nodeConnector.connectEdgeToNodes(connectorTypeId, jsiDMNElement, jsiDMNElementReference, entriesById, diagramId, edges, isDMNDIPresent, currentNode);
+
+        verify(nodeConnector).connectWbEdge(eq(connectorTypeId), eq(diagramId), eq(currentNode), eq(requiredNode), eq(existingEdge), eq("789"));
+    }
+
+    @Test
+    public void testConnectEdgeToNodesWhenDMNDIIsPresentButExistingNodeIsNotPresent() {
+
+        when(jsiDMNElementReference.getHref()).thenReturn("#123");
+        when(jsiDMNElement.getId()).thenReturn("789");
+        doNothing().when(nodeConnector).connectWbEdge(any(), any(), any(), any(), any(), any());
+
+        entriesById.put("123", singletonList(nodeEntry));
+        isDMNDIPresent = true;
+
+        nodeConnector.connectEdgeToNodes(connectorTypeId, jsiDMNElement, jsiDMNElementReference, entriesById, diagramId, edges, isDMNDIPresent, currentNode);
+
+        verify(nodeConnector, never()).connectWbEdge(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testConnectEdgeToNodesWhenNodeEntriesIsEmpty() {
+
+        when(jsiDMNElementReference.getHref()).thenReturn("#456");
+        entriesById.put("123", singletonList(nodeEntry));
+
+        nodeConnector.connectEdgeToNodes(connectorTypeId, jsiDMNElement, jsiDMNElementReference, entriesById, diagramId, edges, isDMNDIPresent, currentNode);
+
+        verify(nodeConnector, never()).connectWbEdge(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testConnectWbEdge() {
+
+        final JSIDMNEdge edge = mock(JSIDMNEdge.class);
+        final Element element = mock(Element.class);
+        final String id = "123";
+        final Edge wbEdge = mock(Edge.class);
+        final ViewConnector viewConnector = mock(ViewConnector.class);
+
+        when(factoryManager.newElement("diagramId#123", connectorTypeId)).thenReturn(element);
+        when(element.asEdge()).thenReturn(wbEdge);
+        when(wbEdge.getContent()).thenReturn(viewConnector);
+        doNothing().when(nodeConnector).connectEdge(any(), any(), any());
+        doNothing().when(nodeConnector).setConnectionMagnets(any(), any(), any());
+
+        nodeConnector.connectWbEdge(connectorTypeId, diagramId, currentNode, requiredNode, edge, id);
+
+        verify(nodeConnector).connectEdge(wbEdge, requiredNode, currentNode);
+        verify(nodeConnector).setConnectionMagnets(wbEdge, viewConnector, edge);
+    }
+}

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -71,6 +70,7 @@ import org.xmlunit.diff.DifferenceEvaluators;
 import org.xmlunit.util.Predicate;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.workbench.common.dmn.api.definition.model.DMNModelInstrumentedBase.Namespace.DC;
@@ -1821,6 +1821,25 @@ public class DMNDesignerKogitoSeleniumIT {
     }
 
     @Test
+    public void testDMNModelWithoutDMNDI_KOGITO3696() throws Exception {
+        final String expected = loadResource("KOGITO-3696 (DMN model without DMNDI - expected).xml");
+        final String fixture = loadResource("KOGITO-3696 (DMN model without DMNDI - fixture).xml");
+        final List<String> ignoredAttributes = asList("id", "dmnElementRef");
+
+        setContent(fixture);
+
+        final String actual = getContent();
+        assertThat(actual).isNotBlank();
+
+        XmlAssert.assertThat(actual)
+                .and(expected)
+                .ignoreComments()
+                .ignoreWhitespace()
+                .withAttributeFilter(attr -> !ignoredAttributes.contains(attr.getName()))
+                .areIdentical();
+    }
+
+    @Test
     public void testDecisionTableInputClauseConstraints_KOGITO369() throws Exception {
         final String expected = loadResource("KOGITO-369 (Decision Table Input Clause constraints).xml");
         setContent(expected);
@@ -1961,7 +1980,7 @@ public class DMNDesignerKogitoSeleniumIT {
 
         final ListSeleniumModel listModel = new ListSeleniumModel();
         listModel.setName("Decision-1");
-        listModel.setItems(Arrays.asList("1", "2"));
+        listModel.setItems(asList("1", "2"));
         appendBoxedListExpressionItem(listModel, "3");
 
         final String actual = getContent();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-3696 (DMN model without DMNDI - expected).xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-3696 (DMN model without DMNDI - expected).xml
@@ -1,0 +1,81 @@
+<dmn:definitions xmlns:dmn='http://www.omg.org/spec/DMN/20180521/MODEL/' xmlns='https://kiegroup.org/dmn/_FD3D17D0-D23E-457E-B41A-380644F030A8' xmlns:dc='http://www.omg.org/spec/DMN/20180521/DC/' xmlns:di='http://www.omg.org/spec/DMN/20180521/DI/' xmlns:dmndi='http://www.omg.org/spec/DMN/20180521/DMNDI/' xmlns:kie='http://www.drools.org/kie/dmn/1.2' expressionLanguage='http://www.omg.org/spec/DMN/20180521/FEEL/' id='_0A66FB20-34AD-4ED7-A150-0B5C22E17AB9' name='Can Drink?' namespace='https://kiegroup.org/dmn/_FD3D17D0-D23E-457E-B41A-380644F030A8' typeLanguage='http://www.omg.org/spec/DMN/20180521/FEEL/'>
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id='_24A858CF-C26C-4EE0-9D94-F590FA558DCF' isCollection='false' name='tPerson'>
+    <dmn:itemComponent id='_78DAD12F-709D-4F52-B661-9A647273CC6E' isCollection='false' name='age'>
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id='_9E7EF613-318B-4E51-A001-271ABF375A6C' name='a person'>
+    <dmn:extensionElements/>
+    <dmn:variable id='_E9897BA9-470C-488D-AFB0-9E41924031FA' name='a person' typeRef='tPerson'/>
+  </dmn:inputData>
+  <dmn:decision id='_76551D85-48DF-40F8-8D99-C4996014887B' name='Can Drink?'>
+    <dmn:extensionElements/>
+    <dmn:variable id='_A0DBCF3D-D243-48F1-9790-A610897E2822' name='Can Drink?' typeRef='boolean'/>
+    <dmn:informationRequirement id='_9E7EF613-318B-4E51-A001-271ABF375A6C'>
+      <dmn:requiredInput href='#_9E7EF613-318B-4E51-A001-271ABF375A6C'/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable hitPolicy='UNIQUE' id='_E3375D4A-93AA-4580-B3DA-63FB0B794FAA' preferredOrientation='Rule-as-Row'>
+      <dmn:input id='_A8B0D99C-DEF3-44E3-82EB-225060911CE9'>
+        <dmn:inputExpression id='_3CC51A96-1DF2-4775-B513-3994EA23D896' typeRef='number'>
+          <dmn:text>a person.age</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id='_63883B3C-C562-4DAE-B908-85AF195567C3'/>
+      <dmn:annotation name='annotation-1'/>
+      <dmn:rule id='_F95E8AA4-0E89-4306-AC73-DC6222E1F742'>
+        <dmn:inputEntry id='_F69B3D6C-6D5B-441A-8AAC-37FBB4B7A7C2'>
+          <dmn:text>&gt;=18</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id='_ACA4D3AF-1BF1-47CF-8E04-F57CE08FB94D'>
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id='_3ED6B377-C8C9-4972-A6D3-FF3EF52532AB'>
+        <dmn:inputEntry id='_8CEDEFE8-C217-4EFD-ACD3-1B9048533E85'>
+          <dmn:text>&lt;18</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id='_C054EC48-4711-4C18-8B1C-131EA518B603'>
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text>underage for most EU</dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id='_151C19BB-FFE9-4950-A7D6-A672639CFC16' name='DRG'>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef='_E3375D4A-93AA-4580-B3DA-63FB0B794FAA'/>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape dmnElementRef='_9E7EF613-318B-4E51-A001-271ABF375A6C' id='dmnshape-drg-_9E7EF613-318B-4E51-A001-271ABF375A6C' isCollapsed='false'>
+        <dmndi:DMNStyle>
+          <dmndi:FillColor blue='255' green='255' red='255'/>
+          <dmndi:StrokeColor blue='0' green='0' red='0'/>
+          <dmndi:FontColor blue='0' green='0' red='0'/>
+        </dmndi:DMNStyle>
+        <dc:Bounds height='50' width='100' x='50' y='225'/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef='_76551D85-48DF-40F8-8D99-C4996014887B' id='dmnshape-drg-_76551D85-48DF-40F8-8D99-C4996014887B' isCollapsed='false'>
+        <dmndi:DMNStyle>
+          <dmndi:FillColor blue='255' green='255' red='255'/>
+          <dmndi:StrokeColor blue='0' green='0' red='0'/>
+          <dmndi:FontColor blue='0' green='0' red='0'/>
+        </dmndi:DMNStyle>
+        <dc:Bounds height='50' width='100' x='50' y='50'/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge dmnElementRef='_9E7EF613-318B-4E51-A001-271ABF375A6C' id='dmnedge-drg-_9E7EF613-318B-4E51-A001-271ABF375A6C'>
+        <di:waypoint x='50' y='225'/>
+        <di:waypoint x='50' y='50'/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-3696 (DMN model without DMNDI - fixture).xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-3696 (DMN model without DMNDI - fixture).xml
@@ -1,0 +1,50 @@
+<dmn:definitions xmlns:dmn='http://www.omg.org/spec/DMN/20180521/MODEL/' xmlns='https://kiegroup.org/dmn/_FD3D17D0-D23E-457E-B41A-380644F030A8' id='_0A66FB20-34AD-4ED7-A150-0B5C22E17AB9' name='Can Drink?' expressionLanguage='http://www.omg.org/spec/DMN/20180521/FEEL/' typeLanguage='http://www.omg.org/spec/DMN/20180521/FEEL/' namespace='https://kiegroup.org/dmn/_FD3D17D0-D23E-457E-B41A-380644F030A8'>
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id='_24A858CF-C26C-4EE0-9D94-F590FA558DCF' name='tPerson' isCollection='false'>
+    <dmn:itemComponent id='_78DAD12F-709D-4F52-B661-9A647273CC6E' name='age' isCollection='false'>
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id='_9E7EF613-318B-4E51-A001-271ABF375A6C' name='a person'>
+    <dmn:extensionElements/>
+    <dmn:variable id='_E9897BA9-470C-488D-AFB0-9E41924031FA' name='a person' typeRef='tPerson'/>
+  </dmn:inputData>
+  <dmn:decision id='_76551D85-48DF-40F8-8D99-C4996014887B' name='Can Drink?'>
+    <dmn:extensionElements/>
+    <dmn:variable id='_A0DBCF3D-D243-48F1-9790-A610897E2822' name='Can Drink?' typeRef='boolean'/>
+    <dmn:informationRequirement id='_19C24205-6E8B-45BE-811B-867A993339C0'>
+      <dmn:requiredInput href='#_9E7EF613-318B-4E51-A001-271ABF375A6C'/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id='_E3375D4A-93AA-4580-B3DA-63FB0B794FAA' hitPolicy='UNIQUE' preferredOrientation='Rule-as-Row'>
+      <dmn:input id='_A8B0D99C-DEF3-44E3-82EB-225060911CE9'>
+        <dmn:inputExpression id='_3CC51A96-1DF2-4775-B513-3994EA23D896' typeRef='number'>
+          <dmn:text>a person.age</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id='_63883B3C-C562-4DAE-B908-85AF195567C3'/>
+      <dmn:annotation name='annotation-1'/>
+      <dmn:rule id='_F95E8AA4-0E89-4306-AC73-DC6222E1F742'>
+        <dmn:inputEntry id='_F69B3D6C-6D5B-441A-8AAC-37FBB4B7A7C2'>
+          <dmn:text>&gt;=18</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id='_ACA4D3AF-1BF1-47CF-8E04-F57CE08FB94D'>
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id='_3ED6B377-C8C9-4972-A6D3-FF3EF52532AB'>
+        <dmn:inputEntry id='_8CEDEFE8-C217-4EFD-ACD3-1B9048533E85'>
+          <dmn:text>&lt;18</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id='_C054EC48-4711-4C18-8B1C-131EA518B603'>
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text>underage for most EU</dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+</dmn:definitions>


### PR DESCRIPTION
**JIRA**: [KOGITO-3696](https://issues.redhat.com/browse/KOGITO-3696): DMN Editor regression failing display edge when xml missing DMNDI

**VS Code**: [plugin](https://www.dropbox.com/s/x1vsvyzlommqd3d/plugin-KOGITO-3696.vsix?dl=0)

**Asset to test the PR**: [canDrink.dmn](https://issues.redhat.com/secure/attachment/12500383/canDrink.dmn)

<img width="1847" alt="Screen Shot 2020-11-06 at 01 39 37" src="https://user-images.githubusercontent.com/1079279/98326933-2982dc80-1fd1-11eb-8241-71b2577174ac.png">

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
