### PR TITLE
[7.44.x] RHPAM-3244 - Stunner - Users and Groups reversed in resulted file for Reassignment property

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/reassignment/ReassignmentValue.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/reassignment/ReassignmentValue.java
@@ -45,8 +45,8 @@ public class ReassignmentValue {
 
     public ReassignmentValue(@MapsTo("type") String type,
                              @MapsTo("duration") String duration,
-                             @MapsTo("users") List<String> groups,
-                             @MapsTo("groups") List<String> users) {
+                             @MapsTo("users") List<String> users,
+                             @MapsTo("groups") List<String> groups) {
         this.type = type;
         this.duration = duration;
         this.groups = groups;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ReassignmentValueTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/definition/property/task/ReassignmentValueTest.java
@@ -41,12 +41,12 @@ public class ReassignmentValueTest {
 
                 .addTrueCase(new ReassignmentValue("AAA",
                                                    "1h",
-                                                   Arrays.asList(new String[]{"foo", "bar", "baz"}),
-                                                   Collections.EMPTY_LIST),
+                                                   Collections.EMPTY_LIST,
+                                                   Arrays.asList(new String[]{"foo", "bar", "baz"})),
                              new ReassignmentValue("AAA",
                                                    "1h",
-                                                   Arrays.asList(new String[]{"foo", "bar", "baz"}),
-                                                   Collections.EMPTY_LIST))
+                                                   Collections.EMPTY_LIST,
+                                                   Arrays.asList(new String[]{"foo", "bar", "baz"})))
                 .addTrueCase(new ReassignmentValue("AAA",
                                                    "1h",
                                                    Arrays.asList(new String[]{"foo", "bar", "baz"}),
@@ -67,12 +67,12 @@ public class ReassignmentValueTest {
 
                 .addFalseCase(new ReassignmentValue("AAA",
                                                     "1h",
-                                                    Arrays.asList(new String[]{"foo1", "bar", "baz"}),
-                                                    Collections.EMPTY_LIST),
+                                                    Collections.EMPTY_LIST,
+                                                    Arrays.asList(new String[]{"foo1", "bar", "baz"})),
                               new ReassignmentValue("AAA",
                                                     "1h",
-                                                    Arrays.asList(new String[]{"foo", "bar", "baz"}),
-                                                    Collections.EMPTY_LIST))
+                                                    Collections.EMPTY_LIST,
+                                                    Arrays.asList(new String[]{"foo", "bar", "baz"})))
                 .addFalseCase(new ReassignmentValue("AAA",
                                                     "1h",
                                                     Arrays.asList(new String[]{"foo", "bar", "baz"}),


### PR DESCRIPTION
Hi @romartin, @LuboTerifaj, @domhanak this is cherry-pick of https://github.com/kiegroup/kie-wb-common/commit/e032b472a404245dd149aaf6e205431dd56fb6ed I compiled it locally with 7.44.x and it works good. I didn't attach VS Code plugin, since if I correct there will be no Kogito releases from this branch. Thank you!

**JIRA**: [RHPAM-3244](https://issues.redhat.com/browse/RHPAM-3244)

**Business Central**: [business-central-7.44.1-SNAPSHOT-wildfly19-RHPAM-3244.war](https://drive.google.com/file/d/1GrIEGSIvC5xhF3KkTUG2YDNfa6hIlEFN/view?usp=sharing)

**VS Code**: not applicable

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
