### PR TITLE
KOGITO-3909: Add OuiaAttributes to Data Type entry

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
@@ -40,6 +40,10 @@ import org.kie.workbench.common.dmn.client.editors.types.listview.common.ListIte
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.SmallSwitchComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.DataTypeConstraint;
 import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
+import org.uberfire.client.workbench.ouia.OuiaAttribute;
+import org.uberfire.client.workbench.ouia.OuiaComponent;
+import org.uberfire.client.workbench.ouia.OuiaComponentIdAttribute;
+import org.uberfire.client.workbench.ouia.OuiaComponentTypeAttribute;
 
 import static org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper.hide;
 import static org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper.show;
@@ -59,7 +63,8 @@ import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConsta
 
 @Dependent
 @Templated
-public class DataTypeListItemView implements DataTypeListItem.View {
+public class DataTypeListItemView implements DataTypeListItem.View,
+                                             OuiaComponent {
 
     public static final String UUID_ATTR = "data-row-uuid";
 
@@ -97,12 +102,30 @@ public class DataTypeListItemView implements DataTypeListItem.View {
         return view;
     }
 
+    @Override
+    public OuiaComponentTypeAttribute ouiaComponentType() {
+        return new OuiaComponentTypeAttribute("dmn-data-type-item");
+    }
+
+    @Override
+    public OuiaComponentIdAttribute ouiaComponentId() {
+        return new OuiaComponentIdAttribute(presenter != null && presenter.getDataType() != null ?
+                                                    presenter.getDataType().getName() : "unknown");
+    }
+
+    @Override
+    public Consumer<OuiaAttribute> ouiaAttributeRenderer() {
+        return ouiaAttribute -> view.setAttribute(ouiaAttribute.getName(),
+                                                  ouiaAttribute.getValue());
+    }
+
     void setupRowMetadata(final DataType dataType) {
 
         getDragAndDropElement().setAttribute(UUID_ATTR, dataType.getUUID());
         getDragAndDropElement().setAttribute(PARENT_UUID_ATTR, dataType.getParentUUID());
 
         setupRowCSSClass(dataType);
+        initOuiaComponentAttributes();
     }
 
     void setupRowCSSClass(final DataType dataType) {
@@ -423,6 +446,7 @@ public class DataTypeListItemView implements DataTypeListItem.View {
     OnclickFn getOnSaveAction() {
         return (e) -> {
             presenter.saveAndCloseEditMode();
+            ouiaAttributeRenderer().accept(ouiaComponentId());
             return true;
         };
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.html
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.html
@@ -24,7 +24,7 @@
         </div>
         <div class="search-bar-container" data-field="search-bar-container"></div>
         <div class="action-button">
-            <button data-field="add-button" class="btn btn-default">
+            <button data-field="add-button" class="btn btn-default" data-ouia-component-type="add-data-type-button" data-ouia-component-id="new">
                 <span data-i18n-key="NewDataType"></span>
             </button>
             <button data-field="import-data-object-button" class="btn btn-default">
@@ -40,7 +40,7 @@
             <h1 data-i18n-key="NoCustomDataTitle"></h1>
             <p data-i18n-key="NoCustomData1"></p>
             <p data-i18n-key="NoCustomData2"></p>
-            <button data-field="add-button-placeholder" class="btn btn-primary">
+            <button data-field="add-button-placeholder" class="btn btn-primary" data-ouia-component-type="add-data-type-button" data-ouia-component-id="first">
                 <i class="fa fa-plus-circle"></i>
                 <span data-i18n-key="AddACustomDataType"></span>
             </button>


### PR DESCRIPTION
For easier testing of KOGITO-3909 we add some OuiaAttributes into Dmn Data Types list
For more details see: https://issues.redhat.com/browse/KOGITO-3909

Ensemble together with:
- https://github.com/kiegroup/appformer/pull/1090

Prerequisite for:
- https://github.com/kiegroup/kogito-tooling/pull/372