### PR TITLE
Revert "DROOLS-5737: [DMN Designer] change in Decision Navigator does not dirty context (#3468)"

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSession.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSession.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
@@ -45,7 +44,6 @@ import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.client.mvp.LockRequiredEvent;
 
 import static java.util.Collections.emptyList;
 
@@ -63,8 +61,6 @@ public class DMNDiagramsSession implements GraphsProvider {
 
     private Map<String, DMNDiagramsSessionState> dmnSessionStatesByPathURI = new HashMap<>();
 
-    private Event<LockRequiredEvent> locker;
-
     public DMNDiagramsSession() {
         // CDI
     }
@@ -72,12 +68,10 @@ public class DMNDiagramsSession implements GraphsProvider {
     @Inject
     public DMNDiagramsSession(final ManagedInstance<DMNDiagramsSessionState> dmnDiagramsSessionStates,
                               final SessionManager sessionManager,
-                              final DMNDiagramUtils dmnDiagramUtils,
-                              final Event<LockRequiredEvent> locker) {
+                              final DMNDiagramUtils dmnDiagramUtils) {
         this.dmnDiagramsSessionStates = dmnDiagramsSessionStates;
         this.sessionManager = sessionManager;
         this.dmnDiagramUtils = dmnDiagramUtils;
-        this.locker = locker;
     }
 
     public void destroyState(final Metadata metadata) {
@@ -126,14 +120,12 @@ public class DMNDiagramsSession implements GraphsProvider {
         final String diagramId = dmnDiagram.getId().getValue();
         getSessionState().getDiagramsByDiagramId().put(diagramId, stunnerDiagram);
         getSessionState().getDMNDiagramsByDiagramId().put(diagramId, dmnDiagram);
-        locker.fire(new LockRequiredEvent());
     }
 
     public void remove(final DMNDiagramElement dmnDiagram) {
         final String diagramId = dmnDiagram.getId().getValue();
         getSessionState().getDiagramsByDiagramId().remove(diagramId);
         getSessionState().getDMNDiagramsByDiagramId().remove(diagramId);
-        locker.fire(new LockRequiredEvent());
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeView.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -42,7 +41,6 @@ import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem;
 import org.kie.workbench.common.dmn.client.editors.common.RemoveHelper;
-import org.uberfire.client.mvp.LockRequiredEvent;
 
 import static java.util.Optional.ofNullable;
 
@@ -184,8 +182,6 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
 
         private DecisionNavigatorItem item;
 
-        private final Event<LockRequiredEvent> locker;
-
         @Inject
         public TreeItem(final @Named("span") HTMLElement textContent,
                         final HTMLInputElement inputText,
@@ -193,8 +189,7 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
                         final HTMLUListElement subItems,
                         final @Named("i") HTMLElement save,
                         final @Named("i") HTMLElement edit,
-                        final @Named("i") HTMLElement remove,
-                        final Event<LockRequiredEvent> locker) {
+                        final @Named("i") HTMLElement remove) {
             this.textContent = textContent;
             this.inputText = inputText;
             this.icon = icon;
@@ -202,7 +197,6 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
             this.save = save;
             this.edit = edit;
             this.remove = remove;
-            this.locker = locker;
         }
 
         @EventHandler("icon")
@@ -240,12 +234,10 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
 
         @EventHandler("remove")
         public void onRemoveClick(final ClickEvent event) {
-            locker.fire(new LockRequiredEvent());
             getItem().onRemove();
         }
 
         void save() {
-            locker.fire(new LockRequiredEvent());
             getItem().setLabel(inputText.value);
             getElement().getClassList().remove("editing");
             updateLabel();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSessionTest.java
@@ -39,7 +39,6 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.mocks.EventSourceMock;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -80,9 +79,6 @@ public class DMNDiagramsSessionTest {
     @Mock
     private Diagram diagram;
 
-    @Mock
-    private EventSourceMock locker;
-
     private String uri = "://cyber/v.dmn";
 
     private Map<String, Diagram> diagramsByDiagramElementId = new HashMap<>();
@@ -97,7 +93,7 @@ public class DMNDiagramsSessionTest {
     public void setup() {
 
         dmnDiagramsSessionState = spy(new DMNDiagramsSessionState(dmnDiagramUtils));
-        dmnDiagramsSession = spy(new DMNDiagramsSession(dmnDiagramsSessionStates, sessionManager, dmnDiagramUtils, locker));
+        dmnDiagramsSession = spy(new DMNDiagramsSession(dmnDiagramsSessionStates, sessionManager, dmnDiagramUtils));
 
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(clientSession.getCanvasHandler()).thenReturn(canvasHandler);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeViewTest.java
@@ -42,13 +42,10 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItemBuilder;
 import org.mockito.Mock;
-import org.uberfire.client.mvp.LockRequiredEvent;
-import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem.Type.CONTEXT;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -93,9 +90,6 @@ public class DecisionNavigatorTreeViewTest {
     @Mock
     private HTMLUListElement subItems;
 
-    @Mock
-    private EventSourceMock<LockRequiredEvent> locker;
-
     private DecisionNavigatorTreeView treeView;
 
     private DecisionNavigatorTreeView.TreeItem treeItem;
@@ -103,7 +97,7 @@ public class DecisionNavigatorTreeViewTest {
     @Before
     public void setup() {
         treeView = spy(new DecisionNavigatorTreeView(view, items, managedInstance, util));
-        treeItem = spy(new DecisionNavigatorTreeView.TreeItem(textContent, inputText, icon, subItems, save, edit, remove, locker));
+        treeItem = spy(new DecisionNavigatorTreeView.TreeItem(textContent, inputText, icon, subItems, save, edit, remove));
     }
 
     @Test
@@ -329,7 +323,6 @@ public class DecisionNavigatorTreeViewTest {
         treeItem.onRemoveClick(event);
 
         verify(item).onRemove();
-        verify(locker).fire(any());
     }
 
     @Test
@@ -350,7 +343,6 @@ public class DecisionNavigatorTreeViewTest {
         verify(tokenList).remove("editing");
         verify(treeItem).updateLabel();
         verify(item).onUpdate();
-        verify(locker).fire(any());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -17,7 +17,6 @@ package org.kie.workbench.common.dmn.project.client.editor;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -39,8 +38,6 @@ import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.docks.navigator.common.LazyCanvasFocusUtils;
-import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramTuple;
-import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramsSession;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
@@ -75,7 +72,6 @@ import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
 import org.kie.workbench.common.stunner.core.diagram.DiagramParsingException;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
-import org.kie.workbench.common.stunner.core.util.HashUtil;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.kie.workbench.common.stunner.kogito.client.editor.AbstractDiagramEditorMenuSessionItems;
@@ -140,7 +136,6 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
     private final ReadOnlyProvider readOnlyProvider;
     private final DRDNameChanger drdNameChanger;
     private final LazyCanvasFocusUtils lazyCanvasFocusUtils;
-    private final DMNDiagramsSession dmnDiagramsSession;
 
     @Inject
     public DMNDiagramEditor(final View view,
@@ -171,9 +166,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final SearchBarComponent<DMNSearchableElement> searchBarComponent,
                             final MonacoFEELInitializer feelInitializer,
                             final @DMNEditor ReadOnlyProvider readOnlyProvider,
-                            final DRDNameChanger drdNameChanger,
-                            final LazyCanvasFocusUtils lazyCanvasFocusUtils,
-                            final DMNDiagramsSession dmnDiagramsSession) {
+                            final DRDNameChanger drdNameChanger, final LazyCanvasFocusUtils lazyCanvasFocusUtils) {
         super(view,
               xmlEditorView,
               editorSessionPresenterInstances,
@@ -204,7 +197,6 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         this.readOnlyProvider = readOnlyProvider;
         this.drdNameChanger = drdNameChanger;
         this.lazyCanvasFocusUtils = lazyCanvasFocusUtils;
-        this.dmnDiagramsSession = dmnDiagramsSession;
     }
 
     @Override
@@ -265,17 +257,6 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                     }
                 };
             }
-
-            @Override
-            protected int getDiagramHashCode() {
-                int hash = 0;
-                for (final DMNDiagramTuple dmnDiagram : dmnDiagramsSession.getDMNDiagrams()) {
-                    hash = HashUtil.combineHashCodes(hash,
-                                                     dmnDiagram.getStunnerDiagram().hashCode(),
-                                                     dmnDiagram.getDMNDiagram().hashCode());
-                }
-                return hash;
-            }
         };
     }
 
@@ -311,19 +292,8 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         setupSearchComponent();
     }
 
-    @Override
-    protected void updateOriginalHash() {
-        if (Objects.isNull(originalHash) || Objects.equals(originalHash, 0)) {
-            setOriginalHash(getCurrentDiagramHash());
-        }
-    }
-
     void superInitialiseKieEditorForSession(final ProjectDiagram diagram) {
         super.initialiseKieEditorForSession(diagram);
-    }
-
-    Integer getOriginalHash() {
-        return originalHash;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -36,7 +36,6 @@ import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.docks.navigator.common.LazyCanvasFocusUtils;
-import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramsSession;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
@@ -200,9 +199,6 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     @Mock
     private ElementWrapperWidget drdNameWidget;
 
-    @Mock
-    private DMNDiagramsSession dmnDiagramsSession;
-
     @Captor
     private ArgumentCaptor<Consumer<String>> errorConsumerCaptor;
 
@@ -265,8 +261,7 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                  feelInitializer,
                                                  readOnlyProvider,
                                                  drdNameChanger,
-                                                 lazyCanvasFocusUtils,
-                                                 dmnDiagramsSession) {
+                                                 lazyCanvasFocusUtils) {
             {
                 docks = DMNDiagramEditorTest.this.docks;
                 fileMenuBuilder = DMNDiagramEditorTest.this.fileMenuBuilder;
@@ -630,23 +625,5 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         super.testLoadContentWithInvalidFile();
 
         verify(feelInitializer, never()).initializeFEELEditor();
-    }
-
-    @Test
-    public void testUpdateOriginalHash() {
-
-        final Integer currentHash = 27;
-        final Integer previousSetHash = 5;
-        doReturn(currentHash).when(diagramEditor).getCurrentDiagramHash();
-
-        diagramEditor.setOriginalHash(0);
-        diagramEditor.updateOriginalHash();
-
-        assertEquals(currentHash, diagramEditor.getOriginalHash());
-
-        diagramEditor.setOriginalHash(previousSetHash);
-        diagramEditor.updateOriginalHash();
-
-        assertEquals(previousSetHash, diagramEditor.getOriginalHash());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditorCore.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditorCore.java
@@ -124,38 +124,31 @@ public abstract class AbstractDiagramEditorCore<M extends Metadata, D extends Di
     public P makeStunnerEditorProxy() {
         final P proxy = makeEditorProxy();
         proxy.setContentSupplier(() -> makeDiagramResourceImpl(getDiagram()));
-        proxy.setHashCodeSupplier(() -> getHashCodeSupplier());
+        proxy.setHashCodeSupplier(() -> {
+            if (null == getDiagram()) {
+                return 0;
+            }
+            int hash = getDiagram().hashCode();
+            if (null == getCanvasHandler() ||
+                    null == getCanvasHandler().getCanvas() ||
+                    null == getCanvasHandler().getCanvas().getShapes()) {
+                return hash;
+            }
+            Collection<Shape> collectionOfShapes = getCanvasHandler().getCanvas().getShapes();
+            ArrayList<Shape> shapes = new ArrayList<>();
+            shapes.addAll(collectionOfShapes);
+            shapes.sort((a, b) -> (a.getShapeView().getShapeX() == b.getShapeView().getShapeX()) ?
+                    (int) Math.round(a.getShapeView().getShapeY() - b.getShapeView().getShapeY()) :
+                    (int) Math.round(a.getShapeView().getShapeX() - b.getShapeView().getShapeX()));
+            for (Shape shape : shapes) {
+                hash = HashUtil.combineHashCodes(hash,
+                                                 Double.hashCode(shape.getShapeView().getShapeX()),
+                                                 Double.hashCode(shape.getShapeView().getShapeY()));
+            }
+            return hash;
+        });
 
         return proxy;
-    }
-
-    protected int getHashCodeSupplier(){
-        return HashUtil.combineHashCodes(getDiagramHashCode(), getShapesHashCode());
-    }
-
-    protected int getDiagramHashCode() {
-        return getDiagram().hashCode();
-    }
-
-    protected int getShapesHashCode() {
-        int hash = 0;
-        if (null == getCanvasHandler() ||
-                null == getCanvasHandler().getCanvas() ||
-                null == getCanvasHandler().getCanvas().getShapes()) {
-            return hash;
-        }
-        Collection<Shape> collectionOfShapes = getCanvasHandler().getCanvas().getShapes();
-        ArrayList<Shape> shapes = new ArrayList<>();
-        shapes.addAll(collectionOfShapes);
-        shapes.sort((a, b) -> (a.getShapeView().getShapeX() == b.getShapeView().getShapeX()) ?
-                (int) Math.round(a.getShapeView().getShapeY() - b.getShapeView().getShapeY()) :
-                (int) Math.round(a.getShapeView().getShapeX() - b.getShapeView().getShapeX()));
-        for (Shape shape : shapes) {
-            hash = HashUtil.combineHashCodes(hash,
-                                             Double.hashCode(shape.getShapeView().getShapeX()),
-                                             Double.hashCode(shape.getShapeView().getShapeY()));
-        }
-        return hash;
     }
 
     public P makeXmlEditorProxy() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -610,13 +610,9 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
         resetEditorPages(diagram.getMetadata().getOverview());
         updateTitle(diagram.getName());
         addDocumentationPage(diagram);
-        updateOriginalHash();
+        setOriginalHash(getCurrentDiagramHash());
         hideLoadingViews();
         onDiagramLoad();
-    }
-
-    protected void updateOriginalHash() {
-        setOriginalHash(getCurrentDiagramHash());
     }
 
     protected void destroySession() {


### PR DESCRIPTION
This reverts https://github.com/kiegroup/kie-wb-common/pull/3468 as it breaks the `AbstractProjectDiagramEditorTest` tests.
