### PR TITLE
KOGITO-3932 - Stale itemDefinition after update of Intermediate Message Catch Event

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/EventPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/EventPropertyWriter.java
@@ -65,9 +65,9 @@ public abstract class EventPropertyWriter extends PropertyWriter {
     public abstract void setAssignmentsInfo(AssignmentsInfo assignmentsInfo);
 
     public void addMessage(MessageRef messageRef) {
-
-        // since events only have one parameter, look for the only one
-        if (messageRef.getStructure().isEmpty() && this.getItemDefinitions().size() == 1) {
+        if (this.getItemDefinitions().isEmpty()) {
+            messageRef.setStructure("");
+        } else {
             messageRef.setStructure(this.getItemDefinitions().get(0).getStructureRef());
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/EventPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/EventPropertyWriterTest.java
@@ -42,6 +42,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public abstract class EventPropertyWriterTest {
 
+    private static final String EMPTY_STRING = "";
+    private static final String NON_EMPTY_STRING = "nomEmpty";
     private static final String SAMPLE_STRUCTURE_REF = "my.var.ref";
     protected final static String elementId = "MY_ID";
     private final static String ERROR_CODE = "ERROR_CODE";
@@ -51,28 +53,25 @@ public abstract class EventPropertyWriterTest {
 
     @Test
     public void testMessageStructureRef() {
-        MessageRef messageRef = new MessageRef("someVar", "");
         List<ItemDefinition> itemDefinitions = new ArrayList<>();
         ItemDefinition itemDefinition = mock(ItemDefinition.class);
         itemDefinitions.add(itemDefinition);
 
         when(itemDefinition.getStructureRef()).thenReturn(SAMPLE_STRUCTURE_REF);
         when(propertyWriter.getItemDefinitions()).thenReturn(itemDefinitions);
-        propertyWriter.addMessage(messageRef);
-        assertEquals(messageRef.getStructure(), SAMPLE_STRUCTURE_REF);
 
-        messageRef.setStructure("nonEmpty");
-        propertyWriter.addMessage(messageRef);
-        assertEquals(messageRef.getStructure(), "nonEmpty");
+        MessageRef messageRef1 = new MessageRef("someVar", EMPTY_STRING);
+        propertyWriter.addMessage(messageRef1);
+        assertEquals(messageRef1.getStructure(), SAMPLE_STRUCTURE_REF);
+
+        MessageRef messageRef2 = new MessageRef("someVar", NON_EMPTY_STRING);
+        propertyWriter.addMessage(messageRef2);
+        assertEquals(messageRef2.getStructure(), SAMPLE_STRUCTURE_REF);
 
         itemDefinitions.clear();
-        messageRef.setStructure("");
-        propertyWriter.addMessage(messageRef);
-        assertEquals(messageRef.getStructure(), "");
-
-        messageRef.setStructure("nonEmpty");
-        propertyWriter.addMessage(messageRef);
-        assertEquals(messageRef.getStructure(), "nonEmpty");
+        MessageRef messageRef3 = new MessageRef("someVar", NON_EMPTY_STRING);
+        propertyWriter.addMessage(messageRef3);
+        assertEquals(messageRef3.getStructure(), EMPTY_STRING);
     }
 
     @Test


### PR DESCRIPTION
The Structure Ref was changed only when it was empty (when the event had no data ouput).
So after setting it one time, it was not possible to change it anymore.
Now it is possible to clear the value and change it whenever.

**JIRA**: [KOGITO-3932](https://issues.redhat.com/browse/KOGITO-3932)

_This issue does not apply to Business Central, but anyway the artifact is available for any cross-testing._
**Business Central**: [WAR file](https://drive.google.com/file/d/1POW3FP-U3nupKltMG48WOw3dn9WlRhV7/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1Sbap7t83OfYZpyZ6uIxDyT1fom7znaLR/view?usp=sharing)
