### PR TITLE
JBPM-9393 'Add Deployment unit' Fields are missing while creating new

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/NewContainerWizard.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/NewContainerWizard.java
@@ -184,6 +184,7 @@ public class NewContainerWizard extends AbstractMultiPageWizard {
     @Override
     public void pageSelected(final int pageNumber) {
         if (this.getSelectedPage() == pageNumber) {
+            super.pageSelected(pageNumber);
             return;
         }
 

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/wizard/NewContainerWizardTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/wizard/NewContainerWizardTest.java
@@ -293,6 +293,16 @@ public class NewContainerWizardTest {
     }
 
     @Test
+    public void testPageSelectedInSamePage() {
+        preparePageSelected();
+        newContainerWizard.setCurrentPageIndex(0);
+        newContainerWizard.pageSelected(0);
+        verify(view, times(2)).setBodyWidget(any());
+        verify(dependencyPathSelectedEvent, never()).fire(any());
+        verify(notification, never()).fire(any());
+    }
+
+    @Test
     public void testPageSelectedIsSelected() {
         preparePageSelected();
         newContainerWizard.isSelected = true;


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [JBPM-9393](https://issues.redhat.com/browse/JBPM-9393)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
