### PR TITLE
[7.44.x] DROOLS-5808 : XLS to GDST conversion should ensure types work

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/ConversionMessageWidget.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/ConversionMessageWidget.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.list;
+
+import com.google.gwt.cell.client.TextCell;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+import org.kie.workbench.common.widgets.client.resources.CommonImages;
+import org.kie.workbench.common.widgets.client.widget.WidthCalculator;
+
+/**
+ * A widget to display a single conversion result message
+ */
+public class ConversionMessageWidget extends Composite {
+
+    private static WidthCalculator<String> widthCalculator = new WidthCalculator<>(new TextCell());
+
+    @UiField
+    Image image;
+
+    @UiField
+    Label label;
+
+    interface ConversionMessageWidgetBinder
+            extends
+            UiBinder<Widget, ConversionMessageWidget> {
+
+    }
+
+    private static ConversionMessageWidgetBinder uiBinder = GWT.create(ConversionMessageWidgetBinder.class);
+
+    public ConversionMessageWidget(final MessageType messageType, final String message) {
+        initWidget(uiBinder.createAndBindUi(this));
+
+        switch (messageType) {
+            case ERROR:
+                this.image.setResource(CommonImages.INSTANCE.error());
+                break;
+            case INFO:
+                this.image.setResource(CommonImages.INSTANCE.information());
+                break;
+            case WARNING:
+                this.image.setResource(CommonImages.INSTANCE.warning());
+                break;
+            default:
+                throw new IllegalStateException("Unknown message type: " + messageType);
+        }
+        this.label.setText(message);
+
+        //Make containing Panel the width of the content to ensure scroll bars operate correctly
+        int width = widthCalculator.getElementWidth(message) + 32;
+        setWidth(width + "px");
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/ConversionMessageWidget.ui.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/ConversionMessageWidget.ui.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:gwt='urn:import:com.google.gwt.user.client.ui'>
+
+  <gwt:HorizontalPanel width="500px">
+    <gwt:Image ui:field="image"/>
+    <gwt:Label ui:field="label"/>
+  </gwt:HorizontalPanel>
+
+</ui:UiBinder>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/MessageType.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/MessageType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.widgets.client.popups.list;
+
+public enum MessageType {
+    INFO,
+    WARNING,
+    ERROR
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/PopupListWidget.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/PopupListWidget.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.list;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKButton;
+
+/**
+ * A popup that can contain a list of items
+ */
+public class PopupListWidget extends BaseModal {
+
+    interface PopupListWidgetBinder
+            extends
+            UiBinder<Widget, PopupListWidget> {
+
+    }
+
+    private static PopupListWidgetBinder uiBinder = GWT.create(PopupListWidgetBinder.class);
+
+    @UiField
+    protected VerticalPanel list;
+
+    public PopupListWidget() {
+        setWidth("900px");
+
+        setBody(uiBinder.createAndBindUi(this));
+        add(new ModalFooterOKButton(() -> hide()));
+    }
+
+    @Override
+    public void clear() {
+        list.clear();
+    }
+
+    public void addListMessage(final MessageType messageType,
+                               final String message) {
+        this.list.add(new ConversionMessageWidget(messageType,
+                                                  message));
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/PopupListWidget.ui.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/list/PopupListWidget.ui.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+             xmlns:g="urn:import:com.google.gwt.user.client.ui"
+             xmlns:b="urn:import:org.gwtbootstrap3.client.ui">
+
+  <b:Well>
+    <g:ScrollPanel width="100%" height="200px">
+      <g:VerticalPanel ui:field="list"/>
+    </g:ScrollPanel>
+  </b:Well>
+
+</ui:UiBinder>


### PR DESCRIPTION
DROOLS-5807 : GDST to XLS conversion should not convert dialect column

(cherry picked from commit e141e9e22190200b2b23840139ea0b020ade6d75)

Moving few classes from drools-wb so they can be used by both GDST->XLS and XLS-GDST conversion.

**JIRA**: [DROOLS-5807](https://issues.redhat.com/browse/DROOLS-5807)
**JIRA**: [DROOLS-5808](https://issues.redhat.com/browse/DROOLS-5808)

 
**Referenced Pull Requests**:
* https://github.com/kiegroup/kie-wb-common/pull/3497
* https://github.com/kiegroup/drools-wb/pull/1444

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
