### PR TITLE
[backport-7.44.x] AF-2540: Issue re-importing a repository initially created by importing an empty repository in Business Central

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/BaseProjectImportService.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/BaseProjectImportService.java
@@ -279,7 +279,7 @@ public abstract class BaseProjectImportService implements ImportService {
         }
 
         if (gitRepository.getBranches().isEmpty()) {
-            throw new EmptyRemoteRepositoryException(gitRepository.getAlias());
+            throw new EmptyRemoteRepositoryException(getRepositoryAlias(repository.getUrl()));
         }
 
         Set<ImportProject> importProjects = convert(gitRepository.getBranch("master").get(),
@@ -325,6 +325,9 @@ public abstract class BaseProjectImportService implements ImportService {
         // Signal creation of new Project (Creation of OU and Repository, if applicable,
         // are already handled in the corresponding services).
         WorkspaceProject project = projectService.resolveProject(importedRepo);
+
+        // delete the transient repo created in system folder
+        ioService.deleteIfExists(rootPath.getFileSystem().getPath(null));
         return project;
     }
 

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/main/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImpl.java
@@ -17,6 +17,7 @@
 
 package org.kie.workbench.common.screens.examples.backend.server;
 
+import java.time.LocalTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +93,7 @@ public class ProjectImportServiceImpl extends BaseProjectImportService implement
 
         try {
             String url = repository.getUrl();
-            final String alias = getRepositoryAlias(url);
+            final String alias = getRepositoryAlias(url) + "_" + LocalTime.now().toString();
             Credentials credentials = repository.getCredentials();
             String username = null;
             String password = null;

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/src/test/java/org/kie/workbench/common/screens/examples/backend/server/ProjectImportServiceImplTest.java
@@ -68,6 +68,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
 import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
 import org.uberfire.java.nio.fs.jgit.JGitPathImpl;
@@ -86,6 +87,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.spy;
@@ -417,6 +419,7 @@ public class ProjectImportServiceImplTest {
         when(importProject.getSelectedBranches()).thenReturn(branches);
 
         org.uberfire.java.nio.file.Path p = mock(org.uberfire.java.nio.file.Path.class);
+        when(p.getFileSystem()).thenReturn(mock(FileSystem.class));
         doReturn(p).when(pathUtil).convert(any(org.uberfire.backend.vfs.Path.class));
         when(service.getProjectRoot(any(ImportProject.class))).thenReturn(p);
 
@@ -462,8 +465,12 @@ public class ProjectImportServiceImplTest {
 
         final ImportProject importProject = mock(ImportProject.class);
         final Path rootPath = mock(Path.class);
+
         final org.uberfire.java.nio.file.Path convertedRootPath = mock(org.uberfire.java.nio.file.Path.class);
-        when(pathUtil.convert(any(Path.class))).thenReturn(convertedRootPath);
+        when(convertedRootPath.getFileSystem()).thenReturn(mock(FileSystem.class));
+
+        when(service.getProjectRoot(rootPath)).thenReturn(convertedRootPath);
+
         when(importProject.getCredentials()).thenReturn(new Credentials(username,
                                                                         password));
         when(importProject.getRoot()).thenReturn(rootPath);
@@ -472,6 +479,7 @@ public class ProjectImportServiceImplTest {
 
         when(importProject.getSelectedBranches()).thenReturn(branches);
 
+        when(service.getProjectRoot(importProject)).thenReturn(convertedRootPath);
         service.importProject(organizationalUnit,
                               importProject);
 
@@ -496,7 +504,9 @@ public class ProjectImportServiceImplTest {
         final ImportProject importProject = mock(ImportProject.class);
         final Path rootPath = mock(Path.class);
         final org.uberfire.java.nio.file.Path convertedRootPath = mock(org.uberfire.java.nio.file.Path.class);
-        when(pathUtil.convert(any(Path.class))).thenReturn(convertedRootPath);
+        when(convertedRootPath.getFileSystem()).thenReturn(mock(FileSystem.class));
+
+        when(service.getProjectRoot(rootPath)).thenReturn(convertedRootPath);
         when(importProject.getCredentials()).thenReturn(new Credentials(username,
                                                                         password));
         when(importProject.getRoot()).thenReturn(rootPath);
@@ -504,7 +514,7 @@ public class ProjectImportServiceImplTest {
         when(importProject.getOrigin()).thenReturn(origin);
 
         when(importProject.getSelectedBranches()).thenReturn(branches);
-
+        when(service.getProjectRoot(importProject)).thenReturn(convertedRootPath);
         service.importProject(organizationalUnit,
                               importProject);
 
@@ -536,6 +546,7 @@ public class ProjectImportServiceImplTest {
         when(importProject.getSelectedBranches()).thenReturn(branches);
 
         org.uberfire.java.nio.file.Path p = mock(org.uberfire.java.nio.file.Path.class);
+        when(p.getFileSystem()).thenReturn(mock(FileSystem.class));
         doReturn(p).when(pathUtil).convert(any(org.uberfire.backend.vfs.Path.class));
         when(service.getProjectRoot(any(ImportProject.class))).thenReturn(p);
 
@@ -575,8 +586,10 @@ public class ProjectImportServiceImplTest {
         organizationalUnit.getRepositories();
 
         final Path exampleRoot = mock(Path.class);
-        final org.uberfire.java.nio.file.Path exampleRootNioPath = mock(org.uberfire.java.nio.file.Path.class);
-        when(pathUtil.convert(exampleRoot)).thenReturn(exampleRootNioPath);
+        org.uberfire.java.nio.file.Path fspath = mock(org.uberfire.java.nio.file.Path.class);
+        final JGitFileSystem fileSystem = mock(JGitFileSystem.class);
+        doReturn(fileSystem).when(fspath).getFileSystem();
+        final org.uberfire.java.nio.file.Path exampleRootNioPath = fspath;
         String repoURL = "file:///some/repo/url";
         final ImportProject importProject = new ImportProject(exampleRoot,
                                                               "example",
@@ -598,6 +611,7 @@ public class ProjectImportServiceImplTest {
                                           eq(GitRepository.SCHEME.toString()),
                                           any(),
                                           any())).thenReturn(repository);
+        when(service.getProjectRoot(importProject)).thenReturn(exampleRootNioPath);
 
         final WorkspaceProject importedProject = service.importProject(organizationalUnit,
                                                                        importProject);
@@ -623,8 +637,10 @@ public class ProjectImportServiceImplTest {
         organizationalUnit.getRepositories();
 
         final Path exampleRoot = mock(Path.class);
-        final org.uberfire.java.nio.file.Path exampleRootNioPath = mock(org.uberfire.java.nio.file.Path.class);
-        when(pathUtil.convert(exampleRoot)).thenReturn(exampleRootNioPath);
+        org.uberfire.java.nio.file.Path fspath = mock(org.uberfire.java.nio.file.Path.class);
+        final JGitFileSystem fileSystem = mock(JGitFileSystem.class);
+        doReturn(fileSystem).when(fspath).getFileSystem();
+        final org.uberfire.java.nio.file.Path exampleRootNioPath = fspath;
         String repoURL = "file:///C:/some/repo/url";
         final ImportProject importProject = new ImportProject(exampleRoot,
                                                               "example",
@@ -646,7 +662,7 @@ public class ProjectImportServiceImplTest {
                                           eq(GitRepository.SCHEME.toString()),
                                           any(),
                                           any())).thenReturn(repository);
-
+        when(service.getProjectRoot(importProject)).thenReturn(exampleRootNioPath);
         final WorkspaceProject importedProject = service.importProject(organizationalUnit,
                                                                        importProject);
 
@@ -682,7 +698,7 @@ public class ProjectImportServiceImplTest {
                                                                                        true);
         final org.uberfire.java.nio.file.Path repoRoot = exampleRootNioPath.getParent();
         when(fs.getRootDirectories()).thenReturn(() -> Stream.of(repoRoot).iterator());
-        when(pathUtil.convert(exampleRoot)).thenReturn(exampleRootNioPath);
+
         when(pathUtil.stripProtocolAndBranch(any())).then(inv -> realPathUtil.stripProtocolAndBranch(inv.getArgumentAt(0,
                                                                                                                        String.class)));
         when(pathUtil.stripRepoNameAndSpace(any())).then(inv -> realPathUtil.stripRepoNameAndSpace(inv.getArgumentAt(0,
@@ -698,7 +714,7 @@ public class ProjectImportServiceImplTest {
                                                               "description",
                                                               repoURL,
                                                               emptyList());
-
+        when(service.getProjectRoot(importProject)).thenReturn(exampleRootNioPath);
         when(pathUtil.getNiogitRepoPath(any())).thenReturn(repoURL);
 
         final Repository repository = new GitRepository("example",


### PR DESCRIPTION

(cherry picked from commit a727da4a504540399767c47d26a776118a488c13)

**Thank you for submitting this pull request**

**AF-2540**: [AF-2540](https://issues.redhat.com/browse/AF-2540)

**Referenced Pull Requests**:
backport for https://github.com/kiegroup/kie-wb-common/pull/3492

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
