### PR TITLE
JBPM-8153 Container is removed from UI even though it was not possibl…

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
@@ -151,7 +151,9 @@ public class ContainerPresenter {
                 containerSpec != null &&
                 containerSpec.getId() != null &&
                 containerSpec.getId().equals(content.getContainerSpec().getId())) {
-            resetReleaseIdForFailedContainers(content.getContainers(), content.getContainerSpec());
+            if (containerSpec.getStatus() != KieContainerStatus.STOPPED) {
+                resetReleaseIdForFailedContainers(content.getContainers(), content.getContainerSpec());
+            }
             setup(content.getContainerSpec(),
                   content.getContainers());
         } else {
@@ -207,7 +209,7 @@ public class ContainerPresenter {
         containerRemoteStatusPresenter.setup(containerSpec,
                                              containers);
         view.clear();
-        if (isEmpty(containers)) {
+        if (isEmpty(containers))  {
             view.setStatus(containerStatusEmptyPresenter.getView());
         } else {
             view.setStatus(containerRemoteStatusPresenter.getView());
@@ -234,9 +236,17 @@ public class ContainerPresenter {
     }
 
     private boolean isEmpty(final Collection<Container> containers) {
-        for (final Container container : containers) {
-            if (!container.getStatus().equals(KieContainerStatus.STOPPED)) {
-                return false;
+        if (containerSpec.getStatus().equals(KieContainerStatus.STOPPED)) {
+            for (final Container container : containers) {
+                if (!container.getStatus().equals(KieContainerStatus.FAILED) && !container.getStatus().equals(KieContainerStatus.STOPPED)) {
+                    return false;
+                }
+            }
+        } else {
+            for (final Container container : containers) {
+                if (!container.getStatus().equals(KieContainerStatus.STOPPED)) {
+                    return false;
+                }
             }
         }
         return true;

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
@@ -339,7 +339,6 @@ public class ContainerPresenterTest {
 
     }
 
-
     @Test
     public void testRefresh() {
         when(runtimeManagementService.getContainersByContainerSpec(
@@ -390,6 +389,7 @@ public class ContainerPresenterTest {
                                                   null,
                                                   null);
         container.setStatus(KieContainerStatus.FAILED);
+        containerSpecData.getContainerSpec().setStatus(KieContainerStatus.STARTED);
         containerSpecData.getContainers().add(container);
         assertNull(container.getResolvedReleasedId());
         presenter.loadContainers(containerSpecData);
@@ -626,5 +626,37 @@ public class ContainerPresenterTest {
         verify(view).setContainerStopState(State.DISABLED);
         verify(view).updateToggleActivationButton(true);
         verify(view).enableToggleActivationButton();
+    }
+
+    @Test
+    public void testLoadContainersWithStopContainerSpecHasStartedContainer() {
+        final Container container = new Container("containerSpecId",
+                                                  "containerName",
+                                                  new ServerInstanceKey(),
+                                                  Collections.<Message>emptyList(),
+                                                  null,
+                                                  null);
+        container.setStatus(KieContainerStatus.STARTED);
+        containerSpecData.getContainers().add(container);
+        presenter.loadContainers(containerSpecData);
+
+        assertNotEquals(KieContainerStatus.FAILED,containerSpecData.getContainerSpec().getStatus());
+        verifyLoad(false, 1, false);
+    }
+
+    @Test
+    public void testLoadContainersWithStopContainerSpecHasFailedContainer() {
+        final Container container = new Container("containerSpecId",
+                                                  "containerName",
+                                                  new ServerInstanceKey(),
+                                                  Collections.<Message>emptyList(),
+                                                  null,
+                                                  null);
+        container.setStatus(KieContainerStatus.FAILED);
+        containerSpecData.getContainers().add(container);
+        presenter.loadContainers(containerSpecData);
+
+        assertNotEquals(KieContainerStatus.FAILED,containerSpecData.getContainerSpec().getStatus());
+        verifyLoad(true, 1, false);
     }
 }


### PR DESCRIPTION
…e to stop it.

**Thank you for submitting this pull request**

**JIRA**: [JBPM-8153](https://issues.redhat.com/browse/JBPM-8153)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
