### PR TITLE
JBPM-9511: Stunner: Inline Editor doesn't show after morphing a Task to user Task

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
@@ -16,6 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.touch.client.Point;
@@ -116,7 +117,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
     protected void doInit() {
         super.doInit();
         getTextEditorBox().initialize(canvasHandler,
-                                      AbstractCanvasInlineTextEditorControl.this::hide);
+                                      () -> scheduleDeferredCommand(AbstractCanvasInlineTextEditorControl.this::hide));
 
         getFloatingView()
                 .hide()
@@ -159,7 +160,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
         final TextDoubleClickHandler clickHandler = new TextDoubleClickHandler() {
             @Override
             public void handle(final TextDoubleClickEvent event) {
-                AbstractCanvasInlineTextEditorControl.this.show(element);
+                scheduleDeferredCommand(() -> AbstractCanvasInlineTextEditorControl.this.show(element));
             }
         };
         hasEventHandlers.addHandler(ViewEventType.TEXT_DBL_CLICK,
@@ -592,5 +593,9 @@ public abstract class AbstractCanvasInlineTextEditorControl
             getFloatingView().hide();
         }
         return this;
+    }
+
+    public void scheduleDeferredCommand(final Scheduler.ScheduledCommand command) {
+        Scheduler.get().scheduleDeferred(command);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.junit.Before;
@@ -201,6 +202,11 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
         when(session.getKeyboardControl()).thenReturn(keyboardControl);
 
         this.control = spy(getControl());
+
+        doAnswer(i -> {
+            ((Scheduler.ScheduledCommand) i.getArguments()[0]).execute();
+            return null;
+        }).when(control).scheduleDeferredCommand(any(Scheduler.ScheduledCommand.class));
 
         doReturn(textEditBoxWidget).when(control).wrapTextEditorBoxElement(eq(textEditBoxElement));
         doAnswer(i -> abstractCanvas).when(control).getAbstractCanvas();


### PR DESCRIPTION
Hey @romartin, @inodeman: Please, could you review this PR?

**JIRA**: [JBPM-9511](https://issues.redhat.com/browse/JBPM-9511)
**JIRA**: [RHPAM-3350](https://issues.redhat.com/browse/RHPAM-3350)

**Business Central**: [WAR file](https://drive.google.com/file/d/1TUPhhuz-EwiIOnklK8Mlgi6lt55pRUef/view?usp=sharing)

**VS Code**: [extension_pack_kogito_kie_editors](https://drive.google.com/file/d/1-2j8Eol5aAZIK7SKKr8cXr4hFtNv7LJL/view?usp=sharing)
