### PR TITLE
KOGITO-3846: Added Notifications API to Editors

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/wildfly-multinode-kie-server.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/wildfly-multinode-kie-server.xml
@@ -1,0 +1,35 @@
+<kie-server-state>
+  <controllers>
+    <string>http://localhost:8080/workbench/rest/controller</string>
+  </controllers>
+  <configuration>
+    <configItems>
+      <config-item>
+        <name>org.kie.server.controller.user</name>
+        <value>admin</value>
+        <type>java.lang.String</type>
+      </config-item>
+      <config-item>
+        <name>org.kie.server.controller</name>
+        <value>http://localhost:8080/workbench/rest/controller</value>
+        <type>java.lang.String</type>
+      </config-item>
+      <config-item>
+        <name>org.kie.server.id</name>
+        <value>wildfly-multinode-kie-server</value>
+        <type>java.lang.String</type>
+      </config-item>
+      <config-item>
+        <name>org.kie.server.mode</name>
+        <value>PRODUCTION</value>
+        <type>java.lang.String</type>
+      </config-item>
+      <config-item>
+        <name>org.kie.server.controller.pwd</name>
+        <value>admin</value>
+        <type>java.lang.String</type>
+      </config-item>
+    </configItems>
+  </configuration>
+  <containers/>
+</kie-server-state>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/resources/org/kie/workbench/common/stunner/kogito/KogitoBPMNEditor.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/resources/org/kie/workbench/common/stunner/kogito/KogitoBPMNEditor.gwt.xml
@@ -20,6 +20,7 @@
 <module>
 
   <!-- Uberfire dependencies -->
+  <inherits name="org.uberfire.UberfireAPI"/>
   <inherits name="org.uberfire.UberfireClient"/>
   <inherits name="org.uberfire.UberfireBackend"/>
   <inherits name="org.uberfire.client.views.PatternFlyTheme"/>
@@ -30,7 +31,7 @@
   <inherits name="org.uberfire.ext.widgets.core.client.UberfireWidgetsEditors"/>
   <inherits name="org.uberfire.ext.preferences.UberfirePreferences"/>
   <inherits name="org.uberfire.preferences.UberfirePreferencesClient"/>
-  
+
   <!-- Appformer Kogito Bridge -->
   <inherits name="org.appformer.kogito.bridge.AppformerKogitoBridge"/>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditorTest.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerVie
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionEditorPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.impl.SessionViewerPresenter;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
@@ -33,6 +34,7 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
 import org.kie.workbench.common.stunner.core.client.session.impl.ViewerSession;
+import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasDiagramValidator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
@@ -144,6 +146,9 @@ public class BPMNDiagramEditorTest {
     @Mock
     private ClientSession clientSession;
 
+    @Mock
+    private CanvasDiagramValidator<AbstractCanvasHandler> validator;
+
     private Promises promises = new SyncPromises();
 
     @SuppressWarnings("unchecked")
@@ -171,7 +176,8 @@ public class BPMNDiagramEditorTest {
                                            diagramServices,
                                            formsFlushManager,
                                            canvasFileExport,
-                                           promises));
+                                           promises,
+                                           validator));
 
         when(editor.getSessionPresenter()).thenReturn(sessionPresenter);
         when(sessionPresenter.getInstance()).thenReturn(clientSession);


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

https://issues.redhat.com/browse/KOGITO-3846

**referenced Pull Requests**: 

* https://github.com/kiegroup/appformer/pull/1092
* https://github.com/kiegroup/kie-wb-common/pull/3538
* https://github.com/kiegroup/kogito-tooling/pull/374

**Details:**

This PR adds the Notification API that let GWT send notifications to Channels. There are two main notifications: Alerts and Problems. 
* Alerts: ephemeral notification, i.e: Popup. If the notification contains a non empty path it will display a button to open that path. Alerts severity can be INFO, ERROR or WARNING.
* Problems: Notifications that needs to be informed to the users an keep persisted until the problem is fixed. i.e: Problems tab in VSCode. Problems severity can be INFO, ERROR, WARNING, HINT. The path is non empty it will open that location.

To use this notifications api users will need to inject `NotificationsApi class`.
There are 3 main methods:
* `send`: Send a single Alerts/Problem. For problems that notification will not disappear unless user removes it.
* `set` Send a list of Alerts/Problems. For problems, that list will replace the previous list, and for problems all the notification will be join in a single message.
* `remove`: Removes all the problems that belongs to a path. Alerts is not implemented since they are ephimeral.


@yesamer @romartin @karreiro 
