### PR TITLE
DROOLS-5911 - It's not possible to save arrow edits on DMN Editor

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
@@ -684,11 +684,11 @@ public class DMNMarshallerStandaloneTest {
 
         final Connection sourceConnection = connectionContent.getSourceConnection().get();
         assertTrue(sourceConnection instanceof MagnetConnection);
-        assertTrue(((MagnetConnection) sourceConnection).isAuto());
+        assertFalse(((MagnetConnection) sourceConnection).isAuto());
 
         final Connection targetConnection = connectionContent.getTargetConnection().get();
         assertTrue(targetConnection instanceof MagnetConnection);
-        assertTrue(((MagnetConnection) targetConnection).isAuto());
+        assertFalse(((MagnetConnection) targetConnection).isAuto());
     }
 
     @SuppressWarnings("unchecked")
@@ -1955,11 +1955,15 @@ public class DMNMarshallerStandaloneTest {
         final String decisionNode1UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
         final String decisionNode2UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
         final String edgeUUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+        final MagnetConnection sourceConnection = mock(MagnetConnection.class);
+        final MagnetConnection targetConnection = mock(MagnetConnection.class);
 
         final ViewConnector edgeView = marshallAndUnMarshallConnectors(bounds,
                                                                        decisionNode1UUID,
                                                                        decisionNode2UUID,
                                                                        edgeUUID,
+                                                                       sourceConnection,
+                                                                       targetConnection,
                                                                        (sc) -> {
                                                                            when(sc.getMagnetIndex()).thenReturn(OptionalInt.of(MagnetConnection.MAGNET_RIGHT));
                                                                            when(sc.getLocation()).thenReturn(new Point2D(bounds.getWidth(), bounds.getHeight() / 2));
@@ -1969,17 +1973,17 @@ public class DMNMarshallerStandaloneTest {
                                                                            when(tc.getLocation()).thenReturn(new Point2D(0, bounds.getHeight() / 2));
                                                                        });
 
-        final MagnetConnection sourceConnection = (MagnetConnection) edgeView.getSourceConnection().get();
-        assertEquals(bounds.getWidth(), sourceConnection.getLocation().getX(), 0.0);
-        assertEquals(bounds.getHeight() / 2, sourceConnection.getLocation().getY(), 0.0);
-        assertFalse(sourceConnection.getMagnetIndex().isPresent());
-        assertTrue(sourceConnection.isAuto());
+        final MagnetConnection sourceConnectionResult = (MagnetConnection) edgeView.getSourceConnection().get();
+        assertEquals(bounds.getWidth(), sourceConnectionResult.getLocation().getX(), 0.0);
+        assertEquals(bounds.getHeight() / 2, sourceConnectionResult.getLocation().getY(), 0.0);
+        assertFalse(sourceConnectionResult.getMagnetIndex().isPresent());
+        assertFalse(sourceConnectionResult.isAuto());
 
-        final MagnetConnection targetConnection = (MagnetConnection) edgeView.getTargetConnection().get();
-        assertEquals(0, targetConnection.getLocation().getX(), 0.0);
-        assertEquals(bounds.getHeight() / 2, targetConnection.getLocation().getY(), 0.0);
-        assertFalse(targetConnection.getMagnetIndex().isPresent());
-        assertTrue(targetConnection.isAuto());
+        final MagnetConnection targetConnectionResult = (MagnetConnection) edgeView.getTargetConnection().get();
+        assertEquals(0, targetConnectionResult.getLocation().getX(), 0.0);
+        assertEquals(bounds.getHeight() / 2, targetConnectionResult.getLocation().getY(), 0.0);
+        assertFalse(targetConnectionResult.getMagnetIndex().isPresent());
+        assertFalse(targetConnectionResult.isAuto());
     }
 
     @Test
@@ -1988,27 +1992,106 @@ public class DMNMarshallerStandaloneTest {
         final String decisionNode1UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
         final String decisionNode2UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
         final String edgeUUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+        final MagnetConnection sourceConnection = mock(MagnetConnection.class);
+        final MagnetConnection targetConnection = mock(MagnetConnection.class);
 
         final ViewConnector edgeView = marshallAndUnMarshallConnectors(bounds,
                                                                        decisionNode1UUID,
                                                                        decisionNode2UUID,
                                                                        edgeUUID,
+                                                                       sourceConnection,
+                                                                       targetConnection,
                                                                        (sc) -> {/*NOP*/},
                                                                        (tc) -> {/*NOP*/});
 
-        final MagnetConnection sourceConnection = (MagnetConnection) edgeView.getSourceConnection().get();
-        assertEquals(bounds.getWidth() / 2, sourceConnection.getLocation().getX(), 0.0);
-        assertEquals(bounds.getHeight() / 2, sourceConnection.getLocation().getY(), 0.0);
-        assertTrue(sourceConnection.getMagnetIndex().isPresent());
-        assertEquals(MagnetConnection.MAGNET_CENTER, sourceConnection.getMagnetIndex().getAsInt());
-        assertFalse(sourceConnection.isAuto());
+        final MagnetConnection sourceConnectionResult = (MagnetConnection) edgeView.getSourceConnection().get();
+        assertEquals(bounds.getWidth() / 2, sourceConnectionResult.getLocation().getX(), 0.0);
+        assertEquals(bounds.getHeight() / 2, sourceConnectionResult.getLocation().getY(), 0.0);
+        assertTrue(sourceConnectionResult.getMagnetIndex().isPresent());
+        assertEquals(MagnetConnection.MAGNET_CENTER, sourceConnectionResult.getMagnetIndex().getAsInt());
+        assertFalse(sourceConnectionResult.isAuto());
 
-        final MagnetConnection targetConnection = (MagnetConnection) edgeView.getTargetConnection().get();
-        assertEquals(bounds.getWidth() / 2, targetConnection.getLocation().getX(), 0.0);
-        assertEquals(bounds.getHeight() / 2, targetConnection.getLocation().getY(), 0.0);
-        assertTrue(targetConnection.getMagnetIndex().isPresent());
-        assertEquals(MagnetConnection.MAGNET_CENTER, targetConnection.getMagnetIndex().getAsInt());
-        assertFalse(targetConnection.isAuto());
+        final MagnetConnection targetConnectionResult = (MagnetConnection) edgeView.getTargetConnection().get();
+        assertEquals(bounds.getWidth() / 2, targetConnectionResult.getLocation().getX(), 0.0);
+        assertEquals(bounds.getHeight() / 2, targetConnectionResult.getLocation().getY(), 0.0);
+        assertTrue(targetConnectionResult.getMagnetIndex().isPresent());
+        assertEquals(MagnetConnection.MAGNET_CENTER, targetConnectionResult.getMagnetIndex().getAsInt());
+        assertFalse(targetConnectionResult.isAuto());
+    }
+
+    @Test
+    public void testAutoConnector() throws Exception {
+        final org.kie.workbench.common.stunner.core.graph.content.Bounds bounds = org.kie.workbench.common.stunner.core.graph.content.Bounds.create(0, 0, 100, 50);
+        final String decisionNode1UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+        final String decisionNode2UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+        final String edgeUUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+        final MagnetConnection sourceConnection = mock(MagnetConnection.class);
+        final MagnetConnection targetConnection = mock(MagnetConnection.class);
+
+        final ViewConnector edgeView = marshallAndUnMarshallConnectors(bounds,
+                                                                       decisionNode1UUID,
+                                                                       decisionNode2UUID,
+                                                                       edgeUUID,
+                                                                       sourceConnection,
+                                                                       targetConnection,
+                                                                       (sc) -> when(sc.isAuto()).thenReturn(true),
+                                                                       (tc) -> when(tc.isAuto()).thenReturn(true));
+
+        final MagnetConnection sourceConnectionResult = (MagnetConnection) edgeView.getSourceConnection().get();
+        assertEquals(bounds.getWidth() / 2, sourceConnectionResult.getLocation().getX(), 0.0);
+        assertEquals(bounds.getHeight() / 2, sourceConnectionResult.getLocation().getY(), 0.0);
+        assertTrue(sourceConnectionResult.getMagnetIndex().isPresent());
+        assertEquals(MagnetConnection.MAGNET_CENTER, sourceConnectionResult.getMagnetIndex().getAsInt());
+        assertTrue(sourceConnectionResult.isAuto());
+
+        final MagnetConnection targetConnectionResult = (MagnetConnection) edgeView.getTargetConnection().get();
+        assertEquals(bounds.getWidth() / 2, targetConnectionResult.getLocation().getX(), 0.0);
+        assertEquals(bounds.getHeight() / 2, targetConnectionResult.getLocation().getY(), 0.0);
+        assertTrue(targetConnectionResult.getMagnetIndex().isPresent());
+        assertEquals(MagnetConnection.MAGNET_CENTER, targetConnectionResult.getMagnetIndex().getAsInt());
+        assertTrue(targetConnectionResult.isAuto());
+    }
+
+    @Test
+    public void testIncompleteConnector() throws Exception {
+        final org.kie.workbench.common.stunner.core.graph.content.Bounds bounds = org.kie.workbench.common.stunner.core.graph.content.Bounds.create(0, 0, 100, 50);
+        final String decisionNode1UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+        final String decisionNode2UUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+        final String edgeUUID = org.kie.workbench.common.stunner.core.util.UUID.uuid();
+
+        final ViewConnector edgeView1 = marshallAndUnMarshallConnectors(bounds,
+                                                                        decisionNode1UUID,
+                                                                        decisionNode2UUID,
+                                                                        edgeUUID,
+                                                                        null,
+                                                                        null,
+                                                                        (sc) -> {/*NOP*/},
+                                                                        (tc) -> {/*NOP*/});
+
+        final ViewConnector edgeView2 = marshallAndUnMarshallConnectors(bounds,
+                                                                        decisionNode1UUID,
+                                                                        decisionNode2UUID,
+                                                                        edgeUUID,
+                                                                        mock(MagnetConnection.class),
+                                                                        null,
+                                                                        (sc) -> {/*NOP*/},
+                                                                        (tc) -> {/*NOP*/});
+
+        final MagnetConnection sourceConnectionResult1 = (MagnetConnection) edgeView1.getSourceConnection().get();
+        assertFalse(sourceConnectionResult1.isAuto());
+        assertTrue(sourceConnectionResult1.getMagnetIndex().isPresent());
+
+        final MagnetConnection targetConnectionResult1 = (MagnetConnection) edgeView1.getTargetConnection().get();
+        assertFalse(targetConnectionResult1.isAuto());
+        assertTrue(targetConnectionResult1.getMagnetIndex().isPresent());
+
+        final MagnetConnection sourceConnectionResult2 = (MagnetConnection) edgeView2.getSourceConnection().get();
+        assertFalse(sourceConnectionResult2.isAuto());
+        assertTrue(sourceConnectionResult2.getMagnetIndex().isPresent());
+
+        final MagnetConnection targetConnectionResult2 = (MagnetConnection) edgeView2.getTargetConnection().get();
+        assertFalse(targetConnectionResult2.isAuto());
+        assertTrue(targetConnectionResult2.getMagnetIndex().isPresent());
     }
 
     @Test
@@ -2225,6 +2308,27 @@ public class DMNMarshallerStandaloneTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testIsAutoConnection() {
+        String id = "DMNEdge-ID";
+        String autoConnectionID = "#AUTO-CONNECTION";
+
+        DMNEdge dmnEdge1 = mock(DMNEdge.class);
+        when(dmnEdge1.getId()).thenReturn(id);
+
+        DMNEdge dmnEdge2 = mock(DMNEdge.class);
+        when(dmnEdge2.getId()).thenReturn(id + autoConnectionID);
+
+        DMNEdge dmnEdge3 = mock(DMNEdge.class);
+        when(dmnEdge3.getId()).thenReturn(null);
+
+        DMNMarshallerStandalone dmnMarshallerStandalone = new DMNMarshallerStandalone();
+
+        assertFalse(dmnMarshallerStandalone.isAutoConnection(dmnEdge1, autoConnectionID));
+        assertTrue(dmnMarshallerStandalone.isAutoConnection(dmnEdge2, autoConnectionID));
+        assertFalse(dmnMarshallerStandalone.isAutoConnection(dmnEdge3, autoConnectionID));
+    }
+
     @SuppressWarnings("unchecked")
     private void checkImports(final Graph<?, Node<?, ?>> graph) {
         assertNotNull(graph);
@@ -2254,6 +2358,8 @@ public class DMNMarshallerStandaloneTest {
                                                           final String decisionNode1UUID,
                                                           final String decisionNode2UUID,
                                                           final String edgeUUID,
+                                                          final MagnetConnection edgeSourceConnection,
+                                                          final MagnetConnection edgeTargetConnection,
                                                           final Consumer<MagnetConnection> sourceMagnetConsumer,
                                                           final Consumer<MagnetConnection> targetMagnetConsumer) throws Exception {
         final DMNMarshallerStandalone marshaller = getDMNMarshaller();
@@ -2262,6 +2368,8 @@ public class DMNMarshallerStandaloneTest {
                                                                        decisionNode1UUID,
                                                                        decisionNode2UUID,
                                                                        edgeUUID,
+                                                                       edgeSourceConnection,
+                                                                       edgeTargetConnection,
                                                                        sourceMagnetConsumer,
                                                                        targetMagnetConsumer);
 
@@ -2294,6 +2402,8 @@ public class DMNMarshallerStandaloneTest {
                                                      final String decisionNode1UUID,
                                                      final String decisionNode2UUID,
                                                      final String edgeUUID,
+                                                     final MagnetConnection edgeSourceConnection,
+                                                     final MagnetConnection edgeTargetConnection,
                                                      final Consumer<MagnetConnection> sourceMagnetConsumer,
                                                      final Consumer<MagnetConnection> targetMagnetConsumer) {
         final DiagramImpl diagram = createDiagram();
@@ -2323,12 +2433,18 @@ public class DMNMarshallerStandaloneTest {
 
         final Edge edge = mock(Edge.class);
         final ViewConnector edgeView = mock(ViewConnector.class);
+        Optional edgeSourceConnectionOptional = Optional.empty();
+        if (edgeSourceConnection != null) {
+            edgeSourceConnectionOptional = Optional.of(edgeSourceConnection);
+        }
+        Optional edgeTargetConnectionOptional = Optional.empty();
+        if (edgeTargetConnection != null) {
+            edgeTargetConnectionOptional = Optional.of(edgeTargetConnection);
+        }
         when(edge.getUUID()).thenReturn(edgeUUID);
         when(edge.getContent()).thenReturn(edgeView);
-        final MagnetConnection edgeSourceConnection = mock(MagnetConnection.class);
-        final MagnetConnection edgeTargetConnection = mock(MagnetConnection.class);
-        when(edgeView.getSourceConnection()).thenReturn(Optional.of(edgeSourceConnection));
-        when(edgeView.getTargetConnection()).thenReturn(Optional.of(edgeTargetConnection));
+        when(edgeView.getSourceConnection()).thenReturn(edgeSourceConnectionOptional);
+        when(edgeView.getTargetConnection()).thenReturn(edgeTargetConnectionOptional);
         when(edgeView.getControlPoints()).thenReturn(new ControlPoint[]{});
         when(decisionNode1.getOutEdges()).thenReturn(Collections.singletonList(edge));
         when(decisionNode2.getInEdges()).thenReturn(Collections.singletonList(edge));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/common/IdUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/common/IdUtils.java
@@ -31,8 +31,12 @@ public class IdUtils {
 
     private static String COMBINER_DELIMITER = "-";
 
-    public static String getPrefixedId(final String prefixId,
-                                       final String rawId) {
+    public static final String AUTO_SOURCE_CONNECTION = "#AUTO-SOURCE";
+
+    public static final String AUTO_TARGET_CONNECTION = "#AUTO-TARGET";
+
+    public static final String getPrefixedId(final String prefixId,
+                                             final String rawId) {
         return Stream.of(prefixId, rawId)
                 .filter(s -> !isEmpty(s))
                 .collect(Collectors.joining(SEPARATOR_DELIMITER));
@@ -72,10 +76,22 @@ public class IdUtils {
 
     public static String getEdgeId(final JSIDMNDiagram diagram,
                                    final List<String> dmnElementIds,
-                                   final String dmnElementId) {
+                                   final String dmnElementId,
+                                   final boolean autoSourceConnection,
+                                   final boolean autoTargetConnection) {
 
         final String diagramName = lower(diagram.getName());
-        return getUniqueId("dmnedge", diagramName, dmnElementId, 1, dmnElementIds);
+        final String uniqueId = getUniqueId("dmnedge", diagramName, dmnElementId, 1, dmnElementIds);
+
+        String autoConnectionId = "";
+        if (autoSourceConnection) {
+            autoConnectionId += AUTO_SOURCE_CONNECTION;
+        }
+        if (autoTargetConnection) {
+            autoConnectionId += AUTO_TARGET_CONNECTION;
+        }
+
+        return uniqueId + autoConnectionId;
     }
 
     private static String getUniqueId(final String prefix,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
@@ -361,7 +361,7 @@ public class NodeConnector {
         final String reqInputID = getId(jsiDMNElementReference);
         final List<NodeEntry> nodeEntries = entriesById.get(reqInputID);
 
-        if (nodeEntries == null || nodeEntries.size() == 0) {
+        if (nodeEntries == null || nodeEntries.isEmpty()) {
             return;
         }
 
@@ -444,14 +444,16 @@ public class NodeConnector {
         if (null != sourceNode) {
             setConnectionMagnet(sourceNode,
                                 source,
-                                connectionContent::setSourceConnection);
+                                connectionContent::setSourceConnection,
+                                isSourceAutoConnectionEdge(jsidmnEdge));
         }
         final JSIPoint target = Js.uncheckedCast(e.getWaypoint().get(e.getWaypoint().size() - 1));
         final Node<View<?>, Edge> targetNode = edge.getTargetNode();
         if (null != targetNode) {
             setConnectionMagnet(targetNode,
                                 target,
-                                connectionContent::setTargetConnection);
+                                connectionContent::setTargetConnection,
+                                isTargetAutoConnectionEdge(jsidmnEdge));
         }
         if (e.getWaypoint().size() > 2) {
             connectionContent.setControlPoints(e.getWaypoint()
@@ -462,9 +464,27 @@ public class NodeConnector {
         }
     }
 
+    protected boolean isSourceAutoConnectionEdge(JSIDMNEdge jsidmnEdge) {
+        return isAutoConnection(jsidmnEdge, IdUtils.AUTO_SOURCE_CONNECTION);
+    }
+
+    protected boolean isTargetAutoConnectionEdge(JSIDMNEdge jsidmnEdge) {
+        return isAutoConnection(jsidmnEdge, IdUtils.AUTO_TARGET_CONNECTION);
+    }
+
+    protected boolean isAutoConnection(JSIDMNEdge jsidmnEdge, String autoConnectionID) {
+        String dmnEdgeID = jsidmnEdge.getId();
+        if (dmnEdgeID != null) {
+            return dmnEdgeID.contains(autoConnectionID);
+        } else {
+            return false;
+        }
+    }
+
     private void setConnectionMagnet(final Node<View<?>, Edge> node,
                                      final JSIPoint magnetPoint,
-                                     final Consumer<Connection> connectionConsumer) {
+                                     final Consumer<Connection> connectionConsumer,
+                                     final Boolean isAutoConnection) {
         final View<?> view = node.getContent();
         final double viewX = xOfBound(upperLeftBound(view));
         final double viewY = yOfBound(upperLeftBound(view));
@@ -472,14 +492,18 @@ public class NodeConnector {
         final double magnetRelativeY = magnetPoint.getY() - viewY;
         final double viewWidth = view.getBounds().getWidth();
         final double viewHeight = view.getBounds().getHeight();
+
+        MagnetConnection connection;
         if (isCentre(magnetRelativeX,
                      magnetRelativeY,
                      viewWidth,
                      viewHeight)) {
-            connectionConsumer.accept(MagnetConnection.Builder.atCenter(node));
+            connection = MagnetConnection.Builder.atCenter(node);
         } else {
-            connectionConsumer.accept(MagnetConnection.Builder.at(magnetRelativeX, magnetRelativeY).setAuto(true));
+            connection = MagnetConnection.Builder.at(magnetRelativeX, magnetRelativeY);
         }
+        connection.setAuto(isAutoConnection);
+        connectionConsumer.accept(connection);
     }
 
     private boolean isCentre(final double magnetRelativeX,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/common/IdUtilsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/common/IdUtilsTest.java
@@ -25,6 +25,8 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JS
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.kie.workbench.common.dmn.client.marshaller.common.IdUtils.AUTO_SOURCE_CONNECTION;
+import static org.kie.workbench.common.dmn.client.marshaller.common.IdUtils.AUTO_TARGET_CONNECTION;
 import static org.kie.workbench.common.dmn.client.marshaller.common.IdUtils.getComposedId;
 import static org.kie.workbench.common.dmn.client.marshaller.common.IdUtils.getEdgeId;
 import static org.kie.workbench.common.dmn.client.marshaller.common.IdUtils.getPrefixedId;
@@ -74,9 +76,39 @@ public class IdUtilsTest {
 
     @Test
     public void testGetEdgeId() {
+        String dmnElementId = "_1111-2222";
+        String uniqueId = "dmnedge-drg-" + dmnElementId;
+
         final JSIDMNDiagram diagram = mock(JSIDMNDiagram.class);
         when(diagram.getName()).thenReturn("DRG");
-        assertEquals("dmnedge-drg-_1111-2222", getEdgeId(diagram, list(), "_1111-2222"));
+
+        final String result1 = getEdgeId(diagram, list(),
+                                         dmnElementId,
+                                         false,
+                                         false);
+        String expected1 = uniqueId;
+        assertEquals(expected1, result1);
+
+        final String result2 = getEdgeId(diagram, list(),
+                                         dmnElementId,
+                                         true,
+                                         false);
+        String expected2 = uniqueId + AUTO_SOURCE_CONNECTION;
+        assertEquals(expected2, result2);
+
+        final String result3 = getEdgeId(diagram, list(),
+                                         dmnElementId,
+                                         false,
+                                         true);
+        String expected3 = uniqueId + AUTO_TARGET_CONNECTION;
+        assertEquals(expected3, result3);
+
+        final String result4 = getEdgeId(diagram, list(),
+                                         dmnElementId,
+                                         true,
+                                         true);
+        String expected4 = uniqueId + AUTO_SOURCE_CONNECTION + AUTO_TARGET_CONNECTION;
+        assertEquals(expected4, result4);
     }
 
     @Test
@@ -88,7 +120,7 @@ public class IdUtilsTest {
     @Test
     public void testGetEdgeIdWhenDiagramNameIsNull() {
         final JSIDMNDiagram diagram = mock(JSIDMNDiagram.class);
-        assertEquals("dmnedge-_1111-2222", getEdgeId(diagram, list(), "_1111-2222"));
+        assertEquals("dmnedge-_1111-2222", getEdgeId(diagram, list(), "_1111-2222", false, false));
     }
 
     private List<String> list(final String... items) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshallerTest.java
@@ -35,8 +35,15 @@ import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSIT
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITInformationRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITKnowledgeRequirement;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITKnowledgeSource;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNDiagram;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmndi12.JSIDMNEdge;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.view.ControlPoint;
+import org.kie.workbench.common.stunner.core.graph.content.view.DiscreteConnection;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.mockito.invocation.InvocationOnMock;
 
 import static java.util.Arrays.asList;
@@ -269,6 +276,67 @@ public class DMNMarshallerTest {
         assertEquals(2, nodeDiagramImports.size());
         assertTrue(nodeDiagramImports.contains(import1));
         assertTrue(nodeDiagramImports.contains(import2));
+    }
+
+    @Test
+    public void testConnect() {
+        final DMNMarshaller dmnMarshaller = new DMNMarshaller();
+        final JSIDMNDiagram diagram = mock(JSIDMNDiagram.class);
+        final List<String> dmnDiagramElementIds = mock(List.class);
+        final Definitions definitionsStunnerPojo = mock(Definitions.class);
+        final List<JSIDMNEdge> dmnEdges = new ArrayList<>();
+
+        final Node<?, ?> node = mock(Node.class);
+        final List inEdges = new ArrayList<>();
+        final Edge edge = mock(Edge.class);
+        final Node sourceNode = mock(Node.class);
+        final View sourceView = mock(View.class);
+        final ViewConnector viewConnector = mock(ViewConnector.class);
+        final DiscreteConnection sourceConnection = mock(DiscreteConnection.class);
+        final DiscreteConnection targetConnection = mock(DiscreteConnection.class);
+        final View<?> view = mock(View.class);
+
+        inEdges.add(edge);
+        when(edge.getSourceNode()).thenReturn(sourceNode);
+        when(sourceNode.getContent()).thenReturn(sourceView);
+
+        when(node.getInEdges()).thenReturn(inEdges);
+        when(edge.getContent()).thenReturn(viewConnector);
+        when(viewConnector.getControlPoints()).thenReturn(new ControlPoint[]{});
+        when(sourceConnection.isAuto()).thenReturn(true);
+        when(targetConnection.isAuto()).thenReturn(true);
+        when(diagram.getName()).thenReturn("dmnEdge");
+        when(definitionsStunnerPojo.getDefaultNamespace()).thenReturn("org.edge");
+
+        when(viewConnector.getSourceConnection()).thenReturn(Optional.of(sourceConnection));
+        when(viewConnector.getTargetConnection()).thenReturn(Optional.of(targetConnection));
+        dmnMarshaller.connect(diagram,
+                              dmnDiagramElementIds,
+                              definitionsStunnerPojo,
+                              dmnEdges,
+                              node,
+                              view);
+
+        when(viewConnector.getSourceConnection()).thenReturn(Optional.empty());
+        when(viewConnector.getTargetConnection()).thenReturn(Optional.empty());
+        dmnMarshaller.connect(diagram,
+                              dmnDiagramElementIds,
+                              definitionsStunnerPojo,
+                              dmnEdges,
+                              node,
+                              view);
+
+        when(viewConnector.getSourceConnection()).thenReturn(Optional.of(sourceConnection));
+        when(viewConnector.getTargetConnection()).thenReturn(Optional.empty());
+        dmnMarshaller.connect(diagram,
+                              dmnDiagramElementIds,
+                              definitionsStunnerPojo,
+                              dmnEdges,
+                              node,
+                              view);
+
+        verify(sourceConnection).isAuto();
+        verify(targetConnection).isAuto();
     }
 
     private JSITDecision makeDecision(final String id) {


### PR DESCRIPTION
DMN marshallers/unmarshaller were not prepared to handle auto-magnets.
Those will be handled as Double.Nan values (<di:waypoint x="NaN" y="NaN" />).

**JIRA**: [DROOLS-5911](https://issues.redhat.com/browse/DROOLS-5911)

**Business Central**: [WAR file](https://drive.google.com/file/d/1TBt05A-cEfzXN5udnqrv7TLflBK-O_-B/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1o2oWp6z5pW5ObjT7lVciPgWXBqiySq8z/view?usp=sharing)