### PR TITLE
Revert "Revert "DROOLS-5737: [DMN Designer] change in Decision Navigator does not dirty context"

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeView.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -41,6 +42,7 @@ import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem;
 import org.kie.workbench.common.dmn.client.editors.common.RemoveHelper;
+import org.uberfire.client.mvp.LockRequiredEvent;
 
 import static java.util.Optional.ofNullable;
 
@@ -182,6 +184,8 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
 
         private DecisionNavigatorItem item;
 
+        private final Event<LockRequiredEvent> locker;
+
         @Inject
         public TreeItem(final @Named("span") HTMLElement textContent,
                         final HTMLInputElement inputText,
@@ -189,7 +193,8 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
                         final HTMLUListElement subItems,
                         final @Named("i") HTMLElement save,
                         final @Named("i") HTMLElement edit,
-                        final @Named("i") HTMLElement remove) {
+                        final @Named("i") HTMLElement remove,
+                        final Event<LockRequiredEvent> locker) {
             this.textContent = textContent;
             this.inputText = inputText;
             this.icon = icon;
@@ -197,6 +202,7 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
             this.save = save;
             this.edit = edit;
             this.remove = remove;
+            this.locker = locker;
         }
 
         @EventHandler("icon")
@@ -234,10 +240,12 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
 
         @EventHandler("remove")
         public void onRemoveClick(final ClickEvent event) {
+            locker.fire(new LockRequiredEvent());
             getItem().onRemove();
         }
 
         void save() {
+            locker.fire(new LockRequiredEvent());
             getItem().setLabel(inputText.value);
             getElement().getClassList().remove("editing");
             updateLabel();

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSessionTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/drds/DMNDiagramsSessionTest.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.mocks.EventSourceMock;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -79,6 +80,9 @@ public class DMNDiagramsSessionTest {
     @Mock
     private Diagram diagram;
 
+    @Mock
+    private EventSourceMock locker;
+
     private String uri = "://cyber/v.dmn";
 
     private Map<String, Diagram> diagramsByDiagramElementId = new HashMap<>();
@@ -93,7 +97,7 @@ public class DMNDiagramsSessionTest {
     public void setup() {
 
         dmnDiagramsSessionState = spy(new DMNDiagramsSessionState(dmnDiagramUtils));
-        dmnDiagramsSession = spy(new DMNDiagramsSession(dmnDiagramsSessionStates, sessionManager, dmnDiagramUtils));
+        dmnDiagramsSession = spy(new DMNDiagramsSession(dmnDiagramsSessionStates, sessionManager, dmnDiagramUtils, locker));
 
         when(canvasHandler.getDiagram()).thenReturn(diagram);
         when(clientSession.getCanvasHandler()).thenReturn(canvasHandler);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeViewTest.java
@@ -42,10 +42,13 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItemBuilder;
 import org.mockito.Mock;
+import org.uberfire.client.mvp.LockRequiredEvent;
+import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem.Type.CONTEXT;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -90,6 +93,9 @@ public class DecisionNavigatorTreeViewTest {
     @Mock
     private HTMLUListElement subItems;
 
+    @Mock
+    private EventSourceMock<LockRequiredEvent> locker;
+
     private DecisionNavigatorTreeView treeView;
 
     private DecisionNavigatorTreeView.TreeItem treeItem;
@@ -97,7 +103,7 @@ public class DecisionNavigatorTreeViewTest {
     @Before
     public void setup() {
         treeView = spy(new DecisionNavigatorTreeView(view, items, managedInstance, util));
-        treeItem = spy(new DecisionNavigatorTreeView.TreeItem(textContent, inputText, icon, subItems, save, edit, remove));
+        treeItem = spy(new DecisionNavigatorTreeView.TreeItem(textContent, inputText, icon, subItems, save, edit, remove, locker));
     }
 
     @Test
@@ -323,6 +329,7 @@ public class DecisionNavigatorTreeViewTest {
         treeItem.onRemoveClick(event);
 
         verify(item).onRemove();
+        verify(locker).fire(any());
     }
 
     @Test
@@ -343,6 +350,7 @@ public class DecisionNavigatorTreeViewTest {
         verify(tokenList).remove("editing");
         verify(treeItem).updateLabel();
         verify(item).onUpdate();
+        verify(locker).fire(any());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.project.client.editor;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -38,6 +39,8 @@ import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.docks.navigator.common.LazyCanvasFocusUtils;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramTuple;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramsSession;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
@@ -72,6 +75,7 @@ import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
 import org.kie.workbench.common.stunner.core.diagram.DiagramParsingException;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.core.util.HashUtil;
 import org.kie.workbench.common.stunner.core.validation.DiagramElementViolation;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
 import org.kie.workbench.common.stunner.kogito.client.editor.AbstractDiagramEditorMenuSessionItems;
@@ -136,6 +140,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
     private final ReadOnlyProvider readOnlyProvider;
     private final DRDNameChanger drdNameChanger;
     private final LazyCanvasFocusUtils lazyCanvasFocusUtils;
+    private final DMNDiagramsSession dmnDiagramsSession;
 
     @Inject
     public DMNDiagramEditor(final View view,
@@ -166,7 +171,9 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                             final SearchBarComponent<DMNSearchableElement> searchBarComponent,
                             final MonacoFEELInitializer feelInitializer,
                             final @DMNEditor ReadOnlyProvider readOnlyProvider,
-                            final DRDNameChanger drdNameChanger, final LazyCanvasFocusUtils lazyCanvasFocusUtils) {
+                            final DRDNameChanger drdNameChanger,
+                            final LazyCanvasFocusUtils lazyCanvasFocusUtils,
+                            final DMNDiagramsSession dmnDiagramsSession) {
         super(view,
               xmlEditorView,
               editorSessionPresenterInstances,
@@ -197,6 +204,7 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         this.readOnlyProvider = readOnlyProvider;
         this.drdNameChanger = drdNameChanger;
         this.lazyCanvasFocusUtils = lazyCanvasFocusUtils;
+        this.dmnDiagramsSession = dmnDiagramsSession;
     }
 
     @Override
@@ -257,6 +265,17 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
                     }
                 };
             }
+
+            @Override
+            protected int getDiagramHashCode() {
+                int hash = 0;
+                for (final DMNDiagramTuple dmnDiagram : dmnDiagramsSession.getDMNDiagrams()) {
+                    hash = HashUtil.combineHashCodes(hash,
+                                                     dmnDiagram.getStunnerDiagram().hashCode(),
+                                                     dmnDiagram.getDMNDiagram().hashCode());
+                }
+                return hash;
+            }
         };
     }
 
@@ -292,8 +311,19 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         setupSearchComponent();
     }
 
+    @Override
+    protected void updateOriginalHash() {
+        if (Objects.isNull(originalHash) || Objects.equals(originalHash, 0)) {
+            setOriginalHash(getCurrentDiagramHash());
+        }
+    }
+
     void superInitialiseKieEditorForSession(final ProjectDiagram diagram) {
         super.initialiseKieEditorForSession(diagram);
+    }
+
+    Integer getOriginalHash() {
+        return originalHash;
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -268,6 +268,10 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
 
             @Override
             protected int getDiagramHashCode() {
+                if (Objects.isNull(dmnDiagramsSession.getDMNDiagrams()) ||
+                        dmnDiagramsSession.getDMNDiagrams().isEmpty()) {
+                    return super.getDiagramHashCode();
+                }
                 int hash = 0;
                 for (final DMNDiagramTuple dmnDiagram : dmnDiagramsSession.getDMNDiagrams()) {
                     hash = HashUtil.combineHashCodes(hash,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.docks.navigator.common.LazyCanvasFocusUtils;
+import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramsSession;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
@@ -199,6 +200,9 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     @Mock
     private ElementWrapperWidget drdNameWidget;
 
+    @Mock
+    private DMNDiagramsSession dmnDiagramsSession;
+
     @Captor
     private ArgumentCaptor<Consumer<String>> errorConsumerCaptor;
 
@@ -261,7 +265,8 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
                                                  feelInitializer,
                                                  readOnlyProvider,
                                                  drdNameChanger,
-                                                 lazyCanvasFocusUtils) {
+                                                 lazyCanvasFocusUtils,
+                                                 dmnDiagramsSession) {
             {
                 docks = DMNDiagramEditorTest.this.docks;
                 fileMenuBuilder = DMNDiagramEditorTest.this.fileMenuBuilder;
@@ -625,5 +630,23 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         super.testLoadContentWithInvalidFile();
 
         verify(feelInitializer, never()).initializeFEELEditor();
+    }
+
+    @Test
+    public void testUpdateOriginalHash() {
+
+        final Integer currentHash = 27;
+        final Integer previousSetHash = 5;
+        doReturn(currentHash).when(diagramEditor).getCurrentDiagramHash();
+
+        diagramEditor.setOriginalHash(0);
+        diagramEditor.updateOriginalHash();
+
+        assertEquals(currentHash, diagramEditor.getOriginalHash());
+
+        diagramEditor.setOriginalHash(previousSetHash);
+        diagramEditor.updateOriginalHash();
+
+        assertEquals(previousSetHash, diagramEditor.getOriginalHash());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditorCore.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditorCore.java
@@ -124,31 +124,38 @@ public abstract class AbstractDiagramEditorCore<M extends Metadata, D extends Di
     public P makeStunnerEditorProxy() {
         final P proxy = makeEditorProxy();
         proxy.setContentSupplier(() -> makeDiagramResourceImpl(getDiagram()));
-        proxy.setHashCodeSupplier(() -> {
-            if (null == getDiagram()) {
-                return 0;
-            }
-            int hash = getDiagram().hashCode();
-            if (null == getCanvasHandler() ||
-                    null == getCanvasHandler().getCanvas() ||
-                    null == getCanvasHandler().getCanvas().getShapes()) {
-                return hash;
-            }
-            Collection<Shape> collectionOfShapes = getCanvasHandler().getCanvas().getShapes();
-            ArrayList<Shape> shapes = new ArrayList<>();
-            shapes.addAll(collectionOfShapes);
-            shapes.sort((a, b) -> (a.getShapeView().getShapeX() == b.getShapeView().getShapeX()) ?
-                    (int) Math.round(a.getShapeView().getShapeY() - b.getShapeView().getShapeY()) :
-                    (int) Math.round(a.getShapeView().getShapeX() - b.getShapeView().getShapeX()));
-            for (Shape shape : shapes) {
-                hash = HashUtil.combineHashCodes(hash,
-                                                 Double.hashCode(shape.getShapeView().getShapeX()),
-                                                 Double.hashCode(shape.getShapeView().getShapeY()));
-            }
-            return hash;
-        });
+        proxy.setHashCodeSupplier(() -> getHashCodeSupplier());
 
         return proxy;
+    }
+
+    protected int getHashCodeSupplier(){
+        return HashUtil.combineHashCodes(getDiagramHashCode(), getShapesHashCode());
+    }
+
+    protected int getDiagramHashCode() {
+        return getDiagram().hashCode();
+    }
+
+    protected int getShapesHashCode() {
+        int hash = 0;
+        if (null == getCanvasHandler() ||
+                null == getCanvasHandler().getCanvas() ||
+                null == getCanvasHandler().getCanvas().getShapes()) {
+            return hash;
+        }
+        Collection<Shape> collectionOfShapes = getCanvasHandler().getCanvas().getShapes();
+        ArrayList<Shape> shapes = new ArrayList<>();
+        shapes.addAll(collectionOfShapes);
+        shapes.sort((a, b) -> (a.getShapeView().getShapeX() == b.getShapeView().getShapeX()) ?
+                (int) Math.round(a.getShapeView().getShapeY() - b.getShapeView().getShapeY()) :
+                (int) Math.round(a.getShapeView().getShapeX() - b.getShapeView().getShapeX()));
+        for (Shape shape : shapes) {
+            hash = HashUtil.combineHashCodes(hash,
+                                             Double.hashCode(shape.getShapeView().getShapeX()),
+                                             Double.hashCode(shape.getShapeView().getShapeY()));
+        }
+        return hash;
     }
 
     public P makeXmlEditorProxy() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditorCore.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-kogito/kie-wb-common-stunner-kogito-client/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/AbstractDiagramEditorCore.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.kogito.client.editor;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -129,7 +130,10 @@ public abstract class AbstractDiagramEditorCore<M extends Metadata, D extends Di
         return proxy;
     }
 
-    protected int getHashCodeSupplier(){
+    protected int getHashCodeSupplier() {
+        if (Objects.equals(getShapesHashCode(), 0)) {
+            return getDiagramHashCode();
+        }
         return HashUtil.combineHashCodes(getDiagramHashCode(), getShapesHashCode());
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/editor/AbstractProjectDiagramEditor.java
@@ -610,9 +610,13 @@ public abstract class AbstractProjectDiagramEditor<R extends ClientResourceType>
         resetEditorPages(diagram.getMetadata().getOverview());
         updateTitle(diagram.getName());
         addDocumentationPage(diagram);
-        setOriginalHash(getCurrentDiagramHash());
+        updateOriginalHash();
         hideLoadingViews();
         onDiagramLoad();
+    }
+
+    protected void updateOriginalHash() {
+        setOriginalHash(getCurrentDiagramHash());
     }
 
     protected void destroySession() {


### PR DESCRIPTION
The original PR was already tested and merged, but it have some test issues (we didn't waited for the green build).

Then the original PR was reverted.

And this is just the "revert of the revert" with the fixed tests. There's really nothing to test, just asking for @jstastny-cz and @vpellegrino to take a look to see if is ok to merge.

Now we have a green.

ORIGINAL PR MERGED: https://github.com/kiegroup/kie-wb-common/pull/3468

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
