### PR TITLE
KOGITO-3905: DMN readonly mode allows clear of decision expression

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditBusinessKnowledgeModelToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditBusinessKnowledgeModelToolboxAction.java
@@ -23,7 +23,9 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
+import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
@@ -48,14 +50,17 @@ public class DMNEditBusinessKnowledgeModelToolboxAction implements ToolboxAction
     private final SessionManager sessionManager;
     private final ClientTranslationService translationService;
     private final Event<EditExpressionEvent> editExpressionEvent;
+    private final ReadOnlyProvider readOnlyProvider;
 
     @Inject
     public DMNEditBusinessKnowledgeModelToolboxAction(final SessionManager sessionManager,
                                                       final ClientTranslationService translationService,
-                                                      final Event<EditExpressionEvent> editExpressionEvent) {
+                                                      final Event<EditExpressionEvent> editExpressionEvent,
+                                                      final @DMNEditor ReadOnlyProvider readOnlyProvider) {
         this.sessionManager = sessionManager;
         this.translationService = translationService;
         this.editExpressionEvent = editExpressionEvent;
+        this.readOnlyProvider = readOnlyProvider;
     }
 
     @Override
@@ -82,12 +87,12 @@ public class DMNEditBusinessKnowledgeModelToolboxAction implements ToolboxAction
                                                                                                     uuid)
                 .asNode();
         final BusinessKnowledgeModel bkm = (BusinessKnowledgeModel) DefinitionUtils.getElementDefinition(bkmNode);
-        final boolean isOnlyVisualChangeAllowed = bkm.isAllowOnlyVisualChange();
+        final boolean isReadOnly = bkm.isAllowOnlyVisualChange() || readOnlyProvider.isReadOnlyDiagram();
         editExpressionEvent.fire(new EditExpressionEvent(sessionManager.getCurrentSession(),
                                                          uuid,
                                                          bkm.asHasExpression(),
                                                          Optional.of(bkm),
-                                                         isOnlyVisualChangeAllowed));
+                                                         isReadOnly));
 
         return this;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDecisionToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDecisionToolboxAction.java
@@ -23,7 +23,9 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.model.Decision;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
+import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasLayoutUtils;
@@ -48,14 +50,17 @@ public class DMNEditDecisionToolboxAction implements ToolboxAction<AbstractCanva
     private final SessionManager sessionManager;
     private final ClientTranslationService translationService;
     private final Event<EditExpressionEvent> editExpressionEvent;
+    private final ReadOnlyProvider readOnlyProvider;
 
     @Inject
     public DMNEditDecisionToolboxAction(final SessionManager sessionManager,
                                         final ClientTranslationService translationService,
-                                        final Event<EditExpressionEvent> editExpressionEvent) {
+                                        final Event<EditExpressionEvent> editExpressionEvent,
+                                        final @DMNEditor ReadOnlyProvider readOnlyProvider) {
         this.sessionManager = sessionManager;
         this.translationService = translationService;
         this.editExpressionEvent = editExpressionEvent;
+        this.readOnlyProvider = readOnlyProvider;
     }
 
     @Override
@@ -82,12 +87,12 @@ public class DMNEditDecisionToolboxAction implements ToolboxAction<AbstractCanva
                                                                                       uuid)
                 .asNode();
         final Decision decision = (Decision) DefinitionUtils.getElementDefinition(decisionNode);
-        final boolean isOnlyVisualChangeAllowed = decision.isAllowOnlyVisualChange();
+        final boolean isReadOnly = decision.isAllowOnlyVisualChange() || readOnlyProvider.isReadOnlyDiagram();
         editExpressionEvent.fire(new EditExpressionEvent(sessionManager.getCurrentSession(),
                                                          uuid,
                                                          decision,
                                                          Optional.of(decision),
-                                                         isOnlyVisualChangeAllowed));
+                                                         isReadOnly));
 
         return this;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactory.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
@@ -87,19 +88,23 @@ public class DecisionNavigatorNestedItemFactory {
 
     private final BoxedExpressionHelper helper;
 
+    private final ReadOnlyProvider readOnlyProvider;
+
     @Inject
     public DecisionNavigatorNestedItemFactory(final SessionManager sessionManager,
                                               final Event<EditExpressionEvent> editExpressionEvent,
                                               final DMNGraphUtils dmnGraphUtils,
                                               final @DMNEditor Supplier<ExpressionEditorDefinitions> expressionEditorDefinitionsSupplier,
                                               final Event<CanvasSelectionEvent> canvasSelectionEvent,
-                                              final BoxedExpressionHelper helper) {
+                                              final BoxedExpressionHelper helper,
+                                              final ReadOnlyProvider readOnlyProvider) {
         this.sessionManager = sessionManager;
         this.editExpressionEvent = editExpressionEvent;
         this.dmnGraphUtils = dmnGraphUtils;
         this.expressionEditorDefinitionsSupplier = expressionEditorDefinitionsSupplier;
         this.canvasSelectionEvent = canvasSelectionEvent;
         this.helper = helper;
+        this.readOnlyProvider = readOnlyProvider;
     }
 
     public DecisionNavigatorItem makeItem(final Node<View, Edge> node) {
@@ -146,7 +151,7 @@ public class DecisionNavigatorNestedItemFactory {
         final Object definition = DefinitionUtils.getElementDefinition(node);
         final HasExpression hasExpression = helper.getHasExpression(node);
         final Optional<HasName> hasName = Optional.of((HasName) definition);
-        final boolean isOnlyVisualChangeAllowed = isOnlyVisualChangeAllowed(definition);
+        final boolean isOnlyVisualChangeAllowed = isOnlyVisualChangeAllowed(definition) || readOnlyProvider.isReadOnlyDiagram();
 
         return new EditExpressionEvent(currentSession, node.getUUID(), hasExpression, hasName, isOnlyVisualChangeAllowed);
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeView.java
@@ -40,8 +40,10 @@ import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem;
 import org.kie.workbench.common.dmn.client.editors.common.RemoveHelper;
+import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 import org.uberfire.client.mvp.LockRequiredEvent;
 
 import static java.util.Optional.ofNullable;
@@ -161,6 +163,7 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
     @Templated("DecisionNavigatorTreeView.html#item")
     public static class TreeItem implements IsElement {
 
+        private final ReadOnlyProvider readOnlyProvider;
         @DataField("text-content")
         private HTMLElement textContent;
 
@@ -194,7 +197,8 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
                         final @Named("i") HTMLElement save,
                         final @Named("i") HTMLElement edit,
                         final @Named("i") HTMLElement remove,
-                        final Event<LockRequiredEvent> locker) {
+                        final Event<LockRequiredEvent> locker,
+                        final @DMNEditor ReadOnlyProvider readOnlyProvider) {
             this.textContent = textContent;
             this.inputText = inputText;
             this.icon = icon;
@@ -203,6 +207,7 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
             this.edit = edit;
             this.remove = remove;
             this.locker = locker;
+            this.readOnlyProvider = readOnlyProvider;
         }
 
         @EventHandler("icon")
@@ -282,8 +287,10 @@ public class DecisionNavigatorTreeView implements DecisionNavigatorTreePresenter
                 getElement().getClassList().add("parent-node");
             }
 
-            if (getItem().isEditable()) {
-                getElement().getClassList().add("editable");
+            if (!readOnlyProvider.isReadOnlyDiagram()) {
+                if (getItem().isEditable()) {
+                    getElement().getClassList().add("editable");
+                }
             }
         }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactoryTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/factories/DecisionNavigatorNestedItemFactoryTest.java
@@ -34,6 +34,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionE
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.graph.DMNGraphUtils;
+import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
@@ -84,6 +85,9 @@ public class DecisionNavigatorNestedItemFactoryTest {
     @Mock
     private BoxedExpressionHelper boxedExpressionHelper;
 
+    @Mock
+    private ReadOnlyProvider readOnlyProvider;
+
     private DecisionNavigatorNestedItemFactory factory;
 
     @Before
@@ -94,7 +98,8 @@ public class DecisionNavigatorNestedItemFactoryTest {
                                                              dmnGraphUtils,
                                                              expressionEditorDefinitionsSupplier,
                                                              canvasSelectionEvent,
-                                                             boxedExpressionHelper));
+                                                             boxedExpressionHelper,
+                                                             readOnlyProvider));
 
         final ExpressionEditorDefinitions expressionEditorDefinitions = new ExpressionEditorDefinitions();
         expressionEditorDefinitions.add(decisionTableEditorDefinition);
@@ -181,6 +186,31 @@ public class DecisionNavigatorNestedItemFactoryTest {
         assertEquals(Optional.of(hasName), expressionEvent.getHasName());
         assertEquals(hasExpression, expressionEvent.getHasExpression());
         assertFalse(expressionEvent.isOnlyVisualChangeAllowed());
+    }
+
+    @Test
+    public void testMakeEditExpressionEventWhenIsReadOnly() {
+
+        final ClientSession currentSession = mock(ClientSession.class);
+        final HasName hasName = mock(HasName.class);
+        final HasExpression hasExpression = mock(HasExpression.class);
+        final View view = mock(View.class);
+        final String uuid = "uuid";
+
+        when(readOnlyProvider.isReadOnlyDiagram()).thenReturn(true);
+        when(node.getUUID()).thenReturn(uuid);
+        when(sessionManager.getCurrentSession()).thenReturn(currentSession);
+        when(node.getContent()).thenReturn(view);
+        when(view.getDefinition()).thenReturn(hasName);
+        when(boxedExpressionHelper.getHasExpression(node)).thenReturn(hasExpression);
+
+        final EditExpressionEvent expressionEvent = factory.makeEditExpressionEvent(node);
+
+        assertEquals(uuid, expressionEvent.getNodeUUID());
+        assertEquals(currentSession, expressionEvent.getSession());
+        assertEquals(Optional.of(hasName), expressionEvent.getHasName());
+        assertEquals(hasExpression, expressionEvent.getHasExpression());
+        assertTrue(expressionEvent.isOnlyVisualChangeAllowed());
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeViewTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/tree/DecisionNavigatorTreeViewTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItem;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorItemBuilder;
+import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 import org.mockito.Mock;
 import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.mocks.EventSourceMock;
@@ -94,6 +95,9 @@ public class DecisionNavigatorTreeViewTest {
     private HTMLUListElement subItems;
 
     @Mock
+    private ReadOnlyProvider readOnlyProvider;
+
+    @Mock
     private EventSourceMock<LockRequiredEvent> locker;
 
     private DecisionNavigatorTreeView treeView;
@@ -103,7 +107,7 @@ public class DecisionNavigatorTreeViewTest {
     @Before
     public void setup() {
         treeView = spy(new DecisionNavigatorTreeView(view, items, managedInstance, util));
-        treeItem = spy(new DecisionNavigatorTreeView.TreeItem(textContent, inputText, icon, subItems, save, edit, remove, locker));
+        treeItem = spy(new DecisionNavigatorTreeView.TreeItem(textContent, inputText, icon, subItems, save, edit, remove, locker, readOnlyProvider));
     }
 
     @Test
@@ -449,6 +453,55 @@ public class DecisionNavigatorTreeViewTest {
         doReturn(cssClass).when(treeItem).getCSSClass(item);
         when(element.getClassList()).thenReturn(classList);
         when(item.isEditable()).thenReturn(false);
+
+        treeItem.updateCSSClass();
+
+        verify(classList).add(cssClass);
+        verify(classList, never()).add("parent-node");
+        verify(classList, never()).add("editable");
+    }
+
+    @Test
+    public void testTreeItemUpdateCSSClassWhenItemHasChildrenAndIsReadOnly() {
+
+        final DecisionNavigatorItem item = mock(DecisionNavigatorItem.class);
+        final DecisionNavigatorItem child = mock(DecisionNavigatorItem.class);
+        final TreeSet<DecisionNavigatorItem> children = new TreeSet<DecisionNavigatorItem>() {{
+            add(child);
+        }};
+        final org.jboss.errai.common.client.dom.DOMTokenList classList = mock(org.jboss.errai.common.client.dom.DOMTokenList.class);
+        final HTMLElement element = mock(HTMLElement.class);
+        final String cssClass = "css-class";
+
+        doReturn(item).when(treeItem).getItem();
+        doReturn(element).when(treeItem).getElement();
+        doReturn(cssClass).when(treeItem).getCSSClass(item);
+        when(element.getClassList()).thenReturn(classList);
+        when(item.getChildren()).thenReturn(children);
+        when(item.isEditable()).thenReturn(true);
+        when(readOnlyProvider.isReadOnlyDiagram()).thenReturn(true);
+
+        treeItem.updateCSSClass();
+
+        verify(classList).add(cssClass);
+        verify(classList).add("parent-node");
+        verify(classList, never()).add("editable");
+    }
+
+    @Test
+    public void testTreeItemUpdateCSSClassWhenItemDoesNotHaveChildrenAndIsReadOnly() {
+
+        final DecisionNavigatorItem item = mock(DecisionNavigatorItem.class);
+        final org.jboss.errai.common.client.dom.DOMTokenList classList = mock(org.jboss.errai.common.client.dom.DOMTokenList.class);
+        final HTMLElement element = mock(HTMLElement.class);
+        final String cssClass = "css-class";
+
+        doReturn(item).when(treeItem).getItem();
+        doReturn(element).when(treeItem).getElement();
+        doReturn(cssClass).when(treeItem).getCSSClass(item);
+        when(element.getClassList()).thenReturn(classList);
+        when(item.isEditable()).thenReturn(false);
+        when(readOnlyProvider.isReadOnlyDiagram()).thenReturn(true);
 
         treeItem.updateCSSClass();
 


### PR DESCRIPTION
KOGITO-3905: DMN readonly mode allows clear of decision expression
KOGITO-3906: DMN readonly mode allows changes in Decision Navigator panel

**JIRA**: [KOGITO-3905](https://issues.redhat.com/browse/KOGITO-3905)
**JIRA**: [KOGITO-3906](https://issues.redhat.com/browse/KOGITO-3906)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
