### PR TITLE
JBPM-8153 Container is removed from UI even though it was not possibl…

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/src/main/java/org/kie/workbench/common/screens/server/management/service/ContainerService.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/src/main/java/org/kie/workbench/common/screens/server/management/service/ContainerService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.server.management.service;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+
+@Remote
+public interface ContainerService {
+
+    /**
+     * Return true, when the Container has Process Definition and Process instance.
+     * @param containerSpec
+     * @return
+     */
+    boolean isRunningContainer(ContainerSpec containerSpec);
+
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.server.management.backend.service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.QueryServicesClient;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.impl.KieServerInstanceManager;
+import org.kie.server.controller.api.service.SpecManagementService;
+import org.kie.workbench.common.screens.server.management.service.ContainerService;
+
+@Service
+@ApplicationScoped
+public class ContainerServiceImpl implements ContainerService {
+
+    private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
+
+    @Inject
+    @Any
+    private SpecManagementService specManagementService;
+
+    @Override
+    public boolean isRunningContainer(ContainerSpec containerSpec) {
+        ServerTemplate serverTemplate = specManagementService.getServerTemplate(containerSpec.getServerTemplateKey().getId());
+        AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+        for (ServerInstanceKey serverInstanceKey : serverTemplate.getServerInstanceKeys()) {
+            KieServicesClient client = kieServerInstanceManager.getClient(serverInstanceKey.getUrl());
+
+            QueryServicesClient queryServicesClient = client.getServicesClient(QueryServicesClient.class);
+            List<ProcessInstance> processInstances = queryServicesClient.findProcessInstancesByContainerId(containerSpec.getId(), Arrays.asList(0, 1, 4), 0, 100);
+
+            if (!processInstances.isEmpty()) {
+                atomicBoolean.set(true);
+                break;
+            }
+        }
+
+        return atomicBoolean.get();
+    }
+
+    protected void setKieServerInstanceManager(KieServerInstanceManager kieServerInstanceManager) {
+        this.kieServerInstanceManager = kieServerInstanceManager;
+    }
+
+    protected void setSpecManagementService(SpecManagementService specManagementService) {
+        this.specManagementService = specManagementService;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.server.management.backend.service;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.QueryServicesClient;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.kie.server.controller.api.service.SpecManagementService;
+import org.kie.server.controller.impl.KieServerInstanceManager;
+import org.kie.workbench.common.screens.server.management.service.ContainerService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContainerServiceImplTest {
+
+    @Mock
+    SpecManagementService specManagementService ;
+
+    @Mock
+    KieServerInstanceManager kieServerInstanceManager;
+
+    private ContainerService containerService;
+
+    @Before
+    public void init() {
+        containerService = spy(new ContainerServiceImpl());
+        ((ContainerServiceImpl) containerService).setSpecManagementService(specManagementService);
+        ((ContainerServiceImpl) containerService).setKieServerInstanceManager(kieServerInstanceManager);
+    }
+
+    @Test
+    public void testIsRunningContainer() {
+        ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        doReturn(serverTemplate).when(specManagementService).getServerTemplate(any());
+        when(serverTemplate.getServerInstanceKeys()).thenReturn(Arrays.asList(new ServerInstanceKey("test", "test", "test", "test")));
+
+        QueryServicesClient queryServicesClient = mock(QueryServicesClient.class);
+        KieServicesClient client = mock(KieServicesClient.class);
+        when(kieServerInstanceManager.getClient(any())).thenReturn(client);
+        when(client.getServicesClient(QueryServicesClient.class)).thenReturn(queryServicesClient);
+        when(queryServicesClient.findProcessInstancesByContainerId("test", Arrays.asList(0, 1, 4), 0, 100)).thenReturn(Arrays.asList(new ProcessInstance()));
+        boolean runningResult = containerService.isRunningContainer(new ContainerSpec("test", "", new ServerTemplateKey("1", "test"), null, null, null));
+
+        assertEquals(true, runningResult);
+
+        when(queryServicesClient.findProcessInstancesByContainerId("test", Arrays.asList(0, 1, 4), 0, 100)).thenReturn(Collections.emptyList());
+        boolean result = containerService.isRunningContainer(new ContainerSpec("test", "", new ServerTemplateKey("1", "test"), null, null, null));
+        assertEquals(false, result);
+
+        when(queryServicesClient.findProcessesByContainerId("test", 0, 10)).thenReturn(Collections.emptyList());
+        assertEquals(false, result);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerView.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerView.java
@@ -280,6 +280,11 @@ public class ContainerView extends Composite
         return translationService.format(Constants.NewContainer_FailedContainer);
     }
 
+    @Override
+    public String getCanNotStopContainerMessage() {
+        return translationService.format(Constants.CanNot_Stop_Container);
+    }
+
     private String getConfirmRemovePopupMessage() {
         return translationService.format(Constants.ContainerView_ConfirmRemovePopupMessage);
     }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.java
@@ -254,4 +254,6 @@ public class Constants {
     @TranslationKey(defaultValue = "")
     public static final String NewContainer_FailedContainer = "NewContainer.FailedContainer";
 
+    @TranslationKey(defaultValue = "")
+    public static final String CanNot_Stop_Container = "CanNot_Stop_Container";
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/resources/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.properties
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/resources/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.properties
@@ -153,3 +153,4 @@ NewContainer.Save=Ok
 NewContainer.SaveContainerSpec=Save Container Spec
 NewContainer.Deploying={0} is deploying
 NewContainer.FailedContainer=The Container failed on kie server.
+CanNot_Stop_Container=It is not possible to stop the container due to running process instance.


### PR DESCRIPTION
…e to stop it.

**Thank you for submitting this pull request**

**JIRA**: [JBPM-8153](https://issues.redhat.com/browse/JBPM-8153)

**Referenced Pull Requests**:
* https://github.com/kiegroup/droolsjbpm-integration/pull/2358
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
