### PR TITLE
KOGITO-3998 - It's not possible to save arrow edits

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImpl.java
@@ -121,7 +121,8 @@ public class ConnectionAcceptorControlImpl
                                 final Edge<ViewConnector<?>, Node> connector,
                                 final Connection connection) {
         ensureUnHighLight();
-        if (isSourceChanged(source, connector)) {
+        if (isSourceChanged(source, connector) ||
+                isSourceConnectionChanged(connector, connection)) {
             final CommandResult<CanvasViolation> violations =
                     getCommandManager().execute(getCanvasHandler(),
                                                 canvasCommandFactory.setSourceNode(source,
@@ -138,7 +139,8 @@ public class ConnectionAcceptorControlImpl
                                 final Edge<ViewConnector<?>, Node> connector,
                                 final Connection connection) {
         ensureUnHighLight();
-        if (isTargetChanged(target, connector)) {
+        if (isTargetChanged(target, connector) ||
+                isTargetConnectionChanged(connector, connection)) {
             final CommandResult<CanvasViolation> violations =
                     getCommandManager().execute(getCanvasHandler(),
                                                 canvasCommandFactory.setTargetNode(target,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ConnectionAcceptorControlImplTest.java
@@ -291,8 +291,8 @@ public class ConnectionAcceptorControlImplTest {
                                                   connection);
         assertTrue(allow);
         verify(commandManager,
-               never()).execute(eq(canvasHandler),
-                                eq(setConnectionSourceNodeCommand));
+               times(1)).execute(eq(canvasHandler),
+                                 eq(setConnectionSourceNodeCommand));
         verify(commandManager,
                never()).allow(any(AbstractCanvasHandler.class),
                               any(SetConnectionSourceNodeCommand.class));
@@ -307,6 +307,9 @@ public class ConnectionAcceptorControlImplTest {
                                                   edge,
                                                   connection);
         assertTrue(allow);
+        verify(commandManager,
+               times(1)).execute(eq(canvasHandler),
+                                 eq(setConnectionTargetNodeCommand));
         verify(commandManager,
                never()).allow(any(AbstractCanvasHandler.class),
                               any(SetConnectionTargetNodeCommand.class));
@@ -345,6 +348,40 @@ public class ConnectionAcceptorControlImplTest {
         verify(commandManager,
                never()).execute(any(AbstractCanvasHandler.class),
                                 any(SetConnectionSourceNodeCommand.class));
+    }
+
+    @Test
+    public void testAcceptSourceAsOnlyConnectionChanges() {
+        when(edge.getSourceNode()).thenReturn(node);
+        when(edgeContent.getSourceConnection()).thenReturn(Optional.of(mock(Connection.class)));
+        tested.init(canvasHandler);
+        final boolean accept = tested.acceptSource(node,
+                                                   edge,
+                                                   connection);
+        assertTrue(accept);
+        verify(commandManager,
+               times(1)).execute(eq(canvasHandler),
+                                 eq(setConnectionSourceNodeCommand));
+        verify(commandManager,
+               never()).allow(any(AbstractCanvasHandler.class),
+                              any(SetConnectionSourceNodeCommand.class));
+    }
+
+    @Test
+    public void testAcceptTargetAsOnlyConnectionChanges() {
+        when(edge.getTargetNode()).thenReturn(node);
+        when(edgeContent.getTargetConnection()).thenReturn(Optional.of(mock(Connection.class)));
+        tested.init(canvasHandler);
+        final boolean accept = tested.acceptTarget(node,
+                                                   edge,
+                                                   connection);
+        assertTrue(accept);
+        verify(commandManager,
+               times(1)).execute(eq(canvasHandler),
+                                 eq(setConnectionTargetNodeCommand));
+        verify(commandManager,
+               never()).allow(any(AbstractCanvasHandler.class),
+                              any(SetConnectionSourceNodeCommand.class));
     }
 
     @Test


### PR DESCRIPTION
Model was not being updated after changes were made to the sequence flow.

**JIRA**: [KOGITO-3998](https://issues.redhat.com/browse/KOGITO-3998)

**Business Central**: [WAR file](https://drive.google.com/file/d/1JHgi6W8A3LkALKb64LMSpqcOcBdMhuIs/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1VxptH083cAxu87CXMJ_YdldbE_6WhA3n/view?usp=sharing)