### PR TITLE
[KOGITO-2515] DMN Editor decision service wrong layout

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeEntriesFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeEntriesFactory.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.client.marshaller.unmarshall.nodes;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.di.JSIDiag
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITArtifact;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITAssociation;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDRGElement;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDecisionService;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDefinitions;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITImport;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITTextAnnotation;
@@ -75,6 +77,18 @@ public class NodeEntriesFactory {
                 .withDMNDiagrams(dmnDiagrams)
                 .withComponentWidthsConsumer(componentWidthsConsumer)
                 .buildEntries();
+
+        // We need to put all the Decision Services at the begin of the list otherwise the nodes inside
+        // those Decision Services will not be correctly positioned since its parents (the Decision Services nodes)
+        // needs to be positioned first.
+        nodeEntries.sort((n1, n2) -> {
+            if (JSITDecisionService.instanceOf(n1.getDmnElement())) {
+                return -1;
+            } else if (JSITDecisionService.instanceOf(n2.getDmnElement())){
+                return 1;
+            }
+            return 0;
+        });
 
         forEach(dmnDiagrams, dmnDiagram -> {
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeEntriesFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeEntriesFactory.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.dmn.client.marshaller.unmarshall.nodes;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/java/org/kie/workbench/common/dmn/showcase/client/selenium/DMNDesignerKogitoSeleniumIT.java
@@ -1746,6 +1746,25 @@ public class DMNDesignerKogitoSeleniumIT extends DMNDesignerBaseIT {
     }
 
     @Test
+    public void testDecisionServiceWrongLayout_KOGITO2515() throws Exception {
+        final String expected = loadResource("KOGITO-2515 (DMN model with decision services - expected).xml");
+        final String fixture = loadResource("KOGITO-2515 (DMN model with decision services - fixture).xml");
+        final List<String> ignoredAttributes = asList("id", "dmnElementRef", "href");
+
+        setContent(fixture);
+
+        final String actual = getContent();
+        assertThat(actual).isNotBlank();
+
+        XmlAssert.assertThat(actual)
+                .and(expected)
+                .ignoreComments()
+                .ignoreWhitespace()
+                .withAttributeFilter(attr -> !ignoredAttributes.contains(attr.getName()))
+                .areIdentical();
+    }
+
+    @Test
     public void testDecisionTableInputClauseConstraints_KOGITO369() throws Exception {
         final String expected = loadResource("KOGITO-369 (Decision Table Input Clause constraints).xml");
         setContent(expected);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
@@ -21,6 +21,18 @@
       <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
+  <dmn:decisionService id="_decisionService_001" name="decisionService_001">
+    <dmn:extensionElements/>
+    <dmn:variable id="_3C2B65CF-F807-40ED-8952-D89CD769D8F0" name="decisionService_001" typeRef="tDS_001"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_002" name="decisionService_002">
+    <dmn:extensionElements/>
+    <dmn:variable id="_6EAF53F3-A539-477E-BB50-C6456C65E6E4" name="decisionService_002"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_003" name="decisionService_003">
+    <dmn:extensionElements/>
+    <dmn:variable id="_EFC64899-F221-44FA-AD9B-003418F7CFBE" name="decisionService_003"/>
+  </dmn:decisionService>
   <dmn:decision id="_decision_001" name="decision_001">
     <dmn:extensionElements/>
     <dmn:variable id="_172E661A-12E4-41AF-97A4-8F1415B92A19" name="decision_001" typeRef="string"/>
@@ -387,11 +399,7 @@
     <dmn:literalExpression id="_D1D422F5-F236-4FD2-A1C0-047DED9643FE" typeRef="number">
       <dmn:text>["foo"]</dmn:text>
     </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_001" name="decisionService_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_3C2B65CF-F807-40ED-8952-D89CD769D8F0" name="decisionService_001" typeRef="tDS_001"/>
-  </dmn:decisionService>
+  </dmn:decision>  
   <dmn:decision id="_decision_ds_001" name="decision_ds_001">
     <dmn:extensionElements/>
     <dmn:variable id="_1ED16D17-7733-4ADC-AEBD-53BDF9826681" name="decision_ds_001"/>
@@ -399,10 +407,6 @@
       <dmn:text>1000</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
-  <dmn:decisionService id="_decisionService_002" name="decisionService_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_6EAF53F3-A539-477E-BB50-C6456C65E6E4" name="decisionService_002"/>
-  </dmn:decisionService>
   <dmn:decision id="_decision_ds_002" name="decision_ds_002">
     <dmn:extensionElements/>
     <dmn:variable id="_A6D19DB9-2A96-47C1-8236-923E1C6D750A" name="decision_ds_002"/>
@@ -436,11 +440,7 @@
     <dmn:literalExpression id="_F99FC66D-8732-47D8-B935-DD97E5D7D373">
       <dmn:text>decisionService_002(["foo"])</dmn:text>
     </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_003" name="decisionService_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_EFC64899-F221-44FA-AD9B-003418F7CFBE" name="decisionService_003"/>
-  </dmn:decisionService>
+  </dmn:decision>  
   <dmn:decision id="_decision_ds_003" name="decision_ds_003">
     <dmn:extensionElements/>
     <dmn:variable id="_E9DCBB86-FFD6-4B31-8348-FCD868077BB4" name="decision_ds_003"/>
@@ -532,464 +532,464 @@
           <kie:ComponentWidths dmnElementRef="_4F8CF5E0-9664-48AA-B136-5FA70D8D7C4C"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="225" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_004" dmnElementRef="_decision_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_005" dmnElementRef="_decision_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1100" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006" dmnElementRef="_decision_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2150" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_a" dmnElementRef="_decision_006_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2325" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007" dmnElementRef="_decision_007" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2500" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_a" dmnElementRef="_decision_007_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008" dmnElementRef="_decision_008" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_001" dmnElementRef="_bkm_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_001" dmnElementRef="_decision_bkm_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="750" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_002" dmnElementRef="_decision_bkm_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="925" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_002" dmnElementRef="_bkm_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_003" dmnElementRef="_decision_bkm_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="575" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_004" dmnElementRef="_bkm_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_005" dmnElementRef="_bkm_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004" dmnElementRef="_decision_bkm_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1625" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_a" dmnElementRef="_decision_bkm_004_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1800" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_b" dmnElementRef="_decision_bkm_004_b" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1975" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005" dmnElementRef="_decision_bkm_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005_a" dmnElementRef="_decision_bkm_005_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_001" dmnElementRef="_invoke_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1275" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_002" dmnElementRef="_invoke_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1450" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_003" dmnElementRef="_invoke_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_004" dmnElementRef="_invoke_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_005" dmnElementRef="_invoke_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_006" dmnElementRef="_invoke_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_fd_001" dmnElementRef="_fd_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4950" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_fd_002" dmnElementRef="_fd_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5125" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_001" dmnElementRef="_literal_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5300" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_002" dmnElementRef="_literal_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5475" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_003" dmnElementRef="_literal_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5650" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_004" dmnElementRef="_literal_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5825" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_005" dmnElementRef="_literal_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6000" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_006" dmnElementRef="_literal_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6175" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6350" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="6350" y="150"/>
-          <di:waypoint x="6450" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_001" dmnElementRef="_decision_ds_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6525" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3375" y="325"/>
-          <di:waypoint x="3475" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_002" dmnElementRef="_decision_ds_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4250" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_number" dmnElementRef="_ds_invoke_002_with_number" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4075" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_singleton_list" dmnElementRef="_ds_invoke_002_with_singleton_list" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4425" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3725" y="325"/>
-          <di:waypoint x="3825" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_003" dmnElementRef="_decision_ds_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4775" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_003_with_string" dmnElementRef="_ds_invoke_003_with_string" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4600" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_bkm_001" dmnElementRef="_bkm_001">
-        <di:waypoint x="2850" y="225"/>
-        <di:waypoint x="750" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_bkm_002" dmnElementRef="_bkm_002">
-        <di:waypoint x="2675" y="225"/>
-        <di:waypoint x="575" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_bkm_004" dmnElementRef="_bkm_004">
-        <di:waypoint x="3025" y="225"/>
-        <di:waypoint x="1625" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_bkm_005" dmnElementRef="_bkm_005">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="2850" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1">
-        <di:waypoint x="3550" y="225"/>
-        <di:waypoint x="4250" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_002" dmnElementRef="_decisionService_002">
-        <di:waypoint x="3375" y="225"/>
-        <di:waypoint x="4075" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1">
-        <di:waypoint x="3900" y="225"/>
-        <di:waypoint x="4775" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_003" dmnElementRef="_decisionService_003">
-        <di:waypoint x="3725" y="225"/>
-        <di:waypoint x="4600" y="50"/>
-      </dmndi:DMNEdge>
+       <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="50" y="150" />
+               <di:waypoint x="150" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3375" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3375" y="325" />
+               <di:waypoint x="3475" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3550" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3550" y="325" />
+               <di:waypoint x="3650" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_004" dmnElementRef="_decision_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="575" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_005" dmnElementRef="_decision_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1100" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006" dmnElementRef="_decision_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1625" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_a" dmnElementRef="_decision_006_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2500" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007" dmnElementRef="_decision_007" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2675" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_a" dmnElementRef="_decision_007_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2850" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008" dmnElementRef="_decision_008" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3550" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_001" dmnElementRef="_bkm_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2850" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_001" dmnElementRef="_decision_bkm_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="925" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_002" dmnElementRef="_decision_bkm_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1275" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_002" dmnElementRef="_bkm_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2675" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_003" dmnElementRef="_decision_bkm_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="750" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_004" dmnElementRef="_bkm_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3025" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_005" dmnElementRef="_bkm_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3200" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004" dmnElementRef="_decision_bkm_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1450" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_a" dmnElementRef="_decision_bkm_004_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1800" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_b" dmnElementRef="_decision_bkm_004_b" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2150" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005" dmnElementRef="_decision_bkm_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3025" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005_a" dmnElementRef="_decision_bkm_005_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3200" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_001" dmnElementRef="_invoke_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1975" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_002" dmnElementRef="_invoke_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2325" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_003" dmnElementRef="_invoke_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3375" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_004" dmnElementRef="_invoke_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3725" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_005" dmnElementRef="_invoke_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3900" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_006" dmnElementRef="_invoke_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4075" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_fd_001" dmnElementRef="_fd_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5125" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_fd_002" dmnElementRef="_fd_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5300" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_001" dmnElementRef="_literal_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5475" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_002" dmnElementRef="_literal_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5650" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_003" dmnElementRef="_literal_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5825" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_004" dmnElementRef="_literal_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="6000" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_005" dmnElementRef="_literal_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="6175" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_006" dmnElementRef="_literal_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="6350" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_001" dmnElementRef="_decision_ds_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="6525" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_002" dmnElementRef="_decision_ds_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4775" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3725" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_number" dmnElementRef="_ds_invoke_002_with_number" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4250" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_singleton_list" dmnElementRef="_ds_invoke_002_with_singleton_list" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4425" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_003" dmnElementRef="_decision_ds_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4950" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3900" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_003_with_string" dmnElementRef="_ds_invoke_003_with_string" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4600" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drg-_bkm_001" dmnElementRef="_bkm_001">
+            <di:waypoint x="2850" y="225" />
+            <di:waypoint x="925" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_bkm_002" dmnElementRef="_bkm_002">
+            <di:waypoint x="2675" y="225" />
+            <di:waypoint x="750" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_bkm_004" dmnElementRef="_bkm_004">
+            <di:waypoint x="3025" y="225" />
+            <di:waypoint x="1450" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_bkm_005" dmnElementRef="_bkm_005">
+            <di:waypoint x="3200" y="225" />
+            <di:waypoint x="3025" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1">
+            <di:waypoint x="3725" y="225" />
+            <di:waypoint x="4775" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_002" dmnElementRef="_decisionService_002">
+            <di:waypoint x="3375" y="225" />
+            <di:waypoint x="4250" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1">
+            <di:waypoint x="3900" y="225" />
+            <di:waypoint x="4950" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_003" dmnElementRef="_decisionService_003">
+            <di:waypoint x="3550" y="225" />
+            <di:waypoint x="4600" y="50" />
+         </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>
 </dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
@@ -1,1281 +1,1281 @@
-<?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0085-decision-services" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_i9fboPUUEeesLuP4RHs4vA" name="0085-decision-services" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0085-decision-services">
-  <dmn:description>Decision Services</dmn:description>
-  <dmn:extensionElements/>
-  <dmn:decisionService id="_decisionService_001" name="decisionService_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_33CCF06D-6E09-4B9D-9B1A-6C1BB5808C7E" name="decisionService_001"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_001" name="decision_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_36072697-CD94-4DEA-85FB-F2EFD8BC02B1" name="decision_001"/>
-    <dmn:literalExpression id="_11A5E320-866A-4504-BF2F-99F92D030386">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_002" name="decisionService_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_EF2FB74D-4C06-443B-95D4-3513B49BC261" name="decisionService_002"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_002" name="decision_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E7B9F799-2C55-4457-BD4B-816DE3B857BD" name="decision_002"/>
-    <dmn:informationRequirement id="_decision_002_input">
-      <dmn:requiredDecision href="#_decision_002_input"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_6849867A-2FFE-4A79-8A42-0F25CD52735B">
-      <dmn:text>"foo " + decision_002_input</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_002_input" name="decision_002_input">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D6776FC8-9218-4894-8997-B1B3A7158E46" name="decision_002_input"/>
-    <dmn:literalExpression id="_2DECD99B-AD40-4080-830C-5D63AB1286BD">
-      <dmn:text>"bar"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_003" name="decisionService_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D0D37AAE-7A26-434D-9C3A-F756C054532B" name="decisionService_003"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_003" name="decision_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0A59DB00-5655-4008-88F5-F9485A68A925" name="decision_003"/>
-    <dmn:informationRequirement id="_decision_003_input_1">
-      <dmn:requiredDecision href="#_decision_003_input_1"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_decision_003_input_2">
-      <dmn:requiredDecision href="#_decision_003_input_2"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_003">
-      <dmn:requiredInput href="#_inputData_003"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_BB0DA338-9C58-4D4F-ACB7-07DC70506C0E">
-      <dmn:text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_003_input_1" name="decision_003_input_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_777D4C7D-663D-4092-A62F-6F28D05DA862" name="decision_003_input_1"/>
-    <dmn:literalExpression id="_1B1E76D0-05CD-4896-B447-F929DB618FCE">
-      <dmn:text>"d3_1"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_003_input_2" name="decision_003_input_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_27F7CD99-D648-4A65-8D80-939D5CD856DC" name="decision_003_input_2"/>
-    <dmn:literalExpression id="_C33A68AF-2302-4BB5-9AC5-8D3CAB99B1F7">
-      <dmn:text>"d3_2"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_003" name="inputData_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D83CFEC8-373B-46B7-BD13-96F70CA96116" name="inputData_003" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decisionService id="_decisionService_004" name="decisionService_004">
-    <dmn:extensionElements/>
-    <dmn:variable id="_16AEC727-E130-46F7-915B-88C6AEA7631C" name="decisionService_004"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_004_1" name="decision_004_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0FD52969-5A66-41D2-AAFE-1633C588F545" name="decision_004_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_004">
-      <dmn:requiredKnowledge href="#_decisionService_004"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_B360E630-FB08-4CC5-ADDB-C3C6B687BB90">
-      <dmn:text>decisionService_004()</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_004_2" name="decision_004_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D22DF8C7-6DE4-4698-91EB-416AFFA72A4E" name="decision_004_2"/>
-    <dmn:literalExpression id="_F6F6F43A-684B-4083-B1B4-C6A5CBD318B1">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_005" name="decisionService_005">
-    <dmn:extensionElements/>
-    <dmn:variable id="_BC1CE992-4321-483C-8842-D36CA9F38251" name="decisionService_005"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_005_1" name="decision_005_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D7702BC3-B7A0-4675-9C08-0949545A34B2" name="decision_005_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_005">
-      <dmn:requiredKnowledge href="#_decisionService_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_CFBD83E0-2173-4C2A-9EAF-216D768AC37A">
-      <dmn:text>decisionService_005("bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_005_2" name="decision_005_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5C1F11B9-1B4D-424B-BCE3-DD49EB1B96D6" name="decision_005_2" typeRef="string"/>
-    <dmn:literalExpression id="_92B1EAF7-B848-4A1B-B127-443FEB6EBE56">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_006" name="decisionService_006">
-    <dmn:extensionElements/>
-    <dmn:variable id="_967324AA-F314-4447-B2BA-59A7AC1C36E0" name="decisionService_006"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_006_1" name="decision_006_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2B9F8BD9-2D5F-47FD-9C91-D67E3B960BD6" name="decision_006_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_006">
-      <dmn:requiredKnowledge href="#_decisionService_006"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_D3183AD6-B169-4539-8FBC-08F97D9AF2E3">
-      <dmn:text>decisionService_006("bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_006_2" name="decision_006_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0B51645B-7F06-4091-AF15-681DBAA48869" name="decision_006_2"/>
-    <dmn:informationRequirement id="_decision_006_3">
-      <dmn:requiredDecision href="#_decision_006_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_BC002074-D71A-4B6C-A7BA-18E571BCE61A">
-      <dmn:text>"foo " + decision_006_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_006_3" name="decision_006_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_ED21BEBD-3FCB-4E21-B889-1DF98B8C660C" name="decision_006_3" typeRef="string"/>
-    <dmn:literalExpression id="_44B1886F-A166-4A8A-8132-BFE9E9415116">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_007" name="decisionService_007">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D59490ED-9C84-41E5-AD05-AE808FCD7B26" name="decisionService_007"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_007_1" name="decision_007_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_089206C6-AEFD-4D9E-87FA-ED44D47D2B96" name="decision_007_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_007">
-      <dmn:requiredKnowledge href="#_decisionService_007"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_3AE163CE-D1FE-4DA0-8B31-7598A83C5E11">
-      <dmn:text>decisionService_007(123)</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_007_2" name="decision_007_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_F5118D0E-A584-4E92-ABD9-AAC8878A9B29" name="decision_007_2"/>
-    <dmn:informationRequirement id="_decision_007_3">
-      <dmn:requiredDecision href="#_decision_007_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_E8887435-7FD0-48C3-8917-C0D4D626411E">
-      <dmn:text>decision_007_3 = null</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_007_3" name="decision_007_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_94294D78-68B8-4744-BBAF-F243C6F27D64" name="decision_007_3" typeRef="string"/>
-    <dmn:literalExpression id="_0B79D368-03D5-4F1D-8EC8-76EFD1B1460A">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_008" name="decisionService_008">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7A4476D9-EFB4-4C58-B67B-E87AB20224E9" name="decisionService_008"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_008_1" name="decision_008_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_47824DAF-745E-4B99-948B-CE4DE5716A58" name="decision_008_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_008">
-      <dmn:requiredKnowledge href="#_decisionService_008"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_FA0843D8-78D4-42A9-BB9F-2C6E56CB2EF3">
-      <dmn:text>decisionService_008()</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_008_2" name="decision_008_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_824F80B9-5F95-4A2E-ADF1-5E48D256EFD4" name="decision_008_2"/>
-    <dmn:informationRequirement id="_decision_008_3">
-      <dmn:requiredDecision href="#_decision_008_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_EB7DE52E-7910-4E88-BC89-B508EA908FBC">
-      <dmn:text>decision_008_3 = null</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_008_3" name="decision_008_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7B1E7DDD-2472-4BB1-9EDF-76C24B5DA0EA" name="decision_008_3" typeRef="string"/>
-    <dmn:literalExpression id="_1C7E5C19-B8E6-42E7-825A-2C7A030EC428">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_009" name="decisionService_009">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5830C51F-00D6-40A0-95F3-6BAFC7477FED" name="decisionService_009"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_009_1" name="decision_009_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_1482A79E-04DF-4C04-A061-40FE36BF66FD" name="decision_009_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_009">
-      <dmn:requiredKnowledge href="#_decisionService_009"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_A19C8E53-51A8-4675-A48F-2ED4519AECA1">
-      <dmn:text>decisionService_009(decision_009_3: "bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_009_2" name="decision_009_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_C0C7E0E9-F3AD-4320-87AF-B421C549BEB6" name="decision_009_2"/>
-    <dmn:informationRequirement id="_decision_009_3">
-      <dmn:requiredDecision href="#_decision_009_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_6FFF30E1-5BE6-47C5-971E-31E3DEA3E27E">
-      <dmn:text>"foo " + decision_009_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_009_3" name="decision_009_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D75D5048-2076-427A-AF53-98948DEB85DA" name="decision_009_3" typeRef="string"/>
-    <dmn:literalExpression id="_2A9E91EC-6626-421A-8F3E-6A83C729D474">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_010" name="decisionService_010">
-    <dmn:extensionElements/>
-    <dmn:variable id="_830E5E1C-691A-47AB-AF5C-9F70B7F66721" name="decisionService_010"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_010_1" name="decision_010_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_95E40618-386D-4F2B-91E2-D0904DAE4DF7" name="decision_010_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_010">
-      <dmn:requiredKnowledge href="#_decisionService_010"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_6719F1B4-E39E-48D5-8C6C-DE0F122C9A35">
-      <dmn:text>decisionService_010(foo: "bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_010_2" name="decision_010_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_C85AAD56-5367-4D5A-AEDA-FBB0187B9451" name="decision_010_2"/>
-    <dmn:informationRequirement id="_decision_010_3">
-      <dmn:requiredDecision href="#_decision_010_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_791DC98B-07D1-4A53-92AE-D153D8CA70C4">
-      <dmn:text>"foo " + decision_010_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_010_3" name="decision_010_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E3FD610B-3B4B-4DEA-85F9-E9690C2E1C45" name="decision_010_3" typeRef="string"/>
-    <dmn:literalExpression id="_CFB07093-62BD-4750-8DAD-F593E84D688A">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decisionService id="_decisionService_011" name="decisionService_011">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A81810A6-081D-46CB-8CC1-D9610158ED13" name="decisionService_011"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_011_1" name="decision_011_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5CC8B0D6-E392-46D5-9F89-AA688A0682ED" name="decision_011_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_011">
-      <dmn:requiredKnowledge href="#_decisionService_011"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_D60F5EC8-2D96-4D32-837E-34FC9EEF2376">
-      <dmn:text>decisionService_011("A", "B", "C", "D")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_011_2" name="decision_011_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7F158EE2-B5C5-4230-8059-05E645CE0C75" name="decision_011_2" typeRef="string"/>
-    <dmn:informationRequirement id="_decision_011_3">
-      <dmn:requiredDecision href="#_decision_011_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_decision_011_4">
-      <dmn:requiredDecision href="#_decision_011_4"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_011_1">
-      <dmn:requiredInput href="#_inputData_011_1"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_011_2">
-      <dmn:requiredInput href="#_inputData_011_2"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_68CAA703-DF6B-4253-9C89-BE7E42E15444">
-      <dmn:text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_011_3" name="decision_011_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_8FA7E758-CAA2-4474-8DC5-E373968282C5" name="decision_011_3" typeRef="string"/>
-    <dmn:literalExpression id="_DE31E813-8CBB-44D8-ADBE-55099B642320">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_011_4" name="decision_011_4">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0C223E58-6D93-418E-A3B9-E3356694E912" name="decision_011_4" typeRef="string"/>
-    <dmn:literalExpression id="_3202DE56-C431-4A81-93D4-F532C72565B3">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_011_1" name="inputData_011_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2093EADB-0EF2-4E53-BB43-E45ACF5E2C1E" name="inputData_011_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:inputData id="_inputData_011_2" name="inputData_011_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D3F3FD65-C84E-46A0-A667-0571D1EF0A4B" name="inputData_011_2" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decisionService id="_decisionService_012" name="decisionService_012">
-    <dmn:extensionElements/>
-    <dmn:variable id="_05D31EF4-362B-42B9-AAFB-325ADDB4D5B8" name="decisionService_012"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_012_1" name="decision_012_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_F6B10D7D-6A3D-458B-AF09-E4987851FC59" name="decision_012_1"/>
-    <dmn:knowledgeRequirement id="_decisionService_012">
-      <dmn:requiredKnowledge href="#_decisionService_012"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_8CEB871C-55D1-4986-B837-0DBC6D3A5315">
-      <dmn:text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_012_2" name="decision_012_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9E5E5B10-1D7C-4C4A-A72A-6E799EA10B31" name="decision_012_2" typeRef="string"/>
-    <dmn:informationRequirement id="_decision_012_3">
-      <dmn:requiredDecision href="#_decision_012_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_decision_012_4">
-      <dmn:requiredDecision href="#_decision_012_4"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_012_1">
-      <dmn:requiredInput href="#_inputData_012_1"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_012_2">
-      <dmn:requiredInput href="#_inputData_012_2"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_8E2BA3CF-48C7-4F76-9F03-71CFF78CD153">
-      <dmn:text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_012_3" name="decision_012_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_021DD1B7-1500-4194-BDAA-D290CB7B8B85" name="decision_012_3" typeRef="string"/>
-    <dmn:literalExpression id="_589DE15F-36A2-42E9-934C-B87CFD257379">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_012_4" name="decision_012_4">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0C9F3382-EA97-4FD7-B1B9-3D0E7F705350" name="decision_012_4" typeRef="string"/>
-    <dmn:literalExpression id="_DC086668-F9EC-4146-A9D5-C7DC25B06FD6">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_012_1" name="inputData_012_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_76D6F854-14E0-472E-8DFC-311CC43D8722" name="inputData_012_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:inputData id="_inputData_012_2" name="inputData_012_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E22B97B8-98CE-4892-9EDB-7C5226E8DBB2" name="inputData_012_2" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decisionService id="_decisionService_013" name="decisionService_013">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9937AFF5-1B1F-47F3-89A5-A762912C29D4" name="decisionService_013"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_013_1" name="decision_013_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E55DD342-5AA5-49F6-AB3F-7D6A98D540B7" name="decision_013_1"/>
-    <dmn:informationRequirement id="_decision_013_3">
-      <dmn:requiredDecision href="#_decision_013_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_013_1">
-      <dmn:requiredInput href="#_inputData_013_1"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_decisionService_013">
-      <dmn:requiredKnowledge href="#_decisionService_013"/>
-    </dmn:knowledgeRequirement>
-    <dmn:context id="_839C54F0-225D-42C7-84E5-A47E1152CEA2">
-      <dmn:contextEntry>
-        <dmn:variable id="_6CF89EB5-BFBA-4517-AECF-19AB8932D7F5" name="decisionService_013"/>
-        <dmn:literalExpression id="_3205055D-D1F0-41CF-930B-443C5CBA2B29">
-          <dmn:text>decisionService_013("A", "B")</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_DF147A6E-4479-435F-A7BC-297457F6AA84" name="inputData_013_1"/>
-        <dmn:literalExpression id="_141A7BCA-032C-41A0-80A7-994595FA3D7B">
-          <dmn:text>inputData_013_1</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_1CC6B372-B6ED-4A4F-981E-B96F775B588D" name="decision_013_3"/>
-        <dmn:literalExpression id="_4F280D00-47AA-4AA3-AF61-94554CE5838E">
-          <dmn:text>decision_013_3</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-    </dmn:context>
-  </dmn:decision>
-  <dmn:decision id="_decision_013_2" name="decision_013_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_954870E4-D2C4-41FC-8A12-F516A03B7312" name="decision_013_2" typeRef="string"/>
-    <dmn:informationRequirement id="_decision_013_3">
-      <dmn:requiredDecision href="#_decision_013_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_013_1">
-      <dmn:requiredInput href="#_inputData_013_1"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_1AD8CC68-C6AD-4324-974D-F598CE32CC23">
-      <dmn:text>inputData_013_1 + " " + decision_013_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_013_3" name="decision_013_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_8C174444-7293-40CA-A56E-32D98817E3CA" name="decision_013_3" typeRef="string"/>
-    <dmn:literalExpression id="_58A33ECF-C8F2-4030-A5F2-048A0A5C57D2">
-      <dmn:text>"D"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_013_1" name="inputData_013_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B1B026FA-6419-44CD-87B4-49E9D2C1AC53" name="inputData_013_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decisionService id="_decisionService_014" name="decisionService_014">
-    <dmn:extensionElements/>
-    <dmn:variable id="_845884D3-009D-4E23-B5CD-61045646F455" name="decisionService_014"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_014_1" name="decision_014_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_68646646-16A8-45A1-848A-726FB4575E68" name="decision_014_1"/>
-    <dmn:informationRequirement id="_decision_014_3">
-      <dmn:requiredDecision href="#_decision_014_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_014_1">
-      <dmn:requiredInput href="#_inputData_014_1"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_decisionService_014">
-      <dmn:requiredKnowledge href="#_decisionService_014"/>
-    </dmn:knowledgeRequirement>
-    <dmn:context id="_F208C530-4955-40F9-A2AD-ADAB3F481DC0">
-      <dmn:contextEntry>
-        <dmn:variable id="_718AF493-6F3C-43D4-81F8-E4949A9DCB59" name="inputData_014_1"/>
-        <dmn:literalExpression id="_B8416554-A1EB-4609-937C-8FAEC5F3C864">
-          <dmn:text>inputData_014_1</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_62E7D50E-A46A-4F3E-B33D-BAB8373F6823" name="decision_014_3"/>
-        <dmn:literalExpression id="_CBDADCE6-D267-4D70-89C3-2A4C51446521">
-          <dmn:text>decision_014_3</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_65AC5455-13FF-4533-B455-3F776FB88544" name="decisionService_014"/>
-        <dmn:literalExpression id="_DBEB78E6-574E-44C7-8BEF-8706F300E9F6">
-          <dmn:text>decisionService_014("A", "B")</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-    </dmn:context>
-  </dmn:decision>
-  <dmn:decision id="_decision_014_2" name="decision_014_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_58D60BA1-73C1-4BB4-AB00-65F6A9D6587B" name="decision_014_2" typeRef="string"/>
-    <dmn:informationRequirement id="_decision_014_3">
-      <dmn:requiredDecision href="#_decision_014_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_inputData_014_1">
-      <dmn:requiredInput href="#_inputData_014_1"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_B69575D4-B847-4C53-8C14-E517F45223A7">
-      <dmn:text>inputData_014_1 + " " + decision_014_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_014_3" name="decision_014_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0F30A479-0891-45AD-80CA-294C0FFBB824" name="decision_014_3" typeRef="string"/>
-    <dmn:literalExpression id="_A442FC3F-FF3C-48E7-AB4B-89D5E80F756E">
-      <dmn:text>"D"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_014_1" name="inputData_014_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D48CC01E-C6EF-4715-AB8F-473682111289" name="inputData_014_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_EAE49B20-06FD-4B33-950D-0B1EF1BF3E2B" name="DRG">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_11A5E320-866A-4504-BF2F-99F92D030386"/>
-          <kie:ComponentWidths dmnElementRef="_6849867A-2FFE-4A79-8A42-0F25CD52735B"/>
-          <kie:ComponentWidths dmnElementRef="_2DECD99B-AD40-4080-830C-5D63AB1286BD"/>
-          <kie:ComponentWidths dmnElementRef="_BB0DA338-9C58-4D4F-ACB7-07DC70506C0E"/>
-          <kie:ComponentWidths dmnElementRef="_1B1E76D0-05CD-4896-B447-F929DB618FCE"/>
-          <kie:ComponentWidths dmnElementRef="_C33A68AF-2302-4BB5-9AC5-8D3CAB99B1F7"/>
-          <kie:ComponentWidths dmnElementRef="_B360E630-FB08-4CC5-ADDB-C3C6B687BB90"/>
-          <kie:ComponentWidths dmnElementRef="_F6F6F43A-684B-4083-B1B4-C6A5CBD318B1"/>
-          <kie:ComponentWidths dmnElementRef="_CFBD83E0-2173-4C2A-9EAF-216D768AC37A"/>
-          <kie:ComponentWidths dmnElementRef="_92B1EAF7-B848-4A1B-B127-443FEB6EBE56"/>
-          <kie:ComponentWidths dmnElementRef="_D3183AD6-B169-4539-8FBC-08F97D9AF2E3"/>
-          <kie:ComponentWidths dmnElementRef="_BC002074-D71A-4B6C-A7BA-18E571BCE61A"/>
-          <kie:ComponentWidths dmnElementRef="_44B1886F-A166-4A8A-8132-BFE9E9415116"/>
-          <kie:ComponentWidths dmnElementRef="_3AE163CE-D1FE-4DA0-8B31-7598A83C5E11"/>
-          <kie:ComponentWidths dmnElementRef="_E8887435-7FD0-48C3-8917-C0D4D626411E"/>
-          <kie:ComponentWidths dmnElementRef="_0B79D368-03D5-4F1D-8EC8-76EFD1B1460A"/>
-          <kie:ComponentWidths dmnElementRef="_FA0843D8-78D4-42A9-BB9F-2C6E56CB2EF3"/>
-          <kie:ComponentWidths dmnElementRef="_EB7DE52E-7910-4E88-BC89-B508EA908FBC"/>
-          <kie:ComponentWidths dmnElementRef="_1C7E5C19-B8E6-42E7-825A-2C7A030EC428"/>
-          <kie:ComponentWidths dmnElementRef="_A19C8E53-51A8-4675-A48F-2ED4519AECA1"/>
-          <kie:ComponentWidths dmnElementRef="_6FFF30E1-5BE6-47C5-971E-31E3DEA3E27E"/>
-          <kie:ComponentWidths dmnElementRef="_2A9E91EC-6626-421A-8F3E-6A83C729D474"/>
-          <kie:ComponentWidths dmnElementRef="_6719F1B4-E39E-48D5-8C6C-DE0F122C9A35"/>
-          <kie:ComponentWidths dmnElementRef="_791DC98B-07D1-4A53-92AE-D153D8CA70C4"/>
-          <kie:ComponentWidths dmnElementRef="_CFB07093-62BD-4750-8DAD-F593E84D688A"/>
-          <kie:ComponentWidths dmnElementRef="_D60F5EC8-2D96-4D32-837E-34FC9EEF2376"/>
-          <kie:ComponentWidths dmnElementRef="_68CAA703-DF6B-4253-9C89-BE7E42E15444"/>
-          <kie:ComponentWidths dmnElementRef="_DE31E813-8CBB-44D8-ADBE-55099B642320"/>
-          <kie:ComponentWidths dmnElementRef="_3202DE56-C431-4A81-93D4-F532C72565B3"/>
-          <kie:ComponentWidths dmnElementRef="_8CEB871C-55D1-4986-B837-0DBC6D3A5315"/>
-          <kie:ComponentWidths dmnElementRef="_8E2BA3CF-48C7-4F76-9F03-71CFF78CD153"/>
-          <kie:ComponentWidths dmnElementRef="_589DE15F-36A2-42E9-934C-B87CFD257379"/>
-          <kie:ComponentWidths dmnElementRef="_DC086668-F9EC-4146-A9D5-C7DC25B06FD6"/>
-          <kie:ComponentWidths dmnElementRef="_839C54F0-225D-42C7-84E5-A47E1152CEA2"/>
-          <kie:ComponentWidths dmnElementRef="_3205055D-D1F0-41CF-930B-443C5CBA2B29"/>
-          <kie:ComponentWidths dmnElementRef="_141A7BCA-032C-41A0-80A7-994595FA3D7B"/>
-          <kie:ComponentWidths dmnElementRef="_4F280D00-47AA-4AA3-AF61-94554CE5838E"/>
-          <kie:ComponentWidths dmnElementRef="_1AD8CC68-C6AD-4324-974D-F598CE32CC23"/>
-          <kie:ComponentWidths dmnElementRef="_58A33ECF-C8F2-4030-A5F2-048A0A5C57D2"/>
-          <kie:ComponentWidths dmnElementRef="_F208C530-4955-40F9-A2AD-ADAB3F481DC0"/>
-          <kie:ComponentWidths dmnElementRef="_B8416554-A1EB-4609-937C-8FAEC5F3C864"/>
-          <kie:ComponentWidths dmnElementRef="_CBDADCE6-D267-4D70-89C3-2A4C51446521"/>
-          <kie:ComponentWidths dmnElementRef="_DBEB78E6-574E-44C7-8BEF-8706F300E9F6"/>
-          <kie:ComponentWidths dmnElementRef="_B69575D4-B847-4C53-8C14-E517F45223A7"/>
-          <kie:ComponentWidths dmnElementRef="_A442FC3F-FF3C-48E7-AB4B-89D5E80F756E"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3550" y="150"/>
-          <di:waypoint x="3650" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4250" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4250" y="150"/>
-          <di:waypoint x="4350" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_002" dmnElementRef="_decision_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="575" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_002_input" dmnElementRef="_decision_002_input" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="575" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4600" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4600" y="150"/>
-          <di:waypoint x="4700" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="225" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_003" dmnElementRef="_inputData_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_004" dmnElementRef="_decisionService_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1450" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="1450" y="325"/>
-          <di:waypoint x="1550" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_004_1" dmnElementRef="_decision_004_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="925" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_004_2" dmnElementRef="_decision_004_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4950" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_005" dmnElementRef="_decisionService_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1625" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="1625" y="325"/>
-          <di:waypoint x="1725" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_005_1" dmnElementRef="_decision_005_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1100" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_005_2" dmnElementRef="_decision_005_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5125" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_006" dmnElementRef="_decisionService_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1800" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="1800" y="325"/>
-          <di:waypoint x="1900" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_1" dmnElementRef="_decision_006_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1275" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_2" dmnElementRef="_decision_006_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1625" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_3" dmnElementRef="_decision_006_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_007" dmnElementRef="_decisionService_007" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="2850" y="325"/>
-          <di:waypoint x="2950" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_1" dmnElementRef="_decision_007_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1800" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_2" dmnElementRef="_decision_007_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1975" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_3" dmnElementRef="_decision_007_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_008" dmnElementRef="_decisionService_008" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3375" y="325"/>
-          <di:waypoint x="3475" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008_1" dmnElementRef="_decision_008_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2325" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008_2" dmnElementRef="_decision_008_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008_3" dmnElementRef="_decision_008_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_009" dmnElementRef="_decisionService_009" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4075" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4075" y="325"/>
-          <di:waypoint x="4175" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_009_1" dmnElementRef="_decision_009_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_009_2" dmnElementRef="_decision_009_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_009_3" dmnElementRef="_decision_009_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4425" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_010" dmnElementRef="_decisionService_010" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4950" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4950" y="325"/>
-          <di:waypoint x="5050" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_010_1" dmnElementRef="_decision_010_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_010_2" dmnElementRef="_decision_010_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4075" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_010_3" dmnElementRef="_decision_010_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5125" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_011" dmnElementRef="_decisionService_011" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5300" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="5300" y="325"/>
-          <di:waypoint x="5400" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_1" dmnElementRef="_decision_011_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4425" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_2" dmnElementRef="_decision_011_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="750" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_3" dmnElementRef="_decision_011_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="750" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_4" dmnElementRef="_decision_011_4" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="925" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_011_1" dmnElementRef="_inputData_011_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1100" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_011_2" dmnElementRef="_inputData_011_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1275" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_012" dmnElementRef="_decisionService_012" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5475" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="5475" y="325"/>
-          <di:waypoint x="5575" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_1" dmnElementRef="_decision_012_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4775" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_2" dmnElementRef="_decision_012_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1450" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_3" dmnElementRef="_decision_012_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1975" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_4" dmnElementRef="_decision_012_4" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2150" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_012_1" dmnElementRef="_inputData_012_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2325" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_012_2" dmnElementRef="_inputData_012_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2500" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_013" dmnElementRef="_decisionService_013" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3200" y="325"/>
-          <di:waypoint x="3300" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_013_1" dmnElementRef="_decision_013_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2150" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_013_2" dmnElementRef="_decision_013_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2500" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_013_3" dmnElementRef="_decision_013_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_013_1" dmnElementRef="_inputData_013_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_014" dmnElementRef="_decisionService_014" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4250" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4250" y="325"/>
-          <di:waypoint x="4350" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_014_1" dmnElementRef="_decision_014_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_014_2" dmnElementRef="_decision_014_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_014_3" dmnElementRef="_decision_014_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4600" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_014_1" dmnElementRef="_inputData_014_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4775" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_002_input" dmnElementRef="_decision_002_input">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="575" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="400" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="400" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_inputData_003" dmnElementRef="_inputData_003">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_004" dmnElementRef="_decisionService_004">
-        <di:waypoint x="1450" y="225"/>
-        <di:waypoint x="925" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_005" dmnElementRef="_decisionService_005">
-        <di:waypoint x="1625" y="225"/>
-        <di:waypoint x="1100" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_006" dmnElementRef="_decisionService_006">
-        <di:waypoint x="1800" y="225"/>
-        <di:waypoint x="1275" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_006_3" dmnElementRef="_decision_006_3">
-        <di:waypoint x="2675" y="225"/>
-        <di:waypoint x="1625" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_007" dmnElementRef="_decisionService_007">
-        <di:waypoint x="2850" y="225"/>
-        <di:waypoint x="1800" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_007_3" dmnElementRef="_decision_007_3">
-        <di:waypoint x="3025" y="225"/>
-        <di:waypoint x="1975" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_008" dmnElementRef="_decisionService_008">
-        <di:waypoint x="3375" y="225"/>
-        <di:waypoint x="2325" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_008_3" dmnElementRef="_decision_008_3">
-        <di:waypoint x="3900" y="225"/>
-        <di:waypoint x="2675" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_009" dmnElementRef="_decisionService_009">
-        <di:waypoint x="4075" y="225"/>
-        <di:waypoint x="2850" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_009_3" dmnElementRef="_decision_009_3">
-        <di:waypoint x="4425" y="225"/>
-        <di:waypoint x="3200" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_010" dmnElementRef="_decisionService_010">
-        <di:waypoint x="4950" y="225"/>
-        <di:waypoint x="3725" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_010_3" dmnElementRef="_decision_010_3">
-        <di:waypoint x="5125" y="225"/>
-        <di:waypoint x="4075" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_011" dmnElementRef="_decisionService_011">
-        <di:waypoint x="5300" y="225"/>
-        <di:waypoint x="4425" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_011_3" dmnElementRef="_decision_011_3">
-        <di:waypoint x="750" y="225"/>
-        <di:waypoint x="750" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_011_4" dmnElementRef="_decision_011_4">
-        <di:waypoint x="925" y="225"/>
-        <di:waypoint x="750" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_inputData_011_1" dmnElementRef="_inputData_011_1">
-        <di:waypoint x="1100" y="225"/>
-        <di:waypoint x="750" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_inputData_011_2" dmnElementRef="_inputData_011_2">
-        <di:waypoint x="1275" y="225"/>
-        <di:waypoint x="750" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_012" dmnElementRef="_decisionService_012">
-        <di:waypoint x="5475" y="225"/>
-        <di:waypoint x="4775" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_012_3" dmnElementRef="_decision_012_3">
-        <di:waypoint x="1975" y="225"/>
-        <di:waypoint x="1450" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_012_4" dmnElementRef="_decision_012_4">
-        <di:waypoint x="2150" y="225"/>
-        <di:waypoint x="1450" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_inputData_012_1" dmnElementRef="_inputData_012_1">
-        <di:waypoint x="2325" y="225"/>
-        <di:waypoint x="1450" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_inputData_012_2" dmnElementRef="_inputData_012_2">
-        <di:waypoint x="2500" y="225"/>
-        <di:waypoint x="1450" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_013_3" dmnElementRef="_decision_013_3">
-        <di:waypoint x="3550" y="225"/>
-        <di:waypoint x="2150" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_inputData_013_1" dmnElementRef="_inputData_013_1">
-        <di:waypoint x="3725" y="225"/>
-        <di:waypoint x="2150" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_013" dmnElementRef="_decisionService_013">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="2150" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decision_014_3" dmnElementRef="_decision_014_3">
-        <di:waypoint x="4600" y="225"/>
-        <di:waypoint x="3025" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_inputData_014_1" dmnElementRef="_inputData_014_1">
-        <di:waypoint x="4775" y="225"/>
-        <di:waypoint x="3025" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_decisionService_014" dmnElementRef="_decisionService_014">
-        <di:waypoint x="4250" y="225"/>
-        <di:waypoint x="3025" y="50"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-  </dmndi:DMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0085-decision-services" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="_i9fboPUUEeesLuP4RHs4vA" name="0085-decision-services" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0085-decision-services">
+   <dmn:description>Decision Services</dmn:description>
+   <dmn:extensionElements />
+   <dmn:decisionService id="_decisionService_001" name="decisionService_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_37D1E458-DDF9-44CD-BCBD-ED8B13304C1A" name="decisionService_001" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_002" name="decisionService_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_A0260B5C-17AB-4C4D-A71D-6EA328467930" name="decisionService_002" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_003" name="decisionService_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_2DCD4D7F-B586-4395-939D-EF2244334ED9" name="decisionService_003" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_004" name="decisionService_004">
+      <dmn:extensionElements />
+      <dmn:variable id="_AA1DEEB1-7B27-41D9-9693-94AC3BB5EDA4" name="decisionService_004" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_005" name="decisionService_005">
+      <dmn:extensionElements />
+      <dmn:variable id="_4726BCB9-D5FA-41E4-9D5D-94BD103A8833" name="decisionService_005" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_006" name="decisionService_006">
+      <dmn:extensionElements />
+      <dmn:variable id="_8F46F5DC-EEAC-40A5-80EA-546CBB1C92BD" name="decisionService_006" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_007" name="decisionService_007">
+      <dmn:extensionElements />
+      <dmn:variable id="_A3D65BF0-B33B-4B63-8A5D-83567E16CA58" name="decisionService_007" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_008" name="decisionService_008">
+      <dmn:extensionElements />
+      <dmn:variable id="_5D01D2BF-E27C-40AF-A0B0-2AE477002725" name="decisionService_008" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_009" name="decisionService_009">
+      <dmn:extensionElements />
+      <dmn:variable id="_006C5EF0-64B8-491B-8729-2D23965EDA7E" name="decisionService_009" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_010" name="decisionService_010">
+      <dmn:extensionElements />
+      <dmn:variable id="_0A1CD4C1-B473-4D31-8071-9574C324FD2E" name="decisionService_010" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_011" name="decisionService_011">
+      <dmn:extensionElements />
+      <dmn:variable id="_00E8074F-47ED-4AB0-AF97-B7859A62FD3D" name="decisionService_011" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_012" name="decisionService_012">
+      <dmn:extensionElements />
+      <dmn:variable id="_B6F58FA3-3127-4530-9610-1E7E01140B92" name="decisionService_012" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_013" name="decisionService_013">
+      <dmn:extensionElements />
+      <dmn:variable id="_C4B21ACD-47F9-427E-8C33-4D7F8A04015C" name="decisionService_013" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_014" name="decisionService_014">
+      <dmn:extensionElements />
+      <dmn:variable id="_8A85BDE6-3C7B-47AF-8B0C-6AF0979FC18C" name="decisionService_014" />
+   </dmn:decisionService>
+   <dmn:decision id="_decision_001" name="decision_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_E3A91D22-55B6-41F5-9EE9-BE8209AD1303" name="decision_001" />
+      <dmn:literalExpression id="_4C64C5CF-7525-4E43-A132-FA7B76EFCAD8">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_002" name="decision_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_14568229-02C6-4191-844D-E26F9908B6FA" name="decision_002" />
+      <dmn:informationRequirement id="_decision_002_input">
+         <dmn:requiredDecision href="#_decision_002_input" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_4BA5093C-2B64-49FE-A477-9CF1C2B7247C">
+         <dmn:text>"foo " + decision_002_input</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_002_input" name="decision_002_input">
+      <dmn:extensionElements />
+      <dmn:variable id="_86F1A231-A2BB-4711-A1B0-D9CE423A94A9" name="decision_002_input" />
+      <dmn:literalExpression id="_4E10E982-553C-471E-9A2E-B03BB923D463">
+         <dmn:text>"bar"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_003" name="decision_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_E6A5553F-81D2-413F-9422-C98BD5B77CA7" name="decision_003" />
+      <dmn:informationRequirement id="_decision_003_input_1">
+         <dmn:requiredDecision href="#_decision_003_input_1" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_decision_003_input_2">
+         <dmn:requiredDecision href="#_decision_003_input_2" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_003">
+         <dmn:requiredInput href="#_inputData_003" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_F0116906-55F7-4951-9ECA-1C9B4CE02A15">
+         <dmn:text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_003_input_1" name="decision_003_input_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_158BF5E8-2526-46C2-8767-A48B21FA6F7A" name="decision_003_input_1" />
+      <dmn:literalExpression id="_645ADA90-064F-4D70-B9BA-15ED1CF6F467">
+         <dmn:text>"d3_1"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_003_input_2" name="decision_003_input_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_1BD5A74A-DC1A-4C17-B927-5AB1786EF4BA" name="decision_003_input_2" />
+      <dmn:literalExpression id="_EC4E18CE-97B7-4678-99D5-FDB2CFE04E8C">
+         <dmn:text>"d3_2"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_003" name="inputData_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_20E65205-393B-4FFE-9495-750BEE19ED4F" name="inputData_003" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_004_1" name="decision_004_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_44A3550D-9803-43B1-B8AF-BB62DF2AD262" name="decision_004_1" />
+      <dmn:knowledgeRequirement id="_decisionService_004">
+         <dmn:requiredKnowledge href="#_decisionService_004" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_5A734BE4-9B19-4B4C-9F43-2ED83B4FBBDA">
+         <dmn:text>decisionService_004()</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_004_2" name="decision_004_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_E4EE1F6C-C837-4755-8B94-F91775B7EE08" name="decision_004_2" />
+      <dmn:literalExpression id="_BA114448-8390-4314-8357-965F0591FD03">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_005_1" name="decision_005_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_066CF9A4-7D28-42D0-B775-1B2C8A996422" name="decision_005_1" />
+      <dmn:knowledgeRequirement id="_decisionService_005">
+         <dmn:requiredKnowledge href="#_decisionService_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_A33AFF2E-5947-4AA6-AB45-E5A1B455C57C">
+         <dmn:text>decisionService_005("bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_005_2" name="decision_005_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_7F271875-6E67-4472-8A5E-D2855F8F7C5E" name="decision_005_2" typeRef="string" />
+      <dmn:literalExpression id="_080CD506-ABE5-4583-B894-0B910EAAEF9D">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_006_1" name="decision_006_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_9D4CB4B2-D255-424F-BB0A-BB83319A9526" name="decision_006_1" />
+      <dmn:knowledgeRequirement id="_decisionService_006">
+         <dmn:requiredKnowledge href="#_decisionService_006" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_43A61867-1919-40C7-9287-2E2C1FCE4096">
+         <dmn:text>decisionService_006("bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_006_2" name="decision_006_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_3C10DF8D-9D9E-48C5-8ADA-09C7E976A581" name="decision_006_2" />
+      <dmn:informationRequirement id="_decision_006_3">
+         <dmn:requiredDecision href="#_decision_006_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_5CC73F4D-142C-458E-BC33-52562E6F0E2C">
+         <dmn:text>"foo " + decision_006_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_006_3" name="decision_006_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_E05B0430-C4FF-46D8-8F7E-AD9F5B44FECD" name="decision_006_3" typeRef="string" />
+      <dmn:literalExpression id="_32ECDAD7-3F41-44C8-84FE-D3347C4E77E5">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_007_1" name="decision_007_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_E35C6143-1D6E-4DD1-9A39-38036512ABFB" name="decision_007_1" />
+      <dmn:knowledgeRequirement id="_decisionService_007">
+         <dmn:requiredKnowledge href="#_decisionService_007" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_C69A9B78-4145-4CDB-B302-DC3BE7A805DC">
+         <dmn:text>decisionService_007(123)</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_007_2" name="decision_007_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_AF0F7448-93C6-4E07-9AEC-7ED07C00C0C5" name="decision_007_2" />
+      <dmn:informationRequirement id="_decision_007_3">
+         <dmn:requiredDecision href="#_decision_007_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_3E60D199-FC8D-4509-B9CA-71C38613694C">
+         <dmn:text>decision_007_3 = null</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_007_3" name="decision_007_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_279CC7D0-093B-4F2D-A1BD-60DE358F053C" name="decision_007_3" typeRef="string" />
+      <dmn:literalExpression id="_D2AC2879-D2C7-4F43-9AD9-FA92BA639186">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_008_1" name="decision_008_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_F56B5263-3D20-4793-A09D-C60E09D0A8FF" name="decision_008_1" />
+      <dmn:knowledgeRequirement id="_decisionService_008">
+         <dmn:requiredKnowledge href="#_decisionService_008" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_2E8C7D0A-9B10-4D13-9984-CE2F9E78B997">
+         <dmn:text>decisionService_008()</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_008_2" name="decision_008_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_EBB83CC3-514B-4286-8DF5-339207E54557" name="decision_008_2" />
+      <dmn:informationRequirement id="_decision_008_3">
+         <dmn:requiredDecision href="#_decision_008_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_0EE98A61-EE5E-4093-BBB5-583E27390C15">
+         <dmn:text>decision_008_3 = null</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_008_3" name="decision_008_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_FC686AC6-C08C-49FB-9B63-5A1CE742185D" name="decision_008_3" typeRef="string" />
+      <dmn:literalExpression id="_A799255D-9A34-47FB-BB55-F13DADFAB97D">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_009_1" name="decision_009_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_5F1F695A-A216-460E-8C82-174B38450EC0" name="decision_009_1" />
+      <dmn:knowledgeRequirement id="_decisionService_009">
+         <dmn:requiredKnowledge href="#_decisionService_009" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_AC69F8D1-4AE6-4E6F-95E3-ABF3F27A43A0">
+         <dmn:text>decisionService_009(decision_009_3: "bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_009_2" name="decision_009_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_1BEF2202-37D0-4A45-A4DA-AA95376FAAB2" name="decision_009_2" />
+      <dmn:informationRequirement id="_decision_009_3">
+         <dmn:requiredDecision href="#_decision_009_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_06C178EB-E33B-446C-8760-489EA71CC75A">
+         <dmn:text>"foo " + decision_009_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_009_3" name="decision_009_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_1A33E292-DE05-4F30-A68E-5C2DDEB35AFF" name="decision_009_3" typeRef="string" />
+      <dmn:literalExpression id="_005FEEC9-9BE8-460C-8597-AF43CF6F8692">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_010_1" name="decision_010_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_9E6C63F6-4985-4CF6-ACC5-2B38DC3FA6DE" name="decision_010_1" />
+      <dmn:knowledgeRequirement id="_decisionService_010">
+         <dmn:requiredKnowledge href="#_decisionService_010" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_A3D81420-B588-42C9-8F19-A5C18F8E535C">
+         <dmn:text>decisionService_010(foo: "bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_010_2" name="decision_010_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_DD091DE3-CBE7-4682-9342-68FCA9205993" name="decision_010_2" />
+      <dmn:informationRequirement id="_decision_010_3">
+         <dmn:requiredDecision href="#_decision_010_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_CFD9E35A-B575-4C65-9464-BB197467C5FA">
+         <dmn:text>"foo " + decision_010_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_010_3" name="decision_010_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_1123721A-4A3C-4FC0-8240-D4902F6C766E" name="decision_010_3" typeRef="string" />
+      <dmn:literalExpression id="_5F171256-04F0-472E-8DA0-6B3A21E64459">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_1" name="decision_011_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_92CF1219-D83B-4685-8C2B-CE2D97D6C41B" name="decision_011_1" />
+      <dmn:knowledgeRequirement id="_decisionService_011">
+         <dmn:requiredKnowledge href="#_decisionService_011" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_C9EEF6D4-7DCF-4A4F-92B7-CCC0D6E989F0">
+         <dmn:text>decisionService_011("A", "B", "C", "D")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_2" name="decision_011_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_E91E74F2-7B0C-42FD-8EAD-82B7D86F3703" name="decision_011_2" typeRef="string" />
+      <dmn:informationRequirement id="_decision_011_3">
+         <dmn:requiredDecision href="#_decision_011_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_decision_011_4">
+         <dmn:requiredDecision href="#_decision_011_4" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_011_1">
+         <dmn:requiredInput href="#_inputData_011_1" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_011_2">
+         <dmn:requiredInput href="#_inputData_011_2" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_6C1B3316-5C3E-4583-9536-A4587579302D">
+         <dmn:text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_3" name="decision_011_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_E8DC8E10-2F45-4B55-8A1E-375E8B1A9A3D" name="decision_011_3" typeRef="string" />
+      <dmn:literalExpression id="_0BAACA8A-4B84-44CD-8F38-E817CE68236C">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_4" name="decision_011_4">
+      <dmn:extensionElements />
+      <dmn:variable id="_85D0B537-D930-4A6A-9DDE-801E59895C81" name="decision_011_4" typeRef="string" />
+      <dmn:literalExpression id="_95B0A67D-EDC7-4D9C-908F-5378617F1FBE">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_011_1" name="inputData_011_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_1C471FCC-4EF4-4373-A1DA-6CE306B99C40" name="inputData_011_1" typeRef="string" />
+   </dmn:inputData>
+   <dmn:inputData id="_inputData_011_2" name="inputData_011_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_349C8D9A-33A1-4BBF-89F0-B3089D2F2EDC" name="inputData_011_2" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_012_1" name="decision_012_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_4433133C-880F-45D1-B52C-DE56ECC3AEA6" name="decision_012_1" />
+      <dmn:knowledgeRequirement id="_decisionService_012">
+         <dmn:requiredKnowledge href="#_decisionService_012" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_58C823E6-7CA9-4408-8272-DA9CA0B5902C">
+         <dmn:text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_012_2" name="decision_012_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_8CB2AD6F-6C8D-4657-847B-084559C59B95" name="decision_012_2" typeRef="string" />
+      <dmn:informationRequirement id="_decision_012_3">
+         <dmn:requiredDecision href="#_decision_012_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_decision_012_4">
+         <dmn:requiredDecision href="#_decision_012_4" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_012_1">
+         <dmn:requiredInput href="#_inputData_012_1" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_012_2">
+         <dmn:requiredInput href="#_inputData_012_2" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_CE0F18D6-3BCB-4E74-9F97-9CF593274BA5">
+         <dmn:text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_012_3" name="decision_012_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_EACD4136-005C-40BE-A6E7-D29C8A60ED4B" name="decision_012_3" typeRef="string" />
+      <dmn:literalExpression id="_E204D9D8-ED94-476B-9BF3-EF4D63E3D7FE">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_012_4" name="decision_012_4">
+      <dmn:extensionElements />
+      <dmn:variable id="_7D5A1731-115C-44B5-91BE-23B92173BE68" name="decision_012_4" typeRef="string" />
+      <dmn:literalExpression id="_B85C73C3-F4BE-45A5-BEED-106F3CD32C98">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_012_1" name="inputData_012_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_7535E52D-0467-423B-BF1E-F70B884FE3A9" name="inputData_012_1" typeRef="string" />
+   </dmn:inputData>
+   <dmn:inputData id="_inputData_012_2" name="inputData_012_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_778589B5-7475-4468-9396-B184DD924FF8" name="inputData_012_2" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_013_1" name="decision_013_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_012265DF-5BE8-42C9-9FD9-33FEFB992EDB" name="decision_013_1" />
+      <dmn:informationRequirement id="_decision_013_3">
+         <dmn:requiredDecision href="#_decision_013_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_013_1">
+         <dmn:requiredInput href="#_inputData_013_1" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_decisionService_013">
+         <dmn:requiredKnowledge href="#_decisionService_013" />
+      </dmn:knowledgeRequirement>
+      <dmn:context id="_C299F514-F842-46A8-AC95-EEE56D78EE5C">
+         <dmn:contextEntry>
+            <dmn:variable id="_E7B49B05-DFCB-43C1-9429-2AE1BB84E1AB" name="decisionService_013" />
+            <dmn:literalExpression id="_3D1DEFD5-39E1-481C-96A1-2567DB3D540C">
+               <dmn:text>decisionService_013("A", "B")</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_3DD87DE7-212C-4107-AE6E-039EE6B0EB84" name="inputData_013_1" />
+            <dmn:literalExpression id="_04AA4DB6-E120-455B-A3CF-B99F53FDD1C5">
+               <dmn:text>inputData_013_1</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_EB49163C-7C3F-49F5-B2D0-A534C2FF6C03" name="decision_013_3" />
+            <dmn:literalExpression id="_093645FE-A80F-4928-9973-8788FA9F0998">
+               <dmn:text>decision_013_3</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+      </dmn:context>
+   </dmn:decision>
+   <dmn:decision id="_decision_013_2" name="decision_013_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_F355FE27-AD35-4A70-B912-A24B5913525D" name="decision_013_2" typeRef="string" />
+      <dmn:informationRequirement id="_decision_013_3">
+         <dmn:requiredDecision href="#_decision_013_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_013_1">
+         <dmn:requiredInput href="#_inputData_013_1" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_71525EE7-5EBE-4B0B-9C8F-4E0E44413DD9">
+         <dmn:text>inputData_013_1 + " " + decision_013_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_013_3" name="decision_013_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_65DE7173-C9B2-4D89-B240-1335D3BEC608" name="decision_013_3" typeRef="string" />
+      <dmn:literalExpression id="_7F86472E-ECF0-4CA9-805C-BB3105615AB7">
+         <dmn:text>"D"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_013_1" name="inputData_013_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_48D32FC8-4F14-4E48-AEA0-5C660D16876C" name="inputData_013_1" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_014_1" name="decision_014_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_0A2164C2-8CF1-4DF5-80B4-47D2C7A79E87" name="decision_014_1" />
+      <dmn:informationRequirement id="_decision_014_3">
+         <dmn:requiredDecision href="#_decision_014_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_014_1">
+         <dmn:requiredInput href="#_inputData_014_1" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_decisionService_014">
+         <dmn:requiredKnowledge href="#_decisionService_014" />
+      </dmn:knowledgeRequirement>
+      <dmn:context id="_3C4183DE-09A3-4E32-A0B6-19365F34CDA9">
+         <dmn:contextEntry>
+            <dmn:variable id="_E28104E0-6685-4606-9C5B-9CEA26C45DDD" name="inputData_014_1" />
+            <dmn:literalExpression id="_484C4D14-853F-417D-BCB0-6A59FCA5BFAC">
+               <dmn:text>inputData_014_1</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_F331A2E8-31C5-4DCB-8A95-F8C1E9CE2EFD" name="decision_014_3" />
+            <dmn:literalExpression id="_A2FD7673-8979-46C3-AF97-78BE02650AE7">
+               <dmn:text>decision_014_3</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_7EE204B6-7232-48A3-8B8B-3301B4738829" name="decisionService_014" />
+            <dmn:literalExpression id="_6484D194-5F35-43DE-ADAB-F6FB0D9854D1">
+               <dmn:text>decisionService_014("A", "B")</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+      </dmn:context>
+   </dmn:decision>
+   <dmn:decision id="_decision_014_2" name="decision_014_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_6AF7C5F2-0807-4D5A-B050-53ADD13A42E4" name="decision_014_2" typeRef="string" />
+      <dmn:informationRequirement id="_decision_014_3">
+         <dmn:requiredDecision href="#_decision_014_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_inputData_014_1">
+         <dmn:requiredInput href="#_inputData_014_1" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_D1CD27CA-434B-422F-AC70-EF584A95CA8C">
+         <dmn:text>inputData_014_1 + " " + decision_014_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_014_3" name="decision_014_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_C81A9867-133A-4537-A4EE-CBACC07AB3E7" name="decision_014_3" typeRef="string" />
+      <dmn:literalExpression id="_06FF986F-F53F-42CB-8A84-F6CDC44F3E82">
+         <dmn:text>"D"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_014_1" name="inputData_014_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_982610C0-9A5C-4C6C-A5E0-48D31949A7EC" name="inputData_014_1" typeRef="string" />
+   </dmn:inputData>
+   <dmndi:DMNDI>
+      <dmndi:DMNDiagram id="_CCA27F4C-29FD-49E2-AE82-4C837250B1BA" name="DRG">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_4C64C5CF-7525-4E43-A132-FA7B76EFCAD8" />
+               <kie:ComponentWidths dmnElementRef="_4BA5093C-2B64-49FE-A477-9CF1C2B7247C" />
+               <kie:ComponentWidths dmnElementRef="_4E10E982-553C-471E-9A2E-B03BB923D463" />
+               <kie:ComponentWidths dmnElementRef="_F0116906-55F7-4951-9ECA-1C9B4CE02A15" />
+               <kie:ComponentWidths dmnElementRef="_645ADA90-064F-4D70-B9BA-15ED1CF6F467" />
+               <kie:ComponentWidths dmnElementRef="_EC4E18CE-97B7-4678-99D5-FDB2CFE04E8C" />
+               <kie:ComponentWidths dmnElementRef="_5A734BE4-9B19-4B4C-9F43-2ED83B4FBBDA" />
+               <kie:ComponentWidths dmnElementRef="_BA114448-8390-4314-8357-965F0591FD03" />
+               <kie:ComponentWidths dmnElementRef="_A33AFF2E-5947-4AA6-AB45-E5A1B455C57C" />
+               <kie:ComponentWidths dmnElementRef="_080CD506-ABE5-4583-B894-0B910EAAEF9D" />
+               <kie:ComponentWidths dmnElementRef="_43A61867-1919-40C7-9287-2E2C1FCE4096" />
+               <kie:ComponentWidths dmnElementRef="_5CC73F4D-142C-458E-BC33-52562E6F0E2C" />
+               <kie:ComponentWidths dmnElementRef="_32ECDAD7-3F41-44C8-84FE-D3347C4E77E5" />
+               <kie:ComponentWidths dmnElementRef="_C69A9B78-4145-4CDB-B302-DC3BE7A805DC" />
+               <kie:ComponentWidths dmnElementRef="_3E60D199-FC8D-4509-B9CA-71C38613694C" />
+               <kie:ComponentWidths dmnElementRef="_D2AC2879-D2C7-4F43-9AD9-FA92BA639186" />
+               <kie:ComponentWidths dmnElementRef="_2E8C7D0A-9B10-4D13-9984-CE2F9E78B997" />
+               <kie:ComponentWidths dmnElementRef="_0EE98A61-EE5E-4093-BBB5-583E27390C15" />
+               <kie:ComponentWidths dmnElementRef="_A799255D-9A34-47FB-BB55-F13DADFAB97D" />
+               <kie:ComponentWidths dmnElementRef="_AC69F8D1-4AE6-4E6F-95E3-ABF3F27A43A0" />
+               <kie:ComponentWidths dmnElementRef="_06C178EB-E33B-446C-8760-489EA71CC75A" />
+               <kie:ComponentWidths dmnElementRef="_005FEEC9-9BE8-460C-8597-AF43CF6F8692" />
+               <kie:ComponentWidths dmnElementRef="_A3D81420-B588-42C9-8F19-A5C18F8E535C" />
+               <kie:ComponentWidths dmnElementRef="_CFD9E35A-B575-4C65-9464-BB197467C5FA" />
+               <kie:ComponentWidths dmnElementRef="_5F171256-04F0-472E-8DA0-6B3A21E64459" />
+               <kie:ComponentWidths dmnElementRef="_C9EEF6D4-7DCF-4A4F-92B7-CCC0D6E989F0" />
+               <kie:ComponentWidths dmnElementRef="_6C1B3316-5C3E-4583-9536-A4587579302D" />
+               <kie:ComponentWidths dmnElementRef="_0BAACA8A-4B84-44CD-8F38-E817CE68236C" />
+               <kie:ComponentWidths dmnElementRef="_95B0A67D-EDC7-4D9C-908F-5378617F1FBE" />
+               <kie:ComponentWidths dmnElementRef="_58C823E6-7CA9-4408-8272-DA9CA0B5902C" />
+               <kie:ComponentWidths dmnElementRef="_CE0F18D6-3BCB-4E74-9F97-9CF593274BA5" />
+               <kie:ComponentWidths dmnElementRef="_E204D9D8-ED94-476B-9BF3-EF4D63E3D7FE" />
+               <kie:ComponentWidths dmnElementRef="_B85C73C3-F4BE-45A5-BEED-106F3CD32C98" />
+               <kie:ComponentWidths dmnElementRef="_C299F514-F842-46A8-AC95-EEE56D78EE5C" />
+               <kie:ComponentWidths dmnElementRef="_3D1DEFD5-39E1-481C-96A1-2567DB3D540C" />
+               <kie:ComponentWidths dmnElementRef="_04AA4DB6-E120-455B-A3CF-B99F53FDD1C5" />
+               <kie:ComponentWidths dmnElementRef="_093645FE-A80F-4928-9973-8788FA9F0998" />
+               <kie:ComponentWidths dmnElementRef="_71525EE7-5EBE-4B0B-9C8F-4E0E44413DD9" />
+               <kie:ComponentWidths dmnElementRef="_7F86472E-ECF0-4CA9-805C-BB3105615AB7" />
+               <kie:ComponentWidths dmnElementRef="_3C4183DE-09A3-4E32-A0B6-19365F34CDA9" />
+               <kie:ComponentWidths dmnElementRef="_484C4D14-853F-417D-BCB0-6A59FCA5BFAC" />
+               <kie:ComponentWidths dmnElementRef="_A2FD7673-8979-46C3-AF97-78BE02650AE7" />
+               <kie:ComponentWidths dmnElementRef="_6484D194-5F35-43DE-ADAB-F6FB0D9854D1" />
+               <kie:ComponentWidths dmnElementRef="_D1CD27CA-434B-422F-AC70-EF584A95CA8C" />
+               <kie:ComponentWidths dmnElementRef="_06FF986F-F53F-42CB-8A84-F6CDC44F3E82" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3725" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3725" y="150" />
+               <di:waypoint x="3825" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4075" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="4075" y="150" />
+               <di:waypoint x="4175" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4425" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="4425" y="150" />
+               <di:waypoint x="4525" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_004" dmnElementRef="_decisionService_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="575" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="575" y="325" />
+               <di:waypoint x="675" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_005" dmnElementRef="_decisionService_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="750" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="750" y="325" />
+               <di:waypoint x="850" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_006" dmnElementRef="_decisionService_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="925" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="925" y="325" />
+               <di:waypoint x="1025" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_007" dmnElementRef="_decisionService_007" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1800" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="1800" y="325" />
+               <di:waypoint x="1900" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_008" dmnElementRef="_decisionService_008" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2150" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="2150" y="325" />
+               <di:waypoint x="2250" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_009" dmnElementRef="_decisionService_009" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3025" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3025" y="325" />
+               <di:waypoint x="3125" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_010" dmnElementRef="_decisionService_010" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3200" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3200" y="325" />
+               <di:waypoint x="3300" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_011" dmnElementRef="_decisionService_011" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4075" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="4075" y="325" />
+               <di:waypoint x="4175" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_012" dmnElementRef="_decisionService_012" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4950" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="4950" y="325" />
+               <di:waypoint x="5050" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_013" dmnElementRef="_decisionService_013" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3375" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3375" y="325" />
+               <di:waypoint x="3475" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_014" dmnElementRef="_decisionService_014" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4250" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="4250" y="325" />
+               <di:waypoint x="4350" y="325" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4600" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_002" dmnElementRef="_decision_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1450" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_002_input" dmnElementRef="_decision_002_input" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1975" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_003" dmnElementRef="_inputData_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_004_1" dmnElementRef="_decision_004_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="575" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_004_2" dmnElementRef="_decision_004_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4950" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_005_1" dmnElementRef="_decision_005_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="750" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_005_2" dmnElementRef="_decision_005_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5125" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_1" dmnElementRef="_decision_006_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="925" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_2" dmnElementRef="_decision_006_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2500" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_3" dmnElementRef="_decision_006_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3550" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_1" dmnElementRef="_decision_007_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1275" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_2" dmnElementRef="_decision_007_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3200" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_3" dmnElementRef="_decision_007_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4425" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008_1" dmnElementRef="_decision_008_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1625" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008_2" dmnElementRef="_decision_008_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3900" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008_3" dmnElementRef="_decision_008_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5125" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_009_1" dmnElementRef="_decision_009_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1975" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_009_2" dmnElementRef="_decision_009_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4250" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_009_3" dmnElementRef="_decision_009_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5300" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_010_1" dmnElementRef="_decision_010_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2150" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_010_2" dmnElementRef="_decision_010_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4775" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_010_3" dmnElementRef="_decision_010_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5475" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_1" dmnElementRef="_decision_011_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2850" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_2" dmnElementRef="_decision_011_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1100" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_3" dmnElementRef="_decision_011_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1100" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_4" dmnElementRef="_decision_011_4" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1275" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_011_1" dmnElementRef="_inputData_011_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1450" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_011_2" dmnElementRef="_inputData_011_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1625" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_1" dmnElementRef="_decision_012_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3550" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_2" dmnElementRef="_decision_012_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1800" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_3" dmnElementRef="_decision_012_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2325" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_4" dmnElementRef="_decision_012_4" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2500" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_012_1" dmnElementRef="_inputData_012_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2675" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_012_2" dmnElementRef="_inputData_012_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2850" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_013_1" dmnElementRef="_decision_013_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2325" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_013_2" dmnElementRef="_decision_013_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2675" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_013_3" dmnElementRef="_decision_013_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3725" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_013_1" dmnElementRef="_inputData_013_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3900" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_014_1" dmnElementRef="_decision_014_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3025" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_014_2" dmnElementRef="_decision_014_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3375" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_014_3" dmnElementRef="_decision_014_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4600" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_014_1" dmnElementRef="_inputData_014_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4775" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_002_input" dmnElementRef="_decision_002_input">
+            <di:waypoint x="1975" y="225" />
+            <di:waypoint x="1450" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1">
+            <di:waypoint x="50" y="225" />
+            <di:waypoint x="400" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2">
+            <di:waypoint x="225" y="225" />
+            <di:waypoint x="400" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_inputData_003" dmnElementRef="_inputData_003">
+            <di:waypoint x="400" y="225" />
+            <di:waypoint x="400" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_004" dmnElementRef="_decisionService_004">
+            <di:waypoint x="575" y="225" />
+            <di:waypoint x="575" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_005" dmnElementRef="_decisionService_005">
+            <di:waypoint x="750" y="225" />
+            <di:waypoint x="750" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_006" dmnElementRef="_decisionService_006">
+            <di:waypoint x="925" y="225" />
+            <di:waypoint x="925" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_006_3" dmnElementRef="_decision_006_3">
+            <di:waypoint x="3550" y="225" />
+            <di:waypoint x="2500" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_007" dmnElementRef="_decisionService_007">
+            <di:waypoint x="1800" y="225" />
+            <di:waypoint x="1275" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_007_3" dmnElementRef="_decision_007_3">
+            <di:waypoint x="4425" y="225" />
+            <di:waypoint x="3200" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_008" dmnElementRef="_decisionService_008">
+            <di:waypoint x="2150" y="225" />
+            <di:waypoint x="1625" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_008_3" dmnElementRef="_decision_008_3">
+            <di:waypoint x="5125" y="225" />
+            <di:waypoint x="3900" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_009" dmnElementRef="_decisionService_009">
+            <di:waypoint x="3025" y="225" />
+            <di:waypoint x="1975" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_009_3" dmnElementRef="_decision_009_3">
+            <di:waypoint x="5300" y="225" />
+            <di:waypoint x="4250" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_010" dmnElementRef="_decisionService_010">
+            <di:waypoint x="3200" y="225" />
+            <di:waypoint x="2150" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_010_3" dmnElementRef="_decision_010_3">
+            <di:waypoint x="5475" y="225" />
+            <di:waypoint x="4775" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_011" dmnElementRef="_decisionService_011">
+            <di:waypoint x="4075" y="225" />
+            <di:waypoint x="2850" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_011_3" dmnElementRef="_decision_011_3">
+            <di:waypoint x="1100" y="225" />
+            <di:waypoint x="1100" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_011_4" dmnElementRef="_decision_011_4">
+            <di:waypoint x="1275" y="225" />
+            <di:waypoint x="1100" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_inputData_011_1" dmnElementRef="_inputData_011_1">
+            <di:waypoint x="1450" y="225" />
+            <di:waypoint x="1100" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_inputData_011_2" dmnElementRef="_inputData_011_2">
+            <di:waypoint x="1625" y="225" />
+            <di:waypoint x="1100" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_012" dmnElementRef="_decisionService_012">
+            <di:waypoint x="4950" y="225" />
+            <di:waypoint x="3550" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_012_3" dmnElementRef="_decision_012_3">
+            <di:waypoint x="2325" y="225" />
+            <di:waypoint x="1800" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_012_4" dmnElementRef="_decision_012_4">
+            <di:waypoint x="2500" y="225" />
+            <di:waypoint x="1800" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_inputData_012_1" dmnElementRef="_inputData_012_1">
+            <di:waypoint x="2675" y="225" />
+            <di:waypoint x="1800" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_inputData_012_2" dmnElementRef="_inputData_012_2">
+            <di:waypoint x="2850" y="225" />
+            <di:waypoint x="1800" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_013_3" dmnElementRef="_decision_013_3">
+            <di:waypoint x="3725" y="225" />
+            <di:waypoint x="2325" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_inputData_013_1" dmnElementRef="_inputData_013_1">
+            <di:waypoint x="3900" y="225" />
+            <di:waypoint x="2325" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_013" dmnElementRef="_decisionService_013">
+            <di:waypoint x="3375" y="225" />
+            <di:waypoint x="2325" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decision_014_3" dmnElementRef="_decision_014_3">
+            <di:waypoint x="4600" y="225" />
+            <di:waypoint x="3025" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_inputData_014_1" dmnElementRef="_inputData_014_1">
+            <di:waypoint x="4775" y="225" />
+            <di:waypoint x="3025" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_014" dmnElementRef="_decisionService_014">
+            <di:waypoint x="4250" y="225" />
+            <di:waypoint x="3025" y="50" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+   </dmndi:DMNDI>
 </dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0087-chapter-11-example.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0087-chapter-11-example.dmn
@@ -1,4628 +1,4628 @@
-<?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" name="Chapter 11 Example" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4">
-  <dmn:extensionElements/>
-  <dmn:itemDefinition id="_6060F088-A0EF-4963-AF19-DCFC29809AF5" name="tStrategy" isCollection="false">
-    <dmn:typeRef>string</dmn:typeRef>
-    <dmn:allowedValues id="_0CFCEB12-9E7B-4D6A-98A6-0269E74BA221">
-      <dmn:text>"DECLINE","BUREAU","THROUGH"</dmn:text>
-    </dmn:allowedValues>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_72925077-2183-4F44-A45C-6B630ACBE34F" name="tEligibility" isCollection="false">
-    <dmn:typeRef>string</dmn:typeRef>
-    <dmn:allowedValues id="_ACD06A0F-FD0D-412D-99C2-18F632D93E70">
-      <dmn:text>"INELIGIBLE","ELIGIBLE"</dmn:text>
-    </dmn:allowedValues>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_07520BD8-ECE0-4AC8-8613-C7569D3EB5E8" name="tBureauCallType" isCollection="false">
-    <dmn:typeRef>string</dmn:typeRef>
-    <dmn:allowedValues id="_78E1E0C9-6932-40AB-8637-D2FB2F650A2F">
-      <dmn:text>"FULL","MINI","NONE"</dmn:text>
-    </dmn:allowedValues>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_341BB558-F920-4CE0-BA95-97334497CC42" name="tRiskCategory" isCollection="false">
-    <dmn:typeRef>string</dmn:typeRef>
-    <dmn:allowedValues id="_56346CAE-3D8A-4F07-96B7-D90550813E80">
-      <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
-    </dmn:allowedValues>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_5504EC4C-2D38-409D-BA66-1DE0550EDA38" name="tApplicantData" isCollection="false">
-    <dmn:itemComponent id="_df3aab6f-1610-41fa-a407-09678a89d6da" name="Age" isCollection="false">
-      <dmn:typeRef>number</dmn:typeRef>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_d39ad810-7781-4ffb-9644-de51d1ca7f7a" name="MartitalStatus" isCollection="false">
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4" name="Chapter 11 Example" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_9d01a0c4-f529-4ad8-ad8e-ec5fb5d96ad4">
+   <dmn:extensionElements />
+   <dmn:itemDefinition id="_6060F088-A0EF-4963-AF19-DCFC29809AF5" name="tStrategy" isCollection="false">
       <dmn:typeRef>string</dmn:typeRef>
-      <dmn:allowedValues id="_ABFF00EE-E61C-4814-A41A-5D410BB0C201">
-        <dmn:text>"S","M"</dmn:text>
+      <dmn:allowedValues id="_0CFCEB12-9E7B-4D6A-98A6-0269E74BA221">
+         <dmn:text>"DECLINE","BUREAU","THROUGH"</dmn:text>
       </dmn:allowedValues>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_9242f7aa-a9fc-451e-a8ee-60f1ff992664" name="EmploymentStatus" isCollection="false">
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_72925077-2183-4F44-A45C-6B630ACBE34F" name="tEligibility" isCollection="false">
       <dmn:typeRef>string</dmn:typeRef>
-      <dmn:allowedValues id="_B8CA3808-CEFC-4DA1-A8D5-577712D1AEFF">
-        <dmn:text>"EMPLOYED","SELF-EMPLOYED","STUDENT","UNEMPLOYED"</dmn:text>
+      <dmn:allowedValues id="_ACD06A0F-FD0D-412D-99C2-18F632D93E70">
+         <dmn:text>"INELIGIBLE","ELIGIBLE"</dmn:text>
       </dmn:allowedValues>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_5b4cce4a-bb99-41d5-99f2-0b2d7deeea8e" name="ExistingCustomer" isCollection="false">
-      <dmn:typeRef>boolean</dmn:typeRef>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_c3ad187d-246f-4707-aa05-b9d5d8da1f58" name="Monthly" isCollection="false">
-      <dmn:itemComponent id="_0ff9ec7c-ef0f-425a-af5c-d251135e3631" name="Income" isCollection="false">
-        <dmn:typeRef>number</dmn:typeRef>
-      </dmn:itemComponent>
-      <dmn:itemComponent id="_d4389c69-0a87-4db9-96fa-99674bff6b97" name="Repayments" isCollection="false">
-        <dmn:typeRef>number</dmn:typeRef>
-      </dmn:itemComponent>
-      <dmn:itemComponent id="_c0bd1a20-826f-4fe4-86bc-b6cca2af06a1" name="Expenses" isCollection="false">
-        <dmn:typeRef>number</dmn:typeRef>
-      </dmn:itemComponent>
-    </dmn:itemComponent>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_295BDBD0-FE79-4298-B283-8FC2DEF2D42A" name="tBureauData" isCollection="false">
-    <dmn:itemComponent id="_4b58e0c0-649b-472a-8a28-f8dde1e40068" name="Bankrupt" isCollection="false">
-      <dmn:typeRef>boolean</dmn:typeRef>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_42350ffd-8f82-4500-b9cb-696758cc287e" name="CreditScore" isCollection="false">
-      <dmn:typeRef>number</dmn:typeRef>
-      <dmn:allowedValues id="_338E8C57-AC12-4CDA-BB70-F26D9124D307">
-        <dmn:text>[0..999], null</dmn:text>
-      </dmn:allowedValues>
-    </dmn:itemComponent>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_7A47C6BE-9076-4AC4-A730-B40F70637162" name="tRouting" isCollection="false">
-    <dmn:typeRef>string</dmn:typeRef>
-    <dmn:allowedValues id="_9090335D-BBA7-4C44-B1ED-1A42F6AEEBB6">
-      <dmn:text>"DECLINE","REFER","ACCEPT"</dmn:text>
-    </dmn:allowedValues>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_9126CE5C-DE46-47E5-BF45-E78DDCEA79A1" name="tRequestedProduct" isCollection="false">
-    <dmn:itemComponent id="_c993adad-698b-477d-a395-f4021d38ef8b" name="ProductType" isCollection="false">
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_07520BD8-ECE0-4AC8-8613-C7569D3EB5E8" name="tBureauCallType" isCollection="false">
       <dmn:typeRef>string</dmn:typeRef>
-      <dmn:allowedValues id="_4C8661D6-FD5B-4242-AC48-47672DF0518A">
-        <dmn:text>"STANDARD LOAN","SPECIAL LOAN"</dmn:text>
+      <dmn:allowedValues id="_78E1E0C9-6932-40AB-8637-D2FB2F650A2F">
+         <dmn:text>"FULL","MINI","NONE"</dmn:text>
       </dmn:allowedValues>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_5ddc6d4c-67d2-4a00-a9c0-3614d228964b" name="Rate" isCollection="false">
-      <dmn:typeRef>number</dmn:typeRef>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_4e47a0e8-ab4a-46a2-ae8c-209401ebdd8f" name="Term" isCollection="false">
-      <dmn:typeRef>number</dmn:typeRef>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_24103ee1-2867-4e01-abfc-d40b3aed0ce5" name="Amount" isCollection="false">
-      <dmn:typeRef>number</dmn:typeRef>
-    </dmn:itemComponent>
-  </dmn:itemDefinition>
-  <dmn:decision id="_4bd33d4a-741b-444a-968b-64e1841211e7" name="Adjudication">
-    <dmn:extensionElements/>
-    <dmn:variable id="_12f285f8-ae4e-4421-98bd-d9b1fd236e10" name="Adjudication"/>
-    <dmn:informationRequirement id="_290b4df4-ffe6-4106-9e22-07a339146161">
-      <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
-      <dmn:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
-      <dmn:requiredDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_7fc499b6-a180-4e16-80cd-58df441f4d38">
-      <dmn:requiredInput href="#_34cd3187-8764-4249-959d-2664bf9f1847"/>
-    </dmn:informationRequirement>
-    <dmn:authorityRequirement id="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
-      <dmn:requiredAuthority href="#_989d137f-86ff-4249-813f-af67c08a2762"/>
-    </dmn:authorityRequirement>
-  </dmn:decision>
-  <dmn:knowledgeSource id="_989d137f-86ff-4249-813f-af67c08a2762" name="Credit officer">
-    <dmn:extensionElements/>
-  </dmn:knowledgeSource>
-  <dmn:inputData id="_34cd3187-8764-4249-959d-2664bf9f1847" name="Supporting documents">
-    <dmn:extensionElements/>
-    <dmn:variable id="_d996b907-be17-4ff1-a54e-6fe7d62f55b1" name="Supporting documents" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decision id="_5b8356f3-2cf2-40e8-8f80-324937e8b276" name="Bureau call type">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Bureau call type&amp;nbsp;&lt;/span&gt;table, passing the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_207da57c-29a0-487b-b591-751807636337" name="Bureau call type" typeRef="tBureauCallType"/>
-    <dmn:informationRequirement id="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
-      <dmn:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
-      <dmn:requiredKnowledge href="#_a654be71-b54d-4d6e-90f0-ae505125e9a6"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd">
-      <dmn:literalExpression id="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd">
-        <dmn:text>Bureau call type table</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_8f5b7ce8-b4f9-4af4-8aa5-5580682382c6" name="Pre-Bureau Risk Category"/>
-        <dmn:literalExpression id="_40020f96-0afd-405c-828a-0aa6684d150d">
-          <dmn:text>Pre-bureau risk category</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_8b838f06-968a-4c66-875e-f5412fd692cf" name="Strategy">
-    <dmn:description>&lt;p&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Strategy&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, unique-hit decision table deriving Strategy from&amp;nbsp;&lt;/span&gt;Eligibility and Bureau call type.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_80c9b3dd-f6c3-412b-9ee9-48e3e0812746" name="Strategy" typeRef="tStrategy"/>
-    <dmn:informationRequirement id="_114baf7e-1b8f-489a-98c9-e7d26d330119">
-      <dmn:requiredDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
-      <dmn:requiredDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
-    </dmn:informationRequirement>
-    <dmn:decisionTable id="_0991d970-7c58-4669-89ec-a5e3e9d264df" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Strategy">
-      <dmn:input id="_661471d5-5028-4910-b070-1e3bad0125c7">
-        <dmn:inputExpression id="_AC590B2A-235D-49E3-8920-5552312FE75C" typeRef="tEligibility">
-          <dmn:text>Eligibility</dmn:text>
-        </dmn:inputExpression>
-        <dmn:inputValues id="_C226EF3F-0E63-440C-B4B5-C4DD1EB57518">
-          <dmn:text>"INELIGIBLE","ELIGIBLE"</dmn:text>
-        </dmn:inputValues>
-      </dmn:input>
-      <dmn:input id="_b48e30f7-0a90-42d0-ba06-ad931fdfe5da">
-        <dmn:inputExpression id="_69FC0490-34F7-492B-B872-A34433CA8C6F" typeRef="tBureauCallType">
-          <dmn:text>Bureau call type</dmn:text>
-        </dmn:inputExpression>
-        <dmn:inputValues id="_F014B03F-E1D7-400C-9BDF-6F892B67F8EE">
-          <dmn:text>"FULL","MINI","NONE"</dmn:text>
-        </dmn:inputValues>
-      </dmn:input>
-      <dmn:output id="_f722c4f0-299d-4492-9b0c-fa0177239d08">
-        <dmn:outputValues id="_0E7B27DE-4305-42CF-9AB4-CF3D7E0D749D">
-          <dmn:text>"DECLINE","BUREAU","THROUGH"</dmn:text>
-        </dmn:outputValues>
-      </dmn:output>
-      <dmn:annotation name=""/>
-      <dmn:rule id="_799a874e-d695-4683-9774-a4a911bbda7c">
-        <dmn:inputEntry id="_a1e93932-14d9-41aa-b408-418df532584e">
-          <dmn:text>"INELIGIBLE"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:inputEntry id="_46a2c9c2-10ba-4ebd-b596-d8d50ef4e27d">
-          <dmn:text>-</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_ddad297d-4a7e-45b4-bfc5-78cfc1504f8e">
-          <dmn:text>"DECLINE"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_8e10bf87-3308-4cb5-84fd-231656eb15f3">
-        <dmn:inputEntry id="_27b85f52-29db-4114-8393-4c307fda69de">
-          <dmn:text>"ELIGIBLE"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:inputEntry id="_658b9e6d-4039-4a30-a14f-b9af59e9ff3e">
-          <dmn:text>"FULL", "MINI"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_4099772e-6ec4-48e2-a4ac-daa6d7aa1148">
-          <dmn:text>"BUREAU"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_cec87cd2-9715-47b2-97df-087698d8fc70">
-        <dmn:inputEntry id="_617a19de-dd6d-4448-be7b-dc5c0f57de9c">
-          <dmn:text>"ELIGIBLE"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:inputEntry id="_0600d1e9-3293-4c91-b0f1-f1fecb10f422">
-          <dmn:text>"NONE"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_f17c18da-fb15-401b-88a5-550d1918583b">
-          <dmn:text>"THROUGH"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-    </dmn:decisionTable>
-  </dmn:decision>
-  <dmn:decision id="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" name="Eligibility">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Eligibility rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Applicant data.Age as the Age parameter, the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter, and the output of the Pre-bureau affordability decision as the Pre-Bureau Affordability parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_a160fe23-8110-4242-9944-86278d32000e" name="Eligibility" typeRef="tEligibility"/>
-    <dmn:informationRequirement id="_94475973-9022-46d7-a520-756538ba9c00">
-      <dmn:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
-      <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_a1f0d284-033d-4683-9a0c-13f1184e0503">
-      <dmn:requiredDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_1c3489b1-44dd-4137-883a-35da157f0c1d">
-      <dmn:requiredKnowledge href="#_dc2ca64d-2044-4806-9d0e-e705b3b14447"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979">
-      <dmn:literalExpression id="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979">
-        <dmn:text>Eligibility rules</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_07fdfb40-acac-4098-8a66-f09f216cd9ec" name="Age"/>
-        <dmn:literalExpression id="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca">
-          <dmn:text>Applicant data.Age</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_a2bc5321-7041-40c0-be9d-4e53c22442d1" name="Pre-Bureau Risk Category"/>
-        <dmn:literalExpression id="_91986b6f-d45e-4aa7-926d-00b35a47686f">
-          <dmn:text>Pre-bureau risk category</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_c3432a72-40b0-4213-9f94-7f5e8e15ee85" name="Pre-Bureau Affordability"/>
-        <dmn:literalExpression id="_719504be-6121-4c16-9c00-1480b58f2ecb">
-          <dmn:text>Pre-bureau affordability</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:businessKnowledgeModel id="_dc2ca64d-2044-4806-9d0e-e705b3b14447" name="Eligibility rules">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Eligibility from Pre-Bureau Risk Category, Pre-Bureau Affordability and Age.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_fe2d2049-704b-4a88-88be-3d1a56c3d376" name="Eligibility rules" typeRef="tEligibility"/>
-    <dmn:encapsulatedLogic id="_809B2A63-2946-4AC0-BB2A-7C01F85D885B" kind="FEEL">
-      <dmn:formalParameter id="_AF5CF5FF-A53C-4505-BD25-6DBC2B7A2321" name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
-      <dmn:formalParameter id="_23CAE4C5-9875-483B-8042-0B86C91471F1" name="Pre-Bureau Affordability" typeRef="boolean"/>
-      <dmn:formalParameter id="_80C61F87-3F89-4CA5-AB0A-30849F9372D5" name="Age" typeRef="number"/>
-      <dmn:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Eligibility rules">
-        <dmn:input id="_2bab5dc0-be18-4098-b9b4-6b3486955d1b">
-          <dmn:inputExpression id="_FF749C0B-3AB2-44EA-BCF3-46CED726B735" typeRef="tRiskCategory">
-            <dmn:text>Pre-Bureau Risk Category</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_2BB06B1A-6FAB-4402-A9A7-18F1209D5F31">
-            <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:input id="_836645fe-83ba-4f36-9b6d-279b017c59ea">
-          <dmn:inputExpression id="_8D820170-C485-4489-A266-3E9330A1A005" typeRef="boolean">
-            <dmn:text>Pre-Bureau Affordability</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:input id="_4946be73-cb1e-43b4-ac03-b01e378c298a">
-          <dmn:inputExpression id="_D9694AB4-E78F-4A65-A3E4-84E080A77CF6" typeRef="number">
-            <dmn:text>Age</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:output id="_81aab6dd-d832-4c9e-8a3c-55f5f4a89cc7">
-          <dmn:outputValues id="_A966F694-17B2-4E04-9D7B-4D3A5E30D021">
-            <dmn:text>"INELIGIBLE","ELIGIBLE"</dmn:text>
-          </dmn:outputValues>
-        </dmn:output>
-        <dmn:annotation name=""/>
-        <dmn:rule id="_3352c79c-5aa5-4f2a-bf7e-c1e24f72a7ed">
-          <dmn:inputEntry id="_51fa1535-776a-411f-ba5d-4915f04adf46">
-            <dmn:text>"DECLINE"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_209c0b4c-7e1f-4758-bb2d-ff56116ebf70">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_e5e44a50-b664-4ce1-8b48-a7c5b73bec50">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_f506afa7-a3fe-48d5-8ec6-4bf2cc2dd28b">
-            <dmn:text>"INELIGIBLE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_1e4a3e10-0d85-4160-85eb-6d3ad7adee82">
-          <dmn:inputEntry id="_0366fd41-b16b-4848-8759-1c1b2f5defc9">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_4c4d51a8-0927-47d1-bf5d-732eeaf9af50">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_bc0c7201-97b5-41ea-8427-31a3923d674c">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_3611f774-9b66-468d-be7f-06bf14407161">
-            <dmn:text>"INELIGIBLE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_c871d706-98a2-4d65-903c-7cbd1571f17c">
-          <dmn:inputEntry id="_4e174888-d7ca-4561-aba8-5fd8dfb3b35b">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_6e1f9fc4-69b2-4e8c-bcf9-8878ec8bd455">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_a120264e-f028-4b2b-8b94-b29b68aa5499">
-            <dmn:text>&lt; 18</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_504ac7aa-2538-48d1-b518-f10a5ff1d87c">
-            <dmn:text>"INELIGIBLE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_11673d64-2390-42c1-bc6f-43074ee90097">
-          <dmn:inputEntry id="_d1ca6c94-6088-43be-bcfe-83b9de492d8a">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_c19d2814-6733-46dc-92cc-48c7b0e59fa8">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_bac13f3d-00eb-49f7-b715-0d379562c1c3">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_0d0dd4a4-0468-44cc-97fc-6cf243ee28b9">
-            <dmn:text>"ELIGIBLE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-      </dmn:decisionTable>
-    </dmn:encapsulatedLogic>
-    <dmn:authorityRequirement id="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
-      <dmn:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:knowledgeSource id="_a5f9b126-7853-4037-9e23-3dd7e93c4032" name="Product specification">
-    <dmn:extensionElements/>
-  </dmn:knowledgeSource>
-  <dmn:businessKnowledgeModel id="_536d7a39-87a6-4651-b743-6ee03e16e535" name="Routing rules">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing Rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Routing from Post-Bureau Risk Category, Post-Bureau Affordability, Bankrupt and Credit Score.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_08f4f63e-54e4-4b19-b0d2-08aeed21605c" name="Routing rules" typeRef="tRouting"/>
-    <dmn:encapsulatedLogic id="_C6A7891D-03F8-49CF-8275-7AFD1147FC3A" kind="FEEL">
-      <dmn:formalParameter id="_54223840-9F04-4851-85A6-2429ED4FA4FB" name="Post-bureau risk category" typeRef="tRiskCategory"/>
-      <dmn:formalParameter id="_C2E9B628-A66A-424F-A519-E93E23858DEE" name="Post-bureau affordability" typeRef="boolean"/>
-      <dmn:formalParameter id="_CC07B347-12E8-4C7B-BD9A-952502B06FEA" name="Bankrupt" typeRef="boolean"/>
-      <dmn:formalParameter id="_A8D16EEA-AF2B-4053-928D-CB2E15211DB4" name="Credit score" typeRef="number"/>
-      <dmn:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Routing rules">
-        <dmn:input id="_b3bde44f-2274-41d5-8e04-5cb2f7529e6c">
-          <dmn:inputExpression id="_51F5E6E5-BA85-4968-AEB4-832DC813A164" typeRef="tRiskCategory">
-            <dmn:text>Post-bureau risk category</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_79225F36-9FCC-4341-9D0F-E039F9650965">
-            <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:input id="_edb3efb0-2fea-4d55-9b5f-ae279ad5ecaa">
-          <dmn:inputExpression id="_E709D705-1EE2-49F2-99F3-5E2B9F22E5AD" typeRef="boolean">
-            <dmn:text>Post-bureau affordability</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:input id="_1fbd45e7-99d5-497d-beb0-a643dd558b63">
-          <dmn:inputExpression id="_CAE471CE-0234-4E48-805F-6FF8CF30690B" typeRef="boolean">
-            <dmn:text>Bankrupt</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:input id="_83878ad8-a1fc-43b0-b601-f1b093e39b48">
-          <dmn:inputExpression id="_9C89B4FB-A91C-4D80-BDFE-DF5F8CABAE82" typeRef="number">
-            <dmn:text>Credit score</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_CB69CB77-A9B7-46D9-959B-801F5CA2A037">
-            <dmn:text>null, [0..999]</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:output id="_109021ab-349a-47f0-9c9e-564a9fbc20e8">
-          <dmn:outputValues id="_960F7270-F2CC-4BA1-BCA6-6CECBCBB09D7">
-            <dmn:text>"DECLINE","REFER","ACCEPT"</dmn:text>
-          </dmn:outputValues>
-        </dmn:output>
-        <dmn:annotation name=""/>
-        <dmn:rule id="_b9e04531-35ba-4562-9c9e-2a6900315e1c">
-          <dmn:inputEntry id="_2844a3b1-bdcf-49f0-9c5c-f80990077a43">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_7ac71a80-a65f-4b42-b125-682fec1c0cda">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_e3ef460f-b05e-4d54-af1e-355c2d6d191e">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_ec772f81-1eee-475c-872a-596fb40c650c">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_27239ae2-8529-4afd-8981-043bb51d2fb2">
-            <dmn:text>"DECLINE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_3ed8ac44-80a1-4e64-b610-f84d79c5b875">
-          <dmn:inputEntry id="_64077b12-6193-4842-86e2-896290756562">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_07978900-95e3-4102-8916-eb439316c4e1">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_2e822dc4-cba8-4594-82bd-b48b4be2180d">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_b3856c1d-2067-483a-b6ca-ba3c8080f12c">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_684c798b-7ade-4155-ad42-cc111cf920a9">
-            <dmn:text>"DECLINE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_0e511735-f478-4041-97f8-158ea173668b">
-          <dmn:inputEntry id="_9ee5cc2a-42ce-4fc6-b4a2-b6ae3c6590c4">
-            <dmn:text>"HIGH"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_be5739cd-c1c9-47ca-af91-47109d2c288a">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_f4f9d322-ca0a-4a24-a967-916aa32f5136">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_fda948c5-43a7-4023-9c52-4020007ca482">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_000ea279-76af-4c1a-a2d6-b8eda969df7a">
-            <dmn:text>"REFER"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_06c90e6c-99d1-4c99-a443-374ab1288c1b">
-          <dmn:inputEntry id="_c87517c4-b47d-4653-a884-3a265dba1ec7">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_0fc27099-c992-4041-b164-9c4d1dddb462">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_527df004-e723-46de-9475-aa2db4e0f4f7">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_dbc688c4-064b-4fe1-ab7e-6992d6cbaf61">
-            <dmn:text>&lt; 580</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_20941825-2c8b-4d94-9fde-0b3039b12a3c">
-            <dmn:text>"REFER"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_3a1673bb-17ae-4b62-b686-d8ecc0f4657b">
-          <dmn:inputEntry id="_7e258e45-824d-402b-b6e5-a46088e90e1e">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_2f51bdea-d5bc-4b8e-ac34-ae093f1ae170">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_913c21a5-d028-4c3b-8482-83d2a5eae2c6">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_4665c331-032d-4489-97bf-4e19eead103e">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_f77e29ae-79a3-4f1d-9eed-7b3795031861">
-            <dmn:text>"ACCEPT"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-      </dmn:decisionTable>
-    </dmn:encapsulatedLogic>
-    <dmn:authorityRequirement id="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
-      <dmn:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:decision id="_ca1e6032-12eb-428a-a80b-49028a88c0b5" name="Routing">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Routing rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Bureau data . Bankrupt as the Bankrupt parameter, Bureau data . CreditScore as the Credit Score parameter, the output of the Post-bureau risk category decision as the Post-Bureau Risk Category parameter, and the output of the Post-bureau affordability decision as the Post-Bureau Affordability parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Bankrupt and Credit Score parameters will be null.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_da1b4341-41b8-4b67-b33a-f54d2782cf4e" name="Routing" typeRef="tRouting"/>
-    <dmn:informationRequirement id="_132debf9-e318-4710-a226-982da98dd278">
-      <dmn:requiredDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
-      <dmn:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
-      <dmn:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_839ccfec-8902-40ca-8767-df9073f797e5">
-      <dmn:requiredKnowledge href="#_536d7a39-87a6-4651-b743-6ee03e16e535"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_78ce14d2-2c68-454a-b772-075b3f1395c3">
-      <dmn:literalExpression id="literal__78ce14d2-2c68-454a-b772-075b3f1395c3">
-        <dmn:text>Routing rules</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_8a009394-dc06-4ee6-b039-dde94390bf6b" name="Bankrupt"/>
-        <dmn:literalExpression id="_32742ced-8b58-4be0-a6be-d48ab1126f69">
-          <dmn:text>Bureau data.Bankrupt</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_5b79a0ff-62ed-4d3d-b512-ea706cc06f62" name="Credit score"/>
-        <dmn:literalExpression id="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a">
-          <dmn:text>Bureau data.CreditScore</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_79216390-7bf1-4b14-9b3e-91ee83a5cd4a" name="Post-bureau risk category"/>
-        <dmn:literalExpression id="_30a91838-0f0a-4843-a6d0-6b5a655f36b2">
-          <dmn:text>Post-bureau risk category</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_6edce48a-be0d-4896-af06-f5c05980970b" name="Post-bureau affordability"/>
-        <dmn:literalExpression id="_7a672677-fd20-4174-87f9-ba5e9146ddba">
-          <dmn:text>Post-bureau affordability</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:businessKnowledgeModel id="_a654be71-b54d-4d6e-90f0-ae505125e9a6" name="Bureau call type table">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table deriving&amp;nbsp;&lt;/span&gt;Bureau Call Type from Pre-Bureau Risk Category.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_86c4fcfd-1e5a-41ec-9b62-966cf0eed2d3" name="Bureau call type table" typeRef="tBureauCallType"/>
-    <dmn:encapsulatedLogic id="_3E30A977-5CC2-46C9-916C-2CF97DB1CF87" kind="FEEL">
-      <dmn:formalParameter id="_B232360A-19B5-492D-BED5-11C5D55DFCFC" name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
-      <dmn:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Bureau call type table">
-        <dmn:input id="_92e35546-27e5-43a5-b8e6-85a692f42eb8">
-          <dmn:inputExpression id="_5804E953-44B0-48FA-A4E3-8FBB40B7EE5A" typeRef="tRiskCategory">
-            <dmn:text>Pre-Bureau Risk Category</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_A05268BA-A982-4ACC-9694-6415E5828A17">
-            <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:output id="_6254d113-6c92-400f-88d5-fdb340519336">
-          <dmn:outputValues id="_1A5EB4EC-6AFB-4C75-9C7D-BC26584BC6C1">
-            <dmn:text>"FULL","MINI","NONE"</dmn:text>
-          </dmn:outputValues>
-        </dmn:output>
-        <dmn:annotation name=""/>
-        <dmn:rule id="_49d3d12b-8572-4341-9102-6f68667bf81a">
-          <dmn:inputEntry id="_7abba955-f604-4995-aea5-842f7eefa839">
-            <dmn:text>"HIGH", "MEDIUM"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_573aec0a-0759-435a-ba0c-5f27498897a0">
-            <dmn:text>"FULL"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_db49e5ea-da50-4b07-ae82-9db29f3730b9">
-          <dmn:inputEntry id="_1f21c493-c6f2-4b81-92f0-59b6511f9ddd">
-            <dmn:text>"LOW"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_9aa8475c-4b5e-4da3-8f3e-aae70f694f83">
-            <dmn:text>"MINI"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_304ebea6-617f-4f47-949d-aa9ac1dd1227">
-          <dmn:inputEntry id="_d3f0c96c-521d-4228-b073-c945aca7483d">
-            <dmn:text>"VERY LOW", "DECLINE"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_2174bcfa-2d27-44ad-8525-56fce28fb75e">
-            <dmn:text>"NONE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-      </dmn:decisionTable>
-    </dmn:encapsulatedLogic>
-    <dmn:authorityRequirement id="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
-      <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:knowledgeSource id="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" name="Risk manager">
-    <dmn:extensionElements/>
-  </dmn:knowledgeSource>
-  <dmn:businessKnowledgeModel id="_b982a42a-0b62-47fa-8911-6c9d1145d982" name="Credit contingency factor table">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;/span&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Credit contingency factor table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;decision&lt;/span&gt; logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Credit contingency factor from Risk Category.&lt;/p&gt;			&lt;p&gt;&amp;nbsp;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_40c0f987-7b90-4c3e-9dcd-411e56f66c92" name="Credit contingency factor table" typeRef="number"/>
-    <dmn:encapsulatedLogic id="_E6280C1C-D063-4872-8901-7783DA7353DE" kind="FEEL">
-      <dmn:formalParameter id="_355FCCB9-0BB3-440A-AC0F-8C19915F5431" name="Risk Category" typeRef="tRiskCategory"/>
-      <dmn:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Credit contingency factor table">
-        <dmn:input id="_2b8fecfd-e00f-4d4b-acf3-660ca3560ca0">
-          <dmn:inputExpression id="_673A97FB-0D8B-4447-BDC4-A68198CD4AE9" typeRef="tRiskCategory">
-            <dmn:text>Risk Category</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_E401103E-3287-4972-BB30-6B0F86B587A9">
-            <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:output id="_8d0d6fe3-a352-48a7-a35e-1fc1dd192039"/>
-        <dmn:annotation name=""/>
-        <dmn:rule id="_21ec60ae-6137-41e2-b8b5-37447708c47b">
-          <dmn:inputEntry id="_8c7e14f8-23db-4645-8b2a-2c69aada207d">
-            <dmn:text>"HIGH", "DECLINE"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_6052bbc0-6f0e-45db-bdd3-3c0ac4c45793">
-            <dmn:text>0.6</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_8c5eb4e3-1902-4bf5-8257-1e21636fc978">
-          <dmn:inputEntry id="_fe0190b4-e2f3-441f-a989-f22e1d425fd8">
-            <dmn:text>"MEDIUM"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_6320ae5d-459e-4775-b492-f9c0d0d492bb">
-            <dmn:text>0.7</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_93e2a1a2-b281-42a4-8e34-865c28557929">
-          <dmn:inputEntry id="_cd63cc67-53a5-480f-abcd-f394e606a7bd">
-            <dmn:text>"LOW", "VERY LOW"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_fdcb46a5-a23c-4e29-93f1-66ce4e3c25da">
-            <dmn:text>0.8</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-      </dmn:decisionTable>
-    </dmn:encapsulatedLogic>
-    <dmn:authorityRequirement id="_07b3ea4d-1eee-4551-b148-b40052f1407a">
-      <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:knowledgeSource id="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" name="Affordability spreadsheet">
-    <dmn:extensionElements/>
-  </dmn:knowledgeSource>
-  <dmn:businessKnowledgeModel id="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" name="Affordability calculation">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Affordability calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a boxed function deriving Affordability from&amp;nbsp;&lt;/span&gt;Monthly Income, Monthly Repayments, Monthly Expenses and Required Monthly Installment. One step in this calculation derives Credit contingency factor by invoking the Credit contingency factor table business&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_80af1aa7-e29c-47fc-9cce-1959a3e1e717" name="Affordability calculation" typeRef="boolean"/>
-    <dmn:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL">
-      <dmn:formalParameter id="_f916b091-cd6d-44cb-b32b-cc83cc27e333" name="Monthly Income" typeRef="number"/>
-      <dmn:formalParameter id="_d68b6438-cba5-4c02-a708-bce0d2762d35" name="Monthly Repayments" typeRef="number"/>
-      <dmn:formalParameter id="_5fd5609d-89ce-463e-a882-6827921edf54" name="Monthly Expenses" typeRef="number"/>
-      <dmn:formalParameter id="_2acfe2aa-892f-4a5c-b9ab-111c7a8bbd40" name="Risk Category" typeRef="tRiskCategory"/>
-      <dmn:formalParameter id="_3a423c76-11c7-4b66-b86a-07928181a631" name="Required Monthly Installment" typeRef="number"/>
-      <dmn:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256">
-        <dmn:contextEntry>
-          <dmn:variable id="_3cc56162-97c1-416e-acb9-3ae81d692e58" name="Disposable Income" typeRef="number"/>
-          <dmn:literalExpression id="_2fcda742-6d7b-49c5-afe6-6b334c8f049b">
-            <dmn:text>Monthly Income - (Monthly Repayments + Monthly Expenses)</dmn:text>
-          </dmn:literalExpression>
-        </dmn:contextEntry>
-        <dmn:contextEntry>
-          <dmn:variable id="_0f406bed-56f5-422e-b6c3-ad4892a38291" name="Credit Contingency Factor" typeRef="number"/>
-          <dmn:invocation id="_78bc74d6-25a4-4639-8509-186534b3c67a">
-            <dmn:literalExpression id="literal__78bc74d6-25a4-4639-8509-186534b3c67a">
-              <dmn:text>Credit contingency factor table</dmn:text>
-            </dmn:literalExpression>
-            <dmn:binding>
-              <dmn:parameter id="_7fed77e8-7d20-4f3f-9504-2c0c0706bd39" name="Risk Category"/>
-              <dmn:literalExpression id="_a02265a9-3dd1-48cd-a254-84531f28a058">
-                <dmn:text>Risk Category</dmn:text>
-              </dmn:literalExpression>
-            </dmn:binding>
-          </dmn:invocation>
-        </dmn:contextEntry>
-        <dmn:contextEntry>
-          <dmn:variable id="_efb9411e-34c6-4e72-a664-85a30197f5d0" name="Affordability" typeRef="boolean"/>
-          <dmn:literalExpression id="_3051a016-282e-4f83-8cfa-4c57084e559f">
-            <dmn:text>if Disposable Income * Credit Contingency Factor &gt; Required Monthly Installment							then true							else false</dmn:text>
-          </dmn:literalExpression>
-        </dmn:contextEntry>
-        <dmn:contextEntry>
-          <dmn:literalExpression id="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55">
-            <dmn:text>Affordability</dmn:text>
-          </dmn:literalExpression>
-        </dmn:contextEntry>
-      </dmn:context>
-    </dmn:encapsulatedLogic>
-    <dmn:knowledgeRequirement id="_7f7c177a-5acb-4941-9654-23f9408200b3">
-      <dmn:requiredKnowledge href="#_b982a42a-0b62-47fa-8911-6c9d1145d982"/>
-    </dmn:knowledgeRequirement>
-    <dmn:authorityRequirement id="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
-      <dmn:requiredAuthority href="#_18d836e7-6d61-490c-b9a8-be3ce0c60c1e"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:decision id="_ed60265c-25e2-400f-a99f-fafd3b489838" name="Pre-bureau affordability">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Pre-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_bd744aca-06aa-4438-81de-0754fc15a44e" name="Pre-bureau affordability" typeRef="boolean"/>
-    <dmn:informationRequirement id="_00c137a3-a81c-42ff-af6d-5c3247151273">
-      <dmn:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
-      <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
-      <dmn:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
-      <dmn:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_7fea3599-f557-487a-bc0c-6aad2e8e6c86">
-      <dmn:literalExpression id="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86">
-        <dmn:text>Affordability calculation</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_ea45f34e-c7f7-41fe-a2fa-c9329dc03ead" name="Monthly Income"/>
-        <dmn:literalExpression id="_63cbd20f-fab4-480e-9471-1367b2e1fc6c">
-          <dmn:text>Applicant data.Monthly.Income</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_28b8d43b-e005-42f0-a432-5ea3c6547247" name="Monthly Repayments"/>
-        <dmn:literalExpression id="_c35a57bf-208c-4333-973f-c8a9e9ce85f4">
-          <dmn:text>Applicant data.Monthly.Repayments</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_650b93d6-d6cd-46dc-8ebc-d1d80c5c4fa7" name="Monthly Expenses"/>
-        <dmn:literalExpression id="_174c9fb3-c940-455f-ab97-035989e83446">
-          <dmn:text>Applicant data.Monthly.Expenses</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_70836844-402b-49b0-b07a-347c81e0f345" name="Risk Category"/>
-        <dmn:literalExpression id="_34d3db82-c899-45f6-b46c-ef7cb2f550c3">
-          <dmn:text>Pre-bureau risk category</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_b94f43b0-69d0-4f20-9698-5f91b85f026a" name="Required Monthly Installment"/>
-        <dmn:literalExpression id="_47e0147f-030a-4020-a5d3-728c563c0bd2">
-          <dmn:text>Required monthly installment</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" name="Post-bureau affordability">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Post-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_b6f25146-5302-470e-a242-3d71c4311add" name="Post-bureau affordability" typeRef="boolean"/>
-    <dmn:informationRequirement id="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
-      <dmn:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_9eeef063-346f-44d4-b722-2d8071d3d994">
-      <dmn:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_466b70d3-035a-413d-93bd-ae28c778d02d">
-      <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
-      <dmn:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_3e5d9f10-9433-4853-b084-33790988de2a">
-      <dmn:literalExpression id="literal__3e5d9f10-9433-4853-b084-33790988de2a">
-        <dmn:text>Affordability calculation</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_ecb484a1-1ca6-40d8-863f-ba95fea13779" name="Monthly Income"/>
-        <dmn:literalExpression id="_610d5776-9163-4707-85c4-c4f0ff35db0a">
-          <dmn:text>Applicant data.Monthly.Income</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_b5f0835b-4dba-418b-a11c-3a23a76f3ae6" name="Monthly Repayments"/>
-        <dmn:literalExpression id="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36">
-          <dmn:text>Applicant data.Monthly.Repayments</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_f8edc4a3-5000-4558-80f0-45efaee7e339" name="Monthly Expenses"/>
-        <dmn:literalExpression id="_3d3c099c-c287-45ff-82de-ca3079da67b0">
-          <dmn:text>Applicant data.Monthly.Expenses</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_a8c6984b-8bca-41cc-b284-d056a18b43af" name="Risk Category"/>
-        <dmn:literalExpression id="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113">
-          <dmn:text>Post-bureau risk category</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_cac9db30-48f9-4b43-b9fa-699171ac858b" name="Required Monthly Installment"/>
-        <dmn:literalExpression id="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227">
-          <dmn:text>Required monthly installment</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_40b45659-9299-43a6-af30-04c948c5c0ec" name="Post-bureau risk category">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Post-bureau&amp;nbsp;&lt;/span&gt;risk category business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter, Bureau data.CreditScore as the Credit Score parameter, and the output of the Application risk score decision as the Application Risk Score parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Credit Score parameter will be null.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_34b85411-de9d-4d9a-8b03-ad1b1cec8777" name="Post-bureau risk category" typeRef="tRiskCategory"/>
-    <dmn:informationRequirement id="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
-      <dmn:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_668fa95d-373d-4430-b833-7c27308d2a80">
-      <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_655fba60-b529-4c21-bd96-9c778998d3fb">
-      <dmn:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_dc094e13-abbd-4164-bc95-a61b433a7be4">
-      <dmn:requiredKnowledge href="#_1c72ed95-ec72-47b4-8639-5ed14ccb77df"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b">
-      <dmn:literalExpression id="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b">
-        <dmn:text>Post-bureau risk category table</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_a7faf416-0247-43c1-8827-9346540d13c3" name="Existing Customer"/>
-        <dmn:literalExpression id="_9eb92498-0de3-44b1-a8e2-301a2bc091d4">
-          <dmn:text>Applicant data.ExistingCustomer</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_b0bb0d61-0ea4-4c10-8a97-94be610bee0b" name="Credit Score"/>
-        <dmn:literalExpression id="_ad652244-9438-4a76-9637-2ca8dde2cee4">
-          <dmn:text>Bureau data.CreditScore</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_4bb7604e-18d8-4d57-8097-cd2585c59266" name="Application Risk Score"/>
-        <dmn:literalExpression id="_9ead8557-599e-4900-80b8-7157c0653d82">
-          <dmn:text>Application risk score</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:inputData id="_e91de815-22ba-431c-8b46-55891f2a1ef6" name="Bureau data">
-    <dmn:extensionElements/>
-    <dmn:variable id="_aa8440f8-8f48-4e37-b775-ab8d771d24eb" name="Bureau data" typeRef="tBureauData"/>
-  </dmn:inputData>
-  <dmn:businessKnowledgeModel id="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" name="Post-bureau risk category table">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Post-Bureau Risk Category from Existing Customer, Application Risk Score and Credit Score.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_689c96f3-6dd3-4c74-9a8f-721a966eb1af" name="Post-bureau risk category table" typeRef="tRiskCategory"/>
-    <dmn:encapsulatedLogic id="_04437EA6-7362-4693-B4B3-9431E330CEAC" kind="FEEL">
-      <dmn:formalParameter id="_C17D41A5-4349-48DF-8214-B63DF79C6B5F" name="Existing Customer" typeRef="boolean"/>
-      <dmn:formalParameter id="_CD5886D0-BF0E-4597-9F36-C8AA61763B54" name="Application Risk Score" typeRef="number"/>
-      <dmn:formalParameter id="_B0470BB1-6409-42A6-A3D1-BC860328EF03" name="Credit Score" typeRef="number"/>
-      <dmn:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Post-bureau risk category table">
-        <dmn:input id="_fc4cfa6b-926b-4751-81d9-d363b6f19299">
-          <dmn:inputExpression id="_CC27D5E4-1519-4A2B-BF83-5E4364B5C9AE" typeRef="boolean">
-            <dmn:text>Existing Customer</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:input id="_77a90f33-64d6-4050-a932-a9c8454b10ab">
-          <dmn:inputExpression id="_D1B46CF7-92BD-49C1-AAE2-F332CDC1F1B5" typeRef="number">
-            <dmn:text>Application Risk Score</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:input id="_129a63ca-ea08-460a-98f3-bbb9b9a11121">
-          <dmn:inputExpression id="_B2E8029F-1632-416A-883A-AAB8151E029B" typeRef="number">
-            <dmn:text>Credit Score</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:output id="_44033e77-5b86-4040-83a3-63629ae25983">
-          <dmn:outputValues id="_0CC7EC7C-D3C6-4B9F-A45E-3EFD34EAC191">
-            <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
-          </dmn:outputValues>
-        </dmn:output>
-        <dmn:annotation name=""/>
-        <dmn:rule id="_22d41220-e512-4248-bed3-935266abfac6">
-          <dmn:inputEntry id="_2c44dae4-55da-4aad-8dca-6db78b1463ff">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_f75f53c2-d798-4b12-bfbb-f3c2dcbb7d13">
-            <dmn:text>&lt; 120</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_19694f9e-0022-42bd-a10c-8ec5855d2608">
-            <dmn:text>&lt; 590</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_04e9777f-143b-44f5-be3e-a17710658417">
-            <dmn:text>"HIGH"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_ca0d34ce-5f88-489f-b07d-c153cfcc9a9f">
-          <dmn:inputEntry id="_1a227ae6-84eb-46b5-a355-e9414e2b4c68">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_d571de40-d13c-40d1-b4d8-7c9ef4f3d405">
-            <dmn:text>&lt; 120</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_eaad5ff9-9a13-4321-b1ed-b9b81a6bc7c3">
-            <dmn:text>[590..610]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_e47b1857-760e-4a6a-ab76-575d57ed3d75">
-            <dmn:text>"MEDIUM"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_731cfff1-8846-4204-b2d8-d4273e7caf6d">
-          <dmn:inputEntry id="_9398558c-7346-41e6-b466-6db6a65a6886">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_69198768-fbd1-48f4-a233-6a237f8759d3">
-            <dmn:text>&lt; 120</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_9853a883-301b-4134-8411-11fcc78cca01">
-            <dmn:text>&gt; 610</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_e56ad1e0-521d-4648-9209-81909e453bec">
-            <dmn:text>"LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_7124ae55-0a5c-40a5-858a-2e97d3fcee2b">
-          <dmn:inputEntry id="_d66444ed-d5af-47e9-9425-d41c72eab9d8">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_a24e787d-5735-4086-b27e-b536108f0cab">
-            <dmn:text>[120..130]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_801d5239-537e-4147-80ce-2226cf9bb6dd">
-            <dmn:text>&lt; 600</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_27df9777-129b-4e9a-8e01-1c016b90f049">
-            <dmn:text>"HIGH"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_6849c070-ffaf-4afd-b739-c9516e093a2d">
-          <dmn:inputEntry id="_d7cdde1c-c04e-4cf6-9c6e-58e73ceb48e4">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_79cd3d7c-5e16-48c1-bb40-b5f30dec9830">
-            <dmn:text>[120..130]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_1c63b959-c10b-4c66-b024-684fb3773c13">
-            <dmn:text>[600..625]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_ad886bab-7ca9-466a-873e-a7fdc7dc0e29">
-            <dmn:text>"MEDIUM"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_abe53d6c-0c5e-4de6-8835-452442e07761">
-          <dmn:inputEntry id="_8a73641d-2a45-423e-ba92-cc6463dcdefe">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_a4131075-a73f-46cf-9e6b-4cf014f95567">
-            <dmn:text>[120..130]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_d81f0359-dab6-4813-a818-62bebe59d2c6">
-            <dmn:text>&gt; 625</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_28527dae-a87d-4cd3-9f2e-7d244c617b17">
-            <dmn:text>"LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_1a267a70-0937-42cd-a778-9ef369309660">
-          <dmn:inputEntry id="_6d4e7030-c29d-4f31-b1a5-8e57323425fd">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_d0be0dbe-0ef4-4198-b612-7a415e569e73">
-            <dmn:text>&gt; 130</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_ffb1d0e3-4ecb-4497-8df0-6262f0e56ff2">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_3de03ecf-f018-4135-add5-fd54737cee48">
-            <dmn:text>"VERY LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_4ec01cc3-2dce-453f-a195-e8a598be44ab">
-          <dmn:inputEntry id="_69c5f5cb-c384-4596-8fd7-615cdcc4abf4">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_86661a8a-4179-4df7-9556-5e5937b676b9">
-            <dmn:text>&lt;= 100</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_7580e93d-f53b-405c-b6ab-87d9cb1f5fa1">
-            <dmn:text>&lt; 580</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_00ef5d95-f613-41c8-8bf5-35aeee1e55e8">
-            <dmn:text>"HIGH"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_2ca1a47c-33b0-426d-87b4-d1dd23de3e30">
-          <dmn:inputEntry id="_d9bafc07-3e85-442e-bb8a-99f7f2b7488a">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_005e60af-83b1-471c-aa1c-1a1bc9e8f197">
-            <dmn:text>&lt;= 100</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_0a6e9560-ff9a-4b30-b5e4-1f218b8ea6c2">
-            <dmn:text>[580..600]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_2bd1761e-b0f6-4eed-8df0-0f3bedf84817">
-            <dmn:text>"MEDIUM"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_4ad8a80e-0e44-4512-8925-6f3ef0bcf67e">
-          <dmn:inputEntry id="_25c987a9-40dd-4f40-a7b2-7b6b7020f729">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_a8c73104-1d46-4c4d-ba3b-25ac8b812a4b">
-            <dmn:text>&lt;= 100</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_295d25f5-f29a-456e-a000-7b26c3a3ba1d">
-            <dmn:text>&gt; 600</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_ae145544-b4e9-4c07-95d4-9e77237813f6">
-            <dmn:text>"LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_a14b851e-8b11-416e-806b-59222b4b0cc9">
-          <dmn:inputEntry id="_77185ff7-c946-46cc-b93a-dabdc111f5dd">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_be1969ad-6a34-4e7f-8e14-cfabf84c9d33">
-            <dmn:text>&gt; 100</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_b93f37d5-afe8-40e1-aa4f-272d19da02d9">
-            <dmn:text>&lt; 590</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_d7479784-014d-497f-9d06-1b111fa9c29f">
-            <dmn:text>"HIGH"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_4377ced8-b8d9-4069-9dcf-098007969563">
-          <dmn:inputEntry id="_28eee2fe-8a48-4a73-8488-10c506a7add5">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_7c50c99a-c045-42c5-a647-22a4eae50036">
-            <dmn:text>&gt; 100</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_a71f7fc4-f200-4694-9738-23b01485ba78">
-            <dmn:text>[590..615]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_02efcf34-86b8-411c-81bc-98668fe07bb3">
-            <dmn:text>"MEDIUM"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_20a9e6e8-bab5-4d49-803c-12d3b574fdd3">
-          <dmn:inputEntry id="_2ba73fd9-c951-45dc-ac77-f6904c26e37c">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_cf3a2739-9a36-4702-b0f3-e8b0a0338db1">
-            <dmn:text>&gt; 100</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_56cc9c15-43a9-4d81-975a-ab69f53a528b">
-            <dmn:text>&gt; 615</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_13bc4965-9c91-44bd-973c-25dd9c1bebab">
-            <dmn:text>"LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-      </dmn:decisionTable>
-    </dmn:encapsulatedLogic>
-    <dmn:authorityRequirement id="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
-      <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:decision id="_9997fcfd-0f50-4933-939e-88a235b5e2a0" name="Pre-bureau risk category">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-Bureau Risk Category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Pre-bureau&amp;nbsp;&lt;/span&gt;risk category table business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter and the output of the Application risk score decision as the Application Risk Score parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_a739014d-8c5e-438b-b76a-805e3689c977" name="Pre-bureau risk category" typeRef="tRiskCategory"/>
-    <dmn:informationRequirement id="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
-      <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
-      <dmn:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
-      <dmn:requiredKnowledge href="#_51cc9510-3bfa-4e5a-a119-9bf83efdd266"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_04337ddb-db98-40e9-81cd-12802e74401e">
-      <dmn:literalExpression id="literal__04337ddb-db98-40e9-81cd-12802e74401e">
-        <dmn:text>Pre-bureau risk category table</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_74d8aa6b-838e-4d87-8d64-8b734146aac6" name="Existing Customer"/>
-        <dmn:literalExpression id="_4b5e5cfb-d6fa-4d41-a13a-783170887126">
-          <dmn:text>Applicant data.ExistingCustomer</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_929d5796-6174-41eb-b27c-52f956fd44dd" name="Application Risk Score"/>
-        <dmn:literalExpression id="_b93f253e-7f93-4356-a98b-3fae510485e3">
-          <dmn:text>Application risk score</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:businessKnowledgeModel id="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" name="Pre-bureau risk category table">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Pre-bureau risk category from Existing Customer and Application Risk Score.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_cfb1bb8c-ad27-42e2-b52a-50eadea198a6" name="Pre-bureau risk category table" typeRef="tRiskCategory"/>
-    <dmn:encapsulatedLogic id="_530613B3-1EC6-4E64-B33A-899F0E219BA0" kind="FEEL">
-      <dmn:formalParameter id="_4E26B3A4-7FBF-4B0F-8E88-9F9FCA20C4E0" name="Existing Customer" typeRef="boolean"/>
-      <dmn:formalParameter id="_F8C2891C-B02D-438F-98F8-55EB9756CE70" name="Application Risk Score" typeRef="number"/>
-      <dmn:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Pre-bureau risk category table">
-        <dmn:input id="_1ee6291f-423f-47d9-8774-858b392d4762">
-          <dmn:inputExpression id="_C6B71901-5D95-4AEA-96AD-15E29DB11E57" typeRef="boolean">
-            <dmn:text>Existing Customer</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:input id="_22607edc-31dd-4d18-982f-b3d4b4606804">
-          <dmn:inputExpression id="_C1A68048-8A6E-4BB1-A706-9BA92A7D01CF" typeRef="number">
-            <dmn:text>Application Risk Score</dmn:text>
-          </dmn:inputExpression>
-        </dmn:input>
-        <dmn:output id="_f482a2b4-eed1-4dfc-84b6-4860edec088d">
-          <dmn:outputValues id="_027CF4BA-B83F-4893-981E-B1F2906C0899">
-            <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
-          </dmn:outputValues>
-        </dmn:output>
-        <dmn:annotation name=""/>
-        <dmn:rule id="_05c9836c-6f21-49e9-8e4b-0ad029d1a38c">
-          <dmn:inputEntry id="_5dc5082d-6dc3-46ce-821f-3fe0981a0407">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_f9c9f1c0-dba5-4adc-8764-c740d55abc5e">
-            <dmn:text>&lt; 100</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_520b6480-8c90-4ab0-bfd2-2e6107c9c2aa">
-            <dmn:text>"HIGH"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_7d1fbf47-e150-44d1-aa1c-b6c15ccc92c3">
-          <dmn:inputEntry id="_2c0451d5-f065-41a4-ada7-4a3fb29a668d">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_e7f1fb9b-32d4-4a45-95f3-8390801435a8">
-            <dmn:text>[100..120)</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_699696bd-226d-4dca-bba3-1a5b7ad0a8f0">
-            <dmn:text>"MEDIUM"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_da654f4f-3a18-44ec-8087-f27715c1e12b">
-          <dmn:inputEntry id="_5df3c3df-0bed-4171-b915-e084fce11e51">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_dd71d0af-cfb7-4472-a745-28a36251b945">
-            <dmn:text>[120..130]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_331e4bd4-397e-44dd-a403-44b3cf4ad15d">
-            <dmn:text>"LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_524a197c-3981-41ee-baed-1de02c55fac3">
-          <dmn:inputEntry id="_a76ff1d9-f651-4833-8773-7d75925b5fe4">
-            <dmn:text>false</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_123b03ad-4815-4f98-8870-9c25e06fac6b">
-            <dmn:text>&gt; 130</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_f33f040b-a116-43c1-9791-bef711299be6">
-            <dmn:text>"VERY LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_ab1dfe10-5fbc-47fc-8ade-fd56c0a334c5">
-          <dmn:inputEntry id="_acf40b4c-d68c-49d6-a2a4-2a88ace33016">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_ce80bf8c-6cad-400b-8b18-23c920d6f594">
-            <dmn:text>&lt; 80</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_44ea4ff9-e85c-40b6-b1a8-c9a76b1ae13e">
-            <dmn:text>"DECLINE"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_a297a507-5206-4903-94f6-9b6fd6619195">
-          <dmn:inputEntry id="_9a3f8732-e85f-4111-a3f1-2284065f64fe">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_7d398c94-e4c1-4d9c-bf06-cf40f2c04d64">
-            <dmn:text>[80..90)</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_f54b6b94-ec25-451d-8d7d-1049155b3e2b">
-            <dmn:text>"HIGH"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_740e7ddb-0834-4705-bbb3-7b092e9570dc">
-          <dmn:inputEntry id="_7fe40ffd-bd8e-4405-8719-0bd706933fd5">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_4b77407a-565f-40ad-b324-6e3940134518">
-            <dmn:text>[90..110]</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_894b1284-9923-4727-bbc4-fc621b47a28b">
-            <dmn:text>"MEDIUM"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_95fb462f-6435-44b7-8c21-84427ce71bc9">
-          <dmn:inputEntry id="_3e033f1d-a632-41d4-9eb9-63d66e5e4380">
-            <dmn:text>true</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_753f756e-cdee-49d2-8953-dfad7aa9b092">
-            <dmn:text>&gt; 110</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_2fb8f713-e746-4a65-aff0-fa1de216f57a">
-            <dmn:text>"LOW"</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-      </dmn:decisionTable>
-    </dmn:encapsulatedLogic>
-    <dmn:authorityRequirement id="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
-      <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:decision id="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" name="Application risk score">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application Risk Score&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Application&amp;nbsp;&lt;/span&gt;risk score model business knowledge model, passing Applicant data.Age as the Age parameter, Applicant data.MaritalStatus as the Marital Status parameter and Applicant data.EmploymentStatus as the Employment Status parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_f2abe78f-d5d0-4b9e-8d05-f1ea2bd7fc9b" name="Application risk score" typeRef="number"/>
-    <dmn:informationRequirement id="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
-      <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_c94de723-def1-49e4-9aae-5270fe39630f">
-      <dmn:requiredKnowledge href="#_e9e07f04-0ff2-40c4-bd14-e5f06a91f942"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_348139f6-7fd0-40be-952d-66a8bb83d59c">
-      <dmn:literalExpression id="literal__348139f6-7fd0-40be-952d-66a8bb83d59c">
-        <dmn:text>Application risk score model</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_aba556aa-0e5b-4d01-bd6e-d25b780bbf28" name="Age"/>
-        <dmn:literalExpression id="_9c3009af-9a1b-4821-8901-7edf800ac60b">
-          <dmn:text>Applicant data.Age</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_259966f2-bf40-4139-b587-6c9b989f1aa0" name="Marital Status"/>
-        <dmn:literalExpression id="_610941db-8c4e-483c-9d75-789b3d5c2333">
-          <dmn:text>Applicant data.MartitalStatus</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_dc6d2bc7-3bde-4994-838d-b3fa1fe1ab2c" name="Employment Status"/>
-        <dmn:literalExpression id="_c08280b8-beb0-4eb1-a0d0-f022de521d25">
-          <dmn:text>Applicant data.EmploymentStatus</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:knowledgeSource id="_821a6840-e910-418f-809e-4c7d60b0b21a" name="Analytics">
-    <dmn:extensionElements/>
-  </dmn:knowledgeSource>
-  <dmn:businessKnowledgeModel id="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" name="Application risk score model">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application risk score model&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, no-order multiple-hit table&amp;nbsp;&lt;/span&gt;with aggregation, deriving Application risk score from Age, Marital Status and Employment Status, as the sum of the Partial scores of all matching rows (this is therefore a predictive scorecard represented as a decision table).&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_645f4911-6a95-4dbd-8efb-13fac8154fa2" name="Application risk score model" typeRef="number"/>
-    <dmn:encapsulatedLogic id="_3161744E-C244-4C89-ACA8-4462EC11C790" kind="FEEL">
-      <dmn:formalParameter id="_9B4C6309-1948-4C18-8A6D-8E818BE99ABA" name="Age" typeRef="number"/>
-      <dmn:formalParameter id="_BD812E70-C915-41D5-BCEF-FD254CEB3CB9" name="Marital Status" typeRef="string"/>
-      <dmn:formalParameter id="_B1D95DAD-0E2E-471D-8D28-98EC24A25E5B" name="Employment Status" typeRef="string"/>
-      <dmn:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" aggregation="SUM" preferredOrientation="Rule-as-Row" outputLabel="Application risk score model">
-        <dmn:input id="_09b90043-cccb-4cf7-b8bc-44e97787443f">
-          <dmn:inputExpression id="_7D0E7BCC-8406-41CB-82C5-FDE26284A4DB" typeRef="number">
-            <dmn:text>Age</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_CF573CA7-5005-43A9-944C-5C5295B7C0EB">
-            <dmn:text>[18..120]</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:input id="_803f1aa0-731a-4541-bfba-6211a564af69">
-          <dmn:inputExpression id="_1DA5350F-43E0-4CD3-9DA6-51A3B96EF50D" typeRef="string">
-            <dmn:text>Marital Status</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_2F73B19B-0C7D-4897-A4D1-C2BDB856CCF9">
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_341BB558-F920-4CE0-BA95-97334497CC42" name="tRiskCategory" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues id="_56346CAE-3D8A-4F07-96B7-D90550813E80">
+         <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
+      </dmn:allowedValues>
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_5504EC4C-2D38-409D-BA66-1DE0550EDA38" name="tApplicantData" isCollection="false">
+      <dmn:itemComponent id="_df3aab6f-1610-41fa-a407-09678a89d6da" name="Age" isCollection="false">
+         <dmn:typeRef>number</dmn:typeRef>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_d39ad810-7781-4ffb-9644-de51d1ca7f7a" name="MartitalStatus" isCollection="false">
+         <dmn:typeRef>string</dmn:typeRef>
+         <dmn:allowedValues id="_ABFF00EE-E61C-4814-A41A-5D410BB0C201">
             <dmn:text>"S","M"</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:input id="_e32f7b2c-5837-4e18-acea-a100115f412d">
-          <dmn:inputExpression id="_652E4A72-33DB-468A-BB7B-5BE4A964000E" typeRef="string">
-            <dmn:text>Employment Status</dmn:text>
-          </dmn:inputExpression>
-          <dmn:inputValues id="_06CB01A0-DB52-459B-AC00-B68F0C88927C">
-            <dmn:text>"UNEMPLOYED","STUDENT","EMPLOYED","SELF-EMPLOYED"</dmn:text>
-          </dmn:inputValues>
-        </dmn:input>
-        <dmn:output id="_e7b50872-4ad3-496a-ac06-15dc98c9d526"/>
-        <dmn:annotation name=""/>
-        <dmn:rule id="_cd986c20-a58b-413e-96c3-37d2f48fe361">
-          <dmn:inputEntry id="_b5fa1bbc-0cc3-462c-b978-429e932a83ab">
-            <dmn:text>[18..22)</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_43189918-aecd-4713-8e23-231b35b299d7">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_f8be0751-2823-46d8-8007-c4fb601fcba8">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_dab1ccbe-edc2-4cc2-9167-1d452b4ad0c2">
-            <dmn:text>32</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_271d1521-3fb9-4b1d-a74d-0abf1c131186">
-          <dmn:inputEntry id="_57a0f913-e95b-4941-b868-e306d484f045">
-            <dmn:text>[22..26)</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_23b572c3-9c6f-4e17-8bdb-95fd58f404d5">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_85a87989-40c4-4027-b674-6d21b6d5bb64">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_8f6c2458-a000-4d1f-b6a1-a553f8b3c4db">
-            <dmn:text>35</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_558f8923-cd42-484a-b6b0-7cb28bfa7480">
-          <dmn:inputEntry id="_795dc738-ca79-4c60-9746-e44bc1b34663">
-            <dmn:text>[26..36)</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_8492546f-c66a-46e5-9e86-9b0a79ec99d6">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_2efe9985-1475-426d-abb3-760fed744a14">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_7146afbc-d68f-415d-9abf-da3ad5a87527">
-            <dmn:text>40</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_389ee4a2-47d3-42fc-ad04-e8798d638d33">
-          <dmn:inputEntry id="_cf08fa6c-084d-4f2c-ae60-aa0abb5d7b2a">
-            <dmn:text>[36..50)</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_7b81f517-a79a-4213-b74b-4cf01ee9a7c3">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_1101bb57-178a-4c25-9d79-7759553e9d7d">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_10c870e9-f72d-45f0-bcfd-bc6bcc0d2315">
-            <dmn:text>43</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_8c355a92-0f8b-4d41-ada2-b98b05237249">
-          <dmn:inputEntry id="_c28cca26-4eda-4d37-a056-15b23eec9690">
-            <dmn:text>&gt;=50</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_29ab6240-13dd-478f-ac73-0805778efe30">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_3ddc0313-cd5b-40f3-8858-87a384ee1f23">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_c2fe72a6-2591-413b-b4e8-a73a3fca33bc">
-            <dmn:text>48</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_ffdf62cd-9909-4dd0-a15e-19fcb5a5ce6f">
-          <dmn:inputEntry id="_90065ca5-703d-4b29-9924-c949f210683e">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_5167d8a0-f82c-4f9b-b948-94ee8ef9b753">
-            <dmn:text>"S"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_d9f2e10b-80c2-4f8e-af9b-83d3317e14b9">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_f1dd8303-3db4-4fe2-879c-fd5b0ecd970d">
-            <dmn:text>25</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_cf192d51-2d52-4280-a41f-4941f1611b60">
-          <dmn:inputEntry id="_b1e8abb2-ecee-4fdf-8d75-a292d8bf8b0f">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_35f4590a-63a0-4a46-a875-9b37b6e8ada2">
-            <dmn:text>"M"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_e50ee6a1-78bc-4ee0-8030-6f9654057e9a">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_f36c68f8-b188-4675-bb7b-ea5347a08fff">
-            <dmn:text>45</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_90b8f62c-6ca6-4234-97c4-4de2011374b9">
-          <dmn:inputEntry id="_a1de40fe-8951-4ecb-bfc7-516a2d77bf55">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_63f774ad-98ab-44e6-8ebf-83a00437e7d6">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_9e4a3948-ec86-4987-a80d-2f0bc9c63530">
-            <dmn:text>"UNEMPLOYED"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_3f14a6c0-3829-41c2-a57c-154574752788">
-            <dmn:text>15</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_bc447e0a-a445-4029-804b-138b76a766ef">
-          <dmn:inputEntry id="_9196a27c-a829-43d7-b973-73bf13915ec3">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_1d672363-4080-4dd8-82cd-d30ff16d4383">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_28ca5667-24ac-4c8c-8557-ede60e51b461">
-            <dmn:text>"STUDENT"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_90a363e8-d80d-4d78-9e33-2be7cbb9fd05">
-            <dmn:text>18</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_5651d55b-18a5-4ff4-bc28-30ce10385a2d">
-          <dmn:inputEntry id="_93400b3b-bdda-4370-878b-e221bf8521c6">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_df5d20cf-6971-4911-832f-683d2a790c11">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_a0b06347-1422-4b9d-bdd0-ede06b7e5d0b">
-            <dmn:text>"EMPLOYED"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_78582066-9c90-4b16-88a3-1709b784a4ff">
-            <dmn:text>45</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
-        <dmn:rule id="_07c9f995-1814-4a77-9ab1-f03c21337165">
-          <dmn:inputEntry id="_b377eba2-90f6-4913-8a84-e0e358cb4ae5">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_c515456a-3519-4446-aeaa-6f3f613a8812">
-            <dmn:text>-</dmn:text>
-          </dmn:inputEntry>
-          <dmn:inputEntry id="_6d9fc071-2870-4397-83de-802aa5f398a5">
-            <dmn:text>"SELF-EMPLOYED"</dmn:text>
-          </dmn:inputEntry>
-          <dmn:outputEntry id="_233be7af-2d3f-4b9c-bb69-561f8378e870">
-            <dmn:text>36</dmn:text>
-          </dmn:outputEntry>
-          <dmn:annotationEntry>
-            <dmn:text></dmn:text>
-          </dmn:annotationEntry>
-        </dmn:rule>
+         </dmn:allowedValues>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_9242f7aa-a9fc-451e-a8ee-60f1ff992664" name="EmploymentStatus" isCollection="false">
+         <dmn:typeRef>string</dmn:typeRef>
+         <dmn:allowedValues id="_B8CA3808-CEFC-4DA1-A8D5-577712D1AEFF">
+            <dmn:text>"EMPLOYED","SELF-EMPLOYED","STUDENT","UNEMPLOYED"</dmn:text>
+         </dmn:allowedValues>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_5b4cce4a-bb99-41d5-99f2-0b2d7deeea8e" name="ExistingCustomer" isCollection="false">
+         <dmn:typeRef>boolean</dmn:typeRef>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_c3ad187d-246f-4707-aa05-b9d5d8da1f58" name="Monthly" isCollection="false">
+         <dmn:itemComponent id="_0ff9ec7c-ef0f-425a-af5c-d251135e3631" name="Income" isCollection="false">
+            <dmn:typeRef>number</dmn:typeRef>
+         </dmn:itemComponent>
+         <dmn:itemComponent id="_d4389c69-0a87-4db9-96fa-99674bff6b97" name="Repayments" isCollection="false">
+            <dmn:typeRef>number</dmn:typeRef>
+         </dmn:itemComponent>
+         <dmn:itemComponent id="_c0bd1a20-826f-4fe4-86bc-b6cca2af06a1" name="Expenses" isCollection="false">
+            <dmn:typeRef>number</dmn:typeRef>
+         </dmn:itemComponent>
+      </dmn:itemComponent>
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_295BDBD0-FE79-4298-B283-8FC2DEF2D42A" name="tBureauData" isCollection="false">
+      <dmn:itemComponent id="_4b58e0c0-649b-472a-8a28-f8dde1e40068" name="Bankrupt" isCollection="false">
+         <dmn:typeRef>boolean</dmn:typeRef>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_42350ffd-8f82-4500-b9cb-696758cc287e" name="CreditScore" isCollection="false">
+         <dmn:typeRef>number</dmn:typeRef>
+         <dmn:allowedValues id="_338E8C57-AC12-4CDA-BB70-F26D9124D307">
+            <dmn:text>[0..999], null</dmn:text>
+         </dmn:allowedValues>
+      </dmn:itemComponent>
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_7A47C6BE-9076-4AC4-A730-B40F70637162" name="tRouting" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues id="_9090335D-BBA7-4C44-B1ED-1A42F6AEEBB6">
+         <dmn:text>"DECLINE","REFER","ACCEPT"</dmn:text>
+      </dmn:allowedValues>
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_9126CE5C-DE46-47E5-BF45-E78DDCEA79A1" name="tRequestedProduct" isCollection="false">
+      <dmn:itemComponent id="_c993adad-698b-477d-a395-f4021d38ef8b" name="ProductType" isCollection="false">
+         <dmn:typeRef>string</dmn:typeRef>
+         <dmn:allowedValues id="_4C8661D6-FD5B-4242-AC48-47672DF0518A">
+            <dmn:text>"STANDARD LOAN","SPECIAL LOAN"</dmn:text>
+         </dmn:allowedValues>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_5ddc6d4c-67d2-4a00-a9c0-3614d228964b" name="Rate" isCollection="false">
+         <dmn:typeRef>number</dmn:typeRef>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_4e47a0e8-ab4a-46a2-ae8c-209401ebdd8f" name="Term" isCollection="false">
+         <dmn:typeRef>number</dmn:typeRef>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_24103ee1-2867-4e01-abfc-d40b3aed0ce5" name="Amount" isCollection="false">
+         <dmn:typeRef>number</dmn:typeRef>
+      </dmn:itemComponent>
+   </dmn:itemDefinition>
+   <dmn:decision id="_4bd33d4a-741b-444a-968b-64e1841211e7" name="Adjudication">
+      <dmn:extensionElements />
+      <dmn:variable id="_12f285f8-ae4e-4421-98bd-d9b1fd236e10" name="Adjudication" />
+      <dmn:informationRequirement id="_290b4df4-ffe6-4106-9e22-07a339146161">
+         <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+         <dmn:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+         <dmn:requiredDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+         <dmn:requiredInput href="#_34cd3187-8764-4249-959d-2664bf9f1847" />
+      </dmn:informationRequirement>
+      <dmn:authorityRequirement id="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+         <dmn:requiredAuthority href="#_989d137f-86ff-4249-813f-af67c08a2762" />
+      </dmn:authorityRequirement>
+   </dmn:decision>
+   <dmn:knowledgeSource id="_989d137f-86ff-4249-813f-af67c08a2762" name="Credit officer">
+      <dmn:extensionElements />
+   </dmn:knowledgeSource>
+   <dmn:inputData id="_34cd3187-8764-4249-959d-2664bf9f1847" name="Supporting documents">
+      <dmn:extensionElements />
+      <dmn:variable id="_d996b907-be17-4ff1-a54e-6fe7d62f55b1" name="Supporting documents" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_5b8356f3-2cf2-40e8-8f80-324937e8b276" name="Bureau call type">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Bureau call type&amp;nbsp;&lt;/span&gt;table, passing the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_207da57c-29a0-487b-b591-751807636337" name="Bureau call type" typeRef="tBureauCallType" />
+      <dmn:informationRequirement id="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+         <dmn:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+         <dmn:requiredKnowledge href="#_a654be71-b54d-4d6e-90f0-ae505125e9a6" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd">
+         <dmn:literalExpression id="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd">
+            <dmn:text>Bureau call type table</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_8f5b7ce8-b4f9-4af4-8aa5-5580682382c6" name="Pre-Bureau Risk Category" />
+            <dmn:literalExpression id="_40020f96-0afd-405c-828a-0aa6684d150d">
+               <dmn:text>Pre-bureau risk category</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_8b838f06-968a-4c66-875e-f5412fd692cf" name="Strategy">
+      <dmn:description>&lt;p&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Strategy&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, unique-hit decision table deriving Strategy from&amp;nbsp;&lt;/span&gt;Eligibility and Bureau call type.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_80c9b3dd-f6c3-412b-9ee9-48e3e0812746" name="Strategy" typeRef="tStrategy" />
+      <dmn:informationRequirement id="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+         <dmn:requiredDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+         <dmn:requiredDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3" />
+      </dmn:informationRequirement>
+      <dmn:decisionTable id="_0991d970-7c58-4669-89ec-a5e3e9d264df" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Strategy">
+         <dmn:input id="_661471d5-5028-4910-b070-1e3bad0125c7">
+            <dmn:inputExpression id="_AC590B2A-235D-49E3-8920-5552312FE75C" typeRef="tEligibility">
+               <dmn:text>Eligibility</dmn:text>
+            </dmn:inputExpression>
+            <dmn:inputValues id="_C226EF3F-0E63-440C-B4B5-C4DD1EB57518">
+               <dmn:text>"INELIGIBLE","ELIGIBLE"</dmn:text>
+            </dmn:inputValues>
+         </dmn:input>
+         <dmn:input id="_b48e30f7-0a90-42d0-ba06-ad931fdfe5da">
+            <dmn:inputExpression id="_69FC0490-34F7-492B-B872-A34433CA8C6F" typeRef="tBureauCallType">
+               <dmn:text>Bureau call type</dmn:text>
+            </dmn:inputExpression>
+            <dmn:inputValues id="_F014B03F-E1D7-400C-9BDF-6F892B67F8EE">
+               <dmn:text>"FULL","MINI","NONE"</dmn:text>
+            </dmn:inputValues>
+         </dmn:input>
+         <dmn:output id="_f722c4f0-299d-4492-9b0c-fa0177239d08">
+            <dmn:outputValues id="_0E7B27DE-4305-42CF-9AB4-CF3D7E0D749D">
+               <dmn:text>"DECLINE","BUREAU","THROUGH"</dmn:text>
+            </dmn:outputValues>
+         </dmn:output>
+         <dmn:annotation name="" />
+         <dmn:rule id="_799a874e-d695-4683-9774-a4a911bbda7c">
+            <dmn:inputEntry id="_a1e93932-14d9-41aa-b408-418df532584e">
+               <dmn:text>"INELIGIBLE"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_46a2c9c2-10ba-4ebd-b596-d8d50ef4e27d">
+               <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_ddad297d-4a7e-45b4-bfc5-78cfc1504f8e">
+               <dmn:text>"DECLINE"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_8e10bf87-3308-4cb5-84fd-231656eb15f3">
+            <dmn:inputEntry id="_27b85f52-29db-4114-8393-4c307fda69de">
+               <dmn:text>"ELIGIBLE"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_658b9e6d-4039-4a30-a14f-b9af59e9ff3e">
+               <dmn:text>"FULL", "MINI"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_4099772e-6ec4-48e2-a4ac-daa6d7aa1148">
+               <dmn:text>"BUREAU"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_cec87cd2-9715-47b2-97df-087698d8fc70">
+            <dmn:inputEntry id="_617a19de-dd6d-4448-be7b-dc5c0f57de9c">
+               <dmn:text>"ELIGIBLE"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_0600d1e9-3293-4c91-b0f1-f1fecb10f422">
+               <dmn:text>"NONE"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_f17c18da-fb15-401b-88a5-550d1918583b">
+               <dmn:text>"THROUGH"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
       </dmn:decisionTable>
-    </dmn:encapsulatedLogic>
-    <dmn:authorityRequirement id="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
-      <dmn:requiredAuthority href="#_821a6840-e910-418f-809e-4c7d60b0b21a"/>
-    </dmn:authorityRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:inputData id="_d14df033-f4a2-47e3-9590-84e9ff04db4e" name="Applicant data">
-    <dmn:extensionElements/>
-    <dmn:variable id="_76597f43-a435-4d85-bc82-98007b9e0d1d" name="Applicant data" typeRef="tApplicantData"/>
-  </dmn:inputData>
-  <dmn:decision id="_3c8cee68-99dd-418c-847d-0b54697354f2" name="Required monthly installment">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Required monthly installment&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Installment calculation business knowledge model, passing Requested product.ProductType as the Product Type parameter, Requested product.Rate as the Rate parameter, Requested product.Term as the Term parameter, and Requested product.Amount as the Amount parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_f581169e-828d-45cd-9af5-e401eebc8f27" name="Required monthly installment" typeRef="number"/>
-    <dmn:informationRequirement id="_c5e79286-ea8f-4340-bd38-e878054891f2">
-      <dmn:requiredInput href="#_fe938494-ee59-425e-8728-2347ea703563"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_c40b08f2-613a-4a46-841c-c9d2d117578e">
-      <dmn:requiredKnowledge href="#_7235d875-2426-4869-b6df-92ca06ae80c5"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_2cc659df-0249-417c-8074-d3a375c6b5f5">
-      <dmn:literalExpression id="literal__2cc659df-0249-417c-8074-d3a375c6b5f5">
-        <dmn:text>Installment calculation</dmn:text>
-      </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_fa5953c6-c8f2-449e-ac2b-4bc04cb000c2" name="Product Type"/>
-        <dmn:literalExpression id="_87dccb4c-d416-42ca-9c72-a0b591b4ba88">
-          <dmn:text>Requested product.ProductType</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_78623557-831b-47e4-81fe-349a0743fc5a" name="Rate"/>
-        <dmn:literalExpression id="_3ba44309-b466-42d8-8126-bb2ef2d0544e">
-          <dmn:text>Requested product.Rate</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_48ac3dfb-dc98-420f-b051-2a9a3035e5f3" name="Term"/>
-        <dmn:literalExpression id="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce">
-          <dmn:text>Requested product.Term</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-      <dmn:binding>
-        <dmn:parameter id="_a8c6ca38-2e6c-42cb-8d5d-2e40469a4e4a" name="Amount"/>
-        <dmn:literalExpression id="_df160506-5551-4fe3-bf04-1fcb462bcaec">
-          <dmn:text>Requested product.Amount</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:inputData id="_fe938494-ee59-425e-8728-2347ea703563" name="Requested product">
-    <dmn:extensionElements/>
-    <dmn:variable id="_480bcfd2-2643-4d1c-852b-3034dfa62790" name="Requested product" typeRef="tRequestedProduct"/>
-  </dmn:inputData>
-  <dmn:businessKnowledgeModel id="_7235d875-2426-4869-b6df-92ca06ae80c5" name="Installment calculation">
-    <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Installment calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a boxed function deriving monthly installment&amp;nbsp;&lt;/span&gt;from Product Type, Rate, Term and Amount.&lt;/span&gt;&lt;/p&gt;</dmn:description>
-    <dmn:extensionElements/>
-    <dmn:variable id="_c02274e9-a6c8-4498-9d43-eaa33be7a0d9" name="Installment calculation" typeRef="number"/>
-    <dmn:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL">
-      <dmn:formalParameter id="_f6831cd9-3eab-4399-8d29-42b141fd9968" name="Product Type" typeRef="string"/>
-      <dmn:formalParameter id="_c6f48aeb-b65d-4307-8722-dd44f7335566" name="Rate" typeRef="number"/>
-      <dmn:formalParameter id="_708eb9af-fe19-418c-8547-1647cb50f596" name="Term" typeRef="number"/>
-      <dmn:formalParameter id="_fddc99bb-3be6-45b0-bf8c-d8d4c016a90b" name="Amount" typeRef="number"/>
-      <dmn:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4">
-        <dmn:contextEntry>
-          <dmn:variable id="_2db6ada1-2a67-4c84-bb31-e78178cf6b32" name="Monthly Fee" typeRef="number"/>
-          <dmn:literalExpression id="_ad1e4499-e806-42f1-8069-254e98f5d498">
-            <dmn:text>if Product Type = "STANDARD LOAN"							then 20.00							else if Product Type = "SPECIAL LOAN"							then 25.00							else null</dmn:text>
-          </dmn:literalExpression>
-        </dmn:contextEntry>
-        <dmn:contextEntry>
-          <dmn:variable id="_594996b3-1aea-4557-bf8e-f3bc91470fee" name="Monthly Repayment" typeRef="number"/>
-          <dmn:literalExpression id="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3">
-            <dmn:text>PMT(Rate, Term, Amount)</dmn:text>
-          </dmn:literalExpression>
-        </dmn:contextEntry>
-        <dmn:contextEntry>
-          <dmn:literalExpression id="_f6293695-dc2e-4e16-9dc7-1595423f0f91">
-            <dmn:text>Monthly Repayment + Monthly Fee</dmn:text>
-          </dmn:literalExpression>
-        </dmn:contextEntry>
-      </dmn:context>
-    </dmn:encapsulatedLogic>
-    <dmn:knowledgeRequirement id="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
-      <dmn:requiredKnowledge href="#_a30c75ec-7d81-4606-802c-b31ea308392d"/>
-    </dmn:knowledgeRequirement>
-  </dmn:businessKnowledgeModel>
-  <dmn:businessKnowledgeModel id="_a30c75ec-7d81-4606-802c-b31ea308392d" name="PMT">
-    <dmn:extensionElements/>
-    <dmn:variable id="_702e93e8-7d03-4400-aae4-a21543a4d631" name="PMT"/>
-    <dmn:encapsulatedLogic id="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" kind="FEEL">
-      <dmn:formalParameter id="_1787cf94-5e76-4926-ac24-5b4096b28dca" name="Rate" typeRef="number"/>
-      <dmn:formalParameter id="_0d037df5-8942-473f-9feb-2e16d6d7d631" name="Term" typeRef="number"/>
-      <dmn:formalParameter id="_deb10bf3-97f0-4f6b-8ae4-5cbfd44debac" name="Amount" typeRef="number"/>
-      <dmn:literalExpression id="_4d149dbb-89da-498e-853f-2c33f4e9b834">
-        <dmn:text>(Amount *Rate/12) / (1 - (1 + Rate/12)**-Term)</dmn:text>
-      </dmn:literalExpression>
-    </dmn:encapsulatedLogic>
-  </dmn:businessKnowledgeModel>
-  <dmn:decisionService id="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" name="Bureau Strategy Decision Service">
-    <dmn:extensionElements/>
-    <dmn:variable id="_84AC897B-1AF2-4546-A1CE-30EDC0EF815B" name="Bureau Strategy Decision Service"/>
-    <dmn:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf"/>
-    <dmn:outputDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276"/>
-    <dmn:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838"/>
-    <dmn:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0"/>
-    <dmn:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
-    <dmn:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
-    <dmn:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3"/>
-    <dmn:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    <dmn:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_4d91e3a5-acec-4254-81e4-8535a1d336ee" name="Routing Decision Service">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2AF32C5A-7D19-4A9C-A49C-B0737A8AF2DE" name="Routing Decision Service"/>
-    <dmn:outputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5"/>
-    <dmn:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec"/>
-    <dmn:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46"/>
-    <dmn:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2"/>
-    <dmn:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474"/>
-    <dmn:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6"/>
-    <dmn:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e"/>
-    <dmn:inputData href="#_fe938494-ee59-425e-8728-2347ea703563"/>
-  </dmn:decisionService>
-  <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_ce4a4c00-c3a3-46a6-8938-055239f6b326" name="DRD of all automated decision-making">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d"/>
-          <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df"/>
-          <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca"/>
-          <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f"/>
-          <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb"/>
-          <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f"/>
-          <kie:ComponentWidths dmnElementRef="_809B2A63-2946-4AC0-BB2A-7C01F85D885B"/>
-          <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34"/>
-          <kie:ComponentWidths dmnElementRef="_C6A7891D-03F8-49CF-8275-7AFD1147FC3A"/>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-          <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901"/>
-          <kie:ComponentWidths dmnElementRef="_3E30A977-5CC2-46C9-916C-2CF97DB1CF87"/>
-          <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474"/>
-          <kie:ComponentWidths dmnElementRef="_E6280C1C-D063-4872-8901-7783DA7353DE"/>
-          <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256"/>
-          <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b"/>
-          <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058"/>
-          <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f"/>
-          <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55"/>
-          <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267"/>
-          <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c"/>
-          <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4"/>
-          <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446"/>
-          <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3"/>
-          <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2"/>
-          <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a"/>
-          <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36"/>
-          <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0"/>
-          <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113"/>
-          <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227"/>
-          <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4"/>
-          <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82"/>
-          <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0"/>
-          <kie:ComponentWidths dmnElementRef="_04437EA6-7362-4693-B4B3-9431E330CEAC"/>
-          <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126"/>
-          <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3"/>
-          <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f"/>
-          <kie:ComponentWidths dmnElementRef="_530613B3-1EC6-4E64-B33A-899F0E219BA0"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2"/>
-          <kie:ComponentWidths dmnElementRef="_3161744E-C244-4C89-ACA8-4462EC11C790"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-          <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498"/>
-          <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3"/>
-          <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91"/>
-          <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa"/>
-          <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834"/>
-          <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1069" y="54.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="893.5" y="50" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1225.7588291168213" y="262.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="177" y="262.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="277" y="142.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="374" y="262.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="591.5" y="263.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="721.5" y="150" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="810.5" y="263.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1024" y="262.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="88.5" y="370.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="476.4786796569824" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="567" y="365" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="789" y="365" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="695.5" y="476.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="494.5" y="475.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="918.5" y="475.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1024" y="587.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1225.7588291168213" y="715.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1024.5" y="716.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="277" y="587.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="716.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="277" y="822.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="818" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="941.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="503.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="840.5" y="822.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="736.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="945" y="941.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1157" y="941.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_290b4df4-ffe6-4106-9e22-07a339146161" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
-        <di:waypoint x="590.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="1105.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
-        <di:waypoint x="1293.4968013763428" y="715.9786758422852"/>
-        <di:waypoint x="1155.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
-        <di:waypoint x="1100.5" y="262.9786796569824"/>
-        <di:waypoint x="1135.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_7fc499b6-a180-4e16-80cd-58df441f4d38" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
-        <di:waypoint x="1293.4968013763428" y="262.97867584228516"/>
-        <di:waypoint x="1195.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_dabc7bb7-b8be-4654-9f7e-455481cb1c4e" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
-        <di:waypoint x="993.5" y="84.5"/>
-        <di:waypoint x="1069" y="84.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
-        <di:waypoint x="333.5" y="587.9786796569824"/>
-        <di:waypoint x="253.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_18fda7ab-ca43-4860-a94b-760d3cd68ce2" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
-        <di:waypoint x="173.5" y="370.4786796569824"/>
-        <di:waypoint x="223.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
-        <di:waypoint x="253.5" y="262.9786796569824"/>
-        <di:waypoint x="323.5" y="202.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
-        <di:waypoint x="440.5" y="262.9786796569824"/>
-        <di:waypoint x="373.5" y="202.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
-        <di:waypoint x="353.5" y="587.9786796569824"/>
-        <di:waypoint x="440.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
-        <di:waypoint x="550.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="450.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
-        <di:waypoint x="571" y="475.9786796569824"/>
-        <di:waypoint x="460.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_1c3489b1-44dd-4137-883a-35da157f0c1d" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
-        <di:waypoint x="591.5" y="292.4786796569824"/>
-        <di:waypoint x="527" y="292.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
-        <di:waypoint x="734" y="217"/>
-        <di:waypoint x="666.5" y="263.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_57d99f5f-48e1-456c-ab7c-4247e840a7fc" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
-        <di:waypoint x="784" y="203"/>
-        <di:waypoint x="885.5" y="263.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
-        <di:waypoint x="995" y="475.9786796569824"/>
-        <di:waypoint x="1080.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
-        <di:waypoint x="1100.5" y="587.9786796569824"/>
-        <di:waypoint x="1100.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
-        <di:waypoint x="1283.4968013763428" y="715.9786758422852"/>
-        <di:waypoint x="1120.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_839ccfec-8902-40ca-8767-df9073f797e5" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
-        <di:waypoint x="962.5" y="292.4786796569824"/>
-        <di:waypoint x="1024" y="292.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_2cad5b1f-59de-4cf2-9216-b662b2760bff" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
-        <di:waypoint x="100" y="476.4786796569824"/>
-        <di:waypoint x="153.5" y="429.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
-        <di:waypoint x="150" y="490.9786796569824"/>
-        <di:waypoint x="567" y="394"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
-        <di:waypoint x="692" y="424"/>
-        <di:waypoint x="740.5" y="476.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
-        <di:waypoint x="826.5" y="432"/>
-        <di:waypoint x="800.5" y="476.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
-        <di:waypoint x="383.5" y="587.9786796569824"/>
-        <di:waypoint x="531" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
-        <di:waypoint x="570.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="571" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
-        <di:waypoint x="907" y="822.9786796569824"/>
-        <di:waypoint x="601" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
-        <di:waypoint x="695.5" y="505.4786796569824"/>
-        <di:waypoint x="647.5" y="505.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
-        <di:waypoint x="1090.5" y="587.9786796569824"/>
-        <di:waypoint x="995" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
-        <di:waypoint x="927" y="822.9786796569824"/>
-        <di:waypoint x="985" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
-        <di:waypoint x="610.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="965" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
-        <di:waypoint x="847.5" y="505.4786796569824"/>
-        <di:waypoint x="918.5" y="505.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
-        <di:waypoint x="1263.4968013763428" y="715.9786758422852"/>
-        <di:waypoint x="1140.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
-        <di:waypoint x="632.4968013763428" y="950.9786758422852"/>
-        <di:waypoint x="1060.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
-        <di:waypoint x="430" y="842.9786796569824"/>
-        <di:waypoint x="1024" y="617.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_dc094e13-abbd-4164-bc95-a61b433a7be4" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
-        <di:waypoint x="1099.5" y="716.4786796569824"/>
-        <di:waypoint x="1100.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_aa1fbb92-27fc-4108-9257-2017c2dbc601" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
-        <di:waypoint x="150" y="510.9786796569824"/>
-        <di:waypoint x="1024.5" y="735.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
-        <di:waypoint x="530.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="373.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
-        <di:waypoint x="353.5" y="822.9786796569824"/>
-        <di:waypoint x="353.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_d37ce038-f9cc-4576-92a7-dd64eea28a2d" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
-        <di:waypoint x="213" y="716.4786796569824"/>
-        <di:waypoint x="313.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_b752b8ba-8fab-4658-94d9-1aaaa51af3a2" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
-        <di:waypoint x="87.5" y="543.4786796569824"/>
-        <di:waypoint x="146.5" y="724.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
-        <di:waypoint x="510.4968013763428" y="950.9786758422852"/>
-        <di:waypoint x="403.5" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
-        <di:waypoint x="223" y="941.4786796569824"/>
-        <di:waypoint x="323.5" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
-        <di:waypoint x="87.5" y="885"/>
-        <di:waypoint x="138" y="980.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
-        <di:waypoint x="813.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="887" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
-        <di:waypoint x="1010" y="941.4786796569824"/>
-        <di:waypoint x="937" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_f0a6536d-0e7f-44d3-a9bb-5213478173da" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
-        <di:waypoint x="1157" y="970.4786796569824"/>
-        <di:waypoint x="1097" y="970.9786796569824"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-    <dmndi:DMNDiagram id="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262" name="DRD for Decide bureau strategy decision point">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-          <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2"/>
-          <kie:ComponentWidths dmnElementRef="_6DD88A1A-96C6-4F7D-8B2D-D2A870E229F1"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f"/>
-          <kie:ComponentWidths dmnElementRef="_BA60FFB2-058C-43EB-8EBD-878B731D4E1F"/>
-          <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126"/>
-          <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3"/>
-          <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c"/>
-          <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4"/>
-          <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446"/>
-          <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3"/>
-          <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2"/>
-          <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256"/>
-          <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b"/>
-          <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058"/>
-          <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f"/>
-          <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55"/>
-          <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267"/>
-          <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474"/>
-          <kie:ComponentWidths dmnElementRef="_0C1FB4A4-84A4-4EE4-B60E-0D320251B7F4"/>
-          <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901"/>
-          <kie:ComponentWidths dmnElementRef="_34906E73-5467-4F4A-9CD1-F7F556F59E9E"/>
-          <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f"/>
-          <kie:ComponentWidths dmnElementRef="_323EB964-5B52-4124-B482-362748E8C6EC"/>
-          <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca"/>
-          <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f"/>
-          <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb"/>
-          <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df"/>
-          <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d"/>
-          <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834"/>
-          <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943"/>
-          <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498"/>
-          <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3"/>
-          <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91"/>
-          <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="594" y="740.9999923706055" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="698.2411708831787" y="622.9999961853027" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="513.7588291168213" y="856.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="148.5" y="857.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="29.5" y="736.0213203430176" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="275.5" y="741" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="148.5" y="623.4999961853027" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="287.5" y="532" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="505" y="383" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="706" y="383.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="799.5" y="272.0213203430176" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="572.5" y="290.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="29.5" y="417.0213203430176" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="89" y="290.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="732" y="57.02132034301758" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="602" y="170.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="384.5" y="170" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="287.5" y="50" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="187.5" y="170" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="777.8080854415894" y="857.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="777.8080854415894" y="741.4999961853027" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
-        <di:waypoint x="671.7379722595215" y="740.9999923706055"/>
-        <di:waypoint x="744.7411708831787" y="682.9999961853027"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
-        <di:waypoint x="852.8080854415894" y="741.4999961853027"/>
-        <di:waypoint x="794.7411708831787" y="682.9999961853027"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
-        <di:waypoint x="67" y="803.0213203430176"/>
-        <di:waypoint x="148.5" y="886.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
-        <di:waypoint x="520.9968013763428" y="866.9999961853027"/>
-        <di:waypoint x="402" y="801"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
-        <di:waypoint x="233.5" y="857.5"/>
-        <di:waypoint x="322" y="801"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_b752b8ba-8fab-4658-94d9-1aaaa51af3a2" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
-        <di:waypoint x="67" y="484.0213203430176"/>
-        <di:waypoint x="148.5" y="662.4999961853027"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
-        <di:waypoint x="541.4968013763428" y="856.9999961853027"/>
-        <di:waypoint x="384" y="592"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
-        <di:waypoint x="352" y="741"/>
-        <di:waypoint x="354" y="592"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_d37ce038-f9cc-4576-92a7-dd64eea28a2d" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
-        <di:waypoint x="223.5" y="623.4999961853027"/>
-        <di:waypoint x="324" y="592"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
-        <di:waypoint x="394" y="532"/>
-        <di:waypoint x="541.5" y="443"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
-        <di:waypoint x="581.4968013763428" y="856.9999961853027"/>
-        <di:waypoint x="581.5" y="443"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
-        <di:waypoint x="764.7411708831787" y="622.9999961853027"/>
-        <di:waypoint x="611.5" y="443"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
-        <di:waypoint x="706" y="412.5"/>
-        <di:waypoint x="658" y="413"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
-        <di:waypoint x="697.5" y="349.5"/>
-        <di:waypoint x="751" y="383.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
-        <di:waypoint x="837" y="339.0213203430176"/>
-        <di:waypoint x="811" y="383.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
-        <di:waypoint x="129.5" y="431.5213203430176"/>
-        <di:waypoint x="572.5" y="319.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_2cad5b1f-59de-4cf2-9216-b662b2760bff" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
-        <di:waypoint x="79.5" y="417.0213203430176"/>
-        <di:waypoint x="154" y="349.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
-        <di:waypoint x="744.5" y="124.02132034301758"/>
-        <di:waypoint x="677" y="170.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
-        <di:waypoint x="364" y="532"/>
-        <di:waypoint x="451" y="230"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
-        <di:waypoint x="551.4968013763428" y="856.9999961853027"/>
-        <di:waypoint x="461" y="230"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
-        <di:waypoint x="581.5" y="383"/>
-        <di:waypoint x="471" y="230"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_1c3489b1-44dd-4137-883a-35da157f0c1d" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
-        <di:waypoint x="602" y="199.5"/>
-        <di:waypoint x="537.5" y="200"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
-        <di:waypoint x="264" y="170"/>
-        <di:waypoint x="334" y="110"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
-        <di:waypoint x="451" y="170"/>
-        <di:waypoint x="384" y="110"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
-        <di:waypoint x="344" y="532"/>
-        <di:waypoint x="264" y="230"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_18fda7ab-ca43-4860-a94b-760d3cd68ce2" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
-        <di:waypoint x="174" y="290.5"/>
-        <di:waypoint x="234" y="230"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_f0a6536d-0e7f-44d3-a9bb-5213478173da" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
-        <di:waypoint x="852.8080854415894" y="857.5"/>
-        <di:waypoint x="853.8080854415894" y="800.4999961853027"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-    <dmndi:DMNDiagram id="_3275163a-921d-48f8-967a-21c4373b1197" name="DRD for Decide routing decision point">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498"/>
-          <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3"/>
-          <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91"/>
-          <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-          <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2"/>
-          <kie:ComponentWidths dmnElementRef="_210F2212-DE25-46B6-9D2D-84138BF40F3A"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0"/>
-          <kie:ComponentWidths dmnElementRef="_FF67F97A-6BAA-4F83-AE60-34FDB7A31976"/>
-          <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4"/>
-          <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82"/>
-          <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a"/>
-          <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36"/>
-          <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0"/>
-          <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113"/>
-          <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227"/>
-          <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256"/>
-          <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b"/>
-          <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058"/>
-          <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f"/>
-          <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55"/>
-          <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267"/>
-          <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474"/>
-          <kie:ComponentWidths dmnElementRef="_9224EC55-76FD-42B1-9E45-97AD474007AF"/>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-          <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34"/>
-          <kie:ComponentWidths dmnElementRef="_F54BB1DC-F728-40BD-943D-030D34571772"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="338.2411708831787" y="658.9786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="129.5" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="233.7411708831787" y="528.4786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="542.7588291168213" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="938.5" y="528.9786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="990.5" y="393" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="716" y="528.4786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="233.87058544158936" y="398.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="815.7588291168213" y="397.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="598" y="397.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="482.5" y="248.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="259.5" y="249.47867965698242" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="363.87058544158936" y="142" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="249.47867965698242" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="76" y="393" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="598" y="54.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="374.5" y="55.47867965698242" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="192.5" y="50" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
-        <di:waypoint x="207.23797225952148" y="658.4786758422852"/>
-        <di:waypoint x="280.2411708831787" y="588.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
-        <di:waypoint x="403.2411708831787" y="658.9786796569824"/>
-        <di:waypoint x="330.2411708831787" y="588.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
-        <di:waypoint x="1028" y="460"/>
-        <di:waypoint x="1023.5" y="528.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
-        <di:waypoint x="620.4968013763428" y="658.4786758422852"/>
-        <di:waypoint x="792.5" y="588.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
-        <di:waypoint x="938.5" y="557.9786796569824"/>
-        <di:waypoint x="869" y="558.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_aa1fbb92-27fc-4108-9257-2017c2dbc601" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
-        <di:waypoint x="176" y="427.5"/>
-        <di:waypoint x="233.87058544158936" y="427.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
-        <di:waypoint x="815.9968013763428" y="427.97867584228516"/>
-        <di:waypoint x="751" y="427.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
-        <di:waypoint x="610.4968013763428" y="658.4786758422852"/>
-        <di:waypoint x="664.5" y="457.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
-        <di:waypoint x="792.5" y="528.4786796569824"/>
-        <di:waypoint x="714.5" y="457.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_dc094e13-abbd-4164-bc95-a61b433a7be4" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
-        <di:waypoint x="385.87058544158936" y="427.4786796569824"/>
-        <di:waypoint x="598" y="427.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
-        <di:waypoint x="664.5" y="397.9786796569824"/>
-        <di:waypoint x="609" y="308.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
-        <di:waypoint x="320.2411708831787" y="528.4786796569824"/>
-        <di:waypoint x="509" y="308.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
-        <di:waypoint x="600.4968013763428" y="658.4786758422852"/>
-        <di:waypoint x="549" y="308.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
-        <di:waypoint x="411.5" y="278.4786796569824"/>
-        <di:waypoint x="482.5" y="278.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
-        <di:waypoint x="202" y="278.4786796569824"/>
-        <di:waypoint x="259.5" y="278.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
-        <di:waypoint x="401.37058544158936" y="209"/>
-        <di:waypoint x="364.5" y="249.47867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
-        <di:waypoint x="126" y="393"/>
-        <di:waypoint x="126" y="308.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
-        <di:waypoint x="559" y="248.97867965698242"/>
-        <di:waypoint x="654.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
-        <di:waypoint x="674.5" y="397.9786796569824"/>
-        <di:waypoint x="674.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
-        <di:waypoint x="873.4968013763428" y="397.97867584228516"/>
-        <di:waypoint x="694.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_839ccfec-8902-40ca-8767-df9073f797e5" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
-        <di:waypoint x="526.5" y="84.47867965698242"/>
-        <di:waypoint x="598" y="84.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_57d99f5f-48e1-456c-ab7c-4247e840a7fc" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
-        <di:waypoint x="292.5" y="84.5"/>
-        <di:waypoint x="374.5" y="84.47867965698242"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-    <dmndi:DMNDiagram id="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b" name="DRD for Review application decision point">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="57.75882911682129" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="382.2588291168213" y="320.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="179.5" y="320.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="480.2588291168213" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="50" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="225.5" y="54.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_290b4df4-ffe6-4106-9e22-07a339146161" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
-        <di:waypoint x="135.49680137634277" y="222.97867584228516"/>
-        <di:waypoint x="272" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
-        <di:waypoint x="449.9968013763428" y="320.97867584228516"/>
-        <di:waypoint x="302" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
-        <di:waypoint x="256" y="320.9786796569824"/>
-        <di:waypoint x="292" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_7fc499b6-a180-4e16-80cd-58df441f4d38" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
-        <di:waypoint x="547.9968013763428" y="222.97867584228516"/>
-        <di:waypoint x="322" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_dabc7bb7-b8be-4654-9f7e-455481cb1c4e" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
-        <di:waypoint x="150" y="84.5"/>
-        <di:waypoint x="225.5" y="84.97867965698242"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-    <dmndi:DMNDiagram id="_5c111794-4c6b-4747-8dfc-99d2ad0b6313" name="Bureau Strategy Decision Service">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df"/>
-          <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d"/>
-          <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca"/>
-          <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f"/>
-          <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb"/>
-          <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c"/>
-          <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4"/>
-          <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446"/>
-          <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3"/>
-          <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2"/>
-          <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126"/>
-          <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="308.1470727920532" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="524.6294145584106" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_7befd964-eefa-4d8f-908d-8f6ad8d22c67" dmnElementRef="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="50" width="643.8705854415894" height="670"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="50" y="275"/>
-          <di:waypoint x="693.8705854415894" y="275"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="299.38824367523193" y="88" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="136" y="197" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="299.38824367523193" y="307" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="479.5" y="461.5" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="136" y="461.5" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="79" y="600" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="515.8705854415894" y="583" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
-        <di:waypoint x="212.5" y="197"/>
-        <di:waypoint x="345.88824367523193" y="148"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
-        <di:waypoint x="375.88824367523193" y="307"/>
-        <di:waypoint x="375.88824367523193" y="148"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
-        <di:waypoint x="212.5" y="461.5"/>
-        <di:waypoint x="212.5" y="257"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
-        <di:waypoint x="232.5" y="461.5"/>
-        <di:waypoint x="365.88824367523193" y="367"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
-        <di:waypoint x="375.8850450515747" y="782.9999961853027"/>
-        <di:waypoint x="375.88824367523193" y="367"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
-        <di:waypoint x="556" y="461.5"/>
-        <di:waypoint x="385.88824367523193" y="367"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
-        <di:waypoint x="289" y="491.5"/>
-        <di:waypoint x="479.5" y="491.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
-        <di:waypoint x="415.8850450515747" y="782.9999961853027"/>
-        <di:waypoint x="496" y="521.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
-        <di:waypoint x="592.3705854415894" y="583"/>
-        <di:waypoint x="556" y="521.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
-        <di:waypoint x="365.8850450515747" y="782.9999961853027"/>
-        <di:waypoint x="232.5" y="521.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
-        <di:waypoint x="155.5" y="600"/>
-        <di:waypoint x="212.5" y="521.5"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
-        <di:waypoint x="335.8850450515747" y="782.9999961853027"/>
-        <di:waypoint x="155.5" y="660"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
-        <di:waypoint x="592.3673868179321" y="782.9999961853027"/>
-        <di:waypoint x="592.3705854415894" y="643"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-    <dmndi:DMNDiagram id="_69750f88-f46f-4b47-bb3c-fb77f574f2b3" name="Routing Decision Service">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-          <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a"/>
-          <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36"/>
-          <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0"/>
-          <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113"/>
-          <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227"/>
-          <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4"/>
-          <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="607.5176582336426" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="269.7588291168213" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="83.75882911682129" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_4d91e3a5-acec-4254-81e4-8535a1d336ee" dmnElementRef="_4d91e3a5-acec-4254-81e4-8535a1d336ee" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="50" width="693" height="562.4786796569824"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="50" y="190"/>
-          <di:waypoint x="743" y="190"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400.62941455841064" y="82" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="179.62941455841064" y="219.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400.62941455841064" y="369.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400.62941455841064" y="496.4786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-routing-decision-service-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="75" y="369.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
-        <di:waypoint x="256.12941455841064" y="219.97867965698242"/>
-        <di:waypoint x="427.12941455841064" y="142"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
-        <di:waypoint x="477.12941455841064" y="369.9786796569824"/>
-        <di:waypoint x="477.12941455841064" y="142"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
-        <di:waypoint x="675.2556304931641" y="679.4573554992676"/>
-        <di:waypoint x="527.1294145584106" y="142"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
-        <di:waypoint x="467.12941455841064" y="369.9786796569824"/>
-        <di:waypoint x="306.12941455841064" y="279.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
-        <di:waypoint x="161.5" y="369.9786796569824"/>
-        <di:waypoint x="206.12941455841064" y="279.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
-        <di:waypoint x="327.4968013763428" y="679.4573554992676"/>
-        <di:waypoint x="256.12941455841064" y="279.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
-        <di:waypoint x="655.2556304931641" y="679.4573554992676"/>
-        <di:waypoint x="527.1294145584106" y="429.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
-        <di:waypoint x="337.4968013763428" y="679.4573554992676"/>
-        <di:waypoint x="407.12941455841064" y="429.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
-        <di:waypoint x="477.12941455841064" y="496.4786796569824"/>
-        <di:waypoint x="477.12941455841064" y="429.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
-        <di:waypoint x="347.4968013763428" y="679.4573554992676"/>
-        <di:waypoint x="477.12941455841064" y="556.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-routing-decision-service-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
-        <di:waypoint x="151.49680137634277" y="679.4573554992676"/>
-        <di:waypoint x="151.5" y="429.9786796569824"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-    <dmndi:DMNDiagram id="_09D054E0-E545-4D52-8D20-A403C4D0DBCD" name="DRG">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d"/>
-          <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df"/>
-          <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca"/>
-          <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f"/>
-          <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb"/>
-          <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f"/>
-          <kie:ComponentWidths dmnElementRef="_CE2E17C2-BE30-458C-ACA5-308D9A8180EE"/>
-          <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34"/>
-          <kie:ComponentWidths dmnElementRef="_72152DFF-AC18-4EA3-B68B-F73BF3568D7B"/>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-          <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901"/>
-          <kie:ComponentWidths dmnElementRef="_9622ACE3-A8D0-4340-AEBD-84C4C3EA3CFE"/>
-          <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474"/>
-          <kie:ComponentWidths dmnElementRef="_AF929F74-7E06-43FB-B6FC-08E650E02025"/>
-          <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256"/>
-          <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b"/>
-          <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058"/>
-          <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f"/>
-          <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55"/>
-          <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267"/>
-          <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c"/>
-          <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4"/>
-          <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446"/>
-          <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3"/>
-          <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2"/>
-          <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a"/>
-          <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36"/>
-          <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0"/>
-          <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113"/>
-          <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227"/>
-          <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4"/>
-          <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82"/>
-          <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0"/>
-          <kie:ComponentWidths dmnElementRef="_ABF60353-F79B-406B-BBAF-465713AFAD88"/>
-          <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126"/>
-          <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3"/>
-          <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f"/>
-          <kie:ComponentWidths dmnElementRef="_A543B189-F606-470D-A7CB-35C08826A085"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2"/>
-          <kie:ComponentWidths dmnElementRef="_DB17D2B6-9999-4150-A909-7690FDC3D6E6"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-          <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498"/>
-          <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3"/>
-          <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91"/>
-          <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa"/>
-          <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834"/>
-          <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-          <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2"/>
-          <kie:ComponentWidths dmnElementRef="_02E0450D-BE25-434D-B7B3-65E41918F5D6"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f"/>
-          <kie:ComponentWidths dmnElementRef="_7C6FEE4F-086E-46E1-920B-A417C6A4E394"/>
-          <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126"/>
-          <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3"/>
-          <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c"/>
-          <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4"/>
-          <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446"/>
-          <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3"/>
-          <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2"/>
-          <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256"/>
-          <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b"/>
-          <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058"/>
-          <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f"/>
-          <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55"/>
-          <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267"/>
-          <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474"/>
-          <kie:ComponentWidths dmnElementRef="_7E21B83F-87AD-4887-882B-01AB3B4F06D3"/>
-          <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901"/>
-          <kie:ComponentWidths dmnElementRef="_A38E4BBF-69EB-418E-8E4E-935A1F2504FA"/>
-          <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f"/>
-          <kie:ComponentWidths dmnElementRef="_387DE620-29A3-4FA0-81BA-DFD526ADE7CE"/>
-          <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca"/>
-          <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f"/>
-          <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb"/>
-          <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df"/>
-          <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d"/>
-          <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834"/>
-          <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943"/>
-          <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498"/>
-          <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3"/>
-          <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91"/>
-          <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa"/>
-          <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498"/>
-          <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3"/>
-          <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91"/>
-          <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-          <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2"/>
-          <kie:ComponentWidths dmnElementRef="_4AC00783-D19B-4B1D-8BB6-B799F31BD46C"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0"/>
-          <kie:ComponentWidths dmnElementRef="_3CDA02F5-79E7-4C42-B6DE-2E3094082E88"/>
-          <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4"/>
-          <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82"/>
-          <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a"/>
-          <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36"/>
-          <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0"/>
-          <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113"/>
-          <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227"/>
-          <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256"/>
-          <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b"/>
-          <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a"/>
-          <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058"/>
-          <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f"/>
-          <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55"/>
-          <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267"/>
-          <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474"/>
-          <kie:ComponentWidths dmnElementRef="_8C916FCA-2E62-46DC-A4B0-13C46119F22B"/>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-          <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34"/>
-          <kie:ComponentWidths dmnElementRef="_4AC93490-288A-4C8B-A37E-F51DE79B67AD"/>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-          <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df"/>
-          <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd"/>
-          <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d"/>
-          <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979"/>
-          <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca"/>
-          <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f"/>
-          <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb"/>
-          <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86"/>
-          <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c"/>
-          <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4"/>
-          <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446"/>
-          <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3"/>
-          <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2"/>
-          <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e"/>
-          <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126"/>
-          <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-          <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3"/>
-          <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69"/>
-          <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a"/>
-          <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2"/>
-          <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba"/>
-          <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a"/>
-          <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a"/>
-          <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36"/>
-          <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0"/>
-          <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113"/>
-          <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227"/>
-          <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b"/>
-          <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4"/>
-          <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4"/>
-          <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82"/>
-          <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c"/>
-          <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b"/>
-          <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333"/>
-          <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25"/>
-          <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5"/>
-          <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88"/>
-          <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e"/>
-          <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce"/>
-          <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1069" y="54.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="893.5" y="50" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1225.7588291168213" y="262.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="177" y="262.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="277" y="142.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="374" y="262.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="591.5" y="263.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="721.5" y="150" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="810.5" y="263.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1024" y="262.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="88.5" y="370.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="476.4786796569824" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="567" y="365" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="789" y="365" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="695.5" y="476.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="494.5" y="475.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="918.5" y="475.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1024" y="587.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1225.7588291168213" y="715.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1024.5" y="716.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="277" y="587.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="716.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="277" y="822.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="818" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="941.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="503.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="840.5" y="822.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="736.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="945" y="941.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1157" y="941.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1955.2411708831787" y="740.9999923706055" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2059.4823417663574" y="622.9999961853027" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1875" y="856.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1509.7411708831787" y="857.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1390.7411708831787" y="736.0213203430176" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1636.7411708831787" y="741" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1509.7411708831787" y="623.4999961853027" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1648.7411708831787" y="532" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1866.2411708831787" y="383" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2067.2411708831787" y="383.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2160.7411708831787" y="272.0213203430176" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1933.7411708831787" y="290.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1390.7411708831787" y="417.0213203430176" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1450.2411708831787" y="290.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2093.2411708831787" y="57.02132034301758" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1963.2411708831787" y="170.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1745.7411708831787" y="170" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1648.7411708831787" y="50" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1548.7411708831787" y="170" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2139.049256324768" y="857.5" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2139.049256324768" y="741.4999961853027" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1699.4823417663574" y="658.9786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1490.7411708831787" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1594.9823417663574" y="528.4786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1904" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2299.7411708831787" y="528.9786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2351.7411708831787" y="393" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2077.2411708831787" y="528.4786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1595.111756324768" y="398.4786796569824" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2177" y="397.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1959.2411708831787" y="397.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1843.7411708831787" y="248.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1620.7411708831787" y="249.47867965698242" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1725.111756324768" y="142" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1411.2411708831787" y="249.47867965698242" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1437.2411708831787" y="393" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1959.2411708831787" y="54.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1735.7411708831787" y="55.47867965698242" width="152" height="59"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1553.7411708831787" y="50" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-4-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1419" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1743.5" y="320.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1540.7411708831787" y="320.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1841.5" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1411.2411708831787" y="50" width="100" height="69.95735931396484"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-2-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1586.7411708831787" y="54.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-5-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1669.388243675232" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-4-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1885.8705854415894" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7befd964-eefa-4d8f-908d-8f6ad8d22c67" dmnElementRef="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1411.2411708831787" y="50" width="643.8705854415894" height="670"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="1411.2411708831787" y="275"/>
-          <di:waypoint x="2055.111756324768" y="275"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1660.6294145584106" y="88" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1497.2411708831787" y="197" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1660.6294145584106" y="307" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1840.7411708831787" y="461.5" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1497.2411708831787" y="461.5" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-4-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1440.2411708831787" y="600" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-4-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1877.111756324768" y="583" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-4-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1968.7588291168213" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-6-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1631" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-5-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1445" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4d91e3a5-acec-4254-81e4-8535a1d336ee" dmnElementRef="_4d91e3a5-acec-4254-81e4-8535a1d336ee" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1411.2411708831787" y="50" width="693" height="562.4786796569824"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="1411.2411708831787" y="190"/>
-          <di:waypoint x="2104.2411708831787" y="190"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-4-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1761.8705854415894" y="82" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1540.8705854415894" y="219.97867965698242" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-3-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1761.8705854415894" y="369.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-5-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1761.8705854415894" y="496.4786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-5-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1436.2411708831787" y="369.9786796569824" width="153" height="60"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_290b4df4-ffe6-4106-9e22-07a339146161" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
-        <di:waypoint x="590.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="1105.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
-        <di:waypoint x="1293.4968013763428" y="715.9786758422852"/>
-        <di:waypoint x="1155.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
-        <di:waypoint x="1100.5" y="262.9786796569824"/>
-        <di:waypoint x="1135.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7fc499b6-a180-4e16-80cd-58df441f4d38" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
-        <di:waypoint x="1293.4968013763428" y="262.97867584228516"/>
-        <di:waypoint x="1195.5" y="114.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_dabc7bb7-b8be-4654-9f7e-455481cb1c4e" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
-        <di:waypoint x="993.5" y="84.5"/>
-        <di:waypoint x="1069" y="84.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
-        <di:waypoint x="333.5" y="587.9786796569824"/>
-        <di:waypoint x="253.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_18fda7ab-ca43-4860-a94b-760d3cd68ce2" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
-        <di:waypoint x="173.5" y="370.4786796569824"/>
-        <di:waypoint x="223.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
-        <di:waypoint x="253.5" y="262.9786796569824"/>
-        <di:waypoint x="323.5" y="202.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
-        <di:waypoint x="440.5" y="262.9786796569824"/>
-        <di:waypoint x="373.5" y="202.97867965698242"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
-        <di:waypoint x="353.5" y="587.9786796569824"/>
-        <di:waypoint x="440.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
-        <di:waypoint x="550.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="450.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
-        <di:waypoint x="571" y="475.9786796569824"/>
-        <di:waypoint x="460.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1c3489b1-44dd-4137-883a-35da157f0c1d" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
-        <di:waypoint x="591.5" y="292.4786796569824"/>
-        <di:waypoint x="527" y="292.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
-        <di:waypoint x="734" y="217"/>
-        <di:waypoint x="666.5" y="263.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_57d99f5f-48e1-456c-ab7c-4247e840a7fc" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
-        <di:waypoint x="784" y="203"/>
-        <di:waypoint x="885.5" y="263.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
-        <di:waypoint x="995" y="475.9786796569824"/>
-        <di:waypoint x="1080.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
-        <di:waypoint x="1100.5" y="587.9786796569824"/>
-        <di:waypoint x="1100.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
-        <di:waypoint x="1283.4968013763428" y="715.9786758422852"/>
-        <di:waypoint x="1120.5" y="322.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_839ccfec-8902-40ca-8767-df9073f797e5" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
-        <di:waypoint x="962.5" y="292.4786796569824"/>
-        <di:waypoint x="1024" y="292.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2cad5b1f-59de-4cf2-9216-b662b2760bff" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
-        <di:waypoint x="100" y="476.4786796569824"/>
-        <di:waypoint x="153.5" y="429.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
-        <di:waypoint x="150" y="490.9786796569824"/>
-        <di:waypoint x="567" y="394"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
-        <di:waypoint x="692" y="424"/>
-        <di:waypoint x="740.5" y="476.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
-        <di:waypoint x="826.5" y="432"/>
-        <di:waypoint x="800.5" y="476.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
-        <di:waypoint x="383.5" y="587.9786796569824"/>
-        <di:waypoint x="531" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
-        <di:waypoint x="570.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="571" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
-        <di:waypoint x="907" y="822.9786796569824"/>
-        <di:waypoint x="601" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
-        <di:waypoint x="695.5" y="505.4786796569824"/>
-        <di:waypoint x="647.5" y="505.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
-        <di:waypoint x="1090.5" y="587.9786796569824"/>
-        <di:waypoint x="995" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
-        <di:waypoint x="927" y="822.9786796569824"/>
-        <di:waypoint x="985" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
-        <di:waypoint x="610.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="965" y="535.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
-        <di:waypoint x="847.5" y="505.4786796569824"/>
-        <di:waypoint x="918.5" y="505.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
-        <di:waypoint x="1263.4968013763428" y="715.9786758422852"/>
-        <di:waypoint x="1140.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
-        <di:waypoint x="632.4968013763428" y="950.9786758422852"/>
-        <di:waypoint x="1060.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
-        <di:waypoint x="430" y="842.9786796569824"/>
-        <di:waypoint x="1024" y="617.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_dc094e13-abbd-4164-bc95-a61b433a7be4" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
-        <di:waypoint x="1099.5" y="716.4786796569824"/>
-        <di:waypoint x="1100.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_aa1fbb92-27fc-4108-9257-2017c2dbc601" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
-        <di:waypoint x="150" y="510.9786796569824"/>
-        <di:waypoint x="1024.5" y="735.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
-        <di:waypoint x="530.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="373.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
-        <di:waypoint x="353.5" y="822.9786796569824"/>
-        <di:waypoint x="353.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_d37ce038-f9cc-4576-92a7-dd64eea28a2d" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
-        <di:waypoint x="213" y="716.4786796569824"/>
-        <di:waypoint x="313.5" y="647.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_b752b8ba-8fab-4658-94d9-1aaaa51af3a2" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
-        <di:waypoint x="87.5" y="543.4786796569824"/>
-        <di:waypoint x="146.5" y="724.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
-        <di:waypoint x="510.4968013763428" y="950.9786758422852"/>
-        <di:waypoint x="403.5" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
-        <di:waypoint x="223" y="941.4786796569824"/>
-        <di:waypoint x="323.5" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
-        <di:waypoint x="87.5" y="885"/>
-        <di:waypoint x="138" y="980.4786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
-        <di:waypoint x="813.9968013763428" y="940.9786758422852"/>
-        <di:waypoint x="887" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
-        <di:waypoint x="1010" y="941.4786796569824"/>
-        <di:waypoint x="937" y="882.9786796569824"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_f0a6536d-0e7f-44d3-a9bb-5213478173da" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
-        <di:waypoint x="1157" y="970.4786796569824"/>
-        <di:waypoint x="1097" y="970.9786796569824"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-  </dmndi:DMNDI>
+   </dmn:decision>
+   <dmn:decision id="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" name="Eligibility">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Eligibility rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Applicant data.Age as the Age parameter, the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter, and the output of the Pre-bureau affordability decision as the Pre-Bureau Affordability parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_a160fe23-8110-4242-9944-86278d32000e" name="Eligibility" typeRef="tEligibility" />
+      <dmn:informationRequirement id="_94475973-9022-46d7-a520-756538ba9c00">
+         <dmn:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+         <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+         <dmn:requiredDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+         <dmn:requiredKnowledge href="#_dc2ca64d-2044-4806-9d0e-e705b3b14447" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979">
+         <dmn:literalExpression id="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979">
+            <dmn:text>Eligibility rules</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_07fdfb40-acac-4098-8a66-f09f216cd9ec" name="Age" />
+            <dmn:literalExpression id="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca">
+               <dmn:text>Applicant data.Age</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_a2bc5321-7041-40c0-be9d-4e53c22442d1" name="Pre-Bureau Risk Category" />
+            <dmn:literalExpression id="_91986b6f-d45e-4aa7-926d-00b35a47686f">
+               <dmn:text>Pre-bureau risk category</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_c3432a72-40b0-4213-9f94-7f5e8e15ee85" name="Pre-Bureau Affordability" />
+            <dmn:literalExpression id="_719504be-6121-4c16-9c00-1480b58f2ecb">
+               <dmn:text>Pre-bureau affordability</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:businessKnowledgeModel id="_dc2ca64d-2044-4806-9d0e-e705b3b14447" name="Eligibility rules">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Eligibility from Pre-Bureau Risk Category, Pre-Bureau Affordability and Age.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_fe2d2049-704b-4a88-88be-3d1a56c3d376" name="Eligibility rules" typeRef="tEligibility" />
+      <dmn:encapsulatedLogic id="_809B2A63-2946-4AC0-BB2A-7C01F85D885B" kind="FEEL">
+         <dmn:formalParameter id="_AF5CF5FF-A53C-4505-BD25-6DBC2B7A2321" name="Pre-Bureau Risk Category" typeRef="tRiskCategory" />
+         <dmn:formalParameter id="_23CAE4C5-9875-483B-8042-0B86C91471F1" name="Pre-Bureau Affordability" typeRef="boolean" />
+         <dmn:formalParameter id="_80C61F87-3F89-4CA5-AB0A-30849F9372D5" name="Age" typeRef="number" />
+         <dmn:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Eligibility rules">
+            <dmn:input id="_2bab5dc0-be18-4098-b9b4-6b3486955d1b">
+               <dmn:inputExpression id="_FF749C0B-3AB2-44EA-BCF3-46CED726B735" typeRef="tRiskCategory">
+                  <dmn:text>Pre-Bureau Risk Category</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_2BB06B1A-6FAB-4402-A9A7-18F1209D5F31">
+                  <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:input id="_836645fe-83ba-4f36-9b6d-279b017c59ea">
+               <dmn:inputExpression id="_8D820170-C485-4489-A266-3E9330A1A005" typeRef="boolean">
+                  <dmn:text>Pre-Bureau Affordability</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:input id="_4946be73-cb1e-43b4-ac03-b01e378c298a">
+               <dmn:inputExpression id="_D9694AB4-E78F-4A65-A3E4-84E080A77CF6" typeRef="number">
+                  <dmn:text>Age</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:output id="_81aab6dd-d832-4c9e-8a3c-55f5f4a89cc7">
+               <dmn:outputValues id="_A966F694-17B2-4E04-9D7B-4D3A5E30D021">
+                  <dmn:text>"INELIGIBLE","ELIGIBLE"</dmn:text>
+               </dmn:outputValues>
+            </dmn:output>
+            <dmn:annotation name="" />
+            <dmn:rule id="_3352c79c-5aa5-4f2a-bf7e-c1e24f72a7ed">
+               <dmn:inputEntry id="_51fa1535-776a-411f-ba5d-4915f04adf46">
+                  <dmn:text>"DECLINE"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_209c0b4c-7e1f-4758-bb2d-ff56116ebf70">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_e5e44a50-b664-4ce1-8b48-a7c5b73bec50">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_f506afa7-a3fe-48d5-8ec6-4bf2cc2dd28b">
+                  <dmn:text>"INELIGIBLE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_1e4a3e10-0d85-4160-85eb-6d3ad7adee82">
+               <dmn:inputEntry id="_0366fd41-b16b-4848-8759-1c1b2f5defc9">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_4c4d51a8-0927-47d1-bf5d-732eeaf9af50">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_bc0c7201-97b5-41ea-8427-31a3923d674c">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_3611f774-9b66-468d-be7f-06bf14407161">
+                  <dmn:text>"INELIGIBLE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_c871d706-98a2-4d65-903c-7cbd1571f17c">
+               <dmn:inputEntry id="_4e174888-d7ca-4561-aba8-5fd8dfb3b35b">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_6e1f9fc4-69b2-4e8c-bcf9-8878ec8bd455">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_a120264e-f028-4b2b-8b94-b29b68aa5499">
+                  <dmn:text>&lt; 18</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_504ac7aa-2538-48d1-b518-f10a5ff1d87c">
+                  <dmn:text>"INELIGIBLE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_11673d64-2390-42c1-bc6f-43074ee90097">
+               <dmn:inputEntry id="_d1ca6c94-6088-43be-bcfe-83b9de492d8a">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_c19d2814-6733-46dc-92cc-48c7b0e59fa8">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_bac13f3d-00eb-49f7-b715-0d379562c1c3">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_0d0dd4a4-0468-44cc-97fc-6cf243ee28b9">
+                  <dmn:text>"ELIGIBLE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+         </dmn:decisionTable>
+      </dmn:encapsulatedLogic>
+      <dmn:authorityRequirement id="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+         <dmn:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:knowledgeSource id="_a5f9b126-7853-4037-9e23-3dd7e93c4032" name="Product specification">
+      <dmn:extensionElements />
+   </dmn:knowledgeSource>
+   <dmn:businessKnowledgeModel id="_536d7a39-87a6-4651-b743-6ee03e16e535" name="Routing rules">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing Rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Routing from Post-Bureau Risk Category, Post-Bureau Affordability, Bankrupt and Credit Score.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_08f4f63e-54e4-4b19-b0d2-08aeed21605c" name="Routing rules" typeRef="tRouting" />
+      <dmn:encapsulatedLogic id="_C6A7891D-03F8-49CF-8275-7AFD1147FC3A" kind="FEEL">
+         <dmn:formalParameter id="_54223840-9F04-4851-85A6-2429ED4FA4FB" name="Post-bureau risk category" typeRef="tRiskCategory" />
+         <dmn:formalParameter id="_C2E9B628-A66A-424F-A519-E93E23858DEE" name="Post-bureau affordability" typeRef="boolean" />
+         <dmn:formalParameter id="_CC07B347-12E8-4C7B-BD9A-952502B06FEA" name="Bankrupt" typeRef="boolean" />
+         <dmn:formalParameter id="_A8D16EEA-AF2B-4053-928D-CB2E15211DB4" name="Credit score" typeRef="number" />
+         <dmn:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Routing rules">
+            <dmn:input id="_b3bde44f-2274-41d5-8e04-5cb2f7529e6c">
+               <dmn:inputExpression id="_51F5E6E5-BA85-4968-AEB4-832DC813A164" typeRef="tRiskCategory">
+                  <dmn:text>Post-bureau risk category</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_79225F36-9FCC-4341-9D0F-E039F9650965">
+                  <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:input id="_edb3efb0-2fea-4d55-9b5f-ae279ad5ecaa">
+               <dmn:inputExpression id="_E709D705-1EE2-49F2-99F3-5E2B9F22E5AD" typeRef="boolean">
+                  <dmn:text>Post-bureau affordability</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:input id="_1fbd45e7-99d5-497d-beb0-a643dd558b63">
+               <dmn:inputExpression id="_CAE471CE-0234-4E48-805F-6FF8CF30690B" typeRef="boolean">
+                  <dmn:text>Bankrupt</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:input id="_83878ad8-a1fc-43b0-b601-f1b093e39b48">
+               <dmn:inputExpression id="_9C89B4FB-A91C-4D80-BDFE-DF5F8CABAE82" typeRef="number">
+                  <dmn:text>Credit score</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_CB69CB77-A9B7-46D9-959B-801F5CA2A037">
+                  <dmn:text>null, [0..999]</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:output id="_109021ab-349a-47f0-9c9e-564a9fbc20e8">
+               <dmn:outputValues id="_960F7270-F2CC-4BA1-BCA6-6CECBCBB09D7">
+                  <dmn:text>"DECLINE","REFER","ACCEPT"</dmn:text>
+               </dmn:outputValues>
+            </dmn:output>
+            <dmn:annotation name="" />
+            <dmn:rule id="_b9e04531-35ba-4562-9c9e-2a6900315e1c">
+               <dmn:inputEntry id="_2844a3b1-bdcf-49f0-9c5c-f80990077a43">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_7ac71a80-a65f-4b42-b125-682fec1c0cda">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_e3ef460f-b05e-4d54-af1e-355c2d6d191e">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_ec772f81-1eee-475c-872a-596fb40c650c">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_27239ae2-8529-4afd-8981-043bb51d2fb2">
+                  <dmn:text>"DECLINE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_3ed8ac44-80a1-4e64-b610-f84d79c5b875">
+               <dmn:inputEntry id="_64077b12-6193-4842-86e2-896290756562">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_07978900-95e3-4102-8916-eb439316c4e1">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_2e822dc4-cba8-4594-82bd-b48b4be2180d">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_b3856c1d-2067-483a-b6ca-ba3c8080f12c">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_684c798b-7ade-4155-ad42-cc111cf920a9">
+                  <dmn:text>"DECLINE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_0e511735-f478-4041-97f8-158ea173668b">
+               <dmn:inputEntry id="_9ee5cc2a-42ce-4fc6-b4a2-b6ae3c6590c4">
+                  <dmn:text>"HIGH"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_be5739cd-c1c9-47ca-af91-47109d2c288a">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_f4f9d322-ca0a-4a24-a967-916aa32f5136">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_fda948c5-43a7-4023-9c52-4020007ca482">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_000ea279-76af-4c1a-a2d6-b8eda969df7a">
+                  <dmn:text>"REFER"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_06c90e6c-99d1-4c99-a443-374ab1288c1b">
+               <dmn:inputEntry id="_c87517c4-b47d-4653-a884-3a265dba1ec7">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_0fc27099-c992-4041-b164-9c4d1dddb462">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_527df004-e723-46de-9475-aa2db4e0f4f7">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_dbc688c4-064b-4fe1-ab7e-6992d6cbaf61">
+                  <dmn:text>&lt; 580</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_20941825-2c8b-4d94-9fde-0b3039b12a3c">
+                  <dmn:text>"REFER"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_3a1673bb-17ae-4b62-b686-d8ecc0f4657b">
+               <dmn:inputEntry id="_7e258e45-824d-402b-b6e5-a46088e90e1e">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_2f51bdea-d5bc-4b8e-ac34-ae093f1ae170">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_913c21a5-d028-4c3b-8482-83d2a5eae2c6">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_4665c331-032d-4489-97bf-4e19eead103e">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_f77e29ae-79a3-4f1d-9eed-7b3795031861">
+                  <dmn:text>"ACCEPT"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+         </dmn:decisionTable>
+      </dmn:encapsulatedLogic>
+      <dmn:authorityRequirement id="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+         <dmn:requiredAuthority href="#_a5f9b126-7853-4037-9e23-3dd7e93c4032" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:decision id="_ca1e6032-12eb-428a-a80b-49028a88c0b5" name="Routing">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Routing rules business&amp;nbsp;&lt;/span&gt;knowledge model, passing Bureau data . Bankrupt as the Bankrupt parameter, Bureau data . CreditScore as the Credit Score parameter, the output of the Post-bureau risk category decision as the Post-Bureau Risk Category parameter, and the output of the Post-bureau affordability decision as the Post-Bureau Affordability parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Bankrupt and Credit Score parameters will be null.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_da1b4341-41b8-4b67-b33a-f54d2782cf4e" name="Routing" typeRef="tRouting" />
+      <dmn:informationRequirement id="_132debf9-e318-4710-a226-982da98dd278">
+         <dmn:requiredDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+         <dmn:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+         <dmn:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_839ccfec-8902-40ca-8767-df9073f797e5">
+         <dmn:requiredKnowledge href="#_536d7a39-87a6-4651-b743-6ee03e16e535" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_78ce14d2-2c68-454a-b772-075b3f1395c3">
+         <dmn:literalExpression id="literal__78ce14d2-2c68-454a-b772-075b3f1395c3">
+            <dmn:text>Routing rules</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_8a009394-dc06-4ee6-b039-dde94390bf6b" name="Bankrupt" />
+            <dmn:literalExpression id="_32742ced-8b58-4be0-a6be-d48ab1126f69">
+               <dmn:text>Bureau data.Bankrupt</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_5b79a0ff-62ed-4d3d-b512-ea706cc06f62" name="Credit score" />
+            <dmn:literalExpression id="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a">
+               <dmn:text>Bureau data.CreditScore</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_79216390-7bf1-4b14-9b3e-91ee83a5cd4a" name="Post-bureau risk category" />
+            <dmn:literalExpression id="_30a91838-0f0a-4843-a6d0-6b5a655f36b2">
+               <dmn:text>Post-bureau risk category</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_6edce48a-be0d-4896-af06-f5c05980970b" name="Post-bureau affordability" />
+            <dmn:literalExpression id="_7a672677-fd20-4174-87f9-ba5e9146ddba">
+               <dmn:text>Post-bureau affordability</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:businessKnowledgeModel id="_a654be71-b54d-4d6e-90f0-ae505125e9a6" name="Bureau call type table">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table deriving&amp;nbsp;&lt;/span&gt;Bureau Call Type from Pre-Bureau Risk Category.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_86c4fcfd-1e5a-41ec-9b62-966cf0eed2d3" name="Bureau call type table" typeRef="tBureauCallType" />
+      <dmn:encapsulatedLogic id="_3E30A977-5CC2-46C9-916C-2CF97DB1CF87" kind="FEEL">
+         <dmn:formalParameter id="_B232360A-19B5-492D-BED5-11C5D55DFCFC" name="Pre-Bureau Risk Category" typeRef="tRiskCategory" />
+         <dmn:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Bureau call type table">
+            <dmn:input id="_92e35546-27e5-43a5-b8e6-85a692f42eb8">
+               <dmn:inputExpression id="_5804E953-44B0-48FA-A4E3-8FBB40B7EE5A" typeRef="tRiskCategory">
+                  <dmn:text>Pre-Bureau Risk Category</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_A05268BA-A982-4ACC-9694-6415E5828A17">
+                  <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:output id="_6254d113-6c92-400f-88d5-fdb340519336">
+               <dmn:outputValues id="_1A5EB4EC-6AFB-4C75-9C7D-BC26584BC6C1">
+                  <dmn:text>"FULL","MINI","NONE"</dmn:text>
+               </dmn:outputValues>
+            </dmn:output>
+            <dmn:annotation name="" />
+            <dmn:rule id="_49d3d12b-8572-4341-9102-6f68667bf81a">
+               <dmn:inputEntry id="_7abba955-f604-4995-aea5-842f7eefa839">
+                  <dmn:text>"HIGH", "MEDIUM"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_573aec0a-0759-435a-ba0c-5f27498897a0">
+                  <dmn:text>"FULL"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_db49e5ea-da50-4b07-ae82-9db29f3730b9">
+               <dmn:inputEntry id="_1f21c493-c6f2-4b81-92f0-59b6511f9ddd">
+                  <dmn:text>"LOW"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_9aa8475c-4b5e-4da3-8f3e-aae70f694f83">
+                  <dmn:text>"MINI"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_304ebea6-617f-4f47-949d-aa9ac1dd1227">
+               <dmn:inputEntry id="_d3f0c96c-521d-4228-b073-c945aca7483d">
+                  <dmn:text>"VERY LOW", "DECLINE"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_2174bcfa-2d27-44ad-8525-56fce28fb75e">
+                  <dmn:text>"NONE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+         </dmn:decisionTable>
+      </dmn:encapsulatedLogic>
+      <dmn:authorityRequirement id="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+         <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:knowledgeSource id="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" name="Risk manager">
+      <dmn:extensionElements />
+   </dmn:knowledgeSource>
+   <dmn:businessKnowledgeModel id="_b982a42a-0b62-47fa-8911-6c9d1145d982" name="Credit contingency factor table">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;/span&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Credit contingency factor table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;decision&lt;/span&gt; logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Credit contingency factor from Risk Category.&lt;/p&gt;			&lt;p&gt;&amp;nbsp;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_40c0f987-7b90-4c3e-9dcd-411e56f66c92" name="Credit contingency factor table" typeRef="number" />
+      <dmn:encapsulatedLogic id="_E6280C1C-D063-4872-8901-7783DA7353DE" kind="FEEL">
+         <dmn:formalParameter id="_355FCCB9-0BB3-440A-AC0F-8C19915F5431" name="Risk Category" typeRef="tRiskCategory" />
+         <dmn:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Credit contingency factor table">
+            <dmn:input id="_2b8fecfd-e00f-4d4b-acf3-660ca3560ca0">
+               <dmn:inputExpression id="_673A97FB-0D8B-4447-BDC4-A68198CD4AE9" typeRef="tRiskCategory">
+                  <dmn:text>Risk Category</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_E401103E-3287-4972-BB30-6B0F86B587A9">
+                  <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:output id="_8d0d6fe3-a352-48a7-a35e-1fc1dd192039" />
+            <dmn:annotation name="" />
+            <dmn:rule id="_21ec60ae-6137-41e2-b8b5-37447708c47b">
+               <dmn:inputEntry id="_8c7e14f8-23db-4645-8b2a-2c69aada207d">
+                  <dmn:text>"HIGH", "DECLINE"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_6052bbc0-6f0e-45db-bdd3-3c0ac4c45793">
+                  <dmn:text>0.6</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_8c5eb4e3-1902-4bf5-8257-1e21636fc978">
+               <dmn:inputEntry id="_fe0190b4-e2f3-441f-a989-f22e1d425fd8">
+                  <dmn:text>"MEDIUM"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_6320ae5d-459e-4775-b492-f9c0d0d492bb">
+                  <dmn:text>0.7</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_93e2a1a2-b281-42a4-8e34-865c28557929">
+               <dmn:inputEntry id="_cd63cc67-53a5-480f-abcd-f394e606a7bd">
+                  <dmn:text>"LOW", "VERY LOW"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_fdcb46a5-a23c-4e29-93f1-66ce4e3c25da">
+                  <dmn:text>0.8</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+         </dmn:decisionTable>
+      </dmn:encapsulatedLogic>
+      <dmn:authorityRequirement id="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+         <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:knowledgeSource id="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" name="Affordability spreadsheet">
+      <dmn:extensionElements />
+   </dmn:knowledgeSource>
+   <dmn:businessKnowledgeModel id="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" name="Affordability calculation">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Affordability calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a boxed function deriving Affordability from&amp;nbsp;&lt;/span&gt;Monthly Income, Monthly Repayments, Monthly Expenses and Required Monthly Installment. One step in this calculation derives Credit contingency factor by invoking the Credit contingency factor table business&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_80af1aa7-e29c-47fc-9cce-1959a3e1e717" name="Affordability calculation" typeRef="boolean" />
+      <dmn:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL">
+         <dmn:formalParameter id="_f916b091-cd6d-44cb-b32b-cc83cc27e333" name="Monthly Income" typeRef="number" />
+         <dmn:formalParameter id="_d68b6438-cba5-4c02-a708-bce0d2762d35" name="Monthly Repayments" typeRef="number" />
+         <dmn:formalParameter id="_5fd5609d-89ce-463e-a882-6827921edf54" name="Monthly Expenses" typeRef="number" />
+         <dmn:formalParameter id="_2acfe2aa-892f-4a5c-b9ab-111c7a8bbd40" name="Risk Category" typeRef="tRiskCategory" />
+         <dmn:formalParameter id="_3a423c76-11c7-4b66-b86a-07928181a631" name="Required Monthly Installment" typeRef="number" />
+         <dmn:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256">
+            <dmn:contextEntry>
+               <dmn:variable id="_3cc56162-97c1-416e-acb9-3ae81d692e58" name="Disposable Income" typeRef="number" />
+               <dmn:literalExpression id="_2fcda742-6d7b-49c5-afe6-6b334c8f049b">
+                  <dmn:text>Monthly Income - (Monthly Repayments + Monthly Expenses)</dmn:text>
+               </dmn:literalExpression>
+            </dmn:contextEntry>
+            <dmn:contextEntry>
+               <dmn:variable id="_0f406bed-56f5-422e-b6c3-ad4892a38291" name="Credit Contingency Factor" typeRef="number" />
+               <dmn:invocation id="_78bc74d6-25a4-4639-8509-186534b3c67a">
+                  <dmn:literalExpression id="literal__78bc74d6-25a4-4639-8509-186534b3c67a">
+                     <dmn:text>Credit contingency factor table</dmn:text>
+                  </dmn:literalExpression>
+                  <dmn:binding>
+                     <dmn:parameter id="_7fed77e8-7d20-4f3f-9504-2c0c0706bd39" name="Risk Category" />
+                     <dmn:literalExpression id="_a02265a9-3dd1-48cd-a254-84531f28a058">
+                        <dmn:text>Risk Category</dmn:text>
+                     </dmn:literalExpression>
+                  </dmn:binding>
+               </dmn:invocation>
+            </dmn:contextEntry>
+            <dmn:contextEntry>
+               <dmn:variable id="_efb9411e-34c6-4e72-a664-85a30197f5d0" name="Affordability" typeRef="boolean" />
+               <dmn:literalExpression id="_3051a016-282e-4f83-8cfa-4c57084e559f">
+                  <dmn:text>if Disposable Income * Credit Contingency Factor &gt; Required Monthly Installment							then true							else false</dmn:text>
+               </dmn:literalExpression>
+            </dmn:contextEntry>
+            <dmn:contextEntry>
+               <dmn:literalExpression id="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55">
+                  <dmn:text>Affordability</dmn:text>
+               </dmn:literalExpression>
+            </dmn:contextEntry>
+         </dmn:context>
+      </dmn:encapsulatedLogic>
+      <dmn:knowledgeRequirement id="_7f7c177a-5acb-4941-9654-23f9408200b3">
+         <dmn:requiredKnowledge href="#_b982a42a-0b62-47fa-8911-6c9d1145d982" />
+      </dmn:knowledgeRequirement>
+      <dmn:authorityRequirement id="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+         <dmn:requiredAuthority href="#_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:decision id="_ed60265c-25e2-400f-a99f-fafd3b489838" name="Pre-bureau affordability">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Pre-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_bd744aca-06aa-4438-81de-0754fc15a44e" name="Pre-bureau affordability" typeRef="boolean" />
+      <dmn:informationRequirement id="_00c137a3-a81c-42ff-af6d-5c3247151273">
+         <dmn:requiredDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+         <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+         <dmn:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+         <dmn:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_7fea3599-f557-487a-bc0c-6aad2e8e6c86">
+         <dmn:literalExpression id="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86">
+            <dmn:text>Affordability calculation</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_ea45f34e-c7f7-41fe-a2fa-c9329dc03ead" name="Monthly Income" />
+            <dmn:literalExpression id="_63cbd20f-fab4-480e-9471-1367b2e1fc6c">
+               <dmn:text>Applicant data.Monthly.Income</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_28b8d43b-e005-42f0-a432-5ea3c6547247" name="Monthly Repayments" />
+            <dmn:literalExpression id="_c35a57bf-208c-4333-973f-c8a9e9ce85f4">
+               <dmn:text>Applicant data.Monthly.Repayments</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_650b93d6-d6cd-46dc-8ebc-d1d80c5c4fa7" name="Monthly Expenses" />
+            <dmn:literalExpression id="_174c9fb3-c940-455f-ab97-035989e83446">
+               <dmn:text>Applicant data.Monthly.Expenses</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_70836844-402b-49b0-b07a-347c81e0f345" name="Risk Category" />
+            <dmn:literalExpression id="_34d3db82-c899-45f6-b46c-ef7cb2f550c3">
+               <dmn:text>Pre-bureau risk category</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_b94f43b0-69d0-4f20-9698-5f91b85f026a" name="Required Monthly Installment" />
+            <dmn:literalExpression id="_47e0147f-030a-4020-a5d3-728c563c0bd2">
+               <dmn:text>Required monthly installment</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" name="Post-bureau affordability">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau affordability&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Post-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_b6f25146-5302-470e-a242-3d71c4311add" name="Post-bureau affordability" typeRef="boolean" />
+      <dmn:informationRequirement id="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+         <dmn:requiredDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_9eeef063-346f-44d4-b722-2d8071d3d994">
+         <dmn:requiredDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_466b70d3-035a-413d-93bd-ae28c778d02d">
+         <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+         <dmn:requiredKnowledge href="#_ee893e8d-f393-4e2c-b871-611a9cd30bf5" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_3e5d9f10-9433-4853-b084-33790988de2a">
+         <dmn:literalExpression id="literal__3e5d9f10-9433-4853-b084-33790988de2a">
+            <dmn:text>Affordability calculation</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_ecb484a1-1ca6-40d8-863f-ba95fea13779" name="Monthly Income" />
+            <dmn:literalExpression id="_610d5776-9163-4707-85c4-c4f0ff35db0a">
+               <dmn:text>Applicant data.Monthly.Income</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_b5f0835b-4dba-418b-a11c-3a23a76f3ae6" name="Monthly Repayments" />
+            <dmn:literalExpression id="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36">
+               <dmn:text>Applicant data.Monthly.Repayments</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_f8edc4a3-5000-4558-80f0-45efaee7e339" name="Monthly Expenses" />
+            <dmn:literalExpression id="_3d3c099c-c287-45ff-82de-ca3079da67b0">
+               <dmn:text>Applicant data.Monthly.Expenses</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_a8c6984b-8bca-41cc-b284-d056a18b43af" name="Risk Category" />
+            <dmn:literalExpression id="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113">
+               <dmn:text>Post-bureau risk category</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_cac9db30-48f9-4b43-b9fa-699171ac858b" name="Required Monthly Installment" />
+            <dmn:literalExpression id="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227">
+               <dmn:text>Required monthly installment</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_40b45659-9299-43a6-af30-04c948c5c0ec" name="Post-bureau risk category">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Post-bureau&amp;nbsp;&lt;/span&gt;risk category business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter, Bureau data.CreditScore as the Credit Score parameter, and the output of the Application risk score decision as the Application Risk Score parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Credit Score parameter will be null.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_34b85411-de9d-4d9a-8b03-ad1b1cec8777" name="Post-bureau risk category" typeRef="tRiskCategory" />
+      <dmn:informationRequirement id="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+         <dmn:requiredInput href="#_e91de815-22ba-431c-8b46-55891f2a1ef6" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_668fa95d-373d-4430-b833-7c27308d2a80">
+         <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_655fba60-b529-4c21-bd96-9c778998d3fb">
+         <dmn:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+         <dmn:requiredKnowledge href="#_1c72ed95-ec72-47b4-8639-5ed14ccb77df" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b">
+         <dmn:literalExpression id="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b">
+            <dmn:text>Post-bureau risk category table</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_a7faf416-0247-43c1-8827-9346540d13c3" name="Existing Customer" />
+            <dmn:literalExpression id="_9eb92498-0de3-44b1-a8e2-301a2bc091d4">
+               <dmn:text>Applicant data.ExistingCustomer</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_b0bb0d61-0ea4-4c10-8a97-94be610bee0b" name="Credit Score" />
+            <dmn:literalExpression id="_ad652244-9438-4a76-9637-2ca8dde2cee4">
+               <dmn:text>Bureau data.CreditScore</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_4bb7604e-18d8-4d57-8097-cd2585c59266" name="Application Risk Score" />
+            <dmn:literalExpression id="_9ead8557-599e-4900-80b8-7157c0653d82">
+               <dmn:text>Application risk score</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:inputData id="_e91de815-22ba-431c-8b46-55891f2a1ef6" name="Bureau data">
+      <dmn:extensionElements />
+      <dmn:variable id="_aa8440f8-8f48-4e37-b775-ab8d771d24eb" name="Bureau data" typeRef="tBureauData" />
+   </dmn:inputData>
+   <dmn:businessKnowledgeModel id="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" name="Post-bureau risk category table">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Post-Bureau Risk Category from Existing Customer, Application Risk Score and Credit Score.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_689c96f3-6dd3-4c74-9a8f-721a966eb1af" name="Post-bureau risk category table" typeRef="tRiskCategory" />
+      <dmn:encapsulatedLogic id="_04437EA6-7362-4693-B4B3-9431E330CEAC" kind="FEEL">
+         <dmn:formalParameter id="_C17D41A5-4349-48DF-8214-B63DF79C6B5F" name="Existing Customer" typeRef="boolean" />
+         <dmn:formalParameter id="_CD5886D0-BF0E-4597-9F36-C8AA61763B54" name="Application Risk Score" typeRef="number" />
+         <dmn:formalParameter id="_B0470BB1-6409-42A6-A3D1-BC860328EF03" name="Credit Score" typeRef="number" />
+         <dmn:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Post-bureau risk category table">
+            <dmn:input id="_fc4cfa6b-926b-4751-81d9-d363b6f19299">
+               <dmn:inputExpression id="_CC27D5E4-1519-4A2B-BF83-5E4364B5C9AE" typeRef="boolean">
+                  <dmn:text>Existing Customer</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:input id="_77a90f33-64d6-4050-a932-a9c8454b10ab">
+               <dmn:inputExpression id="_D1B46CF7-92BD-49C1-AAE2-F332CDC1F1B5" typeRef="number">
+                  <dmn:text>Application Risk Score</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:input id="_129a63ca-ea08-460a-98f3-bbb9b9a11121">
+               <dmn:inputExpression id="_B2E8029F-1632-416A-883A-AAB8151E029B" typeRef="number">
+                  <dmn:text>Credit Score</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:output id="_44033e77-5b86-4040-83a3-63629ae25983">
+               <dmn:outputValues id="_0CC7EC7C-D3C6-4B9F-A45E-3EFD34EAC191">
+                  <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
+               </dmn:outputValues>
+            </dmn:output>
+            <dmn:annotation name="" />
+            <dmn:rule id="_22d41220-e512-4248-bed3-935266abfac6">
+               <dmn:inputEntry id="_2c44dae4-55da-4aad-8dca-6db78b1463ff">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_f75f53c2-d798-4b12-bfbb-f3c2dcbb7d13">
+                  <dmn:text>&lt; 120</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_19694f9e-0022-42bd-a10c-8ec5855d2608">
+                  <dmn:text>&lt; 590</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_04e9777f-143b-44f5-be3e-a17710658417">
+                  <dmn:text>"HIGH"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_ca0d34ce-5f88-489f-b07d-c153cfcc9a9f">
+               <dmn:inputEntry id="_1a227ae6-84eb-46b5-a355-e9414e2b4c68">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_d571de40-d13c-40d1-b4d8-7c9ef4f3d405">
+                  <dmn:text>&lt; 120</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_eaad5ff9-9a13-4321-b1ed-b9b81a6bc7c3">
+                  <dmn:text>[590..610]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_e47b1857-760e-4a6a-ab76-575d57ed3d75">
+                  <dmn:text>"MEDIUM"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_731cfff1-8846-4204-b2d8-d4273e7caf6d">
+               <dmn:inputEntry id="_9398558c-7346-41e6-b466-6db6a65a6886">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_69198768-fbd1-48f4-a233-6a237f8759d3">
+                  <dmn:text>&lt; 120</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_9853a883-301b-4134-8411-11fcc78cca01">
+                  <dmn:text>&gt; 610</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_e56ad1e0-521d-4648-9209-81909e453bec">
+                  <dmn:text>"LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_7124ae55-0a5c-40a5-858a-2e97d3fcee2b">
+               <dmn:inputEntry id="_d66444ed-d5af-47e9-9425-d41c72eab9d8">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_a24e787d-5735-4086-b27e-b536108f0cab">
+                  <dmn:text>[120..130]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_801d5239-537e-4147-80ce-2226cf9bb6dd">
+                  <dmn:text>&lt; 600</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_27df9777-129b-4e9a-8e01-1c016b90f049">
+                  <dmn:text>"HIGH"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_6849c070-ffaf-4afd-b739-c9516e093a2d">
+               <dmn:inputEntry id="_d7cdde1c-c04e-4cf6-9c6e-58e73ceb48e4">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_79cd3d7c-5e16-48c1-bb40-b5f30dec9830">
+                  <dmn:text>[120..130]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_1c63b959-c10b-4c66-b024-684fb3773c13">
+                  <dmn:text>[600..625]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_ad886bab-7ca9-466a-873e-a7fdc7dc0e29">
+                  <dmn:text>"MEDIUM"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_abe53d6c-0c5e-4de6-8835-452442e07761">
+               <dmn:inputEntry id="_8a73641d-2a45-423e-ba92-cc6463dcdefe">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_a4131075-a73f-46cf-9e6b-4cf014f95567">
+                  <dmn:text>[120..130]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_d81f0359-dab6-4813-a818-62bebe59d2c6">
+                  <dmn:text>&gt; 625</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_28527dae-a87d-4cd3-9f2e-7d244c617b17">
+                  <dmn:text>"LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_1a267a70-0937-42cd-a778-9ef369309660">
+               <dmn:inputEntry id="_6d4e7030-c29d-4f31-b1a5-8e57323425fd">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_d0be0dbe-0ef4-4198-b612-7a415e569e73">
+                  <dmn:text>&gt; 130</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_ffb1d0e3-4ecb-4497-8df0-6262f0e56ff2">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_3de03ecf-f018-4135-add5-fd54737cee48">
+                  <dmn:text>"VERY LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_4ec01cc3-2dce-453f-a195-e8a598be44ab">
+               <dmn:inputEntry id="_69c5f5cb-c384-4596-8fd7-615cdcc4abf4">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_86661a8a-4179-4df7-9556-5e5937b676b9">
+                  <dmn:text>&lt;= 100</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_7580e93d-f53b-405c-b6ab-87d9cb1f5fa1">
+                  <dmn:text>&lt; 580</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_00ef5d95-f613-41c8-8bf5-35aeee1e55e8">
+                  <dmn:text>"HIGH"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_2ca1a47c-33b0-426d-87b4-d1dd23de3e30">
+               <dmn:inputEntry id="_d9bafc07-3e85-442e-bb8a-99f7f2b7488a">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_005e60af-83b1-471c-aa1c-1a1bc9e8f197">
+                  <dmn:text>&lt;= 100</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_0a6e9560-ff9a-4b30-b5e4-1f218b8ea6c2">
+                  <dmn:text>[580..600]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_2bd1761e-b0f6-4eed-8df0-0f3bedf84817">
+                  <dmn:text>"MEDIUM"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_4ad8a80e-0e44-4512-8925-6f3ef0bcf67e">
+               <dmn:inputEntry id="_25c987a9-40dd-4f40-a7b2-7b6b7020f729">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_a8c73104-1d46-4c4d-ba3b-25ac8b812a4b">
+                  <dmn:text>&lt;= 100</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_295d25f5-f29a-456e-a000-7b26c3a3ba1d">
+                  <dmn:text>&gt; 600</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_ae145544-b4e9-4c07-95d4-9e77237813f6">
+                  <dmn:text>"LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_a14b851e-8b11-416e-806b-59222b4b0cc9">
+               <dmn:inputEntry id="_77185ff7-c946-46cc-b93a-dabdc111f5dd">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_be1969ad-6a34-4e7f-8e14-cfabf84c9d33">
+                  <dmn:text>&gt; 100</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_b93f37d5-afe8-40e1-aa4f-272d19da02d9">
+                  <dmn:text>&lt; 590</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_d7479784-014d-497f-9d06-1b111fa9c29f">
+                  <dmn:text>"HIGH"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_4377ced8-b8d9-4069-9dcf-098007969563">
+               <dmn:inputEntry id="_28eee2fe-8a48-4a73-8488-10c506a7add5">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_7c50c99a-c045-42c5-a647-22a4eae50036">
+                  <dmn:text>&gt; 100</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_a71f7fc4-f200-4694-9738-23b01485ba78">
+                  <dmn:text>[590..615]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_02efcf34-86b8-411c-81bc-98668fe07bb3">
+                  <dmn:text>"MEDIUM"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_20a9e6e8-bab5-4d49-803c-12d3b574fdd3">
+               <dmn:inputEntry id="_2ba73fd9-c951-45dc-ac77-f6904c26e37c">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_cf3a2739-9a36-4702-b0f3-e8b0a0338db1">
+                  <dmn:text>&gt; 100</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_56cc9c15-43a9-4d81-975a-ab69f53a528b">
+                  <dmn:text>&gt; 615</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_13bc4965-9c91-44bd-973c-25dd9c1bebab">
+                  <dmn:text>"LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+         </dmn:decisionTable>
+      </dmn:encapsulatedLogic>
+      <dmn:authorityRequirement id="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+         <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:decision id="_9997fcfd-0f50-4933-939e-88a235b5e2a0" name="Pre-bureau risk category">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-Bureau Risk Category&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Pre-bureau&amp;nbsp;&lt;/span&gt;risk category table business knowledge model, passing Applicant data.ExistingCustomer as the Existing Customer parameter and the output of the Application risk score decision as the Application Risk Score parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_a739014d-8c5e-438b-b76a-805e3689c977" name="Pre-bureau risk category" typeRef="tRiskCategory" />
+      <dmn:informationRequirement id="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+         <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+         <dmn:requiredDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+         <dmn:requiredKnowledge href="#_51cc9510-3bfa-4e5a-a119-9bf83efdd266" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_04337ddb-db98-40e9-81cd-12802e74401e">
+         <dmn:literalExpression id="literal__04337ddb-db98-40e9-81cd-12802e74401e">
+            <dmn:text>Pre-bureau risk category table</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_74d8aa6b-838e-4d87-8d64-8b734146aac6" name="Existing Customer" />
+            <dmn:literalExpression id="_4b5e5cfb-d6fa-4d41-a13a-783170887126">
+               <dmn:text>Applicant data.ExistingCustomer</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_929d5796-6174-41eb-b27c-52f956fd44dd" name="Application Risk Score" />
+            <dmn:literalExpression id="_b93f253e-7f93-4356-a98b-3fae510485e3">
+               <dmn:text>Application risk score</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:businessKnowledgeModel id="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" name="Pre-bureau risk category table">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Pre-bureau risk category from Existing Customer and Application Risk Score.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_cfb1bb8c-ad27-42e2-b52a-50eadea198a6" name="Pre-bureau risk category table" typeRef="tRiskCategory" />
+      <dmn:encapsulatedLogic id="_530613B3-1EC6-4E64-B33A-899F0E219BA0" kind="FEEL">
+         <dmn:formalParameter id="_4E26B3A4-7FBF-4B0F-8E88-9F9FCA20C4E0" name="Existing Customer" typeRef="boolean" />
+         <dmn:formalParameter id="_F8C2891C-B02D-438F-98F8-55EB9756CE70" name="Application Risk Score" typeRef="number" />
+         <dmn:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Pre-bureau risk category table">
+            <dmn:input id="_1ee6291f-423f-47d9-8774-858b392d4762">
+               <dmn:inputExpression id="_C6B71901-5D95-4AEA-96AD-15E29DB11E57" typeRef="boolean">
+                  <dmn:text>Existing Customer</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:input id="_22607edc-31dd-4d18-982f-b3d4b4606804">
+               <dmn:inputExpression id="_C1A68048-8A6E-4BB1-A706-9BA92A7D01CF" typeRef="number">
+                  <dmn:text>Application Risk Score</dmn:text>
+               </dmn:inputExpression>
+            </dmn:input>
+            <dmn:output id="_f482a2b4-eed1-4dfc-84b6-4860edec088d">
+               <dmn:outputValues id="_027CF4BA-B83F-4893-981E-B1F2906C0899">
+                  <dmn:text>"DECLINE","HIGH","MEDIUM","LOW","VERY LOW"</dmn:text>
+               </dmn:outputValues>
+            </dmn:output>
+            <dmn:annotation name="" />
+            <dmn:rule id="_05c9836c-6f21-49e9-8e4b-0ad029d1a38c">
+               <dmn:inputEntry id="_5dc5082d-6dc3-46ce-821f-3fe0981a0407">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_f9c9f1c0-dba5-4adc-8764-c740d55abc5e">
+                  <dmn:text>&lt; 100</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_520b6480-8c90-4ab0-bfd2-2e6107c9c2aa">
+                  <dmn:text>"HIGH"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_7d1fbf47-e150-44d1-aa1c-b6c15ccc92c3">
+               <dmn:inputEntry id="_2c0451d5-f065-41a4-ada7-4a3fb29a668d">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_e7f1fb9b-32d4-4a45-95f3-8390801435a8">
+                  <dmn:text>[100..120)</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_699696bd-226d-4dca-bba3-1a5b7ad0a8f0">
+                  <dmn:text>"MEDIUM"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_da654f4f-3a18-44ec-8087-f27715c1e12b">
+               <dmn:inputEntry id="_5df3c3df-0bed-4171-b915-e084fce11e51">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_dd71d0af-cfb7-4472-a745-28a36251b945">
+                  <dmn:text>[120..130]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_331e4bd4-397e-44dd-a403-44b3cf4ad15d">
+                  <dmn:text>"LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_524a197c-3981-41ee-baed-1de02c55fac3">
+               <dmn:inputEntry id="_a76ff1d9-f651-4833-8773-7d75925b5fe4">
+                  <dmn:text>false</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_123b03ad-4815-4f98-8870-9c25e06fac6b">
+                  <dmn:text>&gt; 130</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_f33f040b-a116-43c1-9791-bef711299be6">
+                  <dmn:text>"VERY LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_ab1dfe10-5fbc-47fc-8ade-fd56c0a334c5">
+               <dmn:inputEntry id="_acf40b4c-d68c-49d6-a2a4-2a88ace33016">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_ce80bf8c-6cad-400b-8b18-23c920d6f594">
+                  <dmn:text>&lt; 80</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_44ea4ff9-e85c-40b6-b1a8-c9a76b1ae13e">
+                  <dmn:text>"DECLINE"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_a297a507-5206-4903-94f6-9b6fd6619195">
+               <dmn:inputEntry id="_9a3f8732-e85f-4111-a3f1-2284065f64fe">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_7d398c94-e4c1-4d9c-bf06-cf40f2c04d64">
+                  <dmn:text>[80..90)</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_f54b6b94-ec25-451d-8d7d-1049155b3e2b">
+                  <dmn:text>"HIGH"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_740e7ddb-0834-4705-bbb3-7b092e9570dc">
+               <dmn:inputEntry id="_7fe40ffd-bd8e-4405-8719-0bd706933fd5">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_4b77407a-565f-40ad-b324-6e3940134518">
+                  <dmn:text>[90..110]</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_894b1284-9923-4727-bbc4-fc621b47a28b">
+                  <dmn:text>"MEDIUM"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_95fb462f-6435-44b7-8c21-84427ce71bc9">
+               <dmn:inputEntry id="_3e033f1d-a632-41d4-9eb9-63d66e5e4380">
+                  <dmn:text>true</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_753f756e-cdee-49d2-8953-dfad7aa9b092">
+                  <dmn:text>&gt; 110</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_2fb8f713-e746-4a65-aff0-fa1de216f57a">
+                  <dmn:text>"LOW"</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+         </dmn:decisionTable>
+      </dmn:encapsulatedLogic>
+      <dmn:authorityRequirement id="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+         <dmn:requiredAuthority href="#_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:decision id="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" name="Application risk score">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application Risk Score&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Application&amp;nbsp;&lt;/span&gt;risk score model business knowledge model, passing Applicant data.Age as the Age parameter, Applicant data.MaritalStatus as the Marital Status parameter and Applicant data.EmploymentStatus as the Employment Status parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_f2abe78f-d5d0-4b9e-8d05-f1ea2bd7fc9b" name="Application risk score" typeRef="number" />
+      <dmn:informationRequirement id="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+         <dmn:requiredInput href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_c94de723-def1-49e4-9aae-5270fe39630f">
+         <dmn:requiredKnowledge href="#_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_348139f6-7fd0-40be-952d-66a8bb83d59c">
+         <dmn:literalExpression id="literal__348139f6-7fd0-40be-952d-66a8bb83d59c">
+            <dmn:text>Application risk score model</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_aba556aa-0e5b-4d01-bd6e-d25b780bbf28" name="Age" />
+            <dmn:literalExpression id="_9c3009af-9a1b-4821-8901-7edf800ac60b">
+               <dmn:text>Applicant data.Age</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_259966f2-bf40-4139-b587-6c9b989f1aa0" name="Marital Status" />
+            <dmn:literalExpression id="_610941db-8c4e-483c-9d75-789b3d5c2333">
+               <dmn:text>Applicant data.MartitalStatus</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_dc6d2bc7-3bde-4994-838d-b3fa1fe1ab2c" name="Employment Status" />
+            <dmn:literalExpression id="_c08280b8-beb0-4eb1-a0d0-f022de521d25">
+               <dmn:text>Applicant data.EmploymentStatus</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:knowledgeSource id="_821a6840-e910-418f-809e-4c7d60b0b21a" name="Analytics">
+      <dmn:extensionElements />
+   </dmn:knowledgeSource>
+   <dmn:businessKnowledgeModel id="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" name="Application risk score model">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application risk score model&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, no-order multiple-hit table&amp;nbsp;&lt;/span&gt;with aggregation, deriving Application risk score from Age, Marital Status and Employment Status, as the sum of the Partial scores of all matching rows (this is therefore a predictive scorecard represented as a decision table).&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_645f4911-6a95-4dbd-8efb-13fac8154fa2" name="Application risk score model" typeRef="number" />
+      <dmn:encapsulatedLogic id="_3161744E-C244-4C89-ACA8-4462EC11C790" kind="FEEL">
+         <dmn:formalParameter id="_9B4C6309-1948-4C18-8A6D-8E818BE99ABA" name="Age" typeRef="number" />
+         <dmn:formalParameter id="_BD812E70-C915-41D5-BCEF-FD254CEB3CB9" name="Marital Status" typeRef="string" />
+         <dmn:formalParameter id="_B1D95DAD-0E2E-471D-8D28-98EC24A25E5B" name="Employment Status" typeRef="string" />
+         <dmn:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" aggregation="SUM" preferredOrientation="Rule-as-Row" outputLabel="Application risk score model">
+            <dmn:input id="_09b90043-cccb-4cf7-b8bc-44e97787443f">
+               <dmn:inputExpression id="_7D0E7BCC-8406-41CB-82C5-FDE26284A4DB" typeRef="number">
+                  <dmn:text>Age</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_CF573CA7-5005-43A9-944C-5C5295B7C0EB">
+                  <dmn:text>[18..120]</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:input id="_803f1aa0-731a-4541-bfba-6211a564af69">
+               <dmn:inputExpression id="_1DA5350F-43E0-4CD3-9DA6-51A3B96EF50D" typeRef="string">
+                  <dmn:text>Marital Status</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_2F73B19B-0C7D-4897-A4D1-C2BDB856CCF9">
+                  <dmn:text>"S","M"</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:input id="_e32f7b2c-5837-4e18-acea-a100115f412d">
+               <dmn:inputExpression id="_652E4A72-33DB-468A-BB7B-5BE4A964000E" typeRef="string">
+                  <dmn:text>Employment Status</dmn:text>
+               </dmn:inputExpression>
+               <dmn:inputValues id="_06CB01A0-DB52-459B-AC00-B68F0C88927C">
+                  <dmn:text>"UNEMPLOYED","STUDENT","EMPLOYED","SELF-EMPLOYED"</dmn:text>
+               </dmn:inputValues>
+            </dmn:input>
+            <dmn:output id="_e7b50872-4ad3-496a-ac06-15dc98c9d526" />
+            <dmn:annotation name="" />
+            <dmn:rule id="_cd986c20-a58b-413e-96c3-37d2f48fe361">
+               <dmn:inputEntry id="_b5fa1bbc-0cc3-462c-b978-429e932a83ab">
+                  <dmn:text>[18..22)</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_43189918-aecd-4713-8e23-231b35b299d7">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_f8be0751-2823-46d8-8007-c4fb601fcba8">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_dab1ccbe-edc2-4cc2-9167-1d452b4ad0c2">
+                  <dmn:text>32</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_271d1521-3fb9-4b1d-a74d-0abf1c131186">
+               <dmn:inputEntry id="_57a0f913-e95b-4941-b868-e306d484f045">
+                  <dmn:text>[22..26)</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_23b572c3-9c6f-4e17-8bdb-95fd58f404d5">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_85a87989-40c4-4027-b674-6d21b6d5bb64">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_8f6c2458-a000-4d1f-b6a1-a553f8b3c4db">
+                  <dmn:text>35</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_558f8923-cd42-484a-b6b0-7cb28bfa7480">
+               <dmn:inputEntry id="_795dc738-ca79-4c60-9746-e44bc1b34663">
+                  <dmn:text>[26..36)</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_8492546f-c66a-46e5-9e86-9b0a79ec99d6">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_2efe9985-1475-426d-abb3-760fed744a14">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_7146afbc-d68f-415d-9abf-da3ad5a87527">
+                  <dmn:text>40</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_389ee4a2-47d3-42fc-ad04-e8798d638d33">
+               <dmn:inputEntry id="_cf08fa6c-084d-4f2c-ae60-aa0abb5d7b2a">
+                  <dmn:text>[36..50)</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_7b81f517-a79a-4213-b74b-4cf01ee9a7c3">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_1101bb57-178a-4c25-9d79-7759553e9d7d">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_10c870e9-f72d-45f0-bcfd-bc6bcc0d2315">
+                  <dmn:text>43</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_8c355a92-0f8b-4d41-ada2-b98b05237249">
+               <dmn:inputEntry id="_c28cca26-4eda-4d37-a056-15b23eec9690">
+                  <dmn:text>&gt;=50</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_29ab6240-13dd-478f-ac73-0805778efe30">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_3ddc0313-cd5b-40f3-8858-87a384ee1f23">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_c2fe72a6-2591-413b-b4e8-a73a3fca33bc">
+                  <dmn:text>48</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_ffdf62cd-9909-4dd0-a15e-19fcb5a5ce6f">
+               <dmn:inputEntry id="_90065ca5-703d-4b29-9924-c949f210683e">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_5167d8a0-f82c-4f9b-b948-94ee8ef9b753">
+                  <dmn:text>"S"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_d9f2e10b-80c2-4f8e-af9b-83d3317e14b9">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_f1dd8303-3db4-4fe2-879c-fd5b0ecd970d">
+                  <dmn:text>25</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_cf192d51-2d52-4280-a41f-4941f1611b60">
+               <dmn:inputEntry id="_b1e8abb2-ecee-4fdf-8d75-a292d8bf8b0f">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_35f4590a-63a0-4a46-a875-9b37b6e8ada2">
+                  <dmn:text>"M"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_e50ee6a1-78bc-4ee0-8030-6f9654057e9a">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_f36c68f8-b188-4675-bb7b-ea5347a08fff">
+                  <dmn:text>45</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_90b8f62c-6ca6-4234-97c4-4de2011374b9">
+               <dmn:inputEntry id="_a1de40fe-8951-4ecb-bfc7-516a2d77bf55">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_63f774ad-98ab-44e6-8ebf-83a00437e7d6">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_9e4a3948-ec86-4987-a80d-2f0bc9c63530">
+                  <dmn:text>"UNEMPLOYED"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_3f14a6c0-3829-41c2-a57c-154574752788">
+                  <dmn:text>15</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_bc447e0a-a445-4029-804b-138b76a766ef">
+               <dmn:inputEntry id="_9196a27c-a829-43d7-b973-73bf13915ec3">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_1d672363-4080-4dd8-82cd-d30ff16d4383">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_28ca5667-24ac-4c8c-8557-ede60e51b461">
+                  <dmn:text>"STUDENT"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_90a363e8-d80d-4d78-9e33-2be7cbb9fd05">
+                  <dmn:text>18</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_5651d55b-18a5-4ff4-bc28-30ce10385a2d">
+               <dmn:inputEntry id="_93400b3b-bdda-4370-878b-e221bf8521c6">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_df5d20cf-6971-4911-832f-683d2a790c11">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_a0b06347-1422-4b9d-bdd0-ede06b7e5d0b">
+                  <dmn:text>"EMPLOYED"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_78582066-9c90-4b16-88a3-1709b784a4ff">
+                  <dmn:text>45</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+            <dmn:rule id="_07c9f995-1814-4a77-9ab1-f03c21337165">
+               <dmn:inputEntry id="_b377eba2-90f6-4913-8a84-e0e358cb4ae5">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_c515456a-3519-4446-aeaa-6f3f613a8812">
+                  <dmn:text>-</dmn:text>
+               </dmn:inputEntry>
+               <dmn:inputEntry id="_6d9fc071-2870-4397-83de-802aa5f398a5">
+                  <dmn:text>"SELF-EMPLOYED"</dmn:text>
+               </dmn:inputEntry>
+               <dmn:outputEntry id="_233be7af-2d3f-4b9c-bb69-561f8378e870">
+                  <dmn:text>36</dmn:text>
+               </dmn:outputEntry>
+               <dmn:annotationEntry>
+                  <dmn:text />
+               </dmn:annotationEntry>
+            </dmn:rule>
+         </dmn:decisionTable>
+      </dmn:encapsulatedLogic>
+      <dmn:authorityRequirement id="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+         <dmn:requiredAuthority href="#_821a6840-e910-418f-809e-4c7d60b0b21a" />
+      </dmn:authorityRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:inputData id="_d14df033-f4a2-47e3-9590-84e9ff04db4e" name="Applicant data">
+      <dmn:extensionElements />
+      <dmn:variable id="_76597f43-a435-4d85-bc82-98007b9e0d1d" name="Applicant data" typeRef="tApplicantData" />
+   </dmn:inputData>
+   <dmn:decision id="_3c8cee68-99dd-418c-847d-0b54697354f2" name="Required monthly installment">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Required monthly installment&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the&amp;nbsp;&lt;/span&gt;Installment calculation business knowledge model, passing Requested product.ProductType as the Product Type parameter, Requested product.Rate as the Rate parameter, Requested product.Term as the Term parameter, and Requested product.Amount as the Amount parameter.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_f581169e-828d-45cd-9af5-e401eebc8f27" name="Required monthly installment" typeRef="number" />
+      <dmn:informationRequirement id="_c5e79286-ea8f-4340-bd38-e878054891f2">
+         <dmn:requiredInput href="#_fe938494-ee59-425e-8728-2347ea703563" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+         <dmn:requiredKnowledge href="#_7235d875-2426-4869-b6df-92ca06ae80c5" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_2cc659df-0249-417c-8074-d3a375c6b5f5">
+         <dmn:literalExpression id="literal__2cc659df-0249-417c-8074-d3a375c6b5f5">
+            <dmn:text>Installment calculation</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_fa5953c6-c8f2-449e-ac2b-4bc04cb000c2" name="Product Type" />
+            <dmn:literalExpression id="_87dccb4c-d416-42ca-9c72-a0b591b4ba88">
+               <dmn:text>Requested product.ProductType</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_78623557-831b-47e4-81fe-349a0743fc5a" name="Rate" />
+            <dmn:literalExpression id="_3ba44309-b466-42d8-8126-bb2ef2d0544e">
+               <dmn:text>Requested product.Rate</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_48ac3dfb-dc98-420f-b051-2a9a3035e5f3" name="Term" />
+            <dmn:literalExpression id="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce">
+               <dmn:text>Requested product.Term</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+         <dmn:binding>
+            <dmn:parameter id="_a8c6ca38-2e6c-42cb-8d5d-2e40469a4e4a" name="Amount" />
+            <dmn:literalExpression id="_df160506-5551-4fe3-bf04-1fcb462bcaec">
+               <dmn:text>Requested product.Amount</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:inputData id="_fe938494-ee59-425e-8728-2347ea703563" name="Requested product">
+      <dmn:extensionElements />
+      <dmn:variable id="_480bcfd2-2643-4d1c-852b-3034dfa62790" name="Requested product" typeRef="tRequestedProduct" />
+   </dmn:inputData>
+   <dmn:businessKnowledgeModel id="_7235d875-2426-4869-b6df-92ca06ae80c5" name="Installment calculation">
+      <dmn:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Installment calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a boxed function deriving monthly installment&amp;nbsp;&lt;/span&gt;from Product Type, Rate, Term and Amount.&lt;/span&gt;&lt;/p&gt;</dmn:description>
+      <dmn:extensionElements />
+      <dmn:variable id="_c02274e9-a6c8-4498-9d43-eaa33be7a0d9" name="Installment calculation" typeRef="number" />
+      <dmn:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL">
+         <dmn:formalParameter id="_f6831cd9-3eab-4399-8d29-42b141fd9968" name="Product Type" typeRef="string" />
+         <dmn:formalParameter id="_c6f48aeb-b65d-4307-8722-dd44f7335566" name="Rate" typeRef="number" />
+         <dmn:formalParameter id="_708eb9af-fe19-418c-8547-1647cb50f596" name="Term" typeRef="number" />
+         <dmn:formalParameter id="_fddc99bb-3be6-45b0-bf8c-d8d4c016a90b" name="Amount" typeRef="number" />
+         <dmn:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4">
+            <dmn:contextEntry>
+               <dmn:variable id="_2db6ada1-2a67-4c84-bb31-e78178cf6b32" name="Monthly Fee" typeRef="number" />
+               <dmn:literalExpression id="_ad1e4499-e806-42f1-8069-254e98f5d498">
+                  <dmn:text>if Product Type = "STANDARD LOAN"							then 20.00							else if Product Type = "SPECIAL LOAN"							then 25.00							else null</dmn:text>
+               </dmn:literalExpression>
+            </dmn:contextEntry>
+            <dmn:contextEntry>
+               <dmn:variable id="_594996b3-1aea-4557-bf8e-f3bc91470fee" name="Monthly Repayment" typeRef="number" />
+               <dmn:literalExpression id="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3">
+                  <dmn:text>PMT(Rate, Term, Amount)</dmn:text>
+               </dmn:literalExpression>
+            </dmn:contextEntry>
+            <dmn:contextEntry>
+               <dmn:literalExpression id="_f6293695-dc2e-4e16-9dc7-1595423f0f91">
+                  <dmn:text>Monthly Repayment + Monthly Fee</dmn:text>
+               </dmn:literalExpression>
+            </dmn:contextEntry>
+         </dmn:context>
+      </dmn:encapsulatedLogic>
+      <dmn:knowledgeRequirement id="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+         <dmn:requiredKnowledge href="#_a30c75ec-7d81-4606-802c-b31ea308392d" />
+      </dmn:knowledgeRequirement>
+   </dmn:businessKnowledgeModel>
+   <dmn:businessKnowledgeModel id="_a30c75ec-7d81-4606-802c-b31ea308392d" name="PMT">
+      <dmn:extensionElements />
+      <dmn:variable id="_702e93e8-7d03-4400-aae4-a21543a4d631" name="PMT" />
+      <dmn:encapsulatedLogic id="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" kind="FEEL">
+         <dmn:formalParameter id="_1787cf94-5e76-4926-ac24-5b4096b28dca" name="Rate" typeRef="number" />
+         <dmn:formalParameter id="_0d037df5-8942-473f-9feb-2e16d6d7d631" name="Term" typeRef="number" />
+         <dmn:formalParameter id="_deb10bf3-97f0-4f6b-8ae4-5cbfd44debac" name="Amount" typeRef="number" />
+         <dmn:literalExpression id="_4d149dbb-89da-498e-853f-2c33f4e9b834">
+            <dmn:text>(Amount *Rate/12) / (1 - (1 + Rate/12)**-Term)</dmn:text>
+         </dmn:literalExpression>
+      </dmn:encapsulatedLogic>
+   </dmn:businessKnowledgeModel>
+   <dmn:decisionService id="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" name="Bureau Strategy Decision Service">
+      <dmn:extensionElements />
+      <dmn:variable id="_84AC897B-1AF2-4546-A1CE-30EDC0EF815B" name="Bureau Strategy Decision Service" />
+      <dmn:outputDecision href="#_8b838f06-968a-4c66-875e-f5412fd692cf" />
+      <dmn:outputDecision href="#_5b8356f3-2cf2-40e8-8f80-324937e8b276" />
+      <dmn:encapsulatedDecision href="#_ed60265c-25e2-400f-a99f-fafd3b489838" />
+      <dmn:encapsulatedDecision href="#_9997fcfd-0f50-4933-939e-88a235b5e2a0" />
+      <dmn:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46" />
+      <dmn:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2" />
+      <dmn:encapsulatedDecision href="#_b5e759df-f662-44cd-94f5-55c3c81f0ee3" />
+      <dmn:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      <dmn:inputData href="#_fe938494-ee59-425e-8728-2347ea703563" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_4d91e3a5-acec-4254-81e4-8535a1d336ee" name="Routing Decision Service">
+      <dmn:extensionElements />
+      <dmn:variable id="_2AF32C5A-7D19-4A9C-A49C-B0737A8AF2DE" name="Routing Decision Service" />
+      <dmn:outputDecision href="#_ca1e6032-12eb-428a-a80b-49028a88c0b5" />
+      <dmn:encapsulatedDecision href="#_40b45659-9299-43a6-af30-04c948c5c0ec" />
+      <dmn:encapsulatedDecision href="#_e905f02c-c5d9-4f2a-ba57-7912ff523b46" />
+      <dmn:encapsulatedDecision href="#_3c8cee68-99dd-418c-847d-0b54697354f2" />
+      <dmn:encapsulatedDecision href="#_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" />
+      <dmn:inputData href="#_e91de815-22ba-431c-8b46-55891f2a1ef6" />
+      <dmn:inputData href="#_d14df033-f4a2-47e3-9590-84e9ff04db4e" />
+      <dmn:inputData href="#_fe938494-ee59-425e-8728-2347ea703563" />
+   </dmn:decisionService>
+   <dmndi:DMNDI>
+      <dmndi:DMNDiagram id="_ce4a4c00-c3a3-46a6-8938-055239f6b326" name="DRD of all automated decision-making">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d" />
+               <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df" />
+               <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca" />
+               <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f" />
+               <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb" />
+               <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f" />
+               <kie:ComponentWidths dmnElementRef="_809B2A63-2946-4AC0-BB2A-7C01F85D885B" />
+               <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34" />
+               <kie:ComponentWidths dmnElementRef="_C6A7891D-03F8-49CF-8275-7AFD1147FC3A" />
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+               <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901" />
+               <kie:ComponentWidths dmnElementRef="_3E30A977-5CC2-46C9-916C-2CF97DB1CF87" />
+               <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474" />
+               <kie:ComponentWidths dmnElementRef="_E6280C1C-D063-4872-8901-7783DA7353DE" />
+               <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" />
+               <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b" />
+               <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058" />
+               <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f" />
+               <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55" />
+               <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267" />
+               <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c" />
+               <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4" />
+               <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446" />
+               <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3" />
+               <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2" />
+               <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a" />
+               <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36" />
+               <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0" />
+               <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113" />
+               <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227" />
+               <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4" />
+               <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4" />
+               <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82" />
+               <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0" />
+               <kie:ComponentWidths dmnElementRef="_04437EA6-7362-4693-B4B3-9431E330CEAC" />
+               <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126" />
+               <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3" />
+               <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" />
+               <kie:ComponentWidths dmnElementRef="_530613B3-1EC6-4E64-B33A-899F0E219BA0" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2" />
+               <kie:ComponentWidths dmnElementRef="_3161744E-C244-4C89-ACA8-4462EC11C790" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+               <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4" />
+               <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498" />
+               <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3" />
+               <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91" />
+               <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa" />
+               <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834" />
+               <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1069" y="54.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="893.5" y="50" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1225.7588291168213" y="262.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="177" y="262.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="277" y="142.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="374" y="262.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="591.5" y="263.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="721.5" y="150" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="810.5" y="263.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1024" y="262.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="88.5" y="370.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="476.4786796569824" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="567" y="365" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="789" y="365" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="695.5" y="476.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="494.5" y="475.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="918.5" y="475.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1024" y="587.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1225.7588291168213" y="715.9786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1024.5" y="716.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="277" y="587.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="138" y="716.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="277" y="822.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="818" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="138" y="941.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="503.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="840.5" y="822.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="736.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="945" y="941.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-of-all-automated-decision-making-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1157" y="941.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_290b4df4-ffe6-4106-9e22-07a339146161" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
+            <di:waypoint x="590.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="1105.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+            <di:waypoint x="1293.4968013763428" y="715.9786758422852" />
+            <di:waypoint x="1155.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+            <di:waypoint x="1100.5" y="262.9786796569824" />
+            <di:waypoint x="1135.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_7fc499b6-a180-4e16-80cd-58df441f4d38" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+            <di:waypoint x="1293.4968013763428" y="262.97867584228516" />
+            <di:waypoint x="1195.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_dabc7bb7-b8be-4654-9f7e-455481cb1c4e" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+            <di:waypoint x="993.5" y="84.5" />
+            <di:waypoint x="1069" y="84.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+            <di:waypoint x="333.5" y="587.9786796569824" />
+            <di:waypoint x="253.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_18fda7ab-ca43-4860-a94b-760d3cd68ce2" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+            <di:waypoint x="173.5" y="370.4786796569824" />
+            <di:waypoint x="223.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+            <di:waypoint x="253.5" y="262.9786796569824" />
+            <di:waypoint x="323.5" y="202.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+            <di:waypoint x="440.5" y="262.9786796569824" />
+            <di:waypoint x="373.5" y="202.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+            <di:waypoint x="353.5" y="587.9786796569824" />
+            <di:waypoint x="440.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+            <di:waypoint x="550.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="450.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+            <di:waypoint x="571" y="475.9786796569824" />
+            <di:waypoint x="460.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_1c3489b1-44dd-4137-883a-35da157f0c1d" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+            <di:waypoint x="591.5" y="292.4786796569824" />
+            <di:waypoint x="527" y="292.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+            <di:waypoint x="734" y="217" />
+            <di:waypoint x="666.5" y="263.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_57d99f5f-48e1-456c-ab7c-4247e840a7fc" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+            <di:waypoint x="784" y="203" />
+            <di:waypoint x="885.5" y="263.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+            <di:waypoint x="995" y="475.9786796569824" />
+            <di:waypoint x="1080.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+            <di:waypoint x="1100.5" y="587.9786796569824" />
+            <di:waypoint x="1100.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+            <di:waypoint x="1283.4968013763428" y="715.9786758422852" />
+            <di:waypoint x="1120.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_839ccfec-8902-40ca-8767-df9073f797e5" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
+            <di:waypoint x="962.5" y="292.4786796569824" />
+            <di:waypoint x="1024" y="292.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_2cad5b1f-59de-4cf2-9216-b662b2760bff" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+            <di:waypoint x="100" y="476.4786796569824" />
+            <di:waypoint x="153.5" y="429.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+            <di:waypoint x="150" y="490.9786796569824" />
+            <di:waypoint x="567" y="394" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+            <di:waypoint x="692" y="424" />
+            <di:waypoint x="740.5" y="476.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+            <di:waypoint x="826.5" y="432" />
+            <di:waypoint x="800.5" y="476.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+            <di:waypoint x="383.5" y="587.9786796569824" />
+            <di:waypoint x="531" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+            <di:waypoint x="570.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="571" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+            <di:waypoint x="907" y="822.9786796569824" />
+            <di:waypoint x="601" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+            <di:waypoint x="695.5" y="505.4786796569824" />
+            <di:waypoint x="647.5" y="505.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+            <di:waypoint x="1090.5" y="587.9786796569824" />
+            <di:waypoint x="995" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+            <di:waypoint x="927" y="822.9786796569824" />
+            <di:waypoint x="985" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+            <di:waypoint x="610.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="965" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+            <di:waypoint x="847.5" y="505.4786796569824" />
+            <di:waypoint x="918.5" y="505.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+            <di:waypoint x="1263.4968013763428" y="715.9786758422852" />
+            <di:waypoint x="1140.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+            <di:waypoint x="632.4968013763428" y="950.9786758422852" />
+            <di:waypoint x="1060.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+            <di:waypoint x="430" y="842.9786796569824" />
+            <di:waypoint x="1024" y="617.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_dc094e13-abbd-4164-bc95-a61b433a7be4" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+            <di:waypoint x="1099.5" y="716.4786796569824" />
+            <di:waypoint x="1100.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_aa1fbb92-27fc-4108-9257-2017c2dbc601" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+            <di:waypoint x="150" y="510.9786796569824" />
+            <di:waypoint x="1024.5" y="735.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+            <di:waypoint x="530.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="373.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+            <di:waypoint x="353.5" y="822.9786796569824" />
+            <di:waypoint x="353.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_d37ce038-f9cc-4576-92a7-dd64eea28a2d" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+            <di:waypoint x="213" y="716.4786796569824" />
+            <di:waypoint x="313.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_b752b8ba-8fab-4658-94d9-1aaaa51af3a2" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+            <di:waypoint x="87.5" y="543.4786796569824" />
+            <di:waypoint x="146.5" y="724.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <di:waypoint x="510.4968013763428" y="950.9786758422852" />
+            <di:waypoint x="403.5" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+            <di:waypoint x="223" y="941.4786796569824" />
+            <di:waypoint x="323.5" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+            <di:waypoint x="87.5" y="885" />
+            <di:waypoint x="138" y="980.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <di:waypoint x="813.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="887" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+            <di:waypoint x="1010" y="941.4786796569824" />
+            <di:waypoint x="937" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-of-all-automated-decision-making-_f0a6536d-0e7f-44d3-a9bb-5213478173da" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+            <di:waypoint x="1157" y="970.4786796569824" />
+            <di:waypoint x="1097" y="970.9786796569824" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+      <dmndi:DMNDiagram id="_0e22b6cf-0a6e-40e1-a81e-44b31ad86262" name="DRD for Decide bureau strategy decision point">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+               <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2" />
+               <kie:ComponentWidths dmnElementRef="_3161744E-C244-4C89-ACA8-4462EC11C790" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" />
+               <kie:ComponentWidths dmnElementRef="_530613B3-1EC6-4E64-B33A-899F0E219BA0" />
+               <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126" />
+               <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3" />
+               <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c" />
+               <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4" />
+               <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446" />
+               <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3" />
+               <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2" />
+               <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" />
+               <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b" />
+               <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058" />
+               <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f" />
+               <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55" />
+               <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267" />
+               <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474" />
+               <kie:ComponentWidths dmnElementRef="_E6280C1C-D063-4872-8901-7783DA7353DE" />
+               <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901" />
+               <kie:ComponentWidths dmnElementRef="_3E30A977-5CC2-46C9-916C-2CF97DB1CF87" />
+               <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f" />
+               <kie:ComponentWidths dmnElementRef="_809B2A63-2946-4AC0-BB2A-7C01F85D885B" />
+               <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca" />
+               <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f" />
+               <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb" />
+               <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df" />
+               <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d" />
+               <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834" />
+               <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" />
+               <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4" />
+               <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498" />
+               <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3" />
+               <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91" />
+               <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="594" y="740.9999923706055" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="698.2411708831787" y="622.9999961853027" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="513.7588291168213" y="856.9999961853027" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="148.5" y="857.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="29.5" y="736.0213203430176" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="275.5" y="741" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="148.5" y="623.4999961853027" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="287.5" y="532" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="505" y="383" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="706" y="383.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="799.5" y="272.0213203430176" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="572.5" y="290.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="29.5" y="417.0213203430176" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="89" y="290.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="732" y="57.02132034301758" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="602" y="170.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="384.5" y="170" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="287.5" y="50" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="187.5" y="170" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="777.8080854415894" y="857.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-bureau-strategy-decision-point-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="777.8080854415894" y="741.4999961853027" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <di:waypoint x="671.7379722595215" y="740.9999923706055" />
+            <di:waypoint x="744.7411708831787" y="682.9999961853027" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+            <di:waypoint x="852.8080854415894" y="741.4999961853027" />
+            <di:waypoint x="794.7411708831787" y="682.9999961853027" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+            <di:waypoint x="67" y="803.0213203430176" />
+            <di:waypoint x="148.5" y="886.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <di:waypoint x="520.9968013763428" y="866.9999961853027" />
+            <di:waypoint x="402" y="801" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+            <di:waypoint x="233.5" y="857.5" />
+            <di:waypoint x="322" y="801" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_b752b8ba-8fab-4658-94d9-1aaaa51af3a2" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+            <di:waypoint x="67" y="484.0213203430176" />
+            <di:waypoint x="148.5" y="662.4999961853027" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+            <di:waypoint x="541.4968013763428" y="856.9999961853027" />
+            <di:waypoint x="384" y="592" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+            <di:waypoint x="352" y="741" />
+            <di:waypoint x="354" y="592" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_d37ce038-f9cc-4576-92a7-dd64eea28a2d" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+            <di:waypoint x="223.5" y="623.4999961853027" />
+            <di:waypoint x="324" y="592" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+            <di:waypoint x="394" y="532" />
+            <di:waypoint x="541.5" y="443" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+            <di:waypoint x="581.4968013763428" y="856.9999961853027" />
+            <di:waypoint x="581.5" y="443" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+            <di:waypoint x="764.7411708831787" y="622.9999961853027" />
+            <di:waypoint x="611.5" y="443" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+            <di:waypoint x="706" y="412.5" />
+            <di:waypoint x="658" y="413" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+            <di:waypoint x="697.5" y="349.5" />
+            <di:waypoint x="751" y="383.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+            <di:waypoint x="837" y="339.0213203430176" />
+            <di:waypoint x="811" y="383.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+            <di:waypoint x="129.5" y="431.5213203430176" />
+            <di:waypoint x="572.5" y="319.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_2cad5b1f-59de-4cf2-9216-b662b2760bff" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+            <di:waypoint x="79.5" y="417.0213203430176" />
+            <di:waypoint x="154" y="349.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+            <di:waypoint x="744.5" y="124.02132034301758" />
+            <di:waypoint x="677" y="170.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+            <di:waypoint x="364" y="532" />
+            <di:waypoint x="451" y="230" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+            <di:waypoint x="551.4968013763428" y="856.9999961853027" />
+            <di:waypoint x="461" y="230" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+            <di:waypoint x="581.5" y="383" />
+            <di:waypoint x="471" y="230" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_1c3489b1-44dd-4137-883a-35da157f0c1d" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+            <di:waypoint x="602" y="199.5" />
+            <di:waypoint x="537.5" y="200" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+            <di:waypoint x="264" y="170" />
+            <di:waypoint x="334" y="110" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+            <di:waypoint x="451" y="170" />
+            <di:waypoint x="384" y="110" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+            <di:waypoint x="344" y="532" />
+            <di:waypoint x="264" y="230" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_18fda7ab-ca43-4860-a94b-760d3cd68ce2" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+            <di:waypoint x="174" y="290.5" />
+            <di:waypoint x="234" y="230" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-bureau-strategy-decision-point-_f0a6536d-0e7f-44d3-a9bb-5213478173da" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+            <di:waypoint x="852.8080854415894" y="857.5" />
+            <di:waypoint x="853.8080854415894" y="800.4999961853027" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+      <dmndi:DMNDiagram id="_3275163a-921d-48f8-967a-21c4373b1197" name="DRD for Decide routing decision point">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4" />
+               <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498" />
+               <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3" />
+               <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91" />
+               <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+               <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2" />
+               <kie:ComponentWidths dmnElementRef="_3161744E-C244-4C89-ACA8-4462EC11C790" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0" />
+               <kie:ComponentWidths dmnElementRef="_04437EA6-7362-4693-B4B3-9431E330CEAC" />
+               <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4" />
+               <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4" />
+               <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82" />
+               <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a" />
+               <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36" />
+               <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0" />
+               <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113" />
+               <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227" />
+               <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" />
+               <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b" />
+               <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058" />
+               <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f" />
+               <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55" />
+               <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267" />
+               <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474" />
+               <kie:ComponentWidths dmnElementRef="_E6280C1C-D063-4872-8901-7783DA7353DE" />
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+               <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34" />
+               <kie:ComponentWidths dmnElementRef="_C6A7891D-03F8-49CF-8275-7AFD1147FC3A" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="338.2411708831787" y="658.9786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="129.5" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="233.7411708831787" y="528.4786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="542.7588291168213" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="938.5" y="528.9786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="990.5" y="393" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="716" y="528.4786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="233.87058544158936" y="398.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="815.7588291168213" y="397.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="598" y="397.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="482.5" y="248.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="259.5" y="249.47867965698242" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="363.87058544158936" y="142" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="249.47867965698242" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="76" y="393" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="598" y="54.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="374.5" y="55.47867965698242" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-decide-routing-decision-point-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="192.5" y="50" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <di:waypoint x="207.23797225952148" y="658.4786758422852" />
+            <di:waypoint x="280.2411708831787" y="588.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+            <di:waypoint x="403.2411708831787" y="658.9786796569824" />
+            <di:waypoint x="330.2411708831787" y="588.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+            <di:waypoint x="1028" y="460" />
+            <di:waypoint x="1023.5" y="528.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <di:waypoint x="620.4968013763428" y="658.4786758422852" />
+            <di:waypoint x="792.5" y="588.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+            <di:waypoint x="938.5" y="557.9786796569824" />
+            <di:waypoint x="869" y="558.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_aa1fbb92-27fc-4108-9257-2017c2dbc601" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+            <di:waypoint x="176" y="427.5" />
+            <di:waypoint x="233.87058544158936" y="427.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+            <di:waypoint x="815.9968013763428" y="427.97867584228516" />
+            <di:waypoint x="751" y="427.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+            <di:waypoint x="610.4968013763428" y="658.4786758422852" />
+            <di:waypoint x="664.5" y="457.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+            <di:waypoint x="792.5" y="528.4786796569824" />
+            <di:waypoint x="714.5" y="457.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_dc094e13-abbd-4164-bc95-a61b433a7be4" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+            <di:waypoint x="385.87058544158936" y="427.4786796569824" />
+            <di:waypoint x="598" y="427.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+            <di:waypoint x="664.5" y="397.9786796569824" />
+            <di:waypoint x="609" y="308.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+            <di:waypoint x="320.2411708831787" y="528.4786796569824" />
+            <di:waypoint x="509" y="308.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+            <di:waypoint x="600.4968013763428" y="658.4786758422852" />
+            <di:waypoint x="549" y="308.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+            <di:waypoint x="411.5" y="278.4786796569824" />
+            <di:waypoint x="482.5" y="278.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+            <di:waypoint x="202" y="278.4786796569824" />
+            <di:waypoint x="259.5" y="278.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+            <di:waypoint x="401.37058544158936" y="209" />
+            <di:waypoint x="364.5" y="249.47867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+            <di:waypoint x="126" y="393" />
+            <di:waypoint x="126" y="308.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+            <di:waypoint x="559" y="248.97867965698242" />
+            <di:waypoint x="654.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+            <di:waypoint x="674.5" y="397.9786796569824" />
+            <di:waypoint x="674.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+            <di:waypoint x="873.4968013763428" y="397.97867584228516" />
+            <di:waypoint x="694.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_839ccfec-8902-40ca-8767-df9073f797e5" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
+            <di:waypoint x="526.5" y="84.47867965698242" />
+            <di:waypoint x="598" y="84.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-decide-routing-decision-point-_57d99f5f-48e1-456c-ab7c-4247e840a7fc" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+            <di:waypoint x="292.5" y="84.5" />
+            <di:waypoint x="374.5" y="84.47867965698242" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+      <dmndi:DMNDiagram id="_a35ef6e9-0408-4288-b8f2-d28ac4baca3b" name="DRD for Review application decision point">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="57.75882911682129" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="382.2588291168213" y="320.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="179.5" y="320.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="480.2588291168213" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="50" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drd-for-review-application-decision-point-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225.5" y="54.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_290b4df4-ffe6-4106-9e22-07a339146161" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
+            <di:waypoint x="135.49680137634277" y="222.97867584228516" />
+            <di:waypoint x="272" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+            <di:waypoint x="449.9968013763428" y="320.97867584228516" />
+            <di:waypoint x="302" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+            <di:waypoint x="256" y="320.9786796569824" />
+            <di:waypoint x="292" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_7fc499b6-a180-4e16-80cd-58df441f4d38" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+            <di:waypoint x="547.9968013763428" y="222.97867584228516" />
+            <di:waypoint x="322" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drd-for-review-application-decision-point-_dabc7bb7-b8be-4654-9f7e-455481cb1c4e" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+            <di:waypoint x="150" y="84.5" />
+            <di:waypoint x="225.5" y="84.97867965698242" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+      <dmndi:DMNDiagram id="_5c111794-4c6b-4747-8dfc-99d2ad0b6313" name="Bureau Strategy Decision Service">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df" />
+               <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d" />
+               <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca" />
+               <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f" />
+               <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb" />
+               <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c" />
+               <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4" />
+               <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446" />
+               <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3" />
+               <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2" />
+               <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126" />
+               <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_7befd964-eefa-4d8f-908d-8f6ad8d22c67" dmnElementRef="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="50" width="643.8705854415894" height="670" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="50" y="275" />
+               <di:waypoint x="693.8705854415894" y="275" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="308.1470727920532" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="524.6294145584106" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="299.38824367523193" y="88" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="136" y="197" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="299.38824367523193" y="307" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="479.5" y="461.5" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="136" y="461.5" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="79" y="600" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-bureau-strategy-decision-service-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="515.8705854415894" y="583" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+            <di:waypoint x="212.5" y="197" />
+            <di:waypoint x="345.88824367523193" y="148" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+            <di:waypoint x="375.88824367523193" y="307" />
+            <di:waypoint x="375.88824367523193" y="148" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+            <di:waypoint x="212.5" y="461.5" />
+            <di:waypoint x="212.5" y="257" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+            <di:waypoint x="232.5" y="461.5" />
+            <di:waypoint x="365.88824367523193" y="367" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+            <di:waypoint x="375.8850450515747" y="782.9999961853027" />
+            <di:waypoint x="375.88824367523193" y="367" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+            <di:waypoint x="556" y="461.5" />
+            <di:waypoint x="385.88824367523193" y="367" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+            <di:waypoint x="289" y="491.5" />
+            <di:waypoint x="479.5" y="491.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+            <di:waypoint x="415.8850450515747" y="782.9999961853027" />
+            <di:waypoint x="496" y="521.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+            <di:waypoint x="592.3705854415894" y="583" />
+            <di:waypoint x="556" y="521.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+            <di:waypoint x="365.8850450515747" y="782.9999961853027" />
+            <di:waypoint x="232.5" y="521.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+            <di:waypoint x="155.5" y="600" />
+            <di:waypoint x="212.5" y="521.5" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <di:waypoint x="335.8850450515747" y="782.9999961853027" />
+            <di:waypoint x="155.5" y="660" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-bureau-strategy-decision-service-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <di:waypoint x="592.3673868179321" y="782.9999961853027" />
+            <di:waypoint x="592.3705854415894" y="643" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+      <dmndi:DMNDiagram id="_69750f88-f46f-4b47-bb3c-fb77f574f2b3" name="Routing Decision Service">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+               <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a" />
+               <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36" />
+               <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0" />
+               <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113" />
+               <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227" />
+               <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4" />
+               <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4" />
+               <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_4d91e3a5-acec-4254-81e4-8535a1d336ee" dmnElementRef="_4d91e3a5-acec-4254-81e4-8535a1d336ee" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="50" width="693" height="562.4786796569824" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="50" y="190" />
+               <di:waypoint x="743" y="190" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="607.5176582336426" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="269.7588291168213" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="83.75882911682129" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400.62941455841064" y="82" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="179.62941455841064" y="219.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400.62941455841064" y="369.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400.62941455841064" y="496.4786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-routing-decision-service-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="75" y="369.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+            <di:waypoint x="256.12941455841064" y="219.97867965698242" />
+            <di:waypoint x="427.12941455841064" y="142" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+            <di:waypoint x="477.12941455841064" y="369.9786796569824" />
+            <di:waypoint x="477.12941455841064" y="142" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+            <di:waypoint x="675.2556304931641" y="679.4573554992676" />
+            <di:waypoint x="527.1294145584106" y="142" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+            <di:waypoint x="467.12941455841064" y="369.9786796569824" />
+            <di:waypoint x="306.12941455841064" y="279.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+            <di:waypoint x="161.5" y="369.9786796569824" />
+            <di:waypoint x="206.12941455841064" y="279.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+            <di:waypoint x="327.4968013763428" y="679.4573554992676" />
+            <di:waypoint x="256.12941455841064" y="279.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+            <di:waypoint x="655.2556304931641" y="679.4573554992676" />
+            <di:waypoint x="527.1294145584106" y="429.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+            <di:waypoint x="337.4968013763428" y="679.4573554992676" />
+            <di:waypoint x="407.12941455841064" y="429.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+            <di:waypoint x="477.12941455841064" y="496.4786796569824" />
+            <di:waypoint x="477.12941455841064" y="429.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <di:waypoint x="347.4968013763428" y="679.4573554992676" />
+            <di:waypoint x="477.12941455841064" y="556.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-routing-decision-service-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <di:waypoint x="151.49680137634277" y="679.4573554992676" />
+            <di:waypoint x="151.5" y="429.9786796569824" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+      <dmndi:DMNDiagram id="_09D054E0-E545-4D52-8D20-A403C4D0DBCD" name="DRG">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d" />
+               <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df" />
+               <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca" />
+               <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f" />
+               <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb" />
+               <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f" />
+               <kie:ComponentWidths dmnElementRef="_809B2A63-2946-4AC0-BB2A-7C01F85D885B" />
+               <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34" />
+               <kie:ComponentWidths dmnElementRef="_C6A7891D-03F8-49CF-8275-7AFD1147FC3A" />
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+               <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901" />
+               <kie:ComponentWidths dmnElementRef="_3E30A977-5CC2-46C9-916C-2CF97DB1CF87" />
+               <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474" />
+               <kie:ComponentWidths dmnElementRef="_E6280C1C-D063-4872-8901-7783DA7353DE" />
+               <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" />
+               <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b" />
+               <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058" />
+               <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f" />
+               <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55" />
+               <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267" />
+               <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c" />
+               <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4" />
+               <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446" />
+               <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3" />
+               <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2" />
+               <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a" />
+               <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36" />
+               <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0" />
+               <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113" />
+               <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227" />
+               <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4" />
+               <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4" />
+               <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82" />
+               <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0" />
+               <kie:ComponentWidths dmnElementRef="_04437EA6-7362-4693-B4B3-9431E330CEAC" />
+               <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126" />
+               <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3" />
+               <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" />
+               <kie:ComponentWidths dmnElementRef="_530613B3-1EC6-4E64-B33A-899F0E219BA0" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2" />
+               <kie:ComponentWidths dmnElementRef="_3161744E-C244-4C89-ACA8-4462EC11C790" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+               <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4" />
+               <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498" />
+               <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3" />
+               <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91" />
+               <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa" />
+               <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834" />
+               <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+               <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2" />
+               <kie:ComponentWidths dmnElementRef="_3161744E-C244-4C89-ACA8-4462EC11C790" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" />
+               <kie:ComponentWidths dmnElementRef="_530613B3-1EC6-4E64-B33A-899F0E219BA0" />
+               <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126" />
+               <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3" />
+               <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c" />
+               <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4" />
+               <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446" />
+               <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3" />
+               <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2" />
+               <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" />
+               <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b" />
+               <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058" />
+               <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f" />
+               <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55" />
+               <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267" />
+               <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474" />
+               <kie:ComponentWidths dmnElementRef="_E6280C1C-D063-4872-8901-7783DA7353DE" />
+               <kie:ComponentWidths dmnElementRef="_ebd84888-6db0-4b91-94f4-b3a228bb2901" />
+               <kie:ComponentWidths dmnElementRef="_3E30A977-5CC2-46C9-916C-2CF97DB1CF87" />
+               <kie:ComponentWidths dmnElementRef="_7d663660-b2e1-47d1-9870-777b5a695e7f" />
+               <kie:ComponentWidths dmnElementRef="_809B2A63-2946-4AC0-BB2A-7C01F85D885B" />
+               <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca" />
+               <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f" />
+               <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb" />
+               <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df" />
+               <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d" />
+               <kie:ComponentWidths dmnElementRef="_4d149dbb-89da-498e-853f-2c33f4e9b834" />
+               <kie:ComponentWidths dmnElementRef="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" />
+               <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4" />
+               <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498" />
+               <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3" />
+               <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91" />
+               <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa" />
+               <kie:ComponentWidths dmnElementRef="_2661f418-77f3-4bab-824a-a4968b8a96d4" />
+               <kie:ComponentWidths dmnElementRef="_ad1e4499-e806-42f1-8069-254e98f5d498" />
+               <kie:ComponentWidths dmnElementRef="_27a56668-bc99-4a6a-8f4f-5b67ab4e3df3" />
+               <kie:ComponentWidths dmnElementRef="_f6293695-dc2e-4e16-9dc7-1595423f0f91" />
+               <kie:ComponentWidths dmnElementRef="_5362b6d5-9520-4081-809c-ee85881e2dfa" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+               <kie:ComponentWidths dmnElementRef="_26378922-484b-42f3-a609-5aecb81afbd2" />
+               <kie:ComponentWidths dmnElementRef="_3161744E-C244-4C89-ACA8-4462EC11C790" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_c494b824-7c60-4115-8773-00f103b636a0" />
+               <kie:ComponentWidths dmnElementRef="_04437EA6-7362-4693-B4B3-9431E330CEAC" />
+               <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4" />
+               <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4" />
+               <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82" />
+               <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a" />
+               <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36" />
+               <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0" />
+               <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113" />
+               <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227" />
+               <kie:ComponentWidths dmnElementRef="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" />
+               <kie:ComponentWidths dmnElementRef="_2fcda742-6d7b-49c5-afe6-6b334c8f049b" />
+               <kie:ComponentWidths dmnElementRef="_78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="literal__78bc74d6-25a4-4639-8509-186534b3c67a" />
+               <kie:ComponentWidths dmnElementRef="_a02265a9-3dd1-48cd-a254-84531f28a058" />
+               <kie:ComponentWidths dmnElementRef="_3051a016-282e-4f83-8cfa-4c57084e559f" />
+               <kie:ComponentWidths dmnElementRef="_25e6d6ce-f19a-48b5-bd00-84baa88d2f55" />
+               <kie:ComponentWidths dmnElementRef="_b3f131dd-5572-4d63-a693-05af46940267" />
+               <kie:ComponentWidths dmnElementRef="_ad7c587e-64cc-47ec-adc4-515b586f9474" />
+               <kie:ComponentWidths dmnElementRef="_E6280C1C-D063-4872-8901-7783DA7353DE" />
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+               <kie:ComponentWidths dmnElementRef="_4dfddea8-3c8e-400a-97bc-dcba00876c34" />
+               <kie:ComponentWidths dmnElementRef="_C6A7891D-03F8-49CF-8275-7AFD1147FC3A" />
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+               <kie:ComponentWidths dmnElementRef="_0991d970-7c58-4669-89ec-a5e3e9d264df" />
+               <kie:ComponentWidths dmnElementRef="_af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="literal__af620f30-1376-4a5d-b6b8-42ec7ebc48bd" />
+               <kie:ComponentWidths dmnElementRef="_40020f96-0afd-405c-828a-0aa6684d150d" />
+               <kie:ComponentWidths dmnElementRef="_6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="literal__6c6672bd-8f05-447c-aa7d-29f8d1b7f979" />
+               <kie:ComponentWidths dmnElementRef="_bbbe553d-dae6-4e29-bbb4-fe602994e8ca" />
+               <kie:ComponentWidths dmnElementRef="_91986b6f-d45e-4aa7-926d-00b35a47686f" />
+               <kie:ComponentWidths dmnElementRef="_719504be-6121-4c16-9c00-1480b58f2ecb" />
+               <kie:ComponentWidths dmnElementRef="_7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="literal__7fea3599-f557-487a-bc0c-6aad2e8e6c86" />
+               <kie:ComponentWidths dmnElementRef="_63cbd20f-fab4-480e-9471-1367b2e1fc6c" />
+               <kie:ComponentWidths dmnElementRef="_c35a57bf-208c-4333-973f-c8a9e9ce85f4" />
+               <kie:ComponentWidths dmnElementRef="_174c9fb3-c940-455f-ab97-035989e83446" />
+               <kie:ComponentWidths dmnElementRef="_34d3db82-c899-45f6-b46c-ef7cb2f550c3" />
+               <kie:ComponentWidths dmnElementRef="_47e0147f-030a-4020-a5d3-728c563c0bd2" />
+               <kie:ComponentWidths dmnElementRef="_04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="literal__04337ddb-db98-40e9-81cd-12802e74401e" />
+               <kie:ComponentWidths dmnElementRef="_4b5e5cfb-d6fa-4d41-a13a-783170887126" />
+               <kie:ComponentWidths dmnElementRef="_b93f253e-7f93-4356-a98b-3fae510485e3" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+               <kie:ComponentWidths dmnElementRef="_78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="literal__78ce14d2-2c68-454a-b772-075b3f1395c3" />
+               <kie:ComponentWidths dmnElementRef="_32742ced-8b58-4be0-a6be-d48ab1126f69" />
+               <kie:ComponentWidths dmnElementRef="_d0e623e6-f72e-47fc-8c2b-5729a72fcf3a" />
+               <kie:ComponentWidths dmnElementRef="_30a91838-0f0a-4843-a6d0-6b5a655f36b2" />
+               <kie:ComponentWidths dmnElementRef="_7a672677-fd20-4174-87f9-ba5e9146ddba" />
+               <kie:ComponentWidths dmnElementRef="_3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="literal__3e5d9f10-9433-4853-b084-33790988de2a" />
+               <kie:ComponentWidths dmnElementRef="_610d5776-9163-4707-85c4-c4f0ff35db0a" />
+               <kie:ComponentWidths dmnElementRef="_309f04dc-a3cf-483c-98e0-65dbd1ed8c36" />
+               <kie:ComponentWidths dmnElementRef="_3d3c099c-c287-45ff-82de-ca3079da67b0" />
+               <kie:ComponentWidths dmnElementRef="_45a5cc86-5fe5-422c-ab9d-b2c73dc52113" />
+               <kie:ComponentWidths dmnElementRef="_8b2bd0c8-28eb-4e2d-91d9-80fc07f81227" />
+               <kie:ComponentWidths dmnElementRef="_cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="literal__cc1e6b62-9878-4f6c-978d-ec6d16bd223b" />
+               <kie:ComponentWidths dmnElementRef="_9eb92498-0de3-44b1-a8e2-301a2bc091d4" />
+               <kie:ComponentWidths dmnElementRef="_ad652244-9438-4a76-9637-2ca8dde2cee4" />
+               <kie:ComponentWidths dmnElementRef="_9ead8557-599e-4900-80b8-7157c0653d82" />
+               <kie:ComponentWidths dmnElementRef="_348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="literal__348139f6-7fd0-40be-952d-66a8bb83d59c" />
+               <kie:ComponentWidths dmnElementRef="_9c3009af-9a1b-4821-8901-7edf800ac60b" />
+               <kie:ComponentWidths dmnElementRef="_610941db-8c4e-483c-9d75-789b3d5c2333" />
+               <kie:ComponentWidths dmnElementRef="_c08280b8-beb0-4eb1-a0d0-f022de521d25" />
+               <kie:ComponentWidths dmnElementRef="_2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="literal__2cc659df-0249-417c-8074-d3a375c6b5f5" />
+               <kie:ComponentWidths dmnElementRef="_87dccb4c-d416-42ca-9c72-a0b591b4ba88" />
+               <kie:ComponentWidths dmnElementRef="_3ba44309-b466-42d8-8126-bb2ef2d0544e" />
+               <kie:ComponentWidths dmnElementRef="_4e7fdc53-9928-4a0a-8ba4-59c22289a1ce" />
+               <kie:ComponentWidths dmnElementRef="_df160506-5551-4fe3-bf04-1fcb462bcaec" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drg-_7befd964-eefa-4d8f-908d-8f6ad8d22c67" dmnElementRef="_7befd964-eefa-4d8f-908d-8f6ad8d22c67" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1411.2411708831787" y="50" width="643.8705854415894" height="670" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="1411.2411708831787" y="275" />
+               <di:waypoint x="2055.111756324768" y="275" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_4d91e3a5-acec-4254-81e4-8535a1d336ee" dmnElementRef="_4d91e3a5-acec-4254-81e4-8535a1d336ee" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1411.2411708831787" y="50" width="693" height="562.4786796569824" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="1411.2411708831787" y="190" />
+               <di:waypoint x="2104.2411708831787" y="190" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1069" y="54.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="893.5" y="50" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1225.7588291168213" y="262.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="177" y="262.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="277" y="142.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="374" y="262.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="591.5" y="263.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="721.5" y="150" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="810.5" y="263.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1024" y="262.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="88.5" y="370.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="476.4786796569824" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="567" y="365" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="789" y="365" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="695.5" y="476.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="494.5" y="475.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="918.5" y="475.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1024" y="587.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1225.7588291168213" y="715.9786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1024.5" y="716.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="277" y="587.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="138" y="716.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="277" y="822.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="818" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="138" y="941.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="503.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="840.5" y="822.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="736.2588291168213" y="940.9786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="945" y="941.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1157" y="941.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1955.2411708831787" y="740.9999923706055" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2059.4823417663574" y="622.9999961853027" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1875" y="856.9999961853027" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1509.7411708831787" y="857.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1390.7411708831787" y="736.0213203430176" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1636.7411708831787" y="741" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_51cc9510-3bfa-4e5a-a119-9bf83efdd266" dmnElementRef="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1509.7411708831787" y="623.4999961853027" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1648.7411708831787" y="532" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1866.2411708831787" y="383" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2067.2411708831787" y="383.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2160.7411708831787" y="272.0213203430176" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1933.7411708831787" y="290.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1390.7411708831787" y="417.0213203430176" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_a654be71-b54d-4d6e-90f0-ae505125e9a6" dmnElementRef="_a654be71-b54d-4d6e-90f0-ae505125e9a6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1450.2411708831787" y="290.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2093.2411708831787" y="57.02132034301758" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_dc2ca64d-2044-4806-9d0e-e705b3b14447" dmnElementRef="_dc2ca64d-2044-4806-9d0e-e705b3b14447" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1963.2411708831787" y="170.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1745.7411708831787" y="170" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1648.7411708831787" y="50" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1548.7411708831787" y="170" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_a30c75ec-7d81-4606-802c-b31ea308392d" dmnElementRef="_a30c75ec-7d81-4606-802c-b31ea308392d" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2139.049256324768" y="857.5" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2139.049256324768" y="741.4999961853027" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_7235d875-2426-4869-b6df-92ca06ae80c5" dmnElementRef="_7235d875-2426-4869-b6df-92ca06ae80c5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1699.4823417663574" y="658.9786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1490.7411708831787" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1594.9823417663574" y="528.4786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1904" y="658.4786758422852" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" dmnElementRef="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2299.7411708831787" y="528.9786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_821a6840-e910-418f-809e-4c7d60b0b21a" dmnElementRef="_821a6840-e910-418f-809e-4c7d60b0b21a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2351.7411708831787" y="393" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2077.2411708831787" y="528.4786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_1c72ed95-ec72-47b4-8639-5ed14ccb77df" dmnElementRef="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1595.111756324768" y="398.4786796569824" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2177" y="397.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1959.2411708831787" y="397.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1843.7411708831787" y="248.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_ee893e8d-f393-4e2c-b871-611a9cd30bf5" dmnElementRef="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1620.7411708831787" y="249.47867965698242" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" dmnElementRef="_18d836e7-6d61-490c-b9a8-be3ce0c60c1e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1725.111756324768" y="142" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_b982a42a-0b62-47fa-8911-6c9d1145d982" dmnElementRef="_b982a42a-0b62-47fa-8911-6c9d1145d982" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1411.2411708831787" y="249.47867965698242" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" dmnElementRef="_974b09c2-2ff1-4eb4-bb7c-2b68fa24ddf9" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1437.2411708831787" y="393" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1959.2411708831787" y="54.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_536d7a39-87a6-4651-b743-6ee03e16e535" dmnElementRef="_536d7a39-87a6-4651-b743-6ee03e16e535" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1735.7411708831787" y="55.47867965698242" width="152" height="59" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_a5f9b126-7853-4037-9e23-3dd7e93c4032" dmnElementRef="_a5f9b126-7853-4037-9e23-3dd7e93c4032" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1553.7411708831787" y="50" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-4-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1419" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1743.5" y="320.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1540.7411708831787" y="320.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_34cd3187-8764-4249-959d-2664bf9f1847" dmnElementRef="_34cd3187-8764-4249-959d-2664bf9f1847" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1841.5" y="222.97867584228516" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_989d137f-86ff-4249-813f-af67c08a2762" dmnElementRef="_989d137f-86ff-4249-813f-af67c08a2762" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1411.2411708831787" y="50" width="100" height="69.95735931396484" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-2-_4bd33d4a-741b-444a-968b-64e1841211e7" dmnElementRef="_4bd33d4a-741b-444a-968b-64e1841211e7" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1586.7411708831787" y="54.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-5-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1669.388243675232" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-4-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1885.8705854415894" y="782.9999961853027" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_8b838f06-968a-4c66-875e-f5412fd692cf" dmnElementRef="_8b838f06-968a-4c66-875e-f5412fd692cf" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1660.6294145584106" y="88" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_5b8356f3-2cf2-40e8-8f80-324937e8b276" dmnElementRef="_5b8356f3-2cf2-40e8-8f80-324937e8b276" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1497.2411708831787" y="197" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_b5e759df-f662-44cd-94f5-55c3c81f0ee3" dmnElementRef="_b5e759df-f662-44cd-94f5-55c3c81f0ee3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1660.6294145584106" y="307" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_ed60265c-25e2-400f-a99f-fafd3b489838" dmnElementRef="_ed60265c-25e2-400f-a99f-fafd3b489838" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1840.7411708831787" y="461.5" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_9997fcfd-0f50-4933-939e-88a235b5e2a0" dmnElementRef="_9997fcfd-0f50-4933-939e-88a235b5e2a0" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1497.2411708831787" y="461.5" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-4-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1440.2411708831787" y="600" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-4-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1877.111756324768" y="583" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-4-_e91de815-22ba-431c-8b46-55891f2a1ef6" dmnElementRef="_e91de815-22ba-431c-8b46-55891f2a1ef6" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1968.7588291168213" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-6-_d14df033-f4a2-47e3-9590-84e9ff04db4e" dmnElementRef="_d14df033-f4a2-47e3-9590-84e9ff04db4e" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1631" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-5-_fe938494-ee59-425e-8728-2347ea703563" dmnElementRef="_fe938494-ee59-425e-8728-2347ea703563" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1445" y="679.4573554992676" width="135.48234176635742" height="60.00000762939453" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-4-_ca1e6032-12eb-428a-a80b-49028a88c0b5" dmnElementRef="_ca1e6032-12eb-428a-a80b-49028a88c0b5" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1761.8705854415894" y="82" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" dmnElementRef="_728e3a50-f00f-42c0-b3ee-1ee5aabd5474" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1540.8705854415894" y="219.97867965698242" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-3-_40b45659-9299-43a6-af30-04c948c5c0ec" dmnElementRef="_40b45659-9299-43a6-af30-04c948c5c0ec" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1761.8705854415894" y="369.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-5-_e905f02c-c5d9-4f2a-ba57-7912ff523b46" dmnElementRef="_e905f02c-c5d9-4f2a-ba57-7912ff523b46" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1761.8705854415894" y="496.4786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-5-_3c8cee68-99dd-418c-847d-0b54697354f2" dmnElementRef="_3c8cee68-99dd-418c-847d-0b54697354f2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1436.2411708831787" y="369.9786796569824" width="153" height="60" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drg-_290b4df4-ffe6-4106-9e22-07a339146161" dmnElementRef="_290b4df4-ffe6-4106-9e22-07a339146161">
+            <di:waypoint x="590.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="1105.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2" dmnElementRef="_5046fe50-d2f2-4e54-b1e4-e7de5ffd4bb2">
+            <di:waypoint x="1293.4968013763428" y="715.9786758422852" />
+            <di:waypoint x="1155.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c" dmnElementRef="_3a4e82d4-7a7a-43c7-9528-efa8b9e69e7c">
+            <di:waypoint x="1100.5" y="262.9786796569824" />
+            <di:waypoint x="1135.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_7fc499b6-a180-4e16-80cd-58df441f4d38" dmnElementRef="_7fc499b6-a180-4e16-80cd-58df441f4d38">
+            <di:waypoint x="1293.4968013763428" y="262.97867584228516" />
+            <di:waypoint x="1195.5" y="114.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_dabc7bb7-b8be-4654-9f7e-455481cb1c4e" dmnElementRef="_dabc7bb7-b8be-4654-9f7e-455481cb1c4e">
+            <di:waypoint x="993.5" y="84.5" />
+            <di:waypoint x="1069" y="84.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_a34e38e6-5d10-46d5-ae80-41c3045c73df" dmnElementRef="_a34e38e6-5d10-46d5-ae80-41c3045c73df">
+            <di:waypoint x="333.5" y="587.9786796569824" />
+            <di:waypoint x="253.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_18fda7ab-ca43-4860-a94b-760d3cd68ce2" dmnElementRef="_18fda7ab-ca43-4860-a94b-760d3cd68ce2">
+            <di:waypoint x="173.5" y="370.4786796569824" />
+            <di:waypoint x="223.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_114baf7e-1b8f-489a-98c9-e7d26d330119" dmnElementRef="_114baf7e-1b8f-489a-98c9-e7d26d330119">
+            <di:waypoint x="253.5" y="262.9786796569824" />
+            <di:waypoint x="323.5" y="202.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_b7de8dff-4db7-4ef0-8412-0d3fe09955d7" dmnElementRef="_b7de8dff-4db7-4ef0-8412-0d3fe09955d7">
+            <di:waypoint x="440.5" y="262.9786796569824" />
+            <di:waypoint x="373.5" y="202.97867965698242" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_94475973-9022-46d7-a520-756538ba9c00" dmnElementRef="_94475973-9022-46d7-a520-756538ba9c00">
+            <di:waypoint x="353.5" y="587.9786796569824" />
+            <di:waypoint x="440.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3" dmnElementRef="_f9db6cb4-f2d6-4e7f-8b04-37f9139dd6c3">
+            <di:waypoint x="550.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="450.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_a1f0d284-033d-4683-9a0c-13f1184e0503" dmnElementRef="_a1f0d284-033d-4683-9a0c-13f1184e0503">
+            <di:waypoint x="571" y="475.9786796569824" />
+            <di:waypoint x="460.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_1c3489b1-44dd-4137-883a-35da157f0c1d" dmnElementRef="_1c3489b1-44dd-4137-883a-35da157f0c1d">
+            <di:waypoint x="591.5" y="292.4786796569824" />
+            <di:waypoint x="527" y="292.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7" dmnElementRef="_e8e3eaaf-3f57-49d7-b5c3-41eb57ecbbe7">
+            <di:waypoint x="734" y="217" />
+            <di:waypoint x="666.5" y="263.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_57d99f5f-48e1-456c-ab7c-4247e840a7fc" dmnElementRef="_57d99f5f-48e1-456c-ab7c-4247e840a7fc">
+            <di:waypoint x="784" y="203" />
+            <di:waypoint x="885.5" y="263.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_132debf9-e318-4710-a226-982da98dd278" dmnElementRef="_132debf9-e318-4710-a226-982da98dd278">
+            <di:waypoint x="995" y="475.9786796569824" />
+            <di:waypoint x="1080.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_78acd4f1-cd28-4e53-aeaf-594a006a0f1d" dmnElementRef="_78acd4f1-cd28-4e53-aeaf-594a006a0f1d">
+            <di:waypoint x="1100.5" y="587.9786796569824" />
+            <di:waypoint x="1100.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_ffe200eb-8e0d-4941-9707-9a100fc8e123" dmnElementRef="_ffe200eb-8e0d-4941-9707-9a100fc8e123">
+            <di:waypoint x="1283.4968013763428" y="715.9786758422852" />
+            <di:waypoint x="1120.5" y="322.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_839ccfec-8902-40ca-8767-df9073f797e5" dmnElementRef="_839ccfec-8902-40ca-8767-df9073f797e5">
+            <di:waypoint x="962.5" y="292.4786796569824" />
+            <di:waypoint x="1024" y="292.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_2cad5b1f-59de-4cf2-9216-b662b2760bff" dmnElementRef="_2cad5b1f-59de-4cf2-9216-b662b2760bff">
+            <di:waypoint x="100" y="476.4786796569824" />
+            <di:waypoint x="153.5" y="429.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_07b3ea4d-1eee-4551-b148-b40052f1407a" dmnElementRef="_07b3ea4d-1eee-4551-b148-b40052f1407a">
+            <di:waypoint x="150" y="490.9786796569824" />
+            <di:waypoint x="567" y="394" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_7f7c177a-5acb-4941-9654-23f9408200b3" dmnElementRef="_7f7c177a-5acb-4941-9654-23f9408200b3">
+            <di:waypoint x="692" y="424" />
+            <di:waypoint x="740.5" y="476.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_c8f97eed-f12b-4d72-8c42-7edeeced9527" dmnElementRef="_c8f97eed-f12b-4d72-8c42-7edeeced9527">
+            <di:waypoint x="826.5" y="432" />
+            <di:waypoint x="800.5" y="476.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_00c137a3-a81c-42ff-af6d-5c3247151273" dmnElementRef="_00c137a3-a81c-42ff-af6d-5c3247151273">
+            <di:waypoint x="383.5" y="587.9786796569824" />
+            <di:waypoint x="531" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_828b316c-d2e4-4c68-8797-9fb6077d10ba" dmnElementRef="_828b316c-d2e4-4c68-8797-9fb6077d10ba">
+            <di:waypoint x="570.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="571" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_b8cf27f2-7b58-4490-8dac-0e6ff99a517b" dmnElementRef="_b8cf27f2-7b58-4490-8dac-0e6ff99a517b">
+            <di:waypoint x="907" y="822.9786796569824" />
+            <di:waypoint x="601" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032" dmnElementRef="_0c8ff057-3467-4ad0-a3ab-a9a3f3d95032">
+            <di:waypoint x="695.5" y="505.4786796569824" />
+            <di:waypoint x="647.5" y="505.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_f7991b2e-6fee-4e49-a79e-fcc667dc8e84" dmnElementRef="_f7991b2e-6fee-4e49-a79e-fcc667dc8e84">
+            <di:waypoint x="1090.5" y="587.9786796569824" />
+            <di:waypoint x="995" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_9eeef063-346f-44d4-b722-2d8071d3d994" dmnElementRef="_9eeef063-346f-44d4-b722-2d8071d3d994">
+            <di:waypoint x="927" y="822.9786796569824" />
+            <di:waypoint x="985" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_466b70d3-035a-413d-93bd-ae28c778d02d" dmnElementRef="_466b70d3-035a-413d-93bd-ae28c778d02d">
+            <di:waypoint x="610.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="965" y="535.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1" dmnElementRef="_8c6d88aa-7775-4b03-8ee2-6455f1eeb4d1">
+            <di:waypoint x="847.5" y="505.4786796569824" />
+            <di:waypoint x="918.5" y="505.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_afa8490a-52e3-48cd-94a6-1602e00ffe59" dmnElementRef="_afa8490a-52e3-48cd-94a6-1602e00ffe59">
+            <di:waypoint x="1263.4968013763428" y="715.9786758422852" />
+            <di:waypoint x="1140.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_668fa95d-373d-4430-b833-7c27308d2a80" dmnElementRef="_668fa95d-373d-4430-b833-7c27308d2a80">
+            <di:waypoint x="632.4968013763428" y="950.9786758422852" />
+            <di:waypoint x="1060.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_655fba60-b529-4c21-bd96-9c778998d3fb" dmnElementRef="_655fba60-b529-4c21-bd96-9c778998d3fb">
+            <di:waypoint x="430" y="842.9786796569824" />
+            <di:waypoint x="1024" y="617.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_dc094e13-abbd-4164-bc95-a61b433a7be4" dmnElementRef="_dc094e13-abbd-4164-bc95-a61b433a7be4">
+            <di:waypoint x="1099.5" y="716.4786796569824" />
+            <di:waypoint x="1100.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_aa1fbb92-27fc-4108-9257-2017c2dbc601" dmnElementRef="_aa1fbb92-27fc-4108-9257-2017c2dbc601">
+            <di:waypoint x="150" y="510.9786796569824" />
+            <di:waypoint x="1024.5" y="735.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_7b60cf6f-1265-4460-bf43-8d10272fe9f2" dmnElementRef="_7b60cf6f-1265-4460-bf43-8d10272fe9f2">
+            <di:waypoint x="530.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="373.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_2f70ff15-13ec-4104-8256-2a6c3d240a56" dmnElementRef="_2f70ff15-13ec-4104-8256-2a6c3d240a56">
+            <di:waypoint x="353.5" y="822.9786796569824" />
+            <di:waypoint x="353.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_d37ce038-f9cc-4576-92a7-dd64eea28a2d" dmnElementRef="_d37ce038-f9cc-4576-92a7-dd64eea28a2d">
+            <di:waypoint x="213" y="716.4786796569824" />
+            <di:waypoint x="313.5" y="647.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_b752b8ba-8fab-4658-94d9-1aaaa51af3a2" dmnElementRef="_b752b8ba-8fab-4658-94d9-1aaaa51af3a2">
+            <di:waypoint x="87.5" y="543.4786796569824" />
+            <di:waypoint x="146.5" y="724.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_fb44eebf-50e6-47db-9894-cd3fd2e135d4" dmnElementRef="_fb44eebf-50e6-47db-9894-cd3fd2e135d4">
+            <di:waypoint x="510.4968013763428" y="950.9786758422852" />
+            <di:waypoint x="403.5" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_c94de723-def1-49e4-9aae-5270fe39630f" dmnElementRef="_c94de723-def1-49e4-9aae-5270fe39630f">
+            <di:waypoint x="223" y="941.4786796569824" />
+            <di:waypoint x="323.5" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_5bccc005-33ba-40e9-8514-3fa3444ac11d" dmnElementRef="_5bccc005-33ba-40e9-8514-3fa3444ac11d">
+            <di:waypoint x="87.5" y="885" />
+            <di:waypoint x="138" y="980.4786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_c5e79286-ea8f-4340-bd38-e878054891f2" dmnElementRef="_c5e79286-ea8f-4340-bd38-e878054891f2">
+            <di:waypoint x="813.9968013763428" y="940.9786758422852" />
+            <di:waypoint x="887" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_c40b08f2-613a-4a46-841c-c9d2d117578e" dmnElementRef="_c40b08f2-613a-4a46-841c-c9d2d117578e">
+            <di:waypoint x="1010" y="941.4786796569824" />
+            <di:waypoint x="937" y="882.9786796569824" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_f0a6536d-0e7f-44d3-a9bb-5213478173da" dmnElementRef="_f0a6536d-0e7f-44d3-a9bb-5213478173da">
+            <di:waypoint x="1157" y="970.4786796569824" />
+            <di:waypoint x="1097" y="970.9786796569824" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+   </dmndi:DMNDI>
 </dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
@@ -1,234 +1,234 @@
-<?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_BA898F11-9F63-4A74-AF32-235D82663253" name="x1" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820">
-  <dmn:extensionElements/>
-  <dmn:itemDefinition id="_1A35CDE5-592B-4C7D-A302-15043E11830C" name="tGrade" isCollection="false">
-    <dmn:typeRef>string</dmn:typeRef>
-    <dmn:allowedValues kie:constraintType="enumeration" id="_E9560012-0F49-44D2-96D8-BA655980F315">
-      <dmn:text>"A", "B", "C", "D", "E", "F"</dmn:text>
-    </dmn:allowedValues>
-  </dmn:itemDefinition>
-  <dmn:decision id="_2770588B-EF63-490A-BA13-B21D4EB1926D" name="Graduation DT">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A41CE5F4-5B2F-490B-90A3-9E5F53ED5B01" name="Graduation DT" typeRef="string"/>
-    <dmn:informationRequirement id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
-      <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C"/>
-    </dmn:informationRequirement>
-    <dmn:decisionTable id="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
-      <dmn:input id="_AF31943B-2A05-4F02-839A-4F1B6C5DC073">
-        <dmn:inputExpression id="_BB692782-9108-449A-9D15-27D06007E04E">
-          <dmn:text>Grade</dmn:text>
-        </dmn:inputExpression>
-      </dmn:input>
-      <dmn:output id="_5F1FEDAD-C742-445A-B194-47B0112573B8"/>
-      <dmn:annotation name=""/>
-      <dmn:rule id="_967C2799-CC1E-45C5-9F6B-BF3C2F5BCF36">
-        <dmn:inputEntry id="_47B77F78-DE9F-4CF3-A78D-AD274A951078">
-          <dmn:text>"A"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_BF4EB2E1-51E3-4087-A9B4-5FB39F646CCB">
-          <dmn:text>"Graduated with merit"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_CC4BEE1B-2A3D-4EE7-8C97-4382E8213EA0">
-        <dmn:inputEntry id="_1DA3FD5D-E479-4153-881A-4A087C9B7F9F">
-          <dmn:text>"B"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_2B336B1E-F6FC-4742-9C43-77D1A21746FC">
-          <dmn:text>"Graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_95BBC24F-F50C-4D0E-A5B5-D07E328680C9">
-        <dmn:inputEntry id="_459FB1AA-8588-4C7B-AD2E-70A670569BD2">
-          <dmn:text>"C"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_92D429DE-3FD9-4E9F-864B-F9147B040121">
-          <dmn:text>"Graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_161963E2-94C8-4391-A8BF-DEC458BEB62C">
-        <dmn:inputEntry id="_076CA1F7-DC4A-4D33-BAF9-3E3D0A4A3462">
-          <dmn:text>"D"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_E14D7E3E-DA88-409E-8506-10A7EE1AC18D">
-          <dmn:text>"Not graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_A3513F68-6132-4535-95E0-739ACE67F456">
-        <dmn:inputEntry id="_F0479B26-22F1-4983-81A9-B53F7D8BCF41">
-          <dmn:text>"E"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_04CFBB41-21E0-456F-B9E5-AB8070DA84C8">
-          <dmn:text>"Not graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_D9577634-8F7B-462D-BBAB-210F5FD586DC">
-        <dmn:inputEntry id="_79112C49-AD12-42B1-B056-8210E5AABF9A">
-          <dmn:text>"F"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_7C07ED74-5578-4906-B542-D294C426B2B9">
-          <dmn:text>"Not graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-    </dmn:decisionTable>
-  </dmn:decision>
-  <dmn:decision id="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" name="Graduation result">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5F80DA91-A764-42C4-A526-3CADCD34E856" name="Graduation result" typeRef="string"/>
-    <dmn:informationRequirement id="_2770588B-EF63-490A-BA13-B21D4EB1926D">
-      <dmn:requiredDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
-      <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
-      <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_0C226138-201A-4073-8ED4-F28FA2A1BC64">
-      <dmn:requiredDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_7C49F288-73F5-41AB-97D8-C569099B2CC7">
-      <dmn:text>Student's name + " is " + Graduation DT + " with grade: " + Grade + " and evaluation: " + Teacher's Evaluation</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_0C226138-201A-4073-8ED4-F28FA2A1BC64" name="Teacher's Evaluation">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A2732FC7-2D94-4EFE-9A70-5A5D5F0EDCA3" name="Teacher's Evaluation"/>
-    <dmn:informationRequirement id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
-      <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794"/>
-    </dmn:informationRequirement>
-    <dmn:authorityRequirement id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32">
-      <dmn:requiredAuthority href="#_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32"/>
-    </dmn:authorityRequirement>
-  </dmn:decision>
-  <dmn:knowledgeSource id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" name="Teacher's knowledge" locationURI="">
-    <dmn:extensionElements/>
-    <dmn:type></dmn:type>
-  </dmn:knowledgeSource>
-  <dmn:inputData id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" name="Student's name">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9114ABD1-CD57-4E59-B6C7-FE7CD5AB1EFD" name="Student's name" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decisionService id="_7A9C80F8-4A44-4080-9031-F28EA411A35C" name="Evaluation DS">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7D7F3394-69B4-46A6-BFED-4F71AFF6ABB3" name="Evaluation DS"/>
-  </dmn:decisionService>
-  <dmn:inputData id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" name="Grade">
-    <dmn:extensionElements/>
-    <dmn:variable id="_22CC6AB7-BBB7-4F30-AFB3-FA67486F2DBA" name="Grade" typeRef="tGrade"/>
-  </dmn:inputData>
-  <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_52995918-2649-4B81-866F-D0887B927DF5" name="DRG">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02"/>
-          <kie:ComponentWidths dmnElementRef="_7C49F288-73F5-41AB-97D8-C569099B2CC7"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="313" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" dmnElementRef="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="400" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="225" y="400" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7A9C80F8-4A44-4080-9031-F28EA411A35C" dmnElementRef="_7A9C80F8-4A44-4080-9031-F28EA411A35C" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="313" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="313" y="150"/>
-          <di:waypoint x="413" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="400" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
-        <di:waypoint x="400" y="400"/>
-        <di:waypoint x="313" y="225"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D">
-        <di:waypoint x="313" y="225"/>
-        <di:waypoint x="138" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
-        <di:waypoint x="225" y="400"/>
-        <di:waypoint x="138" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64">
-        <di:waypoint x="138" y="225"/>
-        <di:waypoint x="138" y="50"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32">
-        <di:waypoint x="50" y="400"/>
-        <di:waypoint x="138" y="225"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-  </dmndi:DMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_BA898F11-9F63-4A74-AF32-235D82663253" name="x1" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820">
+   <dmn:extensionElements />
+   <dmn:itemDefinition id="_1A35CDE5-592B-4C7D-A302-15043E11830C" name="tGrade" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="enumeration" id="_E9560012-0F49-44D2-96D8-BA655980F315">
+         <dmn:text>"A", "B", "C", "D", "E", "F"</dmn:text>
+      </dmn:allowedValues>
+   </dmn:itemDefinition>
+   <dmn:decisionService id="_7A9C80F8-4A44-4080-9031-F28EA411A35C" name="Evaluation DS">
+      <dmn:extensionElements />
+      <dmn:variable id="_7D7F3394-69B4-46A6-BFED-4F71AFF6ABB3" name="Evaluation DS" />
+   </dmn:decisionService>
+   <dmn:decision id="_2770588B-EF63-490A-BA13-B21D4EB1926D" name="Graduation DT">
+      <dmn:extensionElements />
+      <dmn:variable id="_A41CE5F4-5B2F-490B-90A3-9E5F53ED5B01" name="Graduation DT" typeRef="string" />
+      <dmn:informationRequirement id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
+         <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
+      </dmn:informationRequirement>
+      <dmn:decisionTable id="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+         <dmn:input id="_AF31943B-2A05-4F02-839A-4F1B6C5DC073">
+            <dmn:inputExpression id="_BB692782-9108-449A-9D15-27D06007E04E">
+               <dmn:text>Grade</dmn:text>
+            </dmn:inputExpression>
+         </dmn:input>
+         <dmn:output id="_5F1FEDAD-C742-445A-B194-47B0112573B8" />
+         <dmn:annotation name="" />
+         <dmn:rule id="_967C2799-CC1E-45C5-9F6B-BF3C2F5BCF36">
+            <dmn:inputEntry id="_47B77F78-DE9F-4CF3-A78D-AD274A951078">
+               <dmn:text>"A"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_BF4EB2E1-51E3-4087-A9B4-5FB39F646CCB">
+               <dmn:text>"Graduated with merit"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_CC4BEE1B-2A3D-4EE7-8C97-4382E8213EA0">
+            <dmn:inputEntry id="_1DA3FD5D-E479-4153-881A-4A087C9B7F9F">
+               <dmn:text>"B"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_2B336B1E-F6FC-4742-9C43-77D1A21746FC">
+               <dmn:text>"Graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_95BBC24F-F50C-4D0E-A5B5-D07E328680C9">
+            <dmn:inputEntry id="_459FB1AA-8588-4C7B-AD2E-70A670569BD2">
+               <dmn:text>"C"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_92D429DE-3FD9-4E9F-864B-F9147B040121">
+               <dmn:text>"Graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_161963E2-94C8-4391-A8BF-DEC458BEB62C">
+            <dmn:inputEntry id="_076CA1F7-DC4A-4D33-BAF9-3E3D0A4A3462">
+               <dmn:text>"D"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_E14D7E3E-DA88-409E-8506-10A7EE1AC18D">
+               <dmn:text>"Not graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_A3513F68-6132-4535-95E0-739ACE67F456">
+            <dmn:inputEntry id="_F0479B26-22F1-4983-81A9-B53F7D8BCF41">
+               <dmn:text>"E"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_04CFBB41-21E0-456F-B9E5-AB8070DA84C8">
+               <dmn:text>"Not graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_D9577634-8F7B-462D-BBAB-210F5FD586DC">
+            <dmn:inputEntry id="_79112C49-AD12-42B1-B056-8210E5AABF9A">
+               <dmn:text>"F"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_7C07ED74-5578-4906-B542-D294C426B2B9">
+               <dmn:text>"Not graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+      </dmn:decisionTable>
+   </dmn:decision>
+   <dmn:decision id="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" name="Graduation result">
+      <dmn:extensionElements />
+      <dmn:variable id="_5F80DA91-A764-42C4-A526-3CADCD34E856" name="Graduation result" typeRef="string" />
+      <dmn:informationRequirement id="_2770588B-EF63-490A-BA13-B21D4EB1926D">
+         <dmn:requiredDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
+         <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
+         <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_0C226138-201A-4073-8ED4-F28FA2A1BC64">
+         <dmn:requiredDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_7C49F288-73F5-41AB-97D8-C569099B2CC7">
+         <dmn:text>Student's name + " is " + Graduation DT + " with grade: " + Grade + " and evaluation: " + Teacher's Evaluation</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_0C226138-201A-4073-8ED4-F28FA2A1BC64" name="Teacher's Evaluation">
+      <dmn:extensionElements />
+      <dmn:variable id="_A2732FC7-2D94-4EFE-9A70-5A5D5F0EDCA3" name="Teacher's Evaluation" />
+      <dmn:informationRequirement id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
+         <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
+      </dmn:informationRequirement>
+      <dmn:authorityRequirement id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32">
+         <dmn:requiredAuthority href="#_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" />
+      </dmn:authorityRequirement>
+   </dmn:decision>
+   <dmn:knowledgeSource id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" name="Teacher's knowledge" locationURI="">
+      <dmn:extensionElements />
+      <dmn:type />
+   </dmn:knowledgeSource>
+   <dmn:inputData id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" name="Student's name">
+      <dmn:extensionElements />
+      <dmn:variable id="_9114ABD1-CD57-4E59-B6C7-FE7CD5AB1EFD" name="Student's name" typeRef="string" />
+   </dmn:inputData>
+   <dmn:inputData id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" name="Grade">
+      <dmn:extensionElements />
+      <dmn:variable id="_22CC6AB7-BBB7-4F30-AFB3-FA67486F2DBA" name="Grade" typeRef="tGrade" />
+   </dmn:inputData>
+   <dmndi:DMNDI>
+      <dmndi:DMNDiagram id="_52995918-2649-4B81-866F-D0887B927DF5" name="DRG">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" />
+               <kie:ComponentWidths dmnElementRef="_7C49F288-73F5-41AB-97D8-C569099B2CC7" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drg-_7A9C80F8-4A44-4080-9031-F28EA411A35C" dmnElementRef="_7A9C80F8-4A44-4080-9031-F28EA411A35C" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="313" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="313" y="150" />
+               <di:waypoint x="413" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="313" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" dmnElementRef="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="138" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="138" y="225" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="400" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225" y="400" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400" y="400" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
+            <di:waypoint x="400" y="400" />
+            <di:waypoint x="313" y="225" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D">
+            <di:waypoint x="313" y="225" />
+            <di:waypoint x="138" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
+            <di:waypoint x="225" y="400" />
+            <di:waypoint x="138" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64">
+            <di:waypoint x="138" y="225" />
+            <di:waypoint x="138" y="50" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32">
+            <di:waypoint x="50" y="400" />
+            <di:waypoint x="138" y="225" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+   </dmndi:DMNDI>
 </dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-2515 (DMN model with decision services - expected).xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-2515 (DMN model with decision services - expected).xml
@@ -1,0 +1,265 @@
+<?xml version="1.0" ?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="com.thirtyNineDecisions.pluto.calculations.asset" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_A521797C-92FD-442D-B875-6A2FFE79BBB9" name="assetCalculations" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="com.thirtyNineDecisions.pluto.calculations.asset">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_D5819D0D-448F-433C-8A4B-764695088DCE" name="Asset" isCollection="false">
+    <dmn:itemComponent id="_0E2FA3F6-7C11-420F-B8A9-D414790B9DE2" name="label" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_304E3138-BAE2-4679-9822-701568B7E5AC" name="assetType" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_FE0D8D41-918D-4831-BC39-1C9E01E9CB03" name="assetTypeOtherDescription" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_2400BBC6-3BDB-4670-AB44-8CE618C46524" name="cashOrMarketValueAmount" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_E7699566-98A6-4B56-8316-1C05038C9E4C" name="includeInAssetAccountIndicator" isCollection="false">
+      <dmn:typeRef>boolean</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_E14A60F9-414E-42A2-BC14-E0350AB8A409" name="fundsSourceType" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_78A9B0B7-9A36-405D-B881-85888452725E" name="Relationship" isCollection="false">
+    <dmn:itemComponent id="_5122DAA6-A821-45F3-AC5E-436F2C413CE1" name="from" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_554FD6E4-92E8-462E-8E24-71C12C9D20C3" name="to" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_55B5E83F-7A8E-486B-BA28-7B74F228639C" name="arcRole" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_D9481D11-82D6-4581-8B14-2992357F5930" name="CalculationResponse" isCollection="false">
+    <dmn:itemComponent id="_6AE28339-9B88-43BC-99CA-3BA5DFC0549B" name="eligibilityStatus" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_DD9689B1-8315-4FA4-A30B-B6E1371BBDF3" name="ruleIdentifier" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_D989A771-1DC6-4884-B9DA-B7BE5C39F789" name="assetIdentifier" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_E58CF83E-88EA-4EED-9BC0-06CAB2715621" name="Message" isCollection="false">
+    <dmn:itemComponent id="_2516C7CD-BA29-40F5-8D52-0E02B847B1F8" name="messageId" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_BB2C780E-220F-425B-88DF-DD9692AA9DB6" name="messageName" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_4E6C3BF3-880E-4ECF-B87D-230E4DF56B14" name="stringList" isCollection="true">
+    <dmn:typeRef>string</dmn:typeRef>
+  </dmn:itemDefinition>
+  <dmn:decisionService id="_324F55DB-9A6D-41E2-BBD5-D0EC07AFBBC4" name="DecisionService-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_0E6C393C-380E-4227-98EC-A9B38985913F" name="DecisionService-1"/>
+    <dmn:encapsulatedDecision href="#_DB154706-B3D6-45B1-A7D9-F9C79A22D79B"/>
+    <dmn:inputData href="#_147866D7-A820-4A13-8976-A4A5CDA674AE"/>
+    <dmn:inputData href="#_C3FE45D9-365E-4C70-923B-C061678E4847"/>
+  </dmn:decisionService>
+  <dmn:inputData id="_147866D7-A820-4A13-8976-A4A5CDA674AE" name="asset">
+    <dmn:extensionElements/>
+    <dmn:variable id="_053410D3-097F-46FF-93F2-A17A2CB34483" name="asset" typeRef="Asset"/>
+  </dmn:inputData>
+  <dmn:inputData id="_C3FE45D9-365E-4C70-923B-C061678E4847" name="relationship">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A41CBBF7-41D0-4D54-B1FB-9574B1D99F23" name="relationship" typeRef="Relationship"/>
+  </dmn:inputData>
+  <dmn:decision id="_DB154706-B3D6-45B1-A7D9-F9C79A22D79B" name="ValidateAsset">
+    <dmn:extensionElements/>
+    <dmn:variable id="_96F339D0-299E-4FB6-8482-4DA02571089D" name="ValidateAsset" typeRef="CalculationResponse"/>
+    <dmn:informationRequirement id="_2E1BFCEB-0AFB-4050-8E29-6B60721E521F">
+      <dmn:requiredInput href="#_147866D7-A820-4A13-8976-A4A5CDA674AE"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_EA627FF7-E1AA-46D5-B1D0-296077C3E87D">
+      <dmn:requiredInput href="#_C3FE45D9-365E-4C70-923B-C061678E4847"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_F32FA782-EDEF-4B0A-ABDE-07149EFF915C">
+      <dmn:contextEntry>
+        <dmn:variable id="_3EBD513D-3171-41D8-86BE-A2066882C85C" name="calcResponse" typeRef="CalculationResponse"/>
+        <dmn:decisionTable id="_514F8A0B-C4B6-4401-803F-931197CD8383" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+          <dmn:input id="_80098EDF-DE35-4852-8AE0-03019D36D188">
+            <dmn:inputExpression id="_8332DB8C-E799-49D1-8443-E33819F7BDBC" typeRef="string">
+              <dmn:text>asset.assetType</dmn:text>
+            </dmn:inputExpression>
+          </dmn:input>
+          <dmn:input id="_B068A912-ECB6-42E6-917F-869E49BE371A">
+            <dmn:inputExpression id="_7E56DC48-5A79-48B0-B0D5-114E348F075B" typeRef="string">
+              <dmn:text>asset.assetTypeOtherDescription</dmn:text>
+            </dmn:inputExpression>
+          </dmn:input>
+          <dmn:input id="_F25EDB9E-7C47-4354-A01A-81B64C44E4B3">
+            <dmn:inputExpression id="_33A8BB69-5EB1-4DDB-B42A-115A05B983ED" typeRef="string">
+              <dmn:text>asset.fundsSourceType</dmn:text>
+            </dmn:inputExpression>
+          </dmn:input>
+          <dmn:output id="_C0CAD2C3-D4C0-4487-A09C-4DFF1E883665" name="eligibilityStatus" typeRef="string"/>
+          <dmn:output id="_9B018944-AF90-4612-AF74-77E0A7170EB8" name="ruleIdentifier" typeRef="string"/>
+          <dmn:annotation name="annotation-1"/>
+          <dmn:rule id="_FCDA5263-74A0-4612-8293-349D8E20DFC1">
+            <dmn:inputEntry id="_95B5DC6A-425B-417D-858F-42DC662CB9C5">
+              <dmn:text>"Bond"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_0C073145-A908-405A-8B80-FBCE9A01F868">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_1C990AD5-84D2-4E70-B556-579CE9EADC07">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_4D999F2D-5376-439B-A545-A1C7EB91B170">
+              <dmn:text>"Eligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_E9A55DB1-BC2C-4E25-899B-30121E536DDA">
+              <dmn:text>"validate_asset_001"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text></dmn:text>
+            </dmn:annotationEntry>
+          </dmn:rule>
+          <dmn:rule id="_FF24029F-1F35-493E-86A7-FFF31816E5C5">
+            <dmn:inputEntry id="_91D031EB-1706-4E26-8617-68FCB29E4800">
+              <dmn:text>"GiftOfCash"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_2121B2A2-73F3-4315-9DAC-52EA4511AE0B">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_ABD1679F-C9CC-4545-BAD7-E7E4B10DE7ED">
+              <dmn:text>"Lender"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_D7A63A89-50DC-4373-B2AD-0DF31D2577ED">
+              <dmn:text>"InEligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_518D088F-A27F-4054-BC39-21D0DF6FA13C">
+              <dmn:text>"validate_asset_002"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text></dmn:text>
+            </dmn:annotationEntry>
+          </dmn:rule>
+          <dmn:rule id="_24E0A1DC-6843-4312-B8A2-8CA2DAF20479">
+            <dmn:inputEntry id="_A18BC5F0-BAEE-4D4C-A67F-39FFAD8D7ADD">
+              <dmn:text>"CashOnHand"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_9F28573A-8272-4DC1-A5C7-4870FF37FC58">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_A6A3E49E-3B2A-42A6-A9C8-6D172D08CD59">
+              <dmn:text>? in ["Parent", "Relative"]</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_29B43637-8934-4652-81A9-BEA3C97644AC">
+              <dmn:text>"Eligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_D3CE3A9E-2872-410E-9DAB-3B9D8101EF52">
+              <dmn:text>"validate_asset_003"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text></dmn:text>
+            </dmn:annotationEntry>
+          </dmn:rule>
+          <dmn:rule id="_5E9E185A-EC76-43DC-AFF6-38798AD96B96">
+            <dmn:inputEntry id="_B885D75C-1E79-4403-A1FA-E45FC1494FBD">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_F1F2A578-0C9B-4B37-B7DF-2ACA5F48CE33">
+              <dmn:text>"OtherLiquidAsset"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_37F8D303-B706-48DD-81F4-3259CCCD3BDB">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_9A3956F1-BCD4-44CF-A725-1CA569AE70AE">
+              <dmn:text>"Eligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_6768492F-23BF-44C4-AB16-70898500F218">
+              <dmn:text>"validate_asset_0014"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text></dmn:text>
+            </dmn:annotationEntry>
+          </dmn:rule>
+        </dmn:decisionTable>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:literalExpression id="_03CBF49D-E931-4AE7-8060-E29C51048484">
+          <dmn:text>{eligibilityStatus: calcResponse.eligibilityStatus, ruleIdentifier: calcResponse.ruleIdentifier, assetIdentifier:asset.label}</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_385830CA-B4CE-42D0-8173-2C61EF7A7ED0" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_F32FA782-EDEF-4B0A-ABDE-07149EFF915C">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>1082</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_514F8A0B-C4B6-4401-803F-931197CD8383">
+            <kie:width>50</kie:width>
+            <kie:width>132</kie:width>
+            <kie:width>216</kie:width>
+            <kie:width>245</kie:width>
+            <kie:width>136</kie:width>
+            <kie:width>183</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_03CBF49D-E931-4AE7-8060-E29C51048484">
+            <kie:width>1082</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_324F55DB-9A6D-41E2-BBD5-D0EC07AFBBC4" dmnElementRef="_324F55DB-9A6D-41E2-BBD5-D0EC07AFBBC4" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="205" y="36" width="200" height="200"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="205" y="136"/>
+          <di:waypoint x="405" y="136"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_147866D7-A820-4A13-8976-A4A5CDA674AE" dmnElementRef="_147866D7-A820-4A13-8976-A4A5CDA674AE" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="170" y="279" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_C3FE45D9-365E-4C70-923B-C061678E4847" dmnElementRef="_C3FE45D9-365E-4C70-923B-C061678E4847" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="339" y="279" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_DB154706-B3D6-45B1-A7D9-F9C79A22D79B" dmnElementRef="_DB154706-B3D6-45B1-A7D9-F9C79A22D79B" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="245" y="150" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_2E1BFCEB-0AFB-4050-8E29-6B60721E521F" dmnElementRef="_2E1BFCEB-0AFB-4050-8E29-6B60721E521F">
+        <di:waypoint x="220" y="304"/>
+        <di:waypoint x="295" y="200"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_EA627FF7-E1AA-46D5-B1D0-296077C3E87D" dmnElementRef="_EA627FF7-E1AA-46D5-B1D0-296077C3E87D">
+        <di:waypoint x="389" y="304"/>
+        <di:waypoint x="295" y="200"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-2515 (DMN model with decision services - fixture).xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-2515 (DMN model with decision services - fixture).xml
@@ -1,0 +1,264 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="com.thirtyNineDecisions.pluto.calculations.asset" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_A521797C-92FD-442D-B875-6A2FFE79BBB9" name="assetCalculations" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="com.thirtyNineDecisions.pluto.calculations.asset">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_D5819D0D-448F-433C-8A4B-764695088DCE" name="Asset" isCollection="false">
+    <dmn:itemComponent id="_0E2FA3F6-7C11-420F-B8A9-D414790B9DE2" name="label" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_304E3138-BAE2-4679-9822-701568B7E5AC" name="assetType" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_FE0D8D41-918D-4831-BC39-1C9E01E9CB03" name="assetTypeOtherDescription" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_2400BBC6-3BDB-4670-AB44-8CE618C46524" name="cashOrMarketValueAmount" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_E7699566-98A6-4B56-8316-1C05038C9E4C" name="includeInAssetAccountIndicator" isCollection="false">
+      <dmn:typeRef>boolean</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_E14A60F9-414E-42A2-BC14-E0350AB8A409" name="fundsSourceType" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_78A9B0B7-9A36-405D-B881-85888452725E" name="Relationship" isCollection="false">
+    <dmn:itemComponent id="_5122DAA6-A821-45F3-AC5E-436F2C413CE1" name="from" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_554FD6E4-92E8-462E-8E24-71C12C9D20C3" name="to" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_55B5E83F-7A8E-486B-BA28-7B74F228639C" name="arcRole" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_D9481D11-82D6-4581-8B14-2992357F5930" name="CalculationResponse" isCollection="false">
+    <dmn:itemComponent id="_6AE28339-9B88-43BC-99CA-3BA5DFC0549B" name="eligibilityStatus" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_DD9689B1-8315-4FA4-A30B-B6E1371BBDF3" name="ruleIdentifier" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_D989A771-1DC6-4884-B9DA-B7BE5C39F789" name="assetIdentifier" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_E58CF83E-88EA-4EED-9BC0-06CAB2715621" name="Message" isCollection="false">
+    <dmn:itemComponent id="_2516C7CD-BA29-40F5-8D52-0E02B847B1F8" name="messageId" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_BB2C780E-220F-425B-88DF-DD9692AA9DB6" name="messageName" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_4E6C3BF3-880E-4ECF-B87D-230E4DF56B14" name="stringList" isCollection="true">
+    <dmn:typeRef>string</dmn:typeRef>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_147866D7-A820-4A13-8976-A4A5CDA674AE" name="asset">
+    <dmn:extensionElements/>
+    <dmn:variable id="_053410D3-097F-46FF-93F2-A17A2CB34483" name="asset" typeRef="Asset"/>
+  </dmn:inputData>
+  <dmn:inputData id="_C3FE45D9-365E-4C70-923B-C061678E4847" name="relationship">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A41CBBF7-41D0-4D54-B1FB-9574B1D99F23" name="relationship" typeRef="Relationship"/>
+  </dmn:inputData>
+  <dmn:decision id="_DB154706-B3D6-45B1-A7D9-F9C79A22D79B" name="ValidateAsset">
+    <dmn:extensionElements/>
+    <dmn:variable id="_96F339D0-299E-4FB6-8482-4DA02571089D" name="ValidateAsset" typeRef="CalculationResponse"/>
+    <dmn:informationRequirement id="_2E1BFCEB-0AFB-4050-8E29-6B60721E521F">
+      <dmn:requiredInput href="#_147866D7-A820-4A13-8976-A4A5CDA674AE"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_EA627FF7-E1AA-46D5-B1D0-296077C3E87D">
+      <dmn:requiredInput href="#_C3FE45D9-365E-4C70-923B-C061678E4847"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_F32FA782-EDEF-4B0A-ABDE-07149EFF915C">
+      <dmn:contextEntry>
+        <dmn:variable id="_3EBD513D-3171-41D8-86BE-A2066882C85C" name="calcResponse" typeRef="CalculationResponse"/>
+        <dmn:decisionTable id="_514F8A0B-C4B6-4401-803F-931197CD8383" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+          <dmn:input id="_80098EDF-DE35-4852-8AE0-03019D36D188">
+            <dmn:inputExpression id="_8332DB8C-E799-49D1-8443-E33819F7BDBC" typeRef="string">
+              <dmn:text>asset.assetType</dmn:text>
+            </dmn:inputExpression>
+          </dmn:input>
+          <dmn:input id="_B068A912-ECB6-42E6-917F-869E49BE371A">
+            <dmn:inputExpression id="_7E56DC48-5A79-48B0-B0D5-114E348F075B" typeRef="string">
+              <dmn:text>asset.assetTypeOtherDescription</dmn:text>
+            </dmn:inputExpression>
+          </dmn:input>
+          <dmn:input id="_F25EDB9E-7C47-4354-A01A-81B64C44E4B3">
+            <dmn:inputExpression id="_33A8BB69-5EB1-4DDB-B42A-115A05B983ED" typeRef="string">
+              <dmn:text>asset.fundsSourceType</dmn:text>
+            </dmn:inputExpression>
+          </dmn:input>
+          <dmn:output id="_C0CAD2C3-D4C0-4487-A09C-4DFF1E883665" name="eligibilityStatus" typeRef="string"/>
+          <dmn:output id="_9B018944-AF90-4612-AF74-77E0A7170EB8" name="ruleIdentifier" typeRef="string"/>
+          <dmn:annotation name="annotation-1"/>
+          <dmn:rule id="_FCDA5263-74A0-4612-8293-349D8E20DFC1">
+            <dmn:inputEntry id="_95B5DC6A-425B-417D-858F-42DC662CB9C5">
+              <dmn:text>"Bond"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_0C073145-A908-405A-8B80-FBCE9A01F868">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_1C990AD5-84D2-4E70-B556-579CE9EADC07">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_4D999F2D-5376-439B-A545-A1C7EB91B170">
+              <dmn:text>"Eligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_E9A55DB1-BC2C-4E25-899B-30121E536DDA">
+              <dmn:text>"validate_asset_001"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text/>
+            </dmn:annotationEntry>
+          </dmn:rule>
+          <dmn:rule id="_FF24029F-1F35-493E-86A7-FFF31816E5C5">
+            <dmn:inputEntry id="_91D031EB-1706-4E26-8617-68FCB29E4800">
+              <dmn:text>"GiftOfCash"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_2121B2A2-73F3-4315-9DAC-52EA4511AE0B">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_ABD1679F-C9CC-4545-BAD7-E7E4B10DE7ED">
+              <dmn:text>"Lender"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_D7A63A89-50DC-4373-B2AD-0DF31D2577ED">
+              <dmn:text>"InEligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_518D088F-A27F-4054-BC39-21D0DF6FA13C">
+              <dmn:text>"validate_asset_002"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text/>
+            </dmn:annotationEntry>
+          </dmn:rule>
+          <dmn:rule id="_24E0A1DC-6843-4312-B8A2-8CA2DAF20479">
+            <dmn:inputEntry id="_A18BC5F0-BAEE-4D4C-A67F-39FFAD8D7ADD">
+              <dmn:text>"CashOnHand"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_9F28573A-8272-4DC1-A5C7-4870FF37FC58">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_A6A3E49E-3B2A-42A6-A9C8-6D172D08CD59">
+              <dmn:text>? in ["Parent", "Relative"]</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_29B43637-8934-4652-81A9-BEA3C97644AC">
+              <dmn:text>"Eligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_D3CE3A9E-2872-410E-9DAB-3B9D8101EF52">
+              <dmn:text>"validate_asset_003"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text/>
+            </dmn:annotationEntry>
+          </dmn:rule>
+          <dmn:rule id="_5E9E185A-EC76-43DC-AFF6-38798AD96B96">
+            <dmn:inputEntry id="_B885D75C-1E79-4403-A1FA-E45FC1494FBD">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_F1F2A578-0C9B-4B37-B7DF-2ACA5F48CE33">
+              <dmn:text>"OtherLiquidAsset"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:inputEntry id="_37F8D303-B706-48DD-81F4-3259CCCD3BDB">
+              <dmn:text>-</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_9A3956F1-BCD4-44CF-A725-1CA569AE70AE">
+              <dmn:text>"Eligible"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:outputEntry id="_6768492F-23BF-44C4-AB16-70898500F218">
+              <dmn:text>"validate_asset_0014"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+              <dmn:text/>
+            </dmn:annotationEntry>
+          </dmn:rule>
+        </dmn:decisionTable>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:literalExpression id="_03CBF49D-E931-4AE7-8060-E29C51048484">
+          <dmn:text>{eligibilityStatus: calcResponse.eligibilityStatus, ruleIdentifier: calcResponse.ruleIdentifier, assetIdentifier:asset.label}</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmn:decisionService id="_324F55DB-9A6D-41E2-BBD5-D0EC07AFBBC4" name="DecisionService-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_0E6C393C-380E-4227-98EC-A9B38985913F" name="DecisionService-1"/>
+    <dmn:encapsulatedDecision href="#_DB154706-B3D6-45B1-A7D9-F9C79A22D79B"/>
+    <dmn:inputData href="#_147866D7-A820-4A13-8976-A4A5CDA674AE"/>
+    <dmn:inputData href="#_C3FE45D9-365E-4C70-923B-C061678E4847"/>
+  </dmn:decisionService>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_385830CA-B4CE-42D0-8173-2C61EF7A7ED0" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_F32FA782-EDEF-4B0A-ABDE-07149EFF915C">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>1082</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_514F8A0B-C4B6-4401-803F-931197CD8383">
+            <kie:width>50</kie:width>
+            <kie:width>132</kie:width>
+            <kie:width>216</kie:width>
+            <kie:width>245</kie:width>
+            <kie:width>136</kie:width>
+            <kie:width>183</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_03CBF49D-E931-4AE7-8060-E29C51048484">
+            <kie:width>1082</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_147866D7-A820-4A13-8976-A4A5CDA674AE" dmnElementRef="_147866D7-A820-4A13-8976-A4A5CDA674AE" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="170" y="279" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_C3FE45D9-365E-4C70-923B-C061678E4847" dmnElementRef="_C3FE45D9-365E-4C70-923B-C061678E4847" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="339" y="279" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_DB154706-B3D6-45B1-A7D9-F9C79A22D79B" dmnElementRef="_DB154706-B3D6-45B1-A7D9-F9C79A22D79B" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="245" y="150" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_324F55DB-9A6D-41E2-BBD5-D0EC07AFBBC4" dmnElementRef="_324F55DB-9A6D-41E2-BBD5-D0EC07AFBBC4" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="205" y="36" width="200" height="200"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="205" y="136"/>
+          <di:waypoint x="405" y="136"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_2E1BFCEB-0AFB-4050-8E29-6B60721E521F" dmnElementRef="_2E1BFCEB-0AFB-4050-8E29-6B60721E521F">
+        <di:waypoint x="220" y="304"/>
+        <di:waypoint x="295" y="200"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_EA627FF7-E1AA-46D5-B1D0-296077C3E87D" dmnElementRef="_EA627FF7-E1AA-46D5-B1D0-296077C3E87D">
+        <di:waypoint x="389" y="304"/>
+        <di:waypoint x="295" y="200"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>


### PR DESCRIPTION
**JIRA**: [KOGITO-2515](https://issues.redhat.com/browse/KOGITO-2515)

This issue is caused due the order of the `DMNShape` nodes in the .dmn files. If the Decision Service is before its children nodes, then it works. Otherwise it happens the scenario described in the JIRA (nodes in wrong position).

This PR ensure that all the Decision Nodes are positioned first when unmarshalling despite the order in the .dmn file.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
