### PR TITLE
KOGITO-4197: [DMN Designer] DMN 1.1 model can not be fixed to proper DMN 1.2

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
@@ -62,6 +62,7 @@ import org.kie.workbench.common.stunner.core.graph.content.view.MagnetConnection
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.core.graph.impl.EdgeImpl;
+import org.kie.workbench.common.stunner.core.util.UUID;
 
 import static org.kie.workbench.common.dmn.client.marshaller.common.JsInteropUtils.forEach;
 import static org.kie.workbench.common.dmn.client.marshaller.converters.dd.PointUtils.upperLeftBound;
@@ -370,14 +371,13 @@ public class NodeConnector {
             // Generate new a edge and connect it
             final NodeEntry nodeEntry = nodeEntries.get(0);
             final Node requiredNode = nodeEntry.getNode();
-            final String id = nodeEntry.getDmnElement().getId();
 
             connectWbEdge(connectorTypeId,
                           diagramId,
                           currentNode,
                           requiredNode,
                           newEdge(),
-                          id);
+                          uuid());
         } else if (existingEdge.isPresent()) {
             // Connect existing edge
             final JSIDMNEdge edge = Js.uncheckedCast(existingEdge.get());
@@ -515,5 +515,9 @@ public class NodeConnector {
         });
 
         return entriesByPoint2D.get(nearest).getNode();
+    }
+
+    String uuid() {
+        return UUID.uuid();
     }
 }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnectorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnectorTest.java
@@ -71,9 +71,6 @@ public class NodeConnectorTest {
     @Mock
     private Node requiredNode;
 
-    @Mock
-    private JSITDMNElement nodeEntryElement;
-
     private NodeConnector nodeConnector;
 
     private String connectorTypeId = getDefinitionId(InformationRequirement.class);
@@ -98,9 +95,8 @@ public class NodeConnectorTest {
 
         when(jsiDMNElementReference.getHref()).thenReturn("#123");
         when(jsiDMNElement.getId()).thenReturn("789");
-        when(nodeEntry.getDmnElement()).thenReturn(nodeEntryElement);
         when(nodeEntry.getNode()).thenReturn(requiredNode);
-        when(nodeEntryElement.getId()).thenReturn("456");
+        doReturn("456").when(nodeConnector).uuid();
         doReturn(newEdge).when(nodeConnector).newEdge();
         doNothing().when(nodeConnector).connectWbEdge(any(), any(), any(), any(), any(), any());
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-filter.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-filter.dmn
@@ -1,42 +1,47 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_f52ca843-504b-4c3b-a6bc-4d377bffef7a" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_f52ca843-504b-4c3b-a6bc-4d377bffef7a" name="filter01" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_f52ca843-504b-4c3b-a6bc-4d377bffef7a">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_f52ca843-504b-4c3b-a6bc-4d377bffef7a"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_f52ca843-504b-4c3b-a6bc-4d377bffef7a" name="filter01" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_f52ca843-504b-4c3b-a6bc-4d377bffef7a">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tEmployee" name="tEmployee" isCollection="true">
     <dmn:itemComponent id="_c22147cb-9481-404e-8f48-f8eee8d25565" name="id" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_0b26fc3e-dcb9-4106-ac30-f536247fb48c" name="dept" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_e5120ba7-544a-4f7d-8712-f1c659b82f61" name="name" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tNameList" name="tNameList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:decision id="_4a786da5-5cd2-4c3a-ba4d-dcb3051c1812" name="filter01">
     <dmn:extensionElements/>
-    <dmn:variable id="_2FF13799-7BAA-4064-AA85-3C6DB6757203" name="filter01" typeRef="tns:tNameList"/>
-    <dmn:informationRequirement id="_17c8d488-19be-481b-b341-85043176a25c">
+    <dmn:variable id="_177E6D79-C835-4FE1-9B48-102107466292" name="filter01" typeRef="tNameList"/>
+    <dmn:informationRequirement id="_FEA0C425-B1E9-41AD-B0CF-050F22CAABC5">
       <dmn:requiredInput href="#_17c8d488-19be-481b-b341-85043176a25c"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_192651DF-98BE-437B-9744-3C7F41B0ED8B">
+    <dmn:literalExpression id="_F9287AA9-8EB4-4374-A603-5F32CBF411A0">
       <dmn:text>Employee[dept=20].name</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_17c8d488-19be-481b-b341-85043176a25c" name="Employee">
     <dmn:extensionElements/>
-    <dmn:variable id="_3CDF321A-F926-48BE-B711-ED4D369BD337" name="Employee" typeRef="tns:tEmployee"/>
+    <dmn:variable id="_C8935FB2-CB96-4E1F-AA9C-DFF125FB529E" name="Employee" typeRef="tEmployee"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_02F6A567-ED4A-40E8-B9F6-DB0F0B1D49FC" name="DRG">
+    <dmndi:DMNDiagram id="_B005DBC7-0503-4020-8697-F76D79A65AA6" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_192651DF-98BE-437B-9744-3C7F41B0ED8B"/>
+          <kie:ComponentWidths dmnElementRef="_F9287AA9-8EB4-4374-A603-5F32CBF411A0"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_4a786da5-5cd2-4c3a-ba4d-dcb3051c1812" dmnElementRef="tns:_4a786da5-5cd2-4c3a-ba4d-dcb3051c1812" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4a786da5-5cd2-4c3a-ba4d-dcb3051c1812" dmnElementRef="_4a786da5-5cd2-4c3a-ba4d-dcb3051c1812" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -45,7 +50,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_17c8d488-19be-481b-b341-85043176a25c" dmnElementRef="tns:_17c8d488-19be-481b-b341-85043176a25c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_17c8d488-19be-481b-b341-85043176a25c" dmnElementRef="_17c8d488-19be-481b-b341-85043176a25c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -54,7 +59,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_17c8d488-19be-481b-b341-85043176a25c" dmnElementRef="tns:_17c8d488-19be-481b-b341-85043176a25c">
+      <dmndi:DMNEdge id="dmnedge-drg-_FEA0C425-B1E9-41AD-B0CF-050F22CAABC5" dmnElementRef="_FEA0C425-B1E9-41AD-B0CF-050F22CAABC5">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-input-data-string.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-input-data-string.dmn
@@ -1,25 +1,31 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/agilepro/dmn-tck" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0001-input-data-string" name="0001-input-data-string" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="https://github.com/agilepro/dmn-tck"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0001-input-data-string" name="0001-input-data-string" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
   <dmn:extensionElements/>
   <dmn:decision id="d_GreetingMessage" name="Greeting Message">
     <dmn:extensionElements/>
-    <dmn:variable id="_330C0542-0E3B-49A5-AF37-12FFA50B6E1D" name="Greeting Message" typeRef="feel:string"/>
-    <dmn:informationRequirement id="i_FullName">
+    <dmn:variable id="_215A03DB-39E7-4DDC-A3A2-27137DC09CA2" name="Greeting Message" typeRef="string"/>
+    <dmn:informationRequirement id="_62A5A325-DE2E-4DAB-81B0-261BFD455721">
       <dmn:requiredInput href="#i_FullName"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_F5CF2CC8-D54B-4A87-B25F-92AE5768D2C7">
+    <dmn:literalExpression id="_4EFA4D67-5CE7-4816-AFEF-E70D4A69500E">
       <dmn:text>"Hello " + Full Name</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="i_FullName" name="Full Name">
     <dmn:extensionElements/>
-    <dmn:variable id="_D6035E67-1AC4-4395-8E1C-8977E05D5ED0" name="Full Name" typeRef="feel:string"/>
+    <dmn:variable id="_F1E2768D-AD95-4827-9C68-BD80C9691DB2" name="Full Name" typeRef="string"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_587E34DA-6C93-4751-828A-EEAE6FE5DA01" name="DRG">
+    <dmndi:DMNDiagram id="_94F32805-FCC5-43E1-AD96-B384AEA7E2D0" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_F5CF2CC8-D54B-4A87-B25F-92AE5768D2C7"/>
+          <kie:ComponentWidths dmnElementRef="_4EFA4D67-5CE7-4816-AFEF-E70D4A69500E"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
       <dmndi:DMNShape id="dmnshape-drg-d_GreetingMessage" dmnElementRef="d_GreetingMessage" isCollapsed="false">
@@ -40,7 +46,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-i_FullName" dmnElementRef="i_FullName">
+      <dmndi:DMNEdge id="dmnedge-drg-_62A5A325-DE2E-4DAB-81B0-261BFD455721" dmnElementRef="_62A5A325-DE2E-4DAB-81B0-261BFD455721">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-input-data-number.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-input-data-number.dmn
@@ -1,25 +1,31 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/agilepro/dmn-tck" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0002-input-data-number" name="0002-input-data-number" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="https://github.com/agilepro/dmn-tck"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0002-input-data-number" name="0002-input-data-number" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
   <dmn:extensionElements/>
   <dmn:decision id="d_YearlySalary" name="Yearly Salary">
     <dmn:extensionElements/>
-    <dmn:variable id="_BE103E6D-652D-4FC6-95D8-DA31807618E7" name="Yearly Salary" typeRef="feel:number"/>
-    <dmn:informationRequirement id="i_MonthlySalary">
+    <dmn:variable id="_877774FA-F499-404F-8029-E87C4F6C37DE" name="Yearly Salary" typeRef="number"/>
+    <dmn:informationRequirement id="_E3AEED90-FCBF-41A3-95BD-2EFEF0DA557E">
       <dmn:requiredInput href="#i_MonthlySalary"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_F61D4412-D7CE-4E4D-987D-9B4234386341">
+    <dmn:literalExpression id="_1E6CBA36-1B87-46D2-9BD2-0BBB52E6CB75">
       <dmn:text>12 * Monthly Salary</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="i_MonthlySalary" name="Monthly Salary">
     <dmn:extensionElements/>
-    <dmn:variable id="_E476586A-1775-4DCC-93B1-1C650536518F" name="Monthly Salary" typeRef="feel:number"/>
+    <dmn:variable id="_83A8CC91-3DAD-4916-86E6-15370D170A0B" name="Monthly Salary" typeRef="number"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_26252BB5-6E6F-4366-BC41-20EA372CA9D5" name="DRG">
+    <dmndi:DMNDiagram id="_FA0A43CE-395E-49DE-9605-90DA13E6FC81" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_F61D4412-D7CE-4E4D-987D-9B4234386341"/>
+          <kie:ComponentWidths dmnElementRef="_1E6CBA36-1B87-46D2-9BD2-0BBB52E6CB75"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
       <dmndi:DMNShape id="dmnshape-drg-d_YearlySalary" dmnElementRef="d_YearlySalary" isCollapsed="false">
@@ -40,7 +46,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-i_MonthlySalary" dmnElementRef="i_MonthlySalary">
+      <dmndi:DMNEdge id="dmnedge-drg-_E3AEED90-FCBF-41A3-95BD-2EFEF0DA557E" dmnElementRef="_E3AEED90-FCBF-41A3-95BD-2EFEF0DA557E">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-string-functions.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-string-functions.dmn
@@ -1,149 +1,157 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_c2dc9bd5-010e-4351-b375-7db74d8ba69d" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_c2dc9bd5-010e-4351-b375-7db74d8ba69d" name="stringFunctions" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_c2dc9bd5-010e-4351-b375-7db74d8ba69d">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_c2dc9bd5-010e-4351-b375-7db74d8ba69d"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_c2dc9bd5-010e-4351-b375-7db74d8ba69d" name="stringFunctions" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_c2dc9bd5-010e-4351-b375-7db74d8ba69d">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tBasic" name="tBasic" isCollection="false">
     <dmn:itemComponent id="_5d7320fd-aa96-4319-a4da-593ec491d0b0" name="startsWithX" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_bc690f14-ecc7-402b-904d-ca2eeec91881" name="startsWithB" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_9a4db404-cd4b-4de3-8dc6-f06a7c538dae" name="endsWithX" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_1e0cc65d-a319-453e-b55b-e1eff815521c" name="endsWithB" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_558c199a-17d9-46f4-8661-ec76fc67374d" name="containsX" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_ca9df9fb-61f1-4f43-93ca-d9600b87285d" name="containsB" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_82968175-bbd2-4541-8461-2898e9d9b86d" name="substringC1" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_e87917e4-37ae-44a9-b156-d490292a036e" name="stringlength" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_cf4985ae-5244-4b32-9abb-bf9f012233b7" name="uppercase" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_38e20849-e3ab-4eff-847e-f7a017e89778" name="lowercase" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_814080bc-e9cd-4a79-aff0-ce64d6fef8df" name="substringBeforeB" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_b11a7ed7-6bad-4c8a-8edb-c768f2604ed8" name="substringAfterB" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tReplace" name="tReplace" isCollection="false">
     <dmn:itemComponent id="_1d5254b9-0a5f-42d2-be18-338518f861cc" name="Aao" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_71470763-6dbe-43a4-b5e3-eca10bab1814" name="AanplusStarstar" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_afe9608a-b74a-4a66-80f1-6de501eb8d9b" name="encloseVowels" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:inputData id="_0923ed0c-3674-4476-b84c-f9ad5e5e8048" name="A">
     <dmn:extensionElements/>
-    <dmn:variable id="_35B306B1-26F4-4DC8-BEAB-5876DE7522FD" name="A" typeRef="feel:string"/>
+    <dmn:variable id="_A19E67A2-4B0D-44B7-9685-AE828629B984" name="A" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_1df2ad51-3334-4098-b55f-df885fb0e412" name="B">
     <dmn:extensionElements/>
-    <dmn:variable id="_D9C77AAC-8FCC-4290-AFC9-908FFBBC95EF" name="B" typeRef="feel:string"/>
+    <dmn:variable id="_C81E33B8-9B75-4388-A4ED-E85B6E7891BB" name="B" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_6a75944d-7013-4fc3-8770-ab8eaa0e0560" name="NumC">
     <dmn:extensionElements/>
-    <dmn:variable id="_5415077A-7DEC-43DB-8EAE-57DEC9D2EDC8" name="NumC" typeRef="feel:number"/>
+    <dmn:variable id="_5068CFE9-121F-4725-BAB7-8F57318FC44A" name="NumC" typeRef="number"/>
   </dmn:inputData>
   <dmn:decision id="_de5529b1-ed4c-4b39-9e36-e0e056aec20c" name="Basic">
     <dmn:extensionElements/>
-    <dmn:variable id="_7BBC76D0-E581-4BDE-BBE6-2BBB0D57BCDF" name="Basic" typeRef="tns:tBasic"/>
-    <dmn:informationRequirement id="_0923ed0c-3674-4476-b84c-f9ad5e5e8048">
+    <dmn:variable id="_58B0B9DC-FEF7-4035-AEB8-9B86A552894E" name="Basic" typeRef="tBasic"/>
+    <dmn:informationRequirement id="_3FE203E6-7254-4AC6-948E-65BF2EDC7CC9">
       <dmn:requiredInput href="#_0923ed0c-3674-4476-b84c-f9ad5e5e8048"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1df2ad51-3334-4098-b55f-df885fb0e412">
+    <dmn:informationRequirement id="_29220E9C-93C4-4DF5-9FD1-9A6438BE7955">
       <dmn:requiredInput href="#_1df2ad51-3334-4098-b55f-df885fb0e412"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_6a75944d-7013-4fc3-8770-ab8eaa0e0560">
+    <dmn:informationRequirement id="_BD831028-C7E2-47F4-A285-8D9EA191713E">
       <dmn:requiredInput href="#_6a75944d-7013-4fc3-8770-ab8eaa0e0560"/>
     </dmn:informationRequirement>
-    <dmn:context id="_BB1308DC-1438-4EE0-8597-DD6530E91D69">
+    <dmn:context id="_E858E84E-8E06-43BB-B437-BB2BFD8EADCA">
       <dmn:contextEntry>
-        <dmn:variable id="_A28A23B9-1D5E-4C6E-8DC2-AE60AEBFB3B3" name="startsWithX" typeRef="feel:boolean"/>
-        <dmn:literalExpression id="_D2D29068-6C8E-4D76-A06D-447F579FA224">
+        <dmn:variable id="_86A8ABBA-165F-4CF7-BF74-1E4C4D28C8A6" name="startsWithX" typeRef="boolean"/>
+        <dmn:literalExpression id="_D983E47B-E92C-492B-8443-3151B6019730">
           <dmn:text>starts with(A,"x")</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_D47C9C67-6566-4EA8-AA0E-8D56FCE45684" name="startsWithB" typeRef="feel:boolean"/>
-        <dmn:literalExpression id="_73018226-1F3E-45FB-A845-D885F40439A7">
+        <dmn:variable id="_5EE256E8-4391-45BA-B1F9-7FE2CD40D9DC" name="startsWithB" typeRef="boolean"/>
+        <dmn:literalExpression id="_25E404DB-8D08-434C-9370-3D92637336D0">
           <dmn:text>starts with(A,B)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_14724146-6862-4BFB-8505-AAC6A0D6CE01" name="endsWithX" typeRef="feel:boolean"/>
-        <dmn:literalExpression id="_7BB8C288-44F5-443D-B9BC-FC0078DDADF3">
+        <dmn:variable id="_ED54F504-7498-4A30-A364-A964B041D8DD" name="endsWithX" typeRef="boolean"/>
+        <dmn:literalExpression id="_91AC4459-B680-414D-8618-A8C807FE91D6">
           <dmn:text>ends with(A,"x")</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_3E9AD7FC-45BF-4427-92E8-64885D77C2F2" name="endsWithB" typeRef="feel:boolean"/>
-        <dmn:literalExpression id="_899E5793-CC77-482F-A779-6376CC7A6867">
+        <dmn:variable id="_3A1AE358-D977-44A1-8076-9D1A983C8739" name="endsWithB" typeRef="boolean"/>
+        <dmn:literalExpression id="_06002103-3D51-45B5-8E10-8DCA2D67128B">
           <dmn:text>ends with(A,B)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_7DD738D5-D5C5-49CD-8DCB-04DC0837386A" name="containsX" typeRef="feel:boolean"/>
-        <dmn:literalExpression id="_0F362A4D-1DE5-4A62-B52D-49EEE7D52976">
+        <dmn:variable id="_4411A394-B821-4D19-A252-BFB133911E0F" name="containsX" typeRef="boolean"/>
+        <dmn:literalExpression id="_C2493CF3-312D-44C3-8D30-123CABA6E97A">
           <dmn:text>contains(A,"x")</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_27E7DAE9-807F-4EC9-83A2-666F3DBC9417" name="containsB" typeRef="feel:boolean"/>
-        <dmn:literalExpression id="_3811D857-D402-4FD4-BA75-A506E89BB02B">
+        <dmn:variable id="_6B65706F-81BB-45D2-8780-3E0E709519F3" name="containsB" typeRef="boolean"/>
+        <dmn:literalExpression id="_FBD55976-1C75-4FC8-8802-592CD83CC579">
           <dmn:text>contains(A,B)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_1AD0AC6C-F088-47DF-BCE3-203DE62EA3DE" name="substringC1" typeRef="feel:string"/>
-        <dmn:literalExpression id="_5CB7E47E-2A76-43E4-9BB5-527D985744F7">
+        <dmn:variable id="_04D9C6C1-63B0-41AC-AEB4-E9CDB7A545A8" name="substringC1" typeRef="string"/>
+        <dmn:literalExpression id="_30703304-E1CA-4D99-9700-CBC8D7E4E5A5">
           <dmn:text>substring(A,NumC,1)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_FAB16F4F-0237-4B54-BCAD-2D52F41C4044" name="stringlength" typeRef="feel:number"/>
-        <dmn:literalExpression id="_54F092D3-0184-484D-B78C-7DE6F184290B">
+        <dmn:variable id="_0DE0875B-6186-46D9-A70A-B396F4DF334E" name="stringlength" typeRef="number"/>
+        <dmn:literalExpression id="_4CB746D3-BA13-45D0-A33B-E864D40B99E4">
           <dmn:text>string length(A)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_282594B9-0813-41D6-888C-17EB033A35B6" name="uppercase" typeRef="feel:string"/>
-        <dmn:literalExpression id="_C345ED7A-047E-44F5-BFA3-EB0BB9F426A2">
+        <dmn:variable id="_4EB85A05-76FB-4AF2-B308-20BAFF7226DD" name="uppercase" typeRef="string"/>
+        <dmn:literalExpression id="_7103562E-267B-4102-8277-8727932162C3">
           <dmn:text>upper case(A)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_CBF59660-22FE-468B-8023-983542976DD5" name="lowercase" typeRef="feel:string"/>
-        <dmn:literalExpression id="_83CFB32C-CBFC-492C-888F-87F6CDF22451">
+        <dmn:variable id="_0704F071-CD17-4239-BE6F-7677CC718AC9" name="lowercase" typeRef="string"/>
+        <dmn:literalExpression id="_3CB09542-19E1-49AD-B053-52FF1346FF9A">
           <dmn:text>lower case(B)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_92900712-C325-462A-AFE2-64CEE370E2B8" name="substringBeforeB" typeRef="feel:string"/>
-        <dmn:literalExpression id="_7E81E471-7A2D-4ACE-82DF-9C2ED2651857">
+        <dmn:variable id="_793C2E0D-04FB-40BE-8F08-723CFE04DD10" name="substringBeforeB" typeRef="string"/>
+        <dmn:literalExpression id="_AC1C80A9-9104-44D3-BF55-FD419D0693D5">
           <dmn:text>substring before(A,B)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_E886C232-6647-487E-8623-3480F85BD38C" name="substringAfterB" typeRef="feel:string"/>
-        <dmn:literalExpression id="_413E2BBE-7854-4097-B614-E60D1B39A182">
+        <dmn:variable id="_5079DA7C-6445-4D3D-8B3A-0B031FC32964" name="substringAfterB" typeRef="string"/>
+        <dmn:literalExpression id="_94FFD36E-E911-41A2-AFE0-1CF3BD66D106">
           <dmn:text>substring after(A,B)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
@@ -151,42 +159,42 @@
   </dmn:decision>
   <dmn:decision id="_93059496-257a-482b-b966-fcafe28cc84b" name="Matches">
     <dmn:extensionElements/>
-    <dmn:variable id="_0F53F0FA-A02B-4578-8984-79DAF79CC3C9" name="Matches" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_0923ed0c-3674-4476-b84c-f9ad5e5e8048">
+    <dmn:variable id="_382A89CE-CCC1-4677-99F4-B4DE7E76133E" name="Matches" typeRef="boolean"/>
+    <dmn:informationRequirement id="_5DDE4200-3D43-4590-88F2-D9B6EC1520E3">
       <dmn:requiredInput href="#_0923ed0c-3674-4476-b84c-f9ad5e5e8048"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1df2ad51-3334-4098-b55f-df885fb0e412">
+    <dmn:informationRequirement id="_E268A502-7CBC-424A-BBE1-C84656BE3C92">
       <dmn:requiredInput href="#_1df2ad51-3334-4098-b55f-df885fb0e412"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_21496B89-541B-432D-83F0-13E77D49C5B4">
+    <dmn:literalExpression id="_A84FD0D5-612F-49BD-90C0-3E3E8CD8D70E">
       <dmn:text>matches(A,"[a-z]{3}")</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_cc368e53-961d-4399-ad91-df00446b49d8" name="Replace">
     <dmn:extensionElements/>
-    <dmn:variable id="_8159B8E1-3998-438D-8570-DECB4BEE4A34" name="Replace" typeRef="tns:tReplace"/>
-    <dmn:informationRequirement id="_0923ed0c-3674-4476-b84c-f9ad5e5e8048">
+    <dmn:variable id="_4AA8B3DF-D8CA-43DB-A588-D6410E165215" name="Replace" typeRef="tReplace"/>
+    <dmn:informationRequirement id="_11112D2C-9BFE-4C3C-96BF-3423E8A468B4">
       <dmn:requiredInput href="#_0923ed0c-3674-4476-b84c-f9ad5e5e8048"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1df2ad51-3334-4098-b55f-df885fb0e412">
+    <dmn:informationRequirement id="_52089F54-865B-4594-975D-D05181186E5F">
       <dmn:requiredInput href="#_1df2ad51-3334-4098-b55f-df885fb0e412"/>
     </dmn:informationRequirement>
-    <dmn:context id="_A3081A1F-FAA0-4DE9-9397-2E6727A61202">
+    <dmn:context id="_05BE0B4A-7419-4D7B-B529-17A18F463D24">
       <dmn:contextEntry>
-        <dmn:variable id="_E0F5EB42-B690-4F0B-8029-DC3DAB197E4C" name="Aao" typeRef="feel:string"/>
-        <dmn:literalExpression id="_4313B29B-12F3-4DF1-BAB7-35BFBCDA77C3">
+        <dmn:variable id="_780929DF-4A06-4C73-BE65-AF52132FC079" name="Aao" typeRef="string"/>
+        <dmn:literalExpression id="_2CBFB3A3-CFB3-4876-BDCD-2FBA2D92392E">
           <dmn:text>replace(A,"a","o")</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_C90DAFCA-C1F3-4F8C-BE3D-CC3341E3F378" name="AanplusStarstar" typeRef="feel:string"/>
-        <dmn:literalExpression id="_4C657F30-FC7F-4746-B728-0256AE9858EB">
+        <dmn:variable id="_67A1B575-3894-4D97-B16D-AF23940093BD" name="AanplusStarstar" typeRef="string"/>
+        <dmn:literalExpression id="_B3AE35C4-B78F-4B84-A97C-DE77BBBA968B">
           <dmn:text>replace(A,"(an)+", "**")</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_F86C415E-AC66-47E0-80BC-9D9A79B8FAE4" name="encloseVowels" typeRef="feel:string"/>
-        <dmn:literalExpression id="_829F0465-5094-4F78-A07A-9CF4E56DC1E2">
+        <dmn:variable id="_D438B3F7-8339-4F29-81FF-9504B629BD0D" name="encloseVowels" typeRef="string"/>
+        <dmn:literalExpression id="_563D179B-910F-4DBB-BE42-D58D5D4D7EEF">
           <dmn:text>replace(A,"[aeiouy]","[$0]")</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
@@ -194,40 +202,40 @@
   </dmn:decision>
   <dmn:decision id="_255687db-652a-44c5-b4ca-9b3de659fd31" name="Constructor">
     <dmn:extensionElements/>
-    <dmn:variable id="_4A74300A-940B-44B5-BE56-6E8C43AEBBEC" name="Constructor" typeRef="feel:string"/>
-    <dmn:informationRequirement id="_6a75944d-7013-4fc3-8770-ab8eaa0e0560">
+    <dmn:variable id="_66CDEAB4-72F8-4B30-8659-BC260E03F151" name="Constructor" typeRef="string"/>
+    <dmn:informationRequirement id="_C630793E-5B0A-4AB6-9324-3E24B303CEAF">
       <dmn:requiredInput href="#_6a75944d-7013-4fc3-8770-ab8eaa0e0560"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_B4E54419-AC5C-45DE-96D2-340D0B6A3E5A">
+    <dmn:literalExpression id="_C25012D8-4151-402C-8382-0C8AB2FEC49B">
       <dmn:text>string(NumC)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_00E2A25A-6CD3-48A7-8628-AD8742FDB9FA" name="DRG">
+    <dmndi:DMNDiagram id="_5E3F763B-244C-4C0E-9087-3817914ACAE1" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_BB1308DC-1438-4EE0-8597-DD6530E91D69"/>
-          <kie:ComponentWidths dmnElementRef="_D2D29068-6C8E-4D76-A06D-447F579FA224"/>
-          <kie:ComponentWidths dmnElementRef="_73018226-1F3E-45FB-A845-D885F40439A7"/>
-          <kie:ComponentWidths dmnElementRef="_7BB8C288-44F5-443D-B9BC-FC0078DDADF3"/>
-          <kie:ComponentWidths dmnElementRef="_899E5793-CC77-482F-A779-6376CC7A6867"/>
-          <kie:ComponentWidths dmnElementRef="_0F362A4D-1DE5-4A62-B52D-49EEE7D52976"/>
-          <kie:ComponentWidths dmnElementRef="_3811D857-D402-4FD4-BA75-A506E89BB02B"/>
-          <kie:ComponentWidths dmnElementRef="_5CB7E47E-2A76-43E4-9BB5-527D985744F7"/>
-          <kie:ComponentWidths dmnElementRef="_54F092D3-0184-484D-B78C-7DE6F184290B"/>
-          <kie:ComponentWidths dmnElementRef="_C345ED7A-047E-44F5-BFA3-EB0BB9F426A2"/>
-          <kie:ComponentWidths dmnElementRef="_83CFB32C-CBFC-492C-888F-87F6CDF22451"/>
-          <kie:ComponentWidths dmnElementRef="_7E81E471-7A2D-4ACE-82DF-9C2ED2651857"/>
-          <kie:ComponentWidths dmnElementRef="_413E2BBE-7854-4097-B614-E60D1B39A182"/>
-          <kie:ComponentWidths dmnElementRef="_21496B89-541B-432D-83F0-13E77D49C5B4"/>
-          <kie:ComponentWidths dmnElementRef="_A3081A1F-FAA0-4DE9-9397-2E6727A61202"/>
-          <kie:ComponentWidths dmnElementRef="_4313B29B-12F3-4DF1-BAB7-35BFBCDA77C3"/>
-          <kie:ComponentWidths dmnElementRef="_4C657F30-FC7F-4746-B728-0256AE9858EB"/>
-          <kie:ComponentWidths dmnElementRef="_829F0465-5094-4F78-A07A-9CF4E56DC1E2"/>
-          <kie:ComponentWidths dmnElementRef="_B4E54419-AC5C-45DE-96D2-340D0B6A3E5A"/>
+          <kie:ComponentWidths dmnElementRef="_E858E84E-8E06-43BB-B437-BB2BFD8EADCA"/>
+          <kie:ComponentWidths dmnElementRef="_D983E47B-E92C-492B-8443-3151B6019730"/>
+          <kie:ComponentWidths dmnElementRef="_25E404DB-8D08-434C-9370-3D92637336D0"/>
+          <kie:ComponentWidths dmnElementRef="_91AC4459-B680-414D-8618-A8C807FE91D6"/>
+          <kie:ComponentWidths dmnElementRef="_06002103-3D51-45B5-8E10-8DCA2D67128B"/>
+          <kie:ComponentWidths dmnElementRef="_C2493CF3-312D-44C3-8D30-123CABA6E97A"/>
+          <kie:ComponentWidths dmnElementRef="_FBD55976-1C75-4FC8-8802-592CD83CC579"/>
+          <kie:ComponentWidths dmnElementRef="_30703304-E1CA-4D99-9700-CBC8D7E4E5A5"/>
+          <kie:ComponentWidths dmnElementRef="_4CB746D3-BA13-45D0-A33B-E864D40B99E4"/>
+          <kie:ComponentWidths dmnElementRef="_7103562E-267B-4102-8277-8727932162C3"/>
+          <kie:ComponentWidths dmnElementRef="_3CB09542-19E1-49AD-B053-52FF1346FF9A"/>
+          <kie:ComponentWidths dmnElementRef="_AC1C80A9-9104-44D3-BF55-FD419D0693D5"/>
+          <kie:ComponentWidths dmnElementRef="_94FFD36E-E911-41A2-AFE0-1CF3BD66D106"/>
+          <kie:ComponentWidths dmnElementRef="_A84FD0D5-612F-49BD-90C0-3E3E8CD8D70E"/>
+          <kie:ComponentWidths dmnElementRef="_05BE0B4A-7419-4D7B-B529-17A18F463D24"/>
+          <kie:ComponentWidths dmnElementRef="_2CBFB3A3-CFB3-4876-BDCD-2FBA2D92392E"/>
+          <kie:ComponentWidths dmnElementRef="_B3AE35C4-B78F-4B84-A97C-DE77BBBA968B"/>
+          <kie:ComponentWidths dmnElementRef="_563D179B-910F-4DBB-BE42-D58D5D4D7EEF"/>
+          <kie:ComponentWidths dmnElementRef="_C25012D8-4151-402C-8382-0C8AB2FEC49B"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_0923ed0c-3674-4476-b84c-f9ad5e5e8048" dmnElementRef="tns:_0923ed0c-3674-4476-b84c-f9ad5e5e8048" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_0923ed0c-3674-4476-b84c-f9ad5e5e8048" dmnElementRef="_0923ed0c-3674-4476-b84c-f9ad5e5e8048" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -236,7 +244,7 @@
         <dc:Bounds x="137" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_1df2ad51-3334-4098-b55f-df885fb0e412" dmnElementRef="tns:_1df2ad51-3334-4098-b55f-df885fb0e412" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1df2ad51-3334-4098-b55f-df885fb0e412" dmnElementRef="_1df2ad51-3334-4098-b55f-df885fb0e412" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -245,7 +253,7 @@
         <dc:Bounds x="312" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_6a75944d-7013-4fc3-8770-ab8eaa0e0560" dmnElementRef="tns:_6a75944d-7013-4fc3-8770-ab8eaa0e0560" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_6a75944d-7013-4fc3-8770-ab8eaa0e0560" dmnElementRef="_6a75944d-7013-4fc3-8770-ab8eaa0e0560" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -254,7 +262,7 @@
         <dc:Bounds x="487" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_de5529b1-ed4c-4b39-9e36-e0e056aec20c" dmnElementRef="tns:_de5529b1-ed4c-4b39-9e36-e0e056aec20c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_de5529b1-ed4c-4b39-9e36-e0e056aec20c" dmnElementRef="_de5529b1-ed4c-4b39-9e36-e0e056aec20c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -263,7 +271,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_93059496-257a-482b-b966-fcafe28cc84b" dmnElementRef="tns:_93059496-257a-482b-b966-fcafe28cc84b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_93059496-257a-482b-b966-fcafe28cc84b" dmnElementRef="_93059496-257a-482b-b966-fcafe28cc84b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -272,7 +280,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_cc368e53-961d-4399-ad91-df00446b49d8" dmnElementRef="tns:_cc368e53-961d-4399-ad91-df00446b49d8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_cc368e53-961d-4399-ad91-df00446b49d8" dmnElementRef="_cc368e53-961d-4399-ad91-df00446b49d8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -281,7 +289,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_255687db-652a-44c5-b4ca-9b3de659fd31" dmnElementRef="tns:_255687db-652a-44c5-b4ca-9b3de659fd31" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_255687db-652a-44c5-b4ca-9b3de659fd31" dmnElementRef="_255687db-652a-44c5-b4ca-9b3de659fd31" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -290,17 +298,37 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_0923ed0c-3674-4476-b84c-f9ad5e5e8048" dmnElementRef="tns:_0923ed0c-3674-4476-b84c-f9ad5e5e8048">
+      <dmndi:DMNEdge id="dmnedge-drg-_3FE203E6-7254-4AC6-948E-65BF2EDC7CC9" dmnElementRef="_3FE203E6-7254-4AC6-948E-65BF2EDC7CC9">
         <di:waypoint x="137" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1df2ad51-3334-4098-b55f-df885fb0e412" dmnElementRef="tns:_1df2ad51-3334-4098-b55f-df885fb0e412">
+      <dmndi:DMNEdge id="dmnedge-drg-_29220E9C-93C4-4DF5-9FD1-9A6438BE7955" dmnElementRef="_29220E9C-93C4-4DF5-9FD1-9A6438BE7955">
         <di:waypoint x="312" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_6a75944d-7013-4fc3-8770-ab8eaa0e0560" dmnElementRef="tns:_6a75944d-7013-4fc3-8770-ab8eaa0e0560">
+      <dmndi:DMNEdge id="dmnedge-drg-_BD831028-C7E2-47F4-A285-8D9EA191713E" dmnElementRef="_BD831028-C7E2-47F4-A285-8D9EA191713E">
         <di:waypoint x="487" y="225"/>
         <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_5DDE4200-3D43-4590-88F2-D9B6EC1520E3" dmnElementRef="_5DDE4200-3D43-4590-88F2-D9B6EC1520E3">
+        <di:waypoint x="137" y="225"/>
+        <di:waypoint x="50" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E268A502-7CBC-424A-BBE1-C84656BE3C92" dmnElementRef="_E268A502-7CBC-424A-BBE1-C84656BE3C92">
+        <di:waypoint x="312" y="225"/>
+        <di:waypoint x="50" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_11112D2C-9BFE-4C3C-96BF-3423E8A468B4" dmnElementRef="_11112D2C-9BFE-4C3C-96BF-3423E8A468B4">
+        <di:waypoint x="137" y="225"/>
+        <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_52089F54-865B-4594-975D-D05181186E5F" dmnElementRef="_52089F54-865B-4594-975D-D05181186E5F">
+        <di:waypoint x="312" y="225"/>
+        <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C630793E-5B0A-4AB6-9324-3E24B303CEAF" dmnElementRef="_C630793E-5B0A-4AB6-9324-3E24B303CEAF">
+        <di:waypoint x="487" y="225"/>
+        <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-input-data-string-allowed-values.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-input-data-string-allowed-values.dmn
@@ -1,34 +1,40 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tck="https://github.com/agilepro/dmn-tck" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0003-input-data-string-allowed-values" name="0003-input-data-string-allowed-values" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="https://github.com/agilepro/dmn-tck"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0003-input-data-string-allowed-values" name="0003-input-data-string-allowed-values" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
   <dmn:extensionElements/>
-  <dmn:itemDefinition id="_AE8D8377-74D5-43F2-9B4B-1E68C57CF477" name="tEmploymentStatus" isCollection="false">
-    <dmn:typeRef>feel:string</dmn:typeRef>
-    <dmn:allowedValues id="_AAB1E9FA-D3B7-49CC-827B-513DDB82EF9E">
+  <dmn:itemDefinition id="_98045828-5B78-4715-A5A0-F5B8D60AFB81" name="tEmploymentStatus" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues id="_EC2D6A4A-D3BA-40C0-A721-3FCA0AC46384">
       <dmn:text>"UNEMPLOYED","EMPLOYED","SELF-EMPLOYED","STUDENT"</dmn:text>
     </dmn:allowedValues>
   </dmn:itemDefinition>
   <dmn:decision id="d_EmploymentStatusStatement" name="Employment Status Statement">
     <dmn:extensionElements/>
-    <dmn:variable id="_081C4EF9-CD6B-4C65-BBEF-7F770EEE2FA5" name="Employment Status Statement" typeRef="feel:string"/>
-    <dmn:informationRequirement id="i_EmploymentStatus">
+    <dmn:variable id="_1CC985F5-3B4B-4A33-AFBD-67168BDCB07F" name="Employment Status Statement" typeRef="string"/>
+    <dmn:informationRequirement id="_0232CB3B-18B3-4E4E-9EE6-59AC1963B44A">
       <dmn:requiredInput href="#i_EmploymentStatus"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_086E5435-0FF6-49BE-86E6-DA9B07EF97BB">
+    <dmn:literalExpression id="_9233D838-9A9F-424E-86B8-CAEB40B736AA">
       <dmn:text>"You are " + Employment Status</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="i_EmploymentStatus" name="Employment Status">
     <dmn:extensionElements/>
-    <dmn:variable id="_6CA15785-14D2-4DDD-9756-5B03750E9C6B" name="Employment Status" typeRef="tck:tEmploymentStatus"/>
+    <dmn:variable id="_7EE86BD0-5490-4650-BA17-2A4C234D5282" name="Employment Status" typeRef="tEmploymentStatus"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_82F7B3CA-473A-41F3-97DB-C6C7D96EB3C5" name="DRG">
+    <dmndi:DMNDiagram id="_E94680F1-18EB-4386-B360-CB1B9F4157D3" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_086E5435-0FF6-49BE-86E6-DA9B07EF97BB"/>
+          <kie:ComponentWidths dmnElementRef="_9233D838-9A9F-424E-86B8-CAEB40B736AA"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-d_EmploymentStatusStatement" dmnElementRef="tck:d_EmploymentStatusStatement" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_EmploymentStatusStatement" dmnElementRef="d_EmploymentStatusStatement" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -37,7 +43,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_EmploymentStatus" dmnElementRef="tck:i_EmploymentStatus" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_EmploymentStatus" dmnElementRef="i_EmploymentStatus" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -46,7 +52,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-i_EmploymentStatus" dmnElementRef="tck:i_EmploymentStatus">
+      <dmndi:DMNEdge id="dmnedge-drg-_0232CB3B-18B3-4E4E-9EE6-59AC1963B44A" dmnElementRef="_0232CB3B-18B3-4E4E-9EE6-59AC1963B44A">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-iteration.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-iteration.dmn
@@ -1,57 +1,65 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_54863c52-2fa7-4a3d-b383-d4eb2eb88771" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_54863c52-2fa7-4a3d-b383-d4eb2eb88771" name="iteration1" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_54863c52-2fa7-4a3d-b383-d4eb2eb88771">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_54863c52-2fa7-4a3d-b383-d4eb2eb88771"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_54863c52-2fa7-4a3d-b383-d4eb2eb88771" name="iteration1" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_54863c52-2fa7-4a3d-b383-d4eb2eb88771">
   <dmn:extensionElements/>
-  <dmn:itemDefinition id="_89C6240C-1A3A-40EA-9E73-7BC4F2C1998C" name="tLoan" isCollection="false">
-    <dmn:itemComponent id="_F055DE58-3596-48E9-8B54-EBBC0593C39F" name="amount" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+  <dmn:itemDefinition id="_F81B09DB-660D-4FA4-A192-2B6F0B92C625" name="tLoan" isCollection="false">
+    <dmn:itemComponent id="_E6B69812-9754-4697-8C0A-E8DB41CBFD57" name="amount" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_7AAD376D-FBEA-4778-BA35-2FE3ACDC765B" name="rate" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:itemComponent id="_DCF5943C-8A48-4A57-924F-21CAFA1DD8B2" name="rate" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_56B9F262-8C32-43E4-AA97-5F5743DDDADC" name="term" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:itemComponent id="_4F0C98AE-94EA-434D-8F5D-9F04D2FB26AB" name="term" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_4367647D-29BA-4B65-A07C-894E0523ACE8" name="tLoanList" isCollection="true">
-    <dmn:typeRef>tns:tLoan</dmn:typeRef>
+  <dmn:itemDefinition id="_FF0E239E-4C64-4B45-9778-3203F8CAA018" name="tLoanList" isCollection="true">
+    <dmn:typeRef>tLoan</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:decision id="d_MonthlyPayment" name="MonthlyPayment">
     <dmn:extensionElements/>
-    <dmn:variable id="_3D651326-BF93-4E43-A5BA-5255CEFCFCD1" name="MonthlyPayment" typeRef="feel:number"/>
-    <dmn:informationRequirement id="i_Loans">
+    <dmn:variable id="_1D0F42C0-82D3-4D82-892F-A765EE558C3D" name="MonthlyPayment" typeRef="number"/>
+    <dmn:informationRequirement id="_F5229939-6759-47E1-BCC4-7D98D590CD8E">
       <dmn:requiredInput href="#i_Loans"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_PMT2">
+    <dmn:knowledgeRequirement id="_AB4D9418-D21C-4FA4-9C1C-82775846D6C0">
       <dmn:requiredKnowledge href="#b_PMT2"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_D0130B00-329E-4377-90B4-BC956B6B1CC5">
+    <dmn:literalExpression id="_0C614E9B-6ADB-4D7F-844E-7179B654F3AC">
       <dmn:text>for i in Loans return PMT2(i)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="b_PMT2" name="PMT2">
     <dmn:extensionElements/>
-    <dmn:variable id="_69F27356-06B7-4013-B9A1-D19D59DA9CD7" name="PMT2" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_8162F411-CE84-4B30-B10F-6FBD2C6963E1" kind="FEEL">
-      <dmn:formalParameter id="_41CC402E-9F2B-42D5-99E5-E13EC8BB839B" name="loan" typeRef="tns:tLoan"/>
-      <dmn:literalExpression id="_2F5BF703-5D95-46DE-99AC-BA53B40473C9" expressionLanguage="FEEL">
+    <dmn:variable id="_75E2ECF5-45E5-47A6-B2A3-8C36700E59A6" name="PMT2" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_C754909D-C28B-4D64-8DB2-9EF2ED7C4204" kind="FEEL">
+      <dmn:formalParameter id="_FE6519B0-C905-44D3-87C4-3B11579FDA12" name="loan" typeRef="tLoan"/>
+      <dmn:literalExpression id="_72A1C728-C817-4853-B23C-5C24FE8358C8" expressionLanguage="FEEL">
         <dmn:text>(loan.amount * loan.rate/12)/(1-(1+loan.rate/12)**-loan.term)</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:inputData id="i_Loans" name="Loans">
     <dmn:extensionElements/>
-    <dmn:variable id="_D90613B3-69D1-4877-BF46-7CEA1A374997" name="Loans" typeRef="tns:tLoanList"/>
+    <dmn:variable id="_F74AFF27-3990-4433-844D-DAC046359E43" name="Loans" typeRef="tLoanList"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_E3CA9CE2-8F2F-4A4D-B860-24326CB4DE52" name="DRG">
+    <dmndi:DMNDiagram id="_0E46E1A0-251D-48FB-AA1E-346A2FD2C9BA" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_D0130B00-329E-4377-90B4-BC956B6B1CC5"/>
-          <kie:ComponentWidths dmnElementRef="_2F5BF703-5D95-46DE-99AC-BA53B40473C9"/>
-          <kie:ComponentWidths dmnElementRef="_8162F411-CE84-4B30-B10F-6FBD2C6963E1"/>
+          <kie:ComponentWidths dmnElementRef="_0C614E9B-6ADB-4D7F-844E-7179B654F3AC"/>
+          <kie:ComponentWidths dmnElementRef="_72A1C728-C817-4853-B23C-5C24FE8358C8"/>
+          <kie:ComponentWidths dmnElementRef="_C754909D-C28B-4D64-8DB2-9EF2ED7C4204"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-d_MonthlyPayment" dmnElementRef="tns:d_MonthlyPayment" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_MonthlyPayment" dmnElementRef="d_MonthlyPayment" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -60,7 +68,7 @@
         <dc:Bounds x="137" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_PMT2" dmnElementRef="tns:b_PMT2" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_PMT2" dmnElementRef="b_PMT2" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -69,7 +77,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_Loans" dmnElementRef="tns:i_Loans" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_Loans" dmnElementRef="i_Loans" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -78,11 +86,11 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-i_Loans" dmnElementRef="tns:i_Loans">
+      <dmndi:DMNEdge id="dmnedge-drg-_F5229939-6759-47E1-BCC4-7D98D590CD8E" dmnElementRef="_F5229939-6759-47E1-BCC4-7D98D590CD8E">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="137" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_PMT2" dmnElementRef="tns:b_PMT2">
+      <dmndi:DMNEdge id="dmnedge-drg-_AB4D9418-D21C-4FA4-9C1C-82775846D6C0" dmnElementRef="_AB4D9418-D21C-4FA4-9C1C-82775846D6C0">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="137" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-lending.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-lending.dmn
@@ -1,117 +1,125 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b" name="Lending1" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b" name="Lending1" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_4e0f0b70-d31c-471c-bd52-5ca709ed362b">
   <dmn:extensionElements/>
-  <dmn:itemDefinition id="_28FE9C31-B06D-4198-9AED-DC7B9A7B9F23" name="tEligibility" isCollection="false">
-    <dmn:typeRef>feel:string</dmn:typeRef>
-    <dmn:allowedValues id="_8060F43D-97CA-48D4-AEB3-5B236C6331AA">
+  <dmn:itemDefinition id="_2FE9FC60-B4F6-435E-9DF3-899353733BD5" name="tEligibility" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues id="_E8C77D0E-6130-486F-82BF-55F360CA5E32">
       <dmn:text>"INELIGIBLE", "ELIGIBLE"</dmn:text>
     </dmn:allowedValues>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_80FD0531-591C-4D10-9BCF-A54F8AF10A36" name="tBureauCallType" isCollection="false">
-    <dmn:typeRef>feel:string</dmn:typeRef>
-    <dmn:allowedValues id="_488B99EC-0551-44C3-90F9-DE01D612136E">
+  <dmn:itemDefinition id="_3B625205-C958-4652-B061-66CBF45CC786" name="tBureauCallType" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues id="_00407038-6D5E-4985-8739-22B29E00FFD4">
       <dmn:text>"FULL", "MINI", "NONE"</dmn:text>
     </dmn:allowedValues>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_DA4A94C9-9BF3-429C-9BD7-87D0964D4CEF" name="tStrategy" isCollection="false">
-    <dmn:typeRef>feel:string</dmn:typeRef>
-    <dmn:allowedValues id="_318EF4AC-C5AA-40C4-915C-73409EFEF472">
+  <dmn:itemDefinition id="_65C6ECD1-EE28-47AF-B7BB-34B2CA64D9F0" name="tStrategy" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues id="_FB4957AF-74AE-43B4-8F9B-A324A04EFB25">
       <dmn:text>"DECLINE", "BUREAU", "THROUGH"</dmn:text>
     </dmn:allowedValues>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_90A6F8C9-25CD-4065-9FD3-BD2612D37A6D" name="tRiskCategory" isCollection="false">
-    <dmn:typeRef>feel:string</dmn:typeRef>
-    <dmn:allowedValues id="_833003D2-3BD5-4DD0-9F2A-F476FCF61A42">
+  <dmn:itemDefinition id="_EACAAB0B-C9DE-459A-86A6-C6710738EC6D" name="tRiskCategory" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues id="_9FA4B039-1073-4532-AD31-A1AD85CDC518">
       <dmn:text>"DECLINE", "HIGH", "MEDIUM", "LOW", "VERY LOW"</dmn:text>
     </dmn:allowedValues>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_298ED0A6-53F1-47EF-8931-42EA332B975B" name="tRouting" isCollection="false">
-    <dmn:typeRef>feel:string</dmn:typeRef>
-    <dmn:allowedValues id="_F45B1184-FF18-4F74-BFB9-1BCBAC4659CA">
+  <dmn:itemDefinition id="_98AEB0AA-789E-4C06-BD1A-1583951C9621" name="tRouting" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues id="_9062A905-666B-465D-B2AE-F275C352372D">
       <dmn:text>"DECLINE", "REFER", "ACCEPT"</dmn:text>
     </dmn:allowedValues>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_611DE2C6-F696-426B-BE75-7AC1B8383C6F" name="tBureauData" isCollection="false">
-    <dmn:itemComponent id="_23E38B9D-A680-4F66-A38D-9A4BDD40B219" name="CreditScore" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
-      <dmn:allowedValues id="_FD20ED28-48FF-458C-9201-2D19BCB58A36">
+  <dmn:itemDefinition id="_3B2462EF-F5FD-472A-864B-94243FDCACD7" name="tBureauData" isCollection="false">
+    <dmn:itemComponent id="_B5427B1A-821E-423A-AAC6-DD6D43B7F8EA" name="CreditScore" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+      <dmn:allowedValues id="_3F1AB972-29D6-4968-BEF1-A8724C2AA240">
         <dmn:text>[0..999], null</dmn:text>
       </dmn:allowedValues>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_76EA87FD-3EF9-4B5D-9D6E-8B20BFA7A3C1" name="Bankrupt" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+    <dmn:itemComponent id="_DACBF2DB-3D63-4B94-842B-47A86E7AAE02" name="Bankrupt" isCollection="false">
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_AC0687B7-AF84-48CC-86AA-90D2A856B2A4" name="tAdjudication" isCollection="false">
-    <dmn:typeRef>feel:string</dmn:typeRef>
-    <dmn:allowedValues id="_98A287E5-8F39-497D-8964-B0E6D7498EC1">
+  <dmn:itemDefinition id="_EE389A97-FFC4-4A68-BC3E-6A409E3AD791" name="tAdjudication" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues id="_7523EF40-1F0D-4716-98CF-515B0B0DFE41">
       <dmn:text>"DECLINE", "ACCEPT"</dmn:text>
     </dmn:allowedValues>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_6812E46D-AD04-44F1-B33F-B23932CFC6A0" name="tApplicantData" isCollection="false">
-    <dmn:itemComponent id="_23D6F698-6316-4B40-949A-DA15D9DD00FE" name="Monthly" isCollection="false">
-      <dmn:itemComponent id="_78EEF7D7-7D78-4B27-BB57-53D493A1C661" name="Income" isCollection="false">
-        <dmn:typeRef>feel:number</dmn:typeRef>
+  <dmn:itemDefinition id="_399465B7-001A-48FC-B4FC-A322DDFB7B0C" name="tApplicantData" isCollection="false">
+    <dmn:itemComponent id="_B3BB7E4F-2F99-4A15-8963-BCB31A49769D" name="Monthly" isCollection="false">
+      <dmn:itemComponent id="_BE447295-49A6-40C8-A65C-F3A0C474252F" name="Income" isCollection="false">
+        <dmn:typeRef>number</dmn:typeRef>
       </dmn:itemComponent>
-      <dmn:itemComponent id="_14D408A2-549A-4B7F-8407-A926A5792D44" name="Expenses" isCollection="false">
-        <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:itemComponent id="_865EFC1C-BC17-4ABC-B27D-E657656CEC7F" name="Expenses" isCollection="false">
+        <dmn:typeRef>number</dmn:typeRef>
       </dmn:itemComponent>
-      <dmn:itemComponent id="_24435296-5D3C-4240-8172-57F82727230B" name="Repayments" isCollection="false">
-        <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:itemComponent id="_F674A83F-4029-41EB-AEE9-A1D73C1FFD0B" name="Repayments" isCollection="false">
+        <dmn:typeRef>number</dmn:typeRef>
       </dmn:itemComponent>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_F26A7E62-AA2C-4768-85F8-91E47BFE8D37" name="Age" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:itemComponent id="_FB641A1E-D991-4A0C-8051-BADD119ED342" name="Age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_96719FAE-3143-4788-97B5-03201E8E3CDA" name="ExistingCustomer" isCollection="false">
-      <dmn:typeRef>feel:boolean</dmn:typeRef>
+    <dmn:itemComponent id="_C3E3928D-16A3-4C00-BABD-59589A89E839" name="ExistingCustomer" isCollection="false">
+      <dmn:typeRef>boolean</dmn:typeRef>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_5DB7256B-A57C-4B6A-B0FC-62AAB7A7B485" name="MaritalStatus" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
-      <dmn:allowedValues id="_91086DE2-7B04-404B-A398-F41D6791606A">
+    <dmn:itemComponent id="_FC03A62A-AAAB-4130-BDF4-A60BF5114DF2" name="MaritalStatus" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues id="_DF448BC8-B6A8-44DB-9A0A-FC12FB62A437">
         <dmn:text>"S","M"</dmn:text>
       </dmn:allowedValues>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_106D10B5-6C0C-4161-9EC0-7416EA6DE378" name="EmploymentStatus" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
-      <dmn:allowedValues id="_94927273-BC5C-4953-935F-CCEB0428ED83">
+    <dmn:itemComponent id="_D85A1EBD-5EBC-4AAC-B8C0-F855B4B6188B" name="EmploymentStatus" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues id="_701E6E23-5D3B-4241-BA0D-9F56EEBF943D">
         <dmn:text>"EMPLOYED","SELF-EMPLOYED","STUDENT","UNEMPLOYED"</dmn:text>
       </dmn:allowedValues>
     </dmn:itemComponent>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_9BE3755C-CEED-41D9-86FE-2B88E967B0B6" name="tRequestedProduct" isCollection="false">
-    <dmn:itemComponent id="_77F39E31-0CFC-4473-822D-ED8D0B24F867" name="ProductType" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
-      <dmn:allowedValues id="_F76918EE-2F69-417E-89B8-3BBA7D15D4A9">
+  <dmn:itemDefinition id="_F3235EC2-0E4C-4A5D-B8F3-6A44C2B8BF5E" name="tRequestedProduct" isCollection="false">
+    <dmn:itemComponent id="_54680B1B-EAEA-482E-8A14-157A5B720BD4" name="ProductType" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues id="_2429BF43-439B-4636-9B81-44676B1C950A">
         <dmn:text>"STANDARD LOAN", "SPECIAL LOAN"</dmn:text>
       </dmn:allowedValues>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_029B689E-8FAA-4689-888B-DE8A7FD335CA" name="Amount" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:itemComponent id="_3222F218-0A85-4FCF-8723-01CA03BCCAC1" name="Amount" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_1FBA513C-5759-431F-A416-CD87A614E0D0" name="Rate" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:itemComponent id="_B008BCB9-5AD2-47BA-B084-655228FF66E8" name="Rate" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_97EF69C5-F583-475C-9E84-556F0A0B1227" name="Term" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:itemComponent id="_79A6EA22-E550-432F-88EA-88D7A18C42B5" name="Term" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decision id="d_BureauCallType" name="BureauCallType">
     <dmn:extensionElements/>
-    <dmn:variable id="_92A764F1-8558-44A4-A65A-0D099ACA9C7E" name="BureauCallType" typeRef="tns:tBureauCallType"/>
-    <dmn:informationRequirement id="d_Pre-bureauRiskCategory">
+    <dmn:variable id="_5449A912-A3DF-4616-91E9-659788AAA49D" name="BureauCallType" typeRef="tBureauCallType"/>
+    <dmn:informationRequirement id="_C91DE08F-DDC5-447E-A60F-665B4EF3938A">
       <dmn:requiredDecision href="#d_Pre-bureauRiskCategory"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_BureauCallTypeTable">
+    <dmn:knowledgeRequirement id="_A0D7E8FB-0EAB-4344-A83B-B88634994369">
       <dmn:requiredKnowledge href="#b_BureauCallTypeTable"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_DDE7FFE3-6EBD-4EF6-A198-1E80AA3B8BAE">
-      <dmn:literalExpression id="_35DC0099-C237-4E6D-8022-68BEE8C5B7EB">
+    <dmn:invocation id="_29B7A036-C73A-4AEF-8569-265850118352">
+      <dmn:literalExpression id="_09468130-B19E-4FC9-AEBF-7CD2F5955C0F">
         <dmn:text>BureauCallTypeTable</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_65deeb90-626c-4cce-9485-eae9455b2194" name="Pre-bureauRiskCategory"/>
-        <dmn:literalExpression id="_C684A108-F33F-48F7-88BB-6C61C2ADA582">
+        <dmn:literalExpression id="_2CB74430-2276-402B-9F07-7C8007F401C1">
           <dmn:text>Pre-bureauRiskCategory</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -121,32 +129,32 @@
     <dmn:extensionElements/>
     <dmn:question>Is credit bureau call required?</dmn:question>
     <dmn:allowedAnswers>Yes (BUREAU) or No (DECLINE, THROUGH)</dmn:allowedAnswers>
-    <dmn:variable id="_783312FC-335B-4607-8B43-4233E3B42ADE" name="Strategy" typeRef="tns:tStrategy"/>
-    <dmn:informationRequirement id="d_BureauCallType">
+    <dmn:variable id="_337EA47B-3378-48BC-B452-D24609F22A58" name="Strategy" typeRef="tStrategy"/>
+    <dmn:informationRequirement id="_6F67A0F0-5F9B-448F-99E9-889D016D414E">
       <dmn:requiredDecision href="#d_BureauCallType"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="d_Eligibility">
+    <dmn:informationRequirement id="_2BC67540-4C1B-4017-B8A0-ACB450CB5436">
       <dmn:requiredDecision href="#d_Eligibility"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_0311C0E4-9E8A-4925-B362-88F742C44A71" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Strategy">
+    <dmn:decisionTable id="_E59E4BC2-07BF-40CB-8F07-BF83772BF598" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Strategy">
       <dmn:input id="_09a4cf3d-54fa-4232-ada0-e291c67a16c0">
-        <dmn:inputExpression id="_18C7E071-9948-42F4-9819-0784508479D1" typeRef="feel:string">
+        <dmn:inputExpression id="_EE327A9E-33A1-41B7-92FE-54DCE62E2802" typeRef="string">
           <dmn:text>Eligibility</dmn:text>
         </dmn:inputExpression>
-        <dmn:inputValues id="_2964BACC-4854-4BBA-8AA3-1662BC3A2581">
+        <dmn:inputValues id="_8A526F0C-AC89-46E9-A1BE-0FCC36EB4E3E">
           <dmn:text>"ELIGIBLE", "INELIGIBLE"</dmn:text>
         </dmn:inputValues>
       </dmn:input>
       <dmn:input id="_f3816132-3cf1-4414-ab6b-0ed875a5fa1b">
-        <dmn:inputExpression id="_07926047-8E69-4A98-A5D0-43C2EE595659" typeRef="feel:string">
+        <dmn:inputExpression id="_7AFB6331-2D26-4C91-97E6-95ED6E97C2C0" typeRef="string">
           <dmn:text>BureauCallType</dmn:text>
         </dmn:inputExpression>
-        <dmn:inputValues id="_BF98A097-6DF2-412A-AC8D-D3FAEECE066B">
+        <dmn:inputValues id="_ECA3A80F-AFCF-4A5E-8A7E-920A502EE5C1">
           <dmn:text>"FULL", "MINI", "NONE"</dmn:text>
         </dmn:inputValues>
       </dmn:input>
       <dmn:output id="_8c01b3c4-216d-4db4-8c5b-4375e6f524be">
-        <dmn:outputValues id="_395A1D3D-5A94-41AD-9B57-8503F9DB508B">
+        <dmn:outputValues id="_572A07F0-FDAD-4131-8547-85FBF2D31CEE">
           <dmn:text>"DECLINE", "THROUGH", "BUREAU"</dmn:text>
         </dmn:outputValues>
       </dmn:output>
@@ -197,38 +205,38 @@
   </dmn:decision>
   <dmn:decision id="d_Eligibility" name="Eligibility">
     <dmn:extensionElements/>
-    <dmn:variable id="_06D696F1-6619-4B92-99C6-58F821445F44" name="Eligibility" typeRef="tns:tEligibility"/>
-    <dmn:informationRequirement id="d_Pre-bureauAffordability">
+    <dmn:variable id="_69A53B5F-62D8-43FC-A634-46F1D14290D7" name="Eligibility" typeRef="tEligibility"/>
+    <dmn:informationRequirement id="_048C76D3-5EE4-47F2-8EB1-78568A7FC838">
       <dmn:requiredDecision href="#d_Pre-bureauAffordability"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="d_Pre-bureauRiskCategory">
+    <dmn:informationRequirement id="_D408CEF0-827C-4F0F-A109-CBD0A5F030A5">
       <dmn:requiredDecision href="#d_Pre-bureauRiskCategory"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_ApplicantData">
+    <dmn:informationRequirement id="_7E59857C-836F-48F7-9CB1-6AD918ABC4FE">
       <dmn:requiredInput href="#i_ApplicantData"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_EligibilityRules">
+    <dmn:knowledgeRequirement id="_2D49FF9E-9462-4880-9005-887F8C42E6E4">
       <dmn:requiredKnowledge href="#b_EligibilityRules"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_2CC81AB1-87EA-4012-99D3-30219F5F0E3D">
-      <dmn:literalExpression id="_A09F1991-CB48-4DBA-B276-0A9123F72E66">
+    <dmn:invocation id="_70996A6B-6876-4E49-BC6D-6A21C00C7B36">
+      <dmn:literalExpression id="_7F3DE387-D3DD-4FE8-88C4-8F2AE4EC454F">
         <dmn:text>EligibilityRules</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_83d27025-44c2-4bb2-8747-ae3d40e97f25" name="Pre-bureauAffordability"/>
-        <dmn:literalExpression id="_9947739E-7668-4AAD-ADAF-64BDCB0A28B6">
+        <dmn:literalExpression id="_718231B7-DFAF-40B5-B9B6-D0A482253158">
           <dmn:text>Pre-bureauAffordability</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_b5fe2d0c-1d71-4c98-b0c6-a821b854ffc4" name="Pre-bureauRiskCategory"/>
-        <dmn:literalExpression id="_71694435-C845-4731-B8DF-E6101C5B2C24">
+        <dmn:literalExpression id="_0ED44B9D-D022-41DA-AB69-7AF97B4D0BEF">
           <dmn:text>Pre-bureauRiskCategory</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_87021512-68d6-40ba-a159-165a701c197b" name="Age"/>
-        <dmn:literalExpression id="_C58D8D01-EA92-4FE4-A04A-606AEEBDF094">
+        <dmn:literalExpression id="_7321FF54-B182-4F79-BE6C-E18C3A8C86A3">
           <dmn:text>ApplicantData.Age</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -236,29 +244,29 @@
   </dmn:decision>
   <dmn:decision id="d_Pre-bureauRiskCategory" name="Pre-bureauRiskCategory">
     <dmn:extensionElements/>
-    <dmn:variable id="_83BFC699-F277-4178-82CB-A8A3CFCC5E99" name="Pre-bureauRiskCategory" typeRef="tns:tRiskCategory"/>
-    <dmn:informationRequirement id="d_ApplicationRiskScore">
+    <dmn:variable id="_E11C6528-8423-415D-8744-7F20F7C6EEB1" name="Pre-bureauRiskCategory" typeRef="tRiskCategory"/>
+    <dmn:informationRequirement id="_582AE809-39DF-4161-BD66-10F5F9401749">
       <dmn:requiredDecision href="#d_ApplicationRiskScore"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_ApplicantData">
+    <dmn:informationRequirement id="_E9164594-078A-4F26-B97E-5EA99FF5A78C">
       <dmn:requiredInput href="#i_ApplicantData"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_Pre-bureauRiskCategoryTable">
+    <dmn:knowledgeRequirement id="_F9D65271-F2FE-4653-B565-57FB9922EE10">
       <dmn:requiredKnowledge href="#b_Pre-bureauRiskCategoryTable"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_BDA19BD6-778A-4014-AC1D-9CD5085C4395">
-      <dmn:literalExpression id="_80D9AA04-DFC3-47E7-B655-D09269D0082A">
+    <dmn:invocation id="_51B33852-DF7F-4511-9224-491BD2A12BBC">
+      <dmn:literalExpression id="_75D90D65-2A1D-4BDD-85D7-DCBDA78DBE1D">
         <dmn:text>Pre-bureauRiskCategoryTable</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_a4ffd56c-aca1-4cf0-84e0-44fefecb5f48" name="ExistingCustomer"/>
-        <dmn:literalExpression id="_136FA517-6122-43E0-8898-73ABB6858C74">
+        <dmn:literalExpression id="_E6EEBF60-7D37-4BA6-AB7D-B093B354A79D">
           <dmn:text>ApplicantData.ExistingCustomer</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_eb561110-cd9a-4f96-9170-f32b2e6c13f6" name="ApplicationRiskScore"/>
-        <dmn:literalExpression id="_2889BBAB-6F82-4934-8186-4CB6964529DA">
+        <dmn:literalExpression id="_7B17D600-05ED-487A-8601-BCD6F5BCC2FE">
           <dmn:text>ApplicationRiskScore</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -266,38 +274,38 @@
   </dmn:decision>
   <dmn:decision id="d_Post-bureauRiskCategory" name="Post-bureauRiskCategory">
     <dmn:extensionElements/>
-    <dmn:variable id="_8708FF06-3677-444C-A13A-3F5888909462" name="Post-bureauRiskCategory" typeRef="tns:tRiskCategory"/>
-    <dmn:informationRequirement id="d_ApplicationRiskScore">
+    <dmn:variable id="_04F958B8-9674-40C7-8846-8456E9A16D1D" name="Post-bureauRiskCategory" typeRef="tRiskCategory"/>
+    <dmn:informationRequirement id="_A60EE052-6E71-48DC-8DBA-CC32829DCA37">
       <dmn:requiredDecision href="#d_ApplicationRiskScore"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_BureauData">
+    <dmn:informationRequirement id="_8A12BCF4-3323-4A0D-AE01-31A1299F1F3A">
       <dmn:requiredInput href="#i_BureauData"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_ApplicantData">
+    <dmn:informationRequirement id="_EDC16398-4948-4D9A-9598-CB45D067CEE9">
       <dmn:requiredInput href="#i_ApplicantData"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_Post-bureauRiskCategoryTable">
+    <dmn:knowledgeRequirement id="_72F904DC-09B2-4779-AF1E-178111F8C78F">
       <dmn:requiredKnowledge href="#b_Post-bureauRiskCategoryTable"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_813488AF-4D91-4593-AC73-8E22FC11131D">
-      <dmn:literalExpression id="_DA9774D4-AFFD-4F07-9FB3-15520D4FF549">
+    <dmn:invocation id="_13FCF12A-E0E8-4DA4-9F7C-A5C981BC8807">
+      <dmn:literalExpression id="_B502CF7A-5A7D-4FF4-8E4C-B47FB423B06E">
         <dmn:text>Post-bureauRiskCategoryTable</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_a5eee7ca-e12f-49fe-80cb-54a7a5a7912e" name="ExistingCustomer"/>
-        <dmn:literalExpression id="_D84F4290-779B-4A9C-AFA8-3D44F81CEE0F">
+        <dmn:literalExpression id="_3A0DD81B-4465-4103-89BF-E4F0B1363E09">
           <dmn:text>ApplicantData.ExistingCustomer</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_980eaa9b-461d-49fd-bfc0-d115e8261b8b" name="CreditScore"/>
-        <dmn:literalExpression id="_F540B0BF-639F-4B59-A1BC-DB7607F8BAEB">
+        <dmn:literalExpression id="_9B2C90D7-BA02-4BC9-8F73-1FEF0A5B67E7">
           <dmn:text>BureauData.CreditScore</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_222a3f84-eb98-439a-8ea8-6c1460760769" name="ApplicationRiskScore"/>
-        <dmn:literalExpression id="_C117F227-F436-48B1-9BB1-BD91BA1E20A6">
+        <dmn:literalExpression id="_40A7F16C-432C-4223-BCD4-100E11288370">
           <dmn:text>ApplicationRiskScore</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -305,32 +313,32 @@
   </dmn:decision>
   <dmn:decision id="d_ApplicationRiskScore" name="ApplicationRiskScore">
     <dmn:extensionElements/>
-    <dmn:variable id="_F77A724C-13C8-4169-935E-921EAA5456A4" name="ApplicationRiskScore" typeRef="feel:number"/>
-    <dmn:informationRequirement id="i_ApplicantData">
+    <dmn:variable id="_32D8C610-36B6-4AE0-8128-1E66C7054997" name="ApplicationRiskScore" typeRef="number"/>
+    <dmn:informationRequirement id="_DCF5FBCE-33C3-4626-82F9-86D89D52F289">
       <dmn:requiredInput href="#i_ApplicantData"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_ApplicationRiskScoreModel">
+    <dmn:knowledgeRequirement id="_AF61BD10-21B4-4F77-BDF7-8299C53A763B">
       <dmn:requiredKnowledge href="#b_ApplicationRiskScoreModel"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_A893A82C-55B1-4A90-BA21-AAE8354F9F12">
-      <dmn:literalExpression id="_3C5F8131-54B2-487B-B227-C00B2A4DC395">
+    <dmn:invocation id="_54F1569E-6062-4683-B34E-16F46E50C366">
+      <dmn:literalExpression id="_558EE93F-9F5E-473E-B3A0-705A950D48D5">
         <dmn:text>ApplicationRiskScoreModel</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_624532fc-b467-4118-a6d9-498d2891e654" name="Age"/>
-        <dmn:literalExpression id="_24E19D2B-4378-463A-90FE-D260D627BAE5">
+        <dmn:literalExpression id="_86D4C585-DB4A-4ADB-A895-D10967E6894F">
           <dmn:text>ApplicantData.Age</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_a90e9150-f937-446c-94e3-14b13deb1aa7" name="MaritalStatus"/>
-        <dmn:literalExpression id="_B7E26489-150B-46E1-9EAD-ECA03A7B6BD2">
+        <dmn:literalExpression id="_0BFF3882-37FB-4E41-819A-EA3BA6814C4A">
           <dmn:text>ApplicantData.MaritalStatus</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_794f4a7e-a4de-4777-b7b6-5f83df6584dd" name="EmploymentStatus"/>
-        <dmn:literalExpression id="_0DE5B655-246D-4440-A4E4-D1554612BD58">
+        <dmn:literalExpression id="_FF86030B-E4A2-4778-8FF3-50A11520E573">
           <dmn:text>ApplicantData.EmploymentStatus</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -338,50 +346,50 @@
   </dmn:decision>
   <dmn:decision id="d_Pre-bureauAffordability" name="Pre-bureauAffordability">
     <dmn:extensionElements/>
-    <dmn:variable id="_0562E92A-33FA-420A-9DE7-39710ACC3401" name="Pre-bureauAffordability" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="d_RequiredMonthlyInstallment">
+    <dmn:variable id="_004501A7-6E60-4117-81E4-D6E9C8EAF75B" name="Pre-bureauAffordability" typeRef="boolean"/>
+    <dmn:informationRequirement id="_B4FE0787-174C-40C8-AE49-1DEEF5898C3B">
       <dmn:requiredDecision href="#d_RequiredMonthlyInstallment"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="d_Pre-bureauRiskCategory">
+    <dmn:informationRequirement id="_A826343F-8944-40ED-945F-4DE43BE78547">
       <dmn:requiredDecision href="#d_Pre-bureauRiskCategory"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_ApplicantData">
+    <dmn:informationRequirement id="_9D6C69E2-4D34-4635-8B16-3AD296526182">
       <dmn:requiredInput href="#i_ApplicantData"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_AffordabilityCalculation">
+    <dmn:knowledgeRequirement id="_BE2A20AE-2EDB-4080-8576-F207FB4566FC">
       <dmn:requiredKnowledge href="#b_AffordabilityCalculation"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_1150E16E-9210-43DA-8B86-6E57EA0D7575">
-      <dmn:literalExpression id="_B6969926-9DB6-4126-BC88-B7D074BF0FF3">
+    <dmn:invocation id="_7AC1839E-BFE1-4AD7-B524-C690E5422448">
+      <dmn:literalExpression id="_9098B426-68C1-46A6-8CB2-739F8B95B8A9">
         <dmn:text>AffordabilityCalculation</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_688a5d35-c0d1-4faa-b411-2ac96e5db3f2" name="MonthlyIncome"/>
-        <dmn:literalExpression id="_59B4EF5E-1925-4668-AB6E-52C77237AB97">
+        <dmn:literalExpression id="_3879A878-D03C-4A98-BF68-6ABC87A381E3">
           <dmn:text>ApplicantData.Monthly.Income</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_fe44410f-d02b-44c5-b696-0c5a53b3d965" name="MonthlyRepayments"/>
-        <dmn:literalExpression id="_B3D886C6-3260-4D40-A83C-5E66D276652D">
+        <dmn:literalExpression id="_9F4C941B-EEA4-4093-8646-B4CF54060FA0">
           <dmn:text>ApplicantData.Monthly.Repayments</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_3542be62-0447-45db-850a-55ec1c3c59bd" name="MonthlyExpenses"/>
-        <dmn:literalExpression id="_2B600E31-132F-401B-A98A-462E42601A00">
+        <dmn:literalExpression id="_7E6E34A1-370E-47CC-9011-1AA219CD8082">
           <dmn:text>ApplicantData.Monthly.Expenses</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_05524e98-e76d-4109-ac99-f5090cd7bb48" name="RiskCategory"/>
-        <dmn:literalExpression id="_B6D367C8-474C-4D15-8EBD-D24696B415FA">
+        <dmn:literalExpression id="_7DC095D3-0DEE-4022-8C61-FE6CEC425D79">
           <dmn:text>Pre-bureauRiskCategory</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_be179be3-8be2-4abc-81d9-9540abe25e06" name="RequiredMonthlyInstallment"/>
-        <dmn:literalExpression id="_C1E60CE3-17C5-4B12-9C7B-5D09A11D34BC">
+        <dmn:literalExpression id="_ED3C8F5D-1113-43F7-ABB3-C58CB932CCDF">
           <dmn:text>RequiredMonthlyInstallment</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -389,50 +397,50 @@
   </dmn:decision>
   <dmn:decision id="d_Post-bureauAffordability" name="Post-bureauAffordability">
     <dmn:extensionElements/>
-    <dmn:variable id="_A870A2CB-E468-4BE1-B7CD-E16AC3FFF84D" name="Post-bureauAffordability" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="d_RequiredMonthlyInstallment">
+    <dmn:variable id="_EBF5CAD2-F605-4DD2-96B8-47B62EF7ABA1" name="Post-bureauAffordability" typeRef="boolean"/>
+    <dmn:informationRequirement id="_685011D2-3EB8-492F-9EB1-AEF5E6531905">
       <dmn:requiredDecision href="#d_RequiredMonthlyInstallment"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="d_Post-bureauRiskCategory">
+    <dmn:informationRequirement id="_69874D88-9AE2-4751-8A60-C9CDEECB12E6">
       <dmn:requiredDecision href="#d_Post-bureauRiskCategory"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_ApplicantData">
+    <dmn:informationRequirement id="_D208CDBF-FCC3-4088-81E5-5048790EC753">
       <dmn:requiredInput href="#i_ApplicantData"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_AffordabilityCalculation">
+    <dmn:knowledgeRequirement id="_F9E534D8-C75D-4FCC-B98C-44C6E92C2290">
       <dmn:requiredKnowledge href="#b_AffordabilityCalculation"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_CA53695E-3DBC-498E-BFC3-3E1729039DA0">
-      <dmn:literalExpression id="_802932AE-2AA4-440F-AA48-C8E023E40332">
+    <dmn:invocation id="_AA4B76CF-1451-4D37-9E1E-3815D385CDD9">
+      <dmn:literalExpression id="_F214762D-8C12-46D2-A89B-FFF3D9309A6D">
         <dmn:text>AffordabilityCalculation</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_9ddcd6eb-0154-426f-9752-32c9d64471be" name="MonthlyIncome"/>
-        <dmn:literalExpression id="_A802CE66-DCB9-4BCF-AAFD-D8BCB38BF79E">
+        <dmn:literalExpression id="_F394B91E-07A3-41CB-A988-3BEC4313BBA8">
           <dmn:text>ApplicantData.Monthly.Income</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_2ed2cf1c-2dff-4bdc-8cc3-92d0fdc38c81" name="MonthlyRepayments"/>
-        <dmn:literalExpression id="_BEC8803B-8A26-49C4-956D-807F4FAA2E71">
+        <dmn:literalExpression id="_9F89D289-FE12-46C2-83C9-A628B96A58A9">
           <dmn:text>ApplicantData.Monthly.Repayments</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_2d0b4728-c40c-4a0c-980c-81156750bfc1" name="MonthlyExpenses"/>
-        <dmn:literalExpression id="_11426BDC-3B30-4E37-AEF9-AD57B07A952D">
+        <dmn:literalExpression id="_4F0F3DD7-1E73-4C7B-847E-A64A9485BBC7">
           <dmn:text>ApplicantData.Monthly.Expenses</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_f75ffcc3-cb93-46cc-82ae-bad3a7202e99" name="RiskCategory"/>
-        <dmn:literalExpression id="_57E65171-3956-4461-8ED7-DAB34DA1A199">
+        <dmn:literalExpression id="_5E5606F4-FD8F-4AD0-A564-4A49038EFFC0">
           <dmn:text>Post-bureauRiskCategory</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_0f3e2756-3007-4412-b788-81d01f68399d" name="RequiredMonthlyInstallment"/>
-        <dmn:literalExpression id="_13ECBE9A-69C4-4C74-8FBE-C77FB076BC55">
+        <dmn:literalExpression id="_9FCFD300-D76E-49A1-9042-AE7ADC50D5A6">
           <dmn:text>RequiredMonthlyInstallment</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -440,38 +448,38 @@
   </dmn:decision>
   <dmn:decision id="d_RequiredMonthlyInstallment" name="RequiredMonthlyInstallment">
     <dmn:extensionElements/>
-    <dmn:variable id="_E389AEA3-16FD-416E-AEAF-78E720B0238C" name="RequiredMonthlyInstallment" typeRef="feel:number"/>
-    <dmn:informationRequirement id="i_RequestedProduct">
+    <dmn:variable id="_87CA8C3F-A7E2-4A74-B78C-A125E7EFF30E" name="RequiredMonthlyInstallment" typeRef="number"/>
+    <dmn:informationRequirement id="_B80FC328-8828-40B9-9598-0F8D64A9FF3A">
       <dmn:requiredInput href="#i_RequestedProduct"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_InstallmentCalculation">
+    <dmn:knowledgeRequirement id="_A108CD18-2CF0-42D0-A55F-81D36D6AD412">
       <dmn:requiredKnowledge href="#b_InstallmentCalculation"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_D6EBCE6A-DCB6-41C0-8C10-69A3FCBAEFFE">
-      <dmn:literalExpression id="_FBEA263B-3C80-4646-8664-0ADE503F3EDB">
+    <dmn:invocation id="_0444F428-A9D6-4CC4-99EA-A122FFBC2B39">
+      <dmn:literalExpression id="_8AB61741-4D85-48C7-BAF7-CA6A479788C7">
         <dmn:text>InstallmentCalculation</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_2e65e0bd-d6d4-4d73-b806-12b4bc853a17" name="ProductType"/>
-        <dmn:literalExpression id="_0A2D48EA-2A82-4B5F-AD51-A581B2BF4B94">
+        <dmn:literalExpression id="_A825CC45-69DC-4742-A748-B9587675F4EF">
           <dmn:text>RequestedProduct.ProductType</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_ee9f5360-cc2d-4370-b75e-6895002c1c48" name="Rate"/>
-        <dmn:literalExpression id="_041715A8-C550-49A3-B76B-5FAD82337BE5">
+        <dmn:literalExpression id="_9D60820E-82DB-4BCB-84FC-CF4F39C4D6A7">
           <dmn:text>RequestedProduct.Rate</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_b6fddc07-5494-4878-878c-3e1a96fad9fe" name="Term"/>
-        <dmn:literalExpression id="_593E6E4F-4AF0-4153-AF61-97DD33DD5D8E">
+        <dmn:literalExpression id="_8520C83C-E42F-49AB-A7B8-6051A4D8CC5A">
           <dmn:text>RequestedProduct.Term</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_84755f4f-3455-4e76-b182-db4c375b9fb3" name="Amount"/>
-        <dmn:literalExpression id="_07308D21-9C06-43BD-B410-6AE59F5FB402">
+        <dmn:literalExpression id="_9572FCBE-961E-4221-9115-E8029E32751C">
           <dmn:text>RequestedProduct.Amount</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -479,44 +487,44 @@
   </dmn:decision>
   <dmn:decision id="d_Routing" name="Routing">
     <dmn:extensionElements/>
-    <dmn:variable id="_B738ABF3-A72B-4B65-A9B6-C4D582A3948E" name="Routing" typeRef="tns:tRouting"/>
-    <dmn:informationRequirement id="d_Post-bureauAffordability">
+    <dmn:variable id="_3C283FAE-8E7C-4472-A3B7-9CE8AC8F57BE" name="Routing" typeRef="tRouting"/>
+    <dmn:informationRequirement id="_FAC175CE-5DAD-4054-A067-5799F13286B1">
       <dmn:requiredDecision href="#d_Post-bureauAffordability"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="d_Post-bureauRiskCategory">
+    <dmn:informationRequirement id="_96B0D7F9-C453-4139-8D8A-E4C230EF7CB6">
       <dmn:requiredDecision href="#d_Post-bureauRiskCategory"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_BureauData">
+    <dmn:informationRequirement id="_8A07A4C2-075A-4A9B-952D-B84CAE1F697F">
       <dmn:requiredInput href="#i_BureauData"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_RoutingRules">
+    <dmn:knowledgeRequirement id="_5D98E4E0-1011-4D6E-832F-F0BAAF6C9D40">
       <dmn:requiredKnowledge href="#b_RoutingRules"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_38F65FCD-C634-45D6-A930-53E780F11A81">
-      <dmn:literalExpression id="_15CBC4EE-9080-4158-8233-FE2E1D0A7309">
+    <dmn:invocation id="_465049B4-9BCB-4152-B7A9-7CCC26741F18">
+      <dmn:literalExpression id="_310A5DC1-3361-4C5A-B25D-8B2F96AA32D6">
         <dmn:text>RoutingRules</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
         <dmn:parameter id="_c2ebec2c-0072-47af-9703-e202cf8af50b" name="Bankrupt"/>
-        <dmn:literalExpression id="_AB5A4898-E475-4F47-B4DC-2D4B0C4D0067">
+        <dmn:literalExpression id="_4A9BB0D3-EECA-4787-B145-3933F7B40C2F">
           <dmn:text>BureauData.Bankrupt</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_a5193c53-bd02-4579-a249-44ed95dd0c3e" name="CreditScore"/>
-        <dmn:literalExpression id="_F40A76B2-2DD9-4131-9C56-2FA895CAFA77">
+        <dmn:literalExpression id="_EFD59F0C-8273-4F80-8D83-8A4F1060F369">
           <dmn:text>BureauData.CreditScore</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_4b461288-5d18-44ab-b102-835a91946890" name="Post-bureauRiskCategory"/>
-        <dmn:literalExpression id="_D3F9F629-5E11-45C6-BE3B-A41BAF5E66D8">
+        <dmn:literalExpression id="_EFF52895-AA9D-47D1-94B7-AF467D303371">
           <dmn:text>Post-bureauRiskCategory</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
       <dmn:binding>
         <dmn:parameter id="_8846c6e3-65ff-4d46-87b9-7c7cad86ee67" name="Post-bureauAffordability"/>
-        <dmn:literalExpression id="_F04E38D1-C796-4591-ADBB-24EDA8C15538">
+        <dmn:literalExpression id="_BCE49B32-AA01-48C4-B537-AB0B61AEC6A0">
           <dmn:text>Post-bureauAffordability</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -524,78 +532,78 @@
   </dmn:decision>
   <dmn:decision id="d_Adjudication" name="Adjudication">
     <dmn:extensionElements/>
-    <dmn:variable id="_0A5F3DFF-C6CF-40DA-B74B-74B2B3F78857" name="Adjudication" typeRef="tns:tAdjudication"/>
-    <dmn:informationRequirement id="i_BureauData">
+    <dmn:variable id="_D5F003B7-A34B-4EF5-8299-5F61BE5DF8AE" name="Adjudication" typeRef="tAdjudication"/>
+    <dmn:informationRequirement id="_C81A85DD-DED2-4BB0-A4F3-888002E70D84">
       <dmn:requiredInput href="#i_BureauData"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_SupportingDocuments">
+    <dmn:informationRequirement id="_4CB0C6AE-28EE-4548-9446-9E625699F913">
       <dmn:requiredInput href="#i_SupportingDocuments"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_ApplicantData">
+    <dmn:informationRequirement id="_6756474E-7427-459D-B6BB-8F1346782B22">
       <dmn:requiredInput href="#i_ApplicantData"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_EF949ED7-E859-4CC4-B913-C889C5AB0AFB">
+    <dmn:literalExpression id="_E75CE743-0DB0-43E2-8826-03B9B40E8AB6">
       <dmn:text>"ACCEPT"</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="b_AffordabilityCalculation" name="AffordabilityCalculation">
     <dmn:extensionElements/>
-    <dmn:variable id="_0A4CEF8C-8F89-418D-9DB0-A88266F88A68" name="AffordabilityCalculation" typeRef="feel:boolean"/>
-    <dmn:encapsulatedLogic id="_E16A9506-67F9-43AC-B7F8-101E23FA4F79" kind="FEEL">
-      <dmn:formalParameter id="_65FE3BCB-C216-4008-B8F7-88B723B0DD73" name="MonthlyIncome" typeRef="feel:number"/>
-      <dmn:formalParameter id="_D6006D0B-9075-4E0C-987E-3156EEFDF1B7" name="MonthlyRepayments" typeRef="feel:number"/>
-      <dmn:formalParameter id="_81C70221-6680-4ECC-8096-6FAB581121BD" name="MonthlyExpenses" typeRef="feel:number"/>
-      <dmn:formalParameter id="_8C64C43A-5EB7-4245-9C58-C104125ABBBE" name="RiskCategory" typeRef="tns:tRiskCategory"/>
-      <dmn:formalParameter id="_E2053755-E877-4727-99C0-7C6E9E22313E" name="RequiredMonthlyInstallment" typeRef="feel:number"/>
-      <dmn:context id="_9364D634-EB4B-4116-9FCF-A7E2B4E66890">
+    <dmn:variable id="_F7DF987C-7118-495B-990B-B3E7EE9440D8" name="AffordabilityCalculation" typeRef="boolean"/>
+    <dmn:encapsulatedLogic id="_1DF022D9-B0F1-4FFF-AA4A-96F4E2356603" kind="FEEL">
+      <dmn:formalParameter id="_09C479BF-A5AA-479B-A89C-C1CFA5B0CC27" name="MonthlyIncome" typeRef="number"/>
+      <dmn:formalParameter id="_B0C12675-E395-4443-A86C-4C3BD9DD778D" name="MonthlyRepayments" typeRef="number"/>
+      <dmn:formalParameter id="_7F80A6EA-44CA-456D-862C-5BCF5DB8554B" name="MonthlyExpenses" typeRef="number"/>
+      <dmn:formalParameter id="_02B965ED-9138-40A0-B305-C67EFBAFD042" name="RiskCategory" typeRef="tRiskCategory"/>
+      <dmn:formalParameter id="_CD793C02-58FD-451F-AF6F-AF2E36E77FE2" name="RequiredMonthlyInstallment" typeRef="number"/>
+      <dmn:context id="_1B93A301-3ADE-4D67-90CC-D9AC7984CEA9">
         <dmn:contextEntry>
-          <dmn:variable id="_08710073-B36A-4ABC-81D6-5F5FD6602ACB" name="DisposableIncome" typeRef="feel:number"/>
-          <dmn:literalExpression id="_B155BC84-C7C9-4F39-94DD-FFF0ED4432F7">
+          <dmn:variable id="_0D483F58-B422-4576-9538-89EE80278044" name="DisposableIncome" typeRef="number"/>
+          <dmn:literalExpression id="_DA7D0F4C-28B4-41F1-A21E-D353763910F7">
             <dmn:text>MonthlyIncome - (MonthlyExpenses + MonthlyRepayments)</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_E71353DB-1F74-4A2F-87C3-D0562FB68F98" name="CreditContingencyFactor" typeRef="feel:number"/>
-          <dmn:invocation id="_A2234BB8-DDFC-49C5-BB19-BE0D7C82C5D5">
-            <dmn:literalExpression id="_3D79B68F-7001-4845-B7C4-9EA67676E8E4">
+          <dmn:variable id="_1C393F29-0464-4621-B454-A88A034DA39D" name="CreditContingencyFactor" typeRef="number"/>
+          <dmn:invocation id="_1DFC00BF-6F93-49B1-B676-85656193F156">
+            <dmn:literalExpression id="_A5E45ED5-8DF9-40E5-A213-F3ADECD12C73">
               <dmn:text>CreditContingencyFactorTable</dmn:text>
             </dmn:literalExpression>
             <dmn:binding>
               <dmn:parameter id="_cfbad925-5470-4165-b7f0-0945cf321889" name="RiskCategory"/>
-              <dmn:literalExpression id="_498377F6-05AF-4163-9B33-B6AA463ABE22">
+              <dmn:literalExpression id="_DF87409C-7443-4E68-99E4-EE45AF3A2BAC">
                 <dmn:text>RiskCategory</dmn:text>
               </dmn:literalExpression>
             </dmn:binding>
           </dmn:invocation>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_8B53D150-8696-436A-B308-EF948D16D6B1" name="Affordability" typeRef="feel:boolean"/>
-          <dmn:literalExpression id="_08BEE063-DA3F-4614-AB74-60D1BBC72819">
+          <dmn:variable id="_ACECCCFF-C768-47CF-AB4B-ECD709F33E9B" name="Affordability" typeRef="boolean"/>
+          <dmn:literalExpression id="_F353B68B-2813-4E0E-9AD3-B7702BD95230">
             <dmn:text>if DisposableIncome * CreditContingencyFactor &gt; RequiredMonthlyInstallment then true else false</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:literalExpression id="_852AC68E-FBF0-4247-89A3-1627E518E5E9">
+          <dmn:literalExpression id="_1CD3DE71-48C1-4660-A64D-F24E90E46627">
             <dmn:text>Affordability</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
       </dmn:context>
     </dmn:encapsulatedLogic>
-    <dmn:knowledgeRequirement id="b_CreditContingencyFactorTable">
+    <dmn:knowledgeRequirement id="_8EE3AF6F-F478-4FCC-BA0C-7D994D01914D">
       <dmn:requiredKnowledge href="#b_CreditContingencyFactorTable"/>
     </dmn:knowledgeRequirement>
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_CreditContingencyFactorTable" name="CreditContingencyFactorTable">
     <dmn:extensionElements/>
-    <dmn:variable id="_64BE0D13-7419-4371-A014-CCE4B5F1D1CE" name="CreditContingencyFactorTable" typeRef="feel:string"/>
-    <dmn:encapsulatedLogic id="_E369B11C-7814-4A19-A5C0-02FC5ECC70CE" kind="FEEL">
-      <dmn:formalParameter id="_531ED40A-80B5-40DE-8592-A9FE7C759365" name="RiskCategory" typeRef="tns:tRiskCategory"/>
-      <dmn:decisionTable id="_419315D7-1EE5-45F7-A514-C7193159E0E8" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="CreditContingencyFactorTable">
+    <dmn:variable id="_CFACA786-9CD3-4F39-AE09-F32E0C3D9385" name="CreditContingencyFactorTable" typeRef="string"/>
+    <dmn:encapsulatedLogic id="_9366F11E-2780-4C6F-9C76-9E696009EEDD" kind="FEEL">
+      <dmn:formalParameter id="_24D90625-D6ED-4335-8D31-F57D9B0934D8" name="RiskCategory" typeRef="tRiskCategory"/>
+      <dmn:decisionTable id="_5FAE9F72-C4D2-42F4-9DC5-16E72DE3AB54" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="CreditContingencyFactorTable">
         <dmn:input id="_7cdd3950-9a45-41f0-bef0-dc54240fe4c2">
-          <dmn:inputExpression id="_5D63BFC0-1F25-4142-B837-D5F1BFAD792C" typeRef="feel:string">
+          <dmn:inputExpression id="_CEBFDE25-A1C3-4FA1-9D8F-BE9DB88D952E" typeRef="string">
             <dmn:text>RiskCategory</dmn:text>
           </dmn:inputExpression>
-          <dmn:inputValues id="_3091AA78-C59A-4E9F-ABE6-977C3C2AEC55">
+          <dmn:inputValues id="_3987DE77-5DC3-4601-B64A-AE9EA9B24B2C">
             <dmn:text>"DECLINE", "HIGH", "LOW", "MEDIUM", "VERY LOW"</dmn:text>
           </dmn:inputValues>
         </dmn:input>
@@ -639,29 +647,29 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_EligibilityRules" name="EligibilityRules">
     <dmn:extensionElements/>
-    <dmn:variable id="_5A091B73-6F4C-402D-8A13-71F78A00990A" name="EligibilityRules" typeRef="feel:string"/>
-    <dmn:encapsulatedLogic id="_71163946-8730-4519-BE74-0058D92EB041" kind="FEEL">
-      <dmn:formalParameter id="_51E54B73-ED08-4D95-ACF3-D3EA682DFE8A" name="Pre-bureauRiskCategory" typeRef="tns:tRiskCategory"/>
-      <dmn:formalParameter id="_D0CEF021-C057-4CF8-B483-CF80E50ED77C" name="Pre-bureauAffordability" typeRef="feel:boolean"/>
-      <dmn:formalParameter id="_7A1DA344-5BBD-4D57-AA9D-2BC47C1A46C9" name="Age" typeRef="feel:number"/>
-      <dmn:decisionTable id="_7715E033-2040-47B5-9598-3997F45449EA" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="EligibilityRules">
+    <dmn:variable id="_9986DB10-0B9C-4A74-8E57-3D4ED14FF53A" name="EligibilityRules" typeRef="string"/>
+    <dmn:encapsulatedLogic id="_3174D3CB-EB1B-4B77-B528-46DD054EB0CF" kind="FEEL">
+      <dmn:formalParameter id="_9F2084FE-E034-4DC4-A744-9D601E8D2FF4" name="Pre-bureauRiskCategory" typeRef="tRiskCategory"/>
+      <dmn:formalParameter id="_9F0C9B55-0BFE-4116-A7E3-34F50A709819" name="Pre-bureauAffordability" typeRef="boolean"/>
+      <dmn:formalParameter id="_422009CC-D0CF-4A07-94B7-9052416E8B29" name="Age" typeRef="number"/>
+      <dmn:decisionTable id="_C6689A70-CC73-41BA-A370-A239203B91A2" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="EligibilityRules">
         <dmn:input id="_2bc2f208-6c1d-4411-8a19-c5b424fb8fa9">
-          <dmn:inputExpression id="_DA21BC1D-85F9-4963-B6B7-6C0DF426FEEA" typeRef="feel:string">
+          <dmn:inputExpression id="_E6D0501A-DC6D-4414-ADF1-F5DF4999A4DD" typeRef="string">
             <dmn:text>Pre-bureauRiskCategory</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_1d794320-6e6c-46bf-b86d-de073822d6f6">
-          <dmn:inputExpression id="_C81EE4DC-7FD3-4589-994D-99B51D1BB212" typeRef="feel:string">
+          <dmn:inputExpression id="_47DC3300-D4D4-4079-A840-5DBF90B332A3" typeRef="string">
             <dmn:text>Pre-bureauAffordability</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_876096bc-7329-444a-830b-7bd2a06a7982">
-          <dmn:inputExpression id="_441F933E-773A-42B0-80CB-A435AA2E55E6" typeRef="feel:number">
+          <dmn:inputExpression id="_1716790E-EFDB-448F-854B-76B7701E802A" typeRef="number">
             <dmn:text>Age</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:output id="_1beb4059-cfc5-4b79-a73d-cdd369ee308a">
-          <dmn:outputValues id="_06EA4581-8DF4-42A2-B816-8AC2E8A85B21">
+          <dmn:outputValues id="_68632A65-FFFE-4A5A-88E0-20CA6C7BFD75">
             <dmn:text>"INELIGIBLE", "ELIGIBLE"</dmn:text>
           </dmn:outputValues>
         </dmn:output>
@@ -739,12 +747,12 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_BureauCallTypeTable" name="BureauCallTypeTable">
     <dmn:extensionElements/>
-    <dmn:variable id="_DA8385EA-1B38-4CC2-929E-665BA8CA5AB9" name="BureauCallTypeTable" typeRef="feel:string"/>
-    <dmn:encapsulatedLogic id="_D2E5C9CF-B97F-4220-A4CB-9C05BE3AA4B9" kind="FEEL">
-      <dmn:formalParameter id="_63744316-11B4-4AC4-803C-C72607C59C5A" name="Pre-bureauRiskCategory" typeRef="tns:tRiskCategory"/>
-      <dmn:decisionTable id="_0A7ACA07-37D0-4B34-9BF2-6067BD168E80" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="BureauCallTypeTable">
+    <dmn:variable id="_EE4D3281-313C-4F58-AB57-17D10040D2DE" name="BureauCallTypeTable" typeRef="string"/>
+    <dmn:encapsulatedLogic id="_3430AAE2-4A86-42FC-BCF2-3B93B527D2D4" kind="FEEL">
+      <dmn:formalParameter id="_EAC617D3-A143-4AFE-A43A-B3BA70FD898F" name="Pre-bureauRiskCategory" typeRef="tRiskCategory"/>
+      <dmn:decisionTable id="_77D043FE-718A-447C-9CB9-6E32D8DA417B" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="BureauCallTypeTable">
         <dmn:input id="_fcd1287d-7572-4523-ab27-33eff68d965b">
-          <dmn:inputExpression id="_FA26000E-C7F8-4926-BA01-8698529AD38A" typeRef="feel:string">
+          <dmn:inputExpression id="_F74B896E-28B1-4D2D-9D51-7BBCE91559B1" typeRef="string">
             <dmn:text>Pre-bureauRiskCategory</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
@@ -788,18 +796,18 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_Pre-bureauRiskCategoryTable" name="Pre-bureauRiskCategoryTable">
     <dmn:extensionElements/>
-    <dmn:variable id="_C68E2247-6113-4391-AEA6-61FBEE3B1A2C" name="Pre-bureauRiskCategoryTable" typeRef="feel:string"/>
-    <dmn:encapsulatedLogic id="_0CDCEEE4-20CD-4655-B0FF-61749B4FBE47" kind="FEEL">
-      <dmn:formalParameter id="_0E519DB4-15C9-4AB2-9689-0F541C340E66" name="ExistingCustomer" typeRef="feel:boolean"/>
-      <dmn:formalParameter id="_7D6005BD-BA80-432F-9203-0575B2FFE680" name="ApplicationRiskScore" typeRef="feel:number"/>
-      <dmn:decisionTable id="_4E86FE8D-2CC2-4F18-9992-D12BC25A5E8C" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Pre-bureauRiskCategoryTable">
+    <dmn:variable id="_290F30E2-1D49-4FBD-A340-FC8B8EE0A2D5" name="Pre-bureauRiskCategoryTable" typeRef="string"/>
+    <dmn:encapsulatedLogic id="_185DF652-DD51-4C0B-80DD-1B0C4D3E5987" kind="FEEL">
+      <dmn:formalParameter id="_668989E8-D08D-42CE-8E30-D089EC85BB3E" name="ExistingCustomer" typeRef="boolean"/>
+      <dmn:formalParameter id="_5DBF8733-BE73-4192-846A-1D8C0E4F385B" name="ApplicationRiskScore" typeRef="number"/>
+      <dmn:decisionTable id="_90B7E9B3-95C7-4E8D-AA6C-9AC01D6CFEAB" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Pre-bureauRiskCategoryTable">
         <dmn:input id="_6f7fbf13-3fa6-44f5-afe4-7c1e688e76a9">
-          <dmn:inputExpression id="_169BE4A1-F8EC-43E7-9BBD-720A8C253856" typeRef="feel:string">
+          <dmn:inputExpression id="_93B30F28-438C-47E9-AB47-503AC7797C04" typeRef="string">
             <dmn:text>ExistingCustomer</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_89d36bd5-03c2-4c6f-bf47-faa7d28e13a1">
-          <dmn:inputExpression id="_2692D6FA-E464-4EE1-BE7F-426BCC701869" typeRef="feel:string">
+          <dmn:inputExpression id="_C970FEA8-B311-45D3-9B96-AA164B87BDD3" typeRef="string">
             <dmn:text>ApplicationRiskScore</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
@@ -922,24 +930,24 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_Post-bureauRiskCategoryTable" name="Post-bureauRiskCategoryTable">
     <dmn:extensionElements/>
-    <dmn:variable id="_437116BB-67BA-4561-9EA4-279738A5C312" name="Post-bureauRiskCategoryTable" typeRef="feel:string"/>
-    <dmn:encapsulatedLogic id="_4C8D1CA5-604F-4F0F-99A6-15F3FD4A4D31" kind="FEEL">
-      <dmn:formalParameter id="_6934D3A2-93DF-46B0-96CC-F89A70F388B3" name="ExistingCustomer" typeRef="feel:boolean"/>
-      <dmn:formalParameter id="_31AF9339-27EE-4634-9301-73B2A18678CD" name="ApplicationRiskScore" typeRef="feel:number"/>
-      <dmn:formalParameter id="_C8D9189B-98E2-4717-A90E-1FA6B4DFC4F2" name="CreditScore" typeRef="feel:number"/>
-      <dmn:decisionTable id="_3D3073E2-9B3C-46DB-B13A-1E4C732C934D" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Post-bureauRiskCategoryTable">
+    <dmn:variable id="_D196CCE0-878D-445E-9B48-0D5140A9253B" name="Post-bureauRiskCategoryTable" typeRef="string"/>
+    <dmn:encapsulatedLogic id="_4DDAC77D-0E4C-42D5-A4D6-8A271AAA1FDB" kind="FEEL">
+      <dmn:formalParameter id="_FB83BD17-EED8-41A2-8B33-E82C1D186A67" name="ExistingCustomer" typeRef="boolean"/>
+      <dmn:formalParameter id="_5C3AD944-22EF-4F83-8AA5-67050552AB24" name="ApplicationRiskScore" typeRef="number"/>
+      <dmn:formalParameter id="_816B17F1-0A15-4DB3-9813-0D0F503358E0" name="CreditScore" typeRef="number"/>
+      <dmn:decisionTable id="_31730EF2-184A-4F2D-BDA3-345CC7BC7F5D" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Post-bureauRiskCategoryTable">
         <dmn:input id="_0859d2fc-bb13-4eaa-bebf-4bf8f0866c49">
-          <dmn:inputExpression id="_C97B035F-6734-43B3-A649-84A8B8270E8A" typeRef="feel:string">
+          <dmn:inputExpression id="_2412BB2D-35B6-4C86-B740-ADBFF7356C0E" typeRef="string">
             <dmn:text>ExistingCustomer</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_fba27bc9-7678-4457-893e-6bc96fc69626">
-          <dmn:inputExpression id="_0F4EFA1A-FBEB-4918-96A8-AD1956A7244E" typeRef="feel:string">
+          <dmn:inputExpression id="_2E52C9AE-25CB-4455-95D8-D8A18F60CFCB" typeRef="string">
             <dmn:text>ApplicationRiskScore</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_b54042e3-1fe7-4fb3-90d6-ec528047fafb">
-          <dmn:inputExpression id="_14109405-D74C-4DF5-B36C-FEF497205260" typeRef="feel:string">
+          <dmn:inputExpression id="_612F3176-FB71-4BDA-A112-E4A57E6CAA21" typeRef="string">
             <dmn:text>CreditScore</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
@@ -1171,33 +1179,33 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_ApplicationRiskScoreModel" name="ApplicationRiskScoreModel">
     <dmn:extensionElements/>
-    <dmn:variable id="_FA48ADD6-F52E-436E-9BAA-DE0A72EAB62C" name="ApplicationRiskScoreModel" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_19E294B9-B026-490E-AE22-948AEFDB3300" kind="FEEL">
-      <dmn:formalParameter id="_A6CFB09D-431B-40BA-AD1A-A25BA4A8D0B8" name="Age" typeRef="feel:number"/>
-      <dmn:formalParameter id="_F777F90C-7EAF-42A0-9210-338B08877F3E" name="MaritalStatus" typeRef="feel:string"/>
-      <dmn:formalParameter id="_3602C775-6CE1-486D-A1C3-FA5505B4B743" name="EmploymentStatus" typeRef="feel:string"/>
-      <dmn:decisionTable id="_1BD3871C-5E0C-427A-9A09-D1B84548316D" hitPolicy="COLLECT" aggregation="SUM" preferredOrientation="Rule-as-Row" outputLabel="ApplicationRiskScoreModel">
+    <dmn:variable id="_2B477354-3358-4CC1-8604-06466734BA70" name="ApplicationRiskScoreModel" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_61A0846B-BA1F-4088-A490-8858B8E1A917" kind="FEEL">
+      <dmn:formalParameter id="_B4AADE56-9CF4-4C80-A31C-170ACEA41D42" name="Age" typeRef="number"/>
+      <dmn:formalParameter id="_43991AAC-2F18-44E2-A1DD-9B7D9AD92B54" name="MaritalStatus" typeRef="string"/>
+      <dmn:formalParameter id="_8EAA9225-8409-41F2-889E-D461BECF9D31" name="EmploymentStatus" typeRef="string"/>
+      <dmn:decisionTable id="_C1A44E3A-2D4B-40C9-AF40-4BF7A5D6ED63" hitPolicy="COLLECT" aggregation="SUM" preferredOrientation="Rule-as-Row" outputLabel="ApplicationRiskScoreModel">
         <dmn:input id="_dc6c54d5-80a0-4b78-aa83-0a33802de55c">
-          <dmn:inputExpression id="_ECD2EB48-4188-48C0-8C23-47CEC09A151E" typeRef="feel:number">
+          <dmn:inputExpression id="_DC0DD90C-FC91-43E5-BE80-4C977537456E" typeRef="number">
             <dmn:text>Age</dmn:text>
           </dmn:inputExpression>
-          <dmn:inputValues id="_9AEDF5F5-E4E8-4757-B75E-3E0B8E298967">
+          <dmn:inputValues id="_86E9A7CA-DBEA-45D2-A4BF-29B94354E6F7">
             <dmn:text>[18..120]</dmn:text>
           </dmn:inputValues>
         </dmn:input>
         <dmn:input id="_ee956a72-302e-4c89-89a5-1cae18915df9">
-          <dmn:inputExpression id="_74F0EABA-F452-4ECA-BFD4-92514D46070A" typeRef="feel:string">
+          <dmn:inputExpression id="_D6DF70C7-8208-4BBB-89B4-55F156BC33F0" typeRef="string">
             <dmn:text>MaritalStatus</dmn:text>
           </dmn:inputExpression>
-          <dmn:inputValues id="_2EE84B42-6F0D-4FB0-A03E-35EB9BBD941B">
+          <dmn:inputValues id="_7363E680-550D-4FDC-99BC-294A4378D8E2">
             <dmn:text>"S", "M"</dmn:text>
           </dmn:inputValues>
         </dmn:input>
         <dmn:input id="_d6432000-3b07-465e-b31c-8576677b8d39">
-          <dmn:inputExpression id="_810223FE-FF04-4E18-9AA7-0B450278C639" typeRef="feel:string">
+          <dmn:inputExpression id="_C4CF7C93-D47A-434F-B07E-5E5AD83017F7" typeRef="string">
             <dmn:text>EmploymentStatus</dmn:text>
           </dmn:inputExpression>
-          <dmn:inputValues id="_0EE97DB2-272D-4803-9587-346DC9A850A3">
+          <dmn:inputValues id="_AA16B5B2-4FE1-46E0-BFF2-F9B01EA4094D">
             <dmn:text>"UNEMPLOYED", "EMPLOYED", "SELF-EMPLOYED", "STUDENT"</dmn:text>
           </dmn:inputValues>
         </dmn:input>
@@ -1395,27 +1403,27 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_InstallmentCalculation" name="InstallmentCalculation">
     <dmn:extensionElements/>
-    <dmn:variable id="_BBB0F692-5DDE-4629-A3FF-B10E47AD762D" name="InstallmentCalculation" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_DA300CCD-5E2F-4BCE-959A-E81D7C3F0CF1" kind="FEEL">
-      <dmn:formalParameter id="_F911B45A-C7F1-4E9C-B5AE-61BBF62219DA" name="ProductType" typeRef="feel:string"/>
-      <dmn:formalParameter id="_25334906-F4A5-4AF6-B16C-7C6917E7E2A3" name="Rate" typeRef="feel:number"/>
-      <dmn:formalParameter id="_545B0EB7-57A1-4AAD-A24C-68D68D021598" name="Term" typeRef="feel:number"/>
-      <dmn:formalParameter id="_1425C719-6F2A-44EC-9164-057DC9340AF9" name="Amount" typeRef="feel:number"/>
-      <dmn:context id="_8E5CF8D4-2D17-4F6D-BD40-086F430CD179">
+    <dmn:variable id="_0B2CFB54-7252-4D00-B9E4-20381E404C93" name="InstallmentCalculation" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_7FE8BC04-0E45-4645-A854-04868770F906" kind="FEEL">
+      <dmn:formalParameter id="_94511DB8-E2FF-4740-8898-9638C1875282" name="ProductType" typeRef="string"/>
+      <dmn:formalParameter id="_1E8DF5D5-76F4-4C4B-A980-BCC91BD9D74A" name="Rate" typeRef="number"/>
+      <dmn:formalParameter id="_4792A886-0ACF-4A82-A9FE-5D1D0488B2AD" name="Term" typeRef="number"/>
+      <dmn:formalParameter id="_973B466E-0EE3-4A8C-89EF-1A9865AC8010" name="Amount" typeRef="number"/>
+      <dmn:context id="_1255E306-168A-48A3-8161-DD4CE567D110">
         <dmn:contextEntry>
-          <dmn:variable id="_A143C6C9-4491-4DAD-96FE-C681F9E8AA14" name="MonthlyFee" typeRef="feel:number"/>
-          <dmn:literalExpression id="_A84E2A60-59C3-48A1-8766-DAE5C0256728">
+          <dmn:variable id="_133E31C7-ACE5-4E83-A88C-8640DE81CA6E" name="MonthlyFee" typeRef="number"/>
+          <dmn:literalExpression id="_4C6D30AE-B0F7-4CFD-9CDA-D5143E1EF105">
             <dmn:text>if ProductType ="STANDARD LOAN" then 20.00 else if ProductType ="SPECIAL LOAN" then 25.00 else null</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_6D08DAD7-64EA-4E5A-9FBC-D35650300E4C" name="MonthlyRepayment" typeRef="feel:number"/>
-          <dmn:literalExpression id="_D1D976FB-D357-4F68-A407-675D0D000D6E">
+          <dmn:variable id="_15186FB0-1E14-4524-AE47-8E819394DEB6" name="MonthlyRepayment" typeRef="number"/>
+          <dmn:literalExpression id="_87BFC73E-3AC2-4CBE-AE52-B9D791E35492">
             <dmn:text>(Amount *Rate/12) / (1 - (1 + Rate/12)**-Term)</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:literalExpression id="_0E73B9F0-2BC6-480A-97CB-22089D7A2900">
+          <dmn:literalExpression id="_AB144C38-7C5F-4BCA-B32E-D970D31E1F06">
             <dmn:text>MonthlyRepayment+MonthlyFee</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
@@ -1424,35 +1432,35 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_RoutingRules" name="RoutingRules">
     <dmn:extensionElements/>
-    <dmn:variable id="_03972F68-5F35-4311-A4A7-0ED50672D159" name="RoutingRules" typeRef="feel:string"/>
-    <dmn:encapsulatedLogic id="_697A751C-8EC7-44DD-900D-67720E1AA1CA" kind="FEEL">
-      <dmn:formalParameter id="_E4A74A20-EB76-467C-AC8D-55A84D4BA392" name="Post-bureauRiskCategory" typeRef="tns:tRiskCategory"/>
-      <dmn:formalParameter id="_58D125F7-ADDD-45B8-B8BA-F24125B540FF" name="Post-bureauAffordability" typeRef="feel:boolean"/>
-      <dmn:formalParameter id="_D375EC4B-5A63-46D7-ADAF-83C26D30ECEB" name="Bankrupt" typeRef="feel:boolean"/>
-      <dmn:formalParameter id="_8EA92707-61B8-415B-90C9-FBD77FF16B35" name="CreditScore" typeRef="feel:number"/>
-      <dmn:decisionTable id="_5DC0598D-24D2-4E35-B826-B78A59994B66" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="RoutingRules">
+    <dmn:variable id="_0B7CA7C9-428D-4BBA-B31E-782E0076A070" name="RoutingRules" typeRef="string"/>
+    <dmn:encapsulatedLogic id="_DC6BA48E-124A-4E61-BAD4-3E33E203F7A0" kind="FEEL">
+      <dmn:formalParameter id="_FA10AEB9-F448-4754-8EBA-47555368C5C1" name="Post-bureauRiskCategory" typeRef="tRiskCategory"/>
+      <dmn:formalParameter id="_1D6B6C41-D55F-4279-9D67-22FFC22AD71D" name="Post-bureauAffordability" typeRef="boolean"/>
+      <dmn:formalParameter id="_2D47A47E-B4A0-4044-BF04-CB44A3BEC2D9" name="Bankrupt" typeRef="boolean"/>
+      <dmn:formalParameter id="_7CBEFA2C-B13E-48AC-994C-DE5CD95452EF" name="CreditScore" typeRef="number"/>
+      <dmn:decisionTable id="_72067A91-ACA2-4C25-AC07-9B846B0B54E7" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="RoutingRules">
         <dmn:input id="_e4d34fbe-9d83-4126-a268-6ff44d6d33c0">
-          <dmn:inputExpression id="_58AFD679-AFC1-4A27-AE9B-0A9F557D93F3" typeRef="feel:string">
+          <dmn:inputExpression id="_03391DB4-4AD6-48CF-88F2-1F5A7771154C" typeRef="string">
             <dmn:text>Post-bureauRiskCategory</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_fc1055cf-ab08-44a0-91bc-2d6539df00c5">
-          <dmn:inputExpression id="_3BDA5828-3953-4F0C-ABBD-26F3F807ED98" typeRef="feel:string">
+          <dmn:inputExpression id="_87DF124A-4F1E-4FC4-BE36-43E03F87698F" typeRef="string">
             <dmn:text>Post-bureauAffordability</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_17cf72a2-81db-4ee3-a599-aaa70699fdf7">
-          <dmn:inputExpression id="_DC5500C6-3FFC-4730-AD8D-3CC5624C15B7" typeRef="feel:boolean">
+          <dmn:inputExpression id="_C8E35607-4AD0-42C8-8077-BFA5A3106DF9" typeRef="boolean">
             <dmn:text>Bankrupt</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:input id="_f692dbba-dc13-4076-a5ba-275041c0b944">
-          <dmn:inputExpression id="_F452147E-9D4B-40EC-9BD7-0AEFB84B5077" typeRef="feel:string">
+          <dmn:inputExpression id="_418F90FD-6B5B-47CA-9165-0972FEDB7495" typeRef="string">
             <dmn:text>CreditScore</dmn:text>
           </dmn:inputExpression>
         </dmn:input>
         <dmn:output id="_4b478b34-a8f7-4019-a667-1c78d64154fe">
-          <dmn:outputValues id="_156B17FA-4AEE-4B79-8211-ED6E730B10E8">
+          <dmn:outputValues id="_086883DD-D9CD-4F69-8745-9BA43B623B95">
             <dmn:text>"DECLINE", "REFER", "ACCEPT"</dmn:text>
           </dmn:outputValues>
         </dmn:output>
@@ -1562,104 +1570,104 @@
   </dmn:businessKnowledgeModel>
   <dmn:inputData id="i_ApplicantData" name="ApplicantData">
     <dmn:extensionElements/>
-    <dmn:variable id="_237BC1A2-5475-4837-97D6-E3576CAD7A35" name="ApplicantData" typeRef="tns:tApplicantData"/>
+    <dmn:variable id="_FF518ED3-8003-49E7-8486-C036D51F141F" name="ApplicantData" typeRef="tApplicantData"/>
   </dmn:inputData>
   <dmn:inputData id="i_BureauData" name="BureauData">
     <dmn:extensionElements/>
-    <dmn:variable id="_D7B8D569-60B8-42A2-BB82-96067B150386" name="BureauData" typeRef="tns:tBureauData"/>
+    <dmn:variable id="_6F835759-829E-4842-BCFB-08C30F5282C9" name="BureauData" typeRef="tBureauData"/>
   </dmn:inputData>
   <dmn:inputData id="i_RequestedProduct" name="RequestedProduct">
     <dmn:extensionElements/>
-    <dmn:variable id="_AA4E0DEC-85D9-4CD9-B6EE-978BE67DAFBB" name="RequestedProduct" typeRef="tns:tRequestedProduct"/>
+    <dmn:variable id="_C25FC971-E544-46D0-8FFC-A54F79B893A3" name="RequestedProduct" typeRef="tRequestedProduct"/>
   </dmn:inputData>
   <dmn:inputData id="i_SupportingDocuments" name="SupportingDocuments">
     <dmn:extensionElements/>
-    <dmn:variable id="_6D7A1D93-0C49-4264-BAC9-E29937EEC1FF" name="SupportingDocuments" typeRef="feel:string"/>
+    <dmn:variable id="_640825E5-1E5F-40B5-A076-EDE9EF359B2A" name="SupportingDocuments" typeRef="string"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_F8C40705-3D8D-4979-9090-49A85DD8AD71" name="DRG">
+    <dmndi:DMNDiagram id="_0BC68A2A-2089-4A5F-997C-9DED049746ED" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_DDE7FFE3-6EBD-4EF6-A198-1E80AA3B8BAE"/>
-          <kie:ComponentWidths dmnElementRef="_35DC0099-C237-4E6D-8022-68BEE8C5B7EB"/>
-          <kie:ComponentWidths dmnElementRef="_C684A108-F33F-48F7-88BB-6C61C2ADA582"/>
-          <kie:ComponentWidths dmnElementRef="_0311C0E4-9E8A-4925-B362-88F742C44A71"/>
-          <kie:ComponentWidths dmnElementRef="_2CC81AB1-87EA-4012-99D3-30219F5F0E3D"/>
-          <kie:ComponentWidths dmnElementRef="_A09F1991-CB48-4DBA-B276-0A9123F72E66"/>
-          <kie:ComponentWidths dmnElementRef="_9947739E-7668-4AAD-ADAF-64BDCB0A28B6"/>
-          <kie:ComponentWidths dmnElementRef="_71694435-C845-4731-B8DF-E6101C5B2C24"/>
-          <kie:ComponentWidths dmnElementRef="_C58D8D01-EA92-4FE4-A04A-606AEEBDF094"/>
-          <kie:ComponentWidths dmnElementRef="_BDA19BD6-778A-4014-AC1D-9CD5085C4395"/>
-          <kie:ComponentWidths dmnElementRef="_80D9AA04-DFC3-47E7-B655-D09269D0082A"/>
-          <kie:ComponentWidths dmnElementRef="_136FA517-6122-43E0-8898-73ABB6858C74"/>
-          <kie:ComponentWidths dmnElementRef="_2889BBAB-6F82-4934-8186-4CB6964529DA"/>
-          <kie:ComponentWidths dmnElementRef="_813488AF-4D91-4593-AC73-8E22FC11131D"/>
-          <kie:ComponentWidths dmnElementRef="_DA9774D4-AFFD-4F07-9FB3-15520D4FF549"/>
-          <kie:ComponentWidths dmnElementRef="_D84F4290-779B-4A9C-AFA8-3D44F81CEE0F"/>
-          <kie:ComponentWidths dmnElementRef="_F540B0BF-639F-4B59-A1BC-DB7607F8BAEB"/>
-          <kie:ComponentWidths dmnElementRef="_C117F227-F436-48B1-9BB1-BD91BA1E20A6"/>
-          <kie:ComponentWidths dmnElementRef="_A893A82C-55B1-4A90-BA21-AAE8354F9F12"/>
-          <kie:ComponentWidths dmnElementRef="_3C5F8131-54B2-487B-B227-C00B2A4DC395"/>
-          <kie:ComponentWidths dmnElementRef="_24E19D2B-4378-463A-90FE-D260D627BAE5"/>
-          <kie:ComponentWidths dmnElementRef="_B7E26489-150B-46E1-9EAD-ECA03A7B6BD2"/>
-          <kie:ComponentWidths dmnElementRef="_0DE5B655-246D-4440-A4E4-D1554612BD58"/>
-          <kie:ComponentWidths dmnElementRef="_1150E16E-9210-43DA-8B86-6E57EA0D7575"/>
-          <kie:ComponentWidths dmnElementRef="_B6969926-9DB6-4126-BC88-B7D074BF0FF3"/>
-          <kie:ComponentWidths dmnElementRef="_59B4EF5E-1925-4668-AB6E-52C77237AB97"/>
-          <kie:ComponentWidths dmnElementRef="_B3D886C6-3260-4D40-A83C-5E66D276652D"/>
-          <kie:ComponentWidths dmnElementRef="_2B600E31-132F-401B-A98A-462E42601A00"/>
-          <kie:ComponentWidths dmnElementRef="_B6D367C8-474C-4D15-8EBD-D24696B415FA"/>
-          <kie:ComponentWidths dmnElementRef="_C1E60CE3-17C5-4B12-9C7B-5D09A11D34BC"/>
-          <kie:ComponentWidths dmnElementRef="_CA53695E-3DBC-498E-BFC3-3E1729039DA0"/>
-          <kie:ComponentWidths dmnElementRef="_802932AE-2AA4-440F-AA48-C8E023E40332"/>
-          <kie:ComponentWidths dmnElementRef="_A802CE66-DCB9-4BCF-AAFD-D8BCB38BF79E"/>
-          <kie:ComponentWidths dmnElementRef="_BEC8803B-8A26-49C4-956D-807F4FAA2E71"/>
-          <kie:ComponentWidths dmnElementRef="_11426BDC-3B30-4E37-AEF9-AD57B07A952D"/>
-          <kie:ComponentWidths dmnElementRef="_57E65171-3956-4461-8ED7-DAB34DA1A199"/>
-          <kie:ComponentWidths dmnElementRef="_13ECBE9A-69C4-4C74-8FBE-C77FB076BC55"/>
-          <kie:ComponentWidths dmnElementRef="_D6EBCE6A-DCB6-41C0-8C10-69A3FCBAEFFE"/>
-          <kie:ComponentWidths dmnElementRef="_FBEA263B-3C80-4646-8664-0ADE503F3EDB"/>
-          <kie:ComponentWidths dmnElementRef="_0A2D48EA-2A82-4B5F-AD51-A581B2BF4B94"/>
-          <kie:ComponentWidths dmnElementRef="_041715A8-C550-49A3-B76B-5FAD82337BE5"/>
-          <kie:ComponentWidths dmnElementRef="_593E6E4F-4AF0-4153-AF61-97DD33DD5D8E"/>
-          <kie:ComponentWidths dmnElementRef="_07308D21-9C06-43BD-B410-6AE59F5FB402"/>
-          <kie:ComponentWidths dmnElementRef="_38F65FCD-C634-45D6-A930-53E780F11A81"/>
-          <kie:ComponentWidths dmnElementRef="_15CBC4EE-9080-4158-8233-FE2E1D0A7309"/>
-          <kie:ComponentWidths dmnElementRef="_AB5A4898-E475-4F47-B4DC-2D4B0C4D0067"/>
-          <kie:ComponentWidths dmnElementRef="_F40A76B2-2DD9-4131-9C56-2FA895CAFA77"/>
-          <kie:ComponentWidths dmnElementRef="_D3F9F629-5E11-45C6-BE3B-A41BAF5E66D8"/>
-          <kie:ComponentWidths dmnElementRef="_F04E38D1-C796-4591-ADBB-24EDA8C15538"/>
-          <kie:ComponentWidths dmnElementRef="_EF949ED7-E859-4CC4-B913-C889C5AB0AFB"/>
-          <kie:ComponentWidths dmnElementRef="_9364D634-EB4B-4116-9FCF-A7E2B4E66890"/>
-          <kie:ComponentWidths dmnElementRef="_B155BC84-C7C9-4F39-94DD-FFF0ED4432F7"/>
-          <kie:ComponentWidths dmnElementRef="_A2234BB8-DDFC-49C5-BB19-BE0D7C82C5D5"/>
-          <kie:ComponentWidths dmnElementRef="_3D79B68F-7001-4845-B7C4-9EA67676E8E4"/>
-          <kie:ComponentWidths dmnElementRef="_498377F6-05AF-4163-9B33-B6AA463ABE22"/>
-          <kie:ComponentWidths dmnElementRef="_08BEE063-DA3F-4614-AB74-60D1BBC72819"/>
-          <kie:ComponentWidths dmnElementRef="_852AC68E-FBF0-4247-89A3-1627E518E5E9"/>
-          <kie:ComponentWidths dmnElementRef="_E16A9506-67F9-43AC-B7F8-101E23FA4F79"/>
-          <kie:ComponentWidths dmnElementRef="_419315D7-1EE5-45F7-A514-C7193159E0E8"/>
-          <kie:ComponentWidths dmnElementRef="_E369B11C-7814-4A19-A5C0-02FC5ECC70CE"/>
-          <kie:ComponentWidths dmnElementRef="_7715E033-2040-47B5-9598-3997F45449EA"/>
-          <kie:ComponentWidths dmnElementRef="_71163946-8730-4519-BE74-0058D92EB041"/>
-          <kie:ComponentWidths dmnElementRef="_0A7ACA07-37D0-4B34-9BF2-6067BD168E80"/>
-          <kie:ComponentWidths dmnElementRef="_D2E5C9CF-B97F-4220-A4CB-9C05BE3AA4B9"/>
-          <kie:ComponentWidths dmnElementRef="_4E86FE8D-2CC2-4F18-9992-D12BC25A5E8C"/>
-          <kie:ComponentWidths dmnElementRef="_0CDCEEE4-20CD-4655-B0FF-61749B4FBE47"/>
-          <kie:ComponentWidths dmnElementRef="_3D3073E2-9B3C-46DB-B13A-1E4C732C934D"/>
-          <kie:ComponentWidths dmnElementRef="_4C8D1CA5-604F-4F0F-99A6-15F3FD4A4D31"/>
-          <kie:ComponentWidths dmnElementRef="_1BD3871C-5E0C-427A-9A09-D1B84548316D"/>
-          <kie:ComponentWidths dmnElementRef="_19E294B9-B026-490E-AE22-948AEFDB3300"/>
-          <kie:ComponentWidths dmnElementRef="_8E5CF8D4-2D17-4F6D-BD40-086F430CD179"/>
-          <kie:ComponentWidths dmnElementRef="_A84E2A60-59C3-48A1-8766-DAE5C0256728"/>
-          <kie:ComponentWidths dmnElementRef="_D1D976FB-D357-4F68-A407-675D0D000D6E"/>
-          <kie:ComponentWidths dmnElementRef="_0E73B9F0-2BC6-480A-97CB-22089D7A2900"/>
-          <kie:ComponentWidths dmnElementRef="_DA300CCD-5E2F-4BCE-959A-E81D7C3F0CF1"/>
-          <kie:ComponentWidths dmnElementRef="_5DC0598D-24D2-4E35-B826-B78A59994B66"/>
-          <kie:ComponentWidths dmnElementRef="_697A751C-8EC7-44DD-900D-67720E1AA1CA"/>
+          <kie:ComponentWidths dmnElementRef="_29B7A036-C73A-4AEF-8569-265850118352"/>
+          <kie:ComponentWidths dmnElementRef="_09468130-B19E-4FC9-AEBF-7CD2F5955C0F"/>
+          <kie:ComponentWidths dmnElementRef="_2CB74430-2276-402B-9F07-7C8007F401C1"/>
+          <kie:ComponentWidths dmnElementRef="_E59E4BC2-07BF-40CB-8F07-BF83772BF598"/>
+          <kie:ComponentWidths dmnElementRef="_70996A6B-6876-4E49-BC6D-6A21C00C7B36"/>
+          <kie:ComponentWidths dmnElementRef="_7F3DE387-D3DD-4FE8-88C4-8F2AE4EC454F"/>
+          <kie:ComponentWidths dmnElementRef="_718231B7-DFAF-40B5-B9B6-D0A482253158"/>
+          <kie:ComponentWidths dmnElementRef="_0ED44B9D-D022-41DA-AB69-7AF97B4D0BEF"/>
+          <kie:ComponentWidths dmnElementRef="_7321FF54-B182-4F79-BE6C-E18C3A8C86A3"/>
+          <kie:ComponentWidths dmnElementRef="_51B33852-DF7F-4511-9224-491BD2A12BBC"/>
+          <kie:ComponentWidths dmnElementRef="_75D90D65-2A1D-4BDD-85D7-DCBDA78DBE1D"/>
+          <kie:ComponentWidths dmnElementRef="_E6EEBF60-7D37-4BA6-AB7D-B093B354A79D"/>
+          <kie:ComponentWidths dmnElementRef="_7B17D600-05ED-487A-8601-BCD6F5BCC2FE"/>
+          <kie:ComponentWidths dmnElementRef="_13FCF12A-E0E8-4DA4-9F7C-A5C981BC8807"/>
+          <kie:ComponentWidths dmnElementRef="_B502CF7A-5A7D-4FF4-8E4C-B47FB423B06E"/>
+          <kie:ComponentWidths dmnElementRef="_3A0DD81B-4465-4103-89BF-E4F0B1363E09"/>
+          <kie:ComponentWidths dmnElementRef="_9B2C90D7-BA02-4BC9-8F73-1FEF0A5B67E7"/>
+          <kie:ComponentWidths dmnElementRef="_40A7F16C-432C-4223-BCD4-100E11288370"/>
+          <kie:ComponentWidths dmnElementRef="_54F1569E-6062-4683-B34E-16F46E50C366"/>
+          <kie:ComponentWidths dmnElementRef="_558EE93F-9F5E-473E-B3A0-705A950D48D5"/>
+          <kie:ComponentWidths dmnElementRef="_86D4C585-DB4A-4ADB-A895-D10967E6894F"/>
+          <kie:ComponentWidths dmnElementRef="_0BFF3882-37FB-4E41-819A-EA3BA6814C4A"/>
+          <kie:ComponentWidths dmnElementRef="_FF86030B-E4A2-4778-8FF3-50A11520E573"/>
+          <kie:ComponentWidths dmnElementRef="_7AC1839E-BFE1-4AD7-B524-C690E5422448"/>
+          <kie:ComponentWidths dmnElementRef="_9098B426-68C1-46A6-8CB2-739F8B95B8A9"/>
+          <kie:ComponentWidths dmnElementRef="_3879A878-D03C-4A98-BF68-6ABC87A381E3"/>
+          <kie:ComponentWidths dmnElementRef="_9F4C941B-EEA4-4093-8646-B4CF54060FA0"/>
+          <kie:ComponentWidths dmnElementRef="_7E6E34A1-370E-47CC-9011-1AA219CD8082"/>
+          <kie:ComponentWidths dmnElementRef="_7DC095D3-0DEE-4022-8C61-FE6CEC425D79"/>
+          <kie:ComponentWidths dmnElementRef="_ED3C8F5D-1113-43F7-ABB3-C58CB932CCDF"/>
+          <kie:ComponentWidths dmnElementRef="_AA4B76CF-1451-4D37-9E1E-3815D385CDD9"/>
+          <kie:ComponentWidths dmnElementRef="_F214762D-8C12-46D2-A89B-FFF3D9309A6D"/>
+          <kie:ComponentWidths dmnElementRef="_F394B91E-07A3-41CB-A988-3BEC4313BBA8"/>
+          <kie:ComponentWidths dmnElementRef="_9F89D289-FE12-46C2-83C9-A628B96A58A9"/>
+          <kie:ComponentWidths dmnElementRef="_4F0F3DD7-1E73-4C7B-847E-A64A9485BBC7"/>
+          <kie:ComponentWidths dmnElementRef="_5E5606F4-FD8F-4AD0-A564-4A49038EFFC0"/>
+          <kie:ComponentWidths dmnElementRef="_9FCFD300-D76E-49A1-9042-AE7ADC50D5A6"/>
+          <kie:ComponentWidths dmnElementRef="_0444F428-A9D6-4CC4-99EA-A122FFBC2B39"/>
+          <kie:ComponentWidths dmnElementRef="_8AB61741-4D85-48C7-BAF7-CA6A479788C7"/>
+          <kie:ComponentWidths dmnElementRef="_A825CC45-69DC-4742-A748-B9587675F4EF"/>
+          <kie:ComponentWidths dmnElementRef="_9D60820E-82DB-4BCB-84FC-CF4F39C4D6A7"/>
+          <kie:ComponentWidths dmnElementRef="_8520C83C-E42F-49AB-A7B8-6051A4D8CC5A"/>
+          <kie:ComponentWidths dmnElementRef="_9572FCBE-961E-4221-9115-E8029E32751C"/>
+          <kie:ComponentWidths dmnElementRef="_465049B4-9BCB-4152-B7A9-7CCC26741F18"/>
+          <kie:ComponentWidths dmnElementRef="_310A5DC1-3361-4C5A-B25D-8B2F96AA32D6"/>
+          <kie:ComponentWidths dmnElementRef="_4A9BB0D3-EECA-4787-B145-3933F7B40C2F"/>
+          <kie:ComponentWidths dmnElementRef="_EFD59F0C-8273-4F80-8D83-8A4F1060F369"/>
+          <kie:ComponentWidths dmnElementRef="_EFF52895-AA9D-47D1-94B7-AF467D303371"/>
+          <kie:ComponentWidths dmnElementRef="_BCE49B32-AA01-48C4-B537-AB0B61AEC6A0"/>
+          <kie:ComponentWidths dmnElementRef="_E75CE743-0DB0-43E2-8826-03B9B40E8AB6"/>
+          <kie:ComponentWidths dmnElementRef="_1B93A301-3ADE-4D67-90CC-D9AC7984CEA9"/>
+          <kie:ComponentWidths dmnElementRef="_DA7D0F4C-28B4-41F1-A21E-D353763910F7"/>
+          <kie:ComponentWidths dmnElementRef="_1DFC00BF-6F93-49B1-B676-85656193F156"/>
+          <kie:ComponentWidths dmnElementRef="_A5E45ED5-8DF9-40E5-A213-F3ADECD12C73"/>
+          <kie:ComponentWidths dmnElementRef="_DF87409C-7443-4E68-99E4-EE45AF3A2BAC"/>
+          <kie:ComponentWidths dmnElementRef="_F353B68B-2813-4E0E-9AD3-B7702BD95230"/>
+          <kie:ComponentWidths dmnElementRef="_1CD3DE71-48C1-4660-A64D-F24E90E46627"/>
+          <kie:ComponentWidths dmnElementRef="_1DF022D9-B0F1-4FFF-AA4A-96F4E2356603"/>
+          <kie:ComponentWidths dmnElementRef="_5FAE9F72-C4D2-42F4-9DC5-16E72DE3AB54"/>
+          <kie:ComponentWidths dmnElementRef="_9366F11E-2780-4C6F-9C76-9E696009EEDD"/>
+          <kie:ComponentWidths dmnElementRef="_C6689A70-CC73-41BA-A370-A239203B91A2"/>
+          <kie:ComponentWidths dmnElementRef="_3174D3CB-EB1B-4B77-B528-46DD054EB0CF"/>
+          <kie:ComponentWidths dmnElementRef="_77D043FE-718A-447C-9CB9-6E32D8DA417B"/>
+          <kie:ComponentWidths dmnElementRef="_3430AAE2-4A86-42FC-BCF2-3B93B527D2D4"/>
+          <kie:ComponentWidths dmnElementRef="_90B7E9B3-95C7-4E8D-AA6C-9AC01D6CFEAB"/>
+          <kie:ComponentWidths dmnElementRef="_185DF652-DD51-4C0B-80DD-1B0C4D3E5987"/>
+          <kie:ComponentWidths dmnElementRef="_31730EF2-184A-4F2D-BDA3-345CC7BC7F5D"/>
+          <kie:ComponentWidths dmnElementRef="_4DDAC77D-0E4C-42D5-A4D6-8A271AAA1FDB"/>
+          <kie:ComponentWidths dmnElementRef="_C1A44E3A-2D4B-40C9-AF40-4BF7A5D6ED63"/>
+          <kie:ComponentWidths dmnElementRef="_61A0846B-BA1F-4088-A490-8858B8E1A917"/>
+          <kie:ComponentWidths dmnElementRef="_1255E306-168A-48A3-8161-DD4CE567D110"/>
+          <kie:ComponentWidths dmnElementRef="_4C6D30AE-B0F7-4CFD-9CDA-D5143E1EF105"/>
+          <kie:ComponentWidths dmnElementRef="_87BFC73E-3AC2-4CBE-AE52-B9D791E35492"/>
+          <kie:ComponentWidths dmnElementRef="_AB144C38-7C5F-4BCA-B32E-D970D31E1F06"/>
+          <kie:ComponentWidths dmnElementRef="_7FE8BC04-0E45-4645-A854-04868770F906"/>
+          <kie:ComponentWidths dmnElementRef="_72067A91-ACA2-4C25-AC07-9B846B0B54E7"/>
+          <kie:ComponentWidths dmnElementRef="_DC6BA48E-124A-4E61-BAD4-3E33E203F7A0"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-d_BureauCallType" dmnElementRef="tns:d_BureauCallType" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_BureauCallType" dmnElementRef="d_BureauCallType" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1668,7 +1676,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Strategy" dmnElementRef="tns:d_Strategy" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Strategy" dmnElementRef="d_Strategy" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1677,7 +1685,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Eligibility" dmnElementRef="tns:d_Eligibility" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Eligibility" dmnElementRef="d_Eligibility" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1686,7 +1694,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Pre-bureauRiskCategory" dmnElementRef="tns:d_Pre-bureauRiskCategory" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Pre-bureauRiskCategory" dmnElementRef="d_Pre-bureauRiskCategory" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1695,7 +1703,7 @@
         <dc:Bounds x="50" y="575" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Post-bureauRiskCategory" dmnElementRef="tns:d_Post-bureauRiskCategory" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Post-bureauRiskCategory" dmnElementRef="d_Post-bureauRiskCategory" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1704,7 +1712,7 @@
         <dc:Bounds x="488" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_ApplicationRiskScore" dmnElementRef="tns:d_ApplicationRiskScore" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_ApplicationRiskScore" dmnElementRef="d_ApplicationRiskScore" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1713,7 +1721,7 @@
         <dc:Bounds x="50" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Pre-bureauAffordability" dmnElementRef="tns:d_Pre-bureauAffordability" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Pre-bureauAffordability" dmnElementRef="d_Pre-bureauAffordability" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1722,7 +1730,7 @@
         <dc:Bounds x="138" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Post-bureauAffordability" dmnElementRef="tns:d_Post-bureauAffordability" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Post-bureauAffordability" dmnElementRef="d_Post-bureauAffordability" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1731,7 +1739,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_RequiredMonthlyInstallment" dmnElementRef="tns:d_RequiredMonthlyInstallment" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_RequiredMonthlyInstallment" dmnElementRef="d_RequiredMonthlyInstallment" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1740,7 +1748,7 @@
         <dc:Bounds x="225" y="575" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Routing" dmnElementRef="tns:d_Routing" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Routing" dmnElementRef="d_Routing" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1749,7 +1757,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-d_Adjudication" dmnElementRef="tns:d_Adjudication" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_Adjudication" dmnElementRef="d_Adjudication" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1758,7 +1766,7 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_AffordabilityCalculation" dmnElementRef="tns:b_AffordabilityCalculation" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_AffordabilityCalculation" dmnElementRef="b_AffordabilityCalculation" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1767,7 +1775,7 @@
         <dc:Bounds x="400" y="575" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_CreditContingencyFactorTable" dmnElementRef="tns:b_CreditContingencyFactorTable" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_CreditContingencyFactorTable" dmnElementRef="b_CreditContingencyFactorTable" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1776,7 +1784,7 @@
         <dc:Bounds x="575" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_EligibilityRules" dmnElementRef="tns:b_EligibilityRules" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_EligibilityRules" dmnElementRef="b_EligibilityRules" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1785,7 +1793,7 @@
         <dc:Bounds x="313" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_BureauCallTypeTable" dmnElementRef="tns:b_BureauCallTypeTable" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_BureauCallTypeTable" dmnElementRef="b_BureauCallTypeTable" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1794,7 +1802,7 @@
         <dc:Bounds x="663" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_Pre-bureauRiskCategoryTable" dmnElementRef="tns:b_Pre-bureauRiskCategoryTable" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_Pre-bureauRiskCategoryTable" dmnElementRef="b_Pre-bureauRiskCategoryTable" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1803,7 +1811,7 @@
         <dc:Bounds x="225" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_Post-bureauRiskCategoryTable" dmnElementRef="tns:b_Post-bureauRiskCategoryTable" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_Post-bureauRiskCategoryTable" dmnElementRef="b_Post-bureauRiskCategoryTable" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1812,7 +1820,7 @@
         <dc:Bounds x="575" y="575" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_ApplicationRiskScoreModel" dmnElementRef="tns:b_ApplicationRiskScoreModel" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_ApplicationRiskScoreModel" dmnElementRef="b_ApplicationRiskScoreModel" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1821,7 +1829,7 @@
         <dc:Bounds x="313" y="925" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_InstallmentCalculation" dmnElementRef="tns:b_InstallmentCalculation" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_InstallmentCalculation" dmnElementRef="b_InstallmentCalculation" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1830,7 +1838,7 @@
         <dc:Bounds x="400" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_RoutingRules" dmnElementRef="tns:b_RoutingRules" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_RoutingRules" dmnElementRef="b_RoutingRules" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1839,7 +1847,7 @@
         <dc:Bounds x="575" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_ApplicantData" dmnElementRef="tns:i_ApplicantData" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_ApplicantData" dmnElementRef="i_ApplicantData" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1848,7 +1856,7 @@
         <dc:Bounds x="488" y="925" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_BureauData" dmnElementRef="tns:i_BureauData" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_BureauData" dmnElementRef="i_BureauData" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1857,7 +1865,7 @@
         <dc:Bounds x="750" y="575" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_RequestedProduct" dmnElementRef="tns:i_RequestedProduct" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_RequestedProduct" dmnElementRef="i_RequestedProduct" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1866,7 +1874,7 @@
         <dc:Bounds x="750" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_SupportingDocuments" dmnElementRef="tns:i_SupportingDocuments" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_SupportingDocuments" dmnElementRef="i_SupportingDocuments" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -1875,87 +1883,143 @@
         <dc:Bounds x="750" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-d_Pre-bureauRiskCategory" dmnElementRef="tns:d_Pre-bureauRiskCategory">
+      <dmndi:DMNEdge id="dmnedge-drg-_C91DE08F-DDC5-447E-A60F-665B4EF3938A" dmnElementRef="_C91DE08F-DDC5-447E-A60F-665B4EF3938A">
         <di:waypoint x="50" y="575"/>
         <di:waypoint x="50" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_BureauCallTypeTable" dmnElementRef="tns:b_BureauCallTypeTable">
+      <dmndi:DMNEdge id="dmnedge-drg-_A0D7E8FB-0EAB-4344-A83B-B88634994369" dmnElementRef="_A0D7E8FB-0EAB-4344-A83B-B88634994369">
         <di:waypoint x="663" y="400"/>
         <di:waypoint x="50" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_BureauCallType" dmnElementRef="tns:d_BureauCallType">
+      <dmndi:DMNEdge id="dmnedge-drg-_6F67A0F0-5F9B-448F-99E9-889D016D414E" dmnElementRef="_6F67A0F0-5F9B-448F-99E9-889D016D414E">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_Eligibility" dmnElementRef="tns:d_Eligibility">
+      <dmndi:DMNEdge id="dmnedge-drg-_2BC67540-4C1B-4017-B8A0-ACB450CB5436" dmnElementRef="_2BC67540-4C1B-4017-B8A0-ACB450CB5436">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_Pre-bureauAffordability" dmnElementRef="tns:d_Pre-bureauAffordability">
+      <dmndi:DMNEdge id="dmnedge-drg-_048C76D3-5EE4-47F2-8EB1-78568A7FC838" dmnElementRef="_048C76D3-5EE4-47F2-8EB1-78568A7FC838">
         <di:waypoint x="138" y="400"/>
         <di:waypoint x="225" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-i_ApplicantData" dmnElementRef="tns:i_ApplicantData">
+      <dmndi:DMNEdge id="dmnedge-drg-_D408CEF0-827C-4F0F-A109-CBD0A5F030A5" dmnElementRef="_D408CEF0-827C-4F0F-A109-CBD0A5F030A5">
+        <di:waypoint x="50" y="575"/>
+        <di:waypoint x="225" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_7E59857C-836F-48F7-9CB1-6AD918ABC4FE" dmnElementRef="_7E59857C-836F-48F7-9CB1-6AD918ABC4FE">
         <di:waypoint x="488" y="925"/>
         <di:waypoint x="225" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_EligibilityRules" dmnElementRef="tns:b_EligibilityRules">
+      <dmndi:DMNEdge id="dmnedge-drg-_2D49FF9E-9462-4880-9005-887F8C42E6E4" dmnElementRef="_2D49FF9E-9462-4880-9005-887F8C42E6E4">
         <di:waypoint x="313" y="400"/>
         <di:waypoint x="225" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_ApplicationRiskScore" dmnElementRef="tns:d_ApplicationRiskScore">
+      <dmndi:DMNEdge id="dmnedge-drg-_582AE809-39DF-4161-BD66-10F5F9401749" dmnElementRef="_582AE809-39DF-4161-BD66-10F5F9401749">
         <di:waypoint x="50" y="750"/>
         <di:waypoint x="50" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_Pre-bureauRiskCategoryTable" dmnElementRef="tns:b_Pre-bureauRiskCategoryTable">
+      <dmndi:DMNEdge id="dmnedge-drg-_E9164594-078A-4F26-B97E-5EA99FF5A78C" dmnElementRef="_E9164594-078A-4F26-B97E-5EA99FF5A78C">
+        <di:waypoint x="488" y="925"/>
+        <di:waypoint x="50" y="575"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F9D65271-F2FE-4653-B565-57FB9922EE10" dmnElementRef="_F9D65271-F2FE-4653-B565-57FB9922EE10">
         <di:waypoint x="225" y="750"/>
         <di:waypoint x="50" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-i_BureauData" dmnElementRef="tns:i_BureauData">
+      <dmndi:DMNEdge id="dmnedge-drg-_A60EE052-6E71-48DC-8DBA-CC32829DCA37" dmnElementRef="_A60EE052-6E71-48DC-8DBA-CC32829DCA37">
+        <di:waypoint x="50" y="750"/>
+        <di:waypoint x="488" y="400"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8A12BCF4-3323-4A0D-AE01-31A1299F1F3A" dmnElementRef="_8A12BCF4-3323-4A0D-AE01-31A1299F1F3A">
         <di:waypoint x="750" y="575"/>
         <di:waypoint x="488" y="400"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_Post-bureauRiskCategoryTable" dmnElementRef="tns:b_Post-bureauRiskCategoryTable">
+      <dmndi:DMNEdge id="dmnedge-drg-_EDC16398-4948-4D9A-9598-CB45D067CEE9" dmnElementRef="_EDC16398-4948-4D9A-9598-CB45D067CEE9">
+        <di:waypoint x="488" y="925"/>
+        <di:waypoint x="488" y="400"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_72F904DC-09B2-4779-AF1E-178111F8C78F" dmnElementRef="_72F904DC-09B2-4779-AF1E-178111F8C78F">
         <di:waypoint x="575" y="575"/>
         <di:waypoint x="488" y="400"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_ApplicationRiskScoreModel" dmnElementRef="tns:b_ApplicationRiskScoreModel">
+      <dmndi:DMNEdge id="dmnedge-drg-_DCF5FBCE-33C3-4626-82F9-86D89D52F289" dmnElementRef="_DCF5FBCE-33C3-4626-82F9-86D89D52F289">
+        <di:waypoint x="488" y="925"/>
+        <di:waypoint x="50" y="750"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_AF61BD10-21B4-4F77-BDF7-8299C53A763B" dmnElementRef="_AF61BD10-21B4-4F77-BDF7-8299C53A763B">
         <di:waypoint x="313" y="925"/>
         <di:waypoint x="50" y="750"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_RequiredMonthlyInstallment" dmnElementRef="tns:d_RequiredMonthlyInstallment">
+      <dmndi:DMNEdge id="dmnedge-drg-_B4FE0787-174C-40C8-AE49-1DEEF5898C3B" dmnElementRef="_B4FE0787-174C-40C8-AE49-1DEEF5898C3B">
         <di:waypoint x="225" y="575"/>
         <di:waypoint x="138" y="400"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_AffordabilityCalculation" dmnElementRef="tns:b_AffordabilityCalculation">
+      <dmndi:DMNEdge id="dmnedge-drg-_A826343F-8944-40ED-945F-4DE43BE78547" dmnElementRef="_A826343F-8944-40ED-945F-4DE43BE78547">
+        <di:waypoint x="50" y="575"/>
+        <di:waypoint x="138" y="400"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_9D6C69E2-4D34-4635-8B16-3AD296526182" dmnElementRef="_9D6C69E2-4D34-4635-8B16-3AD296526182">
+        <di:waypoint x="488" y="925"/>
+        <di:waypoint x="138" y="400"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_BE2A20AE-2EDB-4080-8576-F207FB4566FC" dmnElementRef="_BE2A20AE-2EDB-4080-8576-F207FB4566FC">
         <di:waypoint x="400" y="575"/>
         <di:waypoint x="138" y="400"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_Post-bureauRiskCategory" dmnElementRef="tns:d_Post-bureauRiskCategory">
+      <dmndi:DMNEdge id="dmnedge-drg-_685011D2-3EB8-492F-9EB1-AEF5E6531905" dmnElementRef="_685011D2-3EB8-492F-9EB1-AEF5E6531905">
+        <di:waypoint x="225" y="575"/>
+        <di:waypoint x="400" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_69874D88-9AE2-4751-8A60-C9CDEECB12E6" dmnElementRef="_69874D88-9AE2-4751-8A60-C9CDEECB12E6">
         <di:waypoint x="488" y="400"/>
         <di:waypoint x="400" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-i_RequestedProduct" dmnElementRef="tns:i_RequestedProduct">
+      <dmndi:DMNEdge id="dmnedge-drg-_D208CDBF-FCC3-4088-81E5-5048790EC753" dmnElementRef="_D208CDBF-FCC3-4088-81E5-5048790EC753">
+        <di:waypoint x="488" y="925"/>
+        <di:waypoint x="400" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F9E534D8-C75D-4FCC-B98C-44C6E92C2290" dmnElementRef="_F9E534D8-C75D-4FCC-B98C-44C6E92C2290">
+        <di:waypoint x="400" y="575"/>
+        <di:waypoint x="400" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_B80FC328-8828-40B9-9598-0F8D64A9FF3A" dmnElementRef="_B80FC328-8828-40B9-9598-0F8D64A9FF3A">
         <di:waypoint x="750" y="750"/>
         <di:waypoint x="225" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_InstallmentCalculation" dmnElementRef="tns:b_InstallmentCalculation">
+      <dmndi:DMNEdge id="dmnedge-drg-_A108CD18-2CF0-42D0-A55F-81D36D6AD412" dmnElementRef="_A108CD18-2CF0-42D0-A55F-81D36D6AD412">
         <di:waypoint x="400" y="750"/>
         <di:waypoint x="225" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_Post-bureauAffordability" dmnElementRef="tns:d_Post-bureauAffordability">
+      <dmndi:DMNEdge id="dmnedge-drg-_FAC175CE-5DAD-4054-A067-5799F13286B1" dmnElementRef="_FAC175CE-5DAD-4054-A067-5799F13286B1">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_RoutingRules" dmnElementRef="tns:b_RoutingRules">
+      <dmndi:DMNEdge id="dmnedge-drg-_96B0D7F9-C453-4139-8D8A-E4C230EF7CB6" dmnElementRef="_96B0D7F9-C453-4139-8D8A-E4C230EF7CB6">
+        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8A07A4C2-075A-4A9B-952D-B84CAE1F697F" dmnElementRef="_8A07A4C2-075A-4A9B-952D-B84CAE1F697F">
+        <di:waypoint x="750" y="575"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_5D98E4E0-1011-4D6E-832F-F0BAAF6C9D40" dmnElementRef="_5D98E4E0-1011-4D6E-832F-F0BAAF6C9D40">
         <di:waypoint x="575" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-i_SupportingDocuments" dmnElementRef="tns:i_SupportingDocuments">
+      <dmndi:DMNEdge id="dmnedge-drg-_C81A85DD-DED2-4BB0-A4F3-888002E70D84" dmnElementRef="_C81A85DD-DED2-4BB0-A4F3-888002E70D84">
+        <di:waypoint x="750" y="575"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_4CB0C6AE-28EE-4548-9446-9E625699F913" dmnElementRef="_4CB0C6AE-28EE-4548-9446-9E625699F913">
         <di:waypoint x="750" y="225"/>
         <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_CreditContingencyFactorTable" dmnElementRef="tns:b_CreditContingencyFactorTable">
+      <dmndi:DMNEdge id="dmnedge-drg-_6756474E-7427-459D-B6BB-8F1346782B22" dmnElementRef="_6756474E-7427-459D-B6BB-8F1346782B22">
+        <di:waypoint x="488" y="925"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8EE3AF6F-F478-4FCC-BA0C-7D994D01914D" dmnElementRef="_8EE3AF6F-F478-4FCC-BA0C-7D994D01914D">
         <di:waypoint x="575" y="750"/>
         <di:waypoint x="400" y="575"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-simpletable-U.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-simpletable-U.dmn
@@ -1,39 +1,47 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_edbd2d8e-a5a8-4660-9bb9-adaa792d900c" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_edbd2d8e-a5a8-4660-9bb9-adaa792d900c" name="simple U table" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_edbd2d8e-a5a8-4660-9bb9-adaa792d900c">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_edbd2d8e-a5a8-4660-9bb9-adaa792d900c"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_edbd2d8e-a5a8-4660-9bb9-adaa792d900c" name="simple U table" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_edbd2d8e-a5a8-4660-9bb9-adaa792d900c">
   <dmn:extensionElements/>
   <dmn:decision id="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" name="Approval Status">
     <dmn:extensionElements/>
-    <dmn:variable id="_EF41F12F-F2D3-4990-B976-C7BFD1C5303E" name="Approval Status" typeRef="feel:string"/>
-    <dmn:informationRequirement id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+    <dmn:variable id="_38C0B079-D457-4DDE-92FB-CEFCFAC681C6" name="Approval Status" typeRef="string"/>
+    <dmn:informationRequirement id="_11F06FEE-B38B-4784-A208-8920DC68C44E">
       <dmn:requiredInput href="#_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_41effb45-b3c4-46ac-b1da-122b3e428a98">
+    <dmn:informationRequirement id="_B2A0A5F3-A2C3-494E-BD2A-B4539D35F5F2">
       <dmn:requiredInput href="#_41effb45-b3c4-46ac-b1da-122b3e428a98"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8ff18665-84e9-49f2-a8df-8981b1844549">
+    <dmn:informationRequirement id="_D1374317-C07B-4CE0-83B0-DBF9E2CD24EF">
       <dmn:requiredInput href="#_8ff18665-84e9-49f2-a8df-8981b1844549"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_E1A5DC6E-F799-41B1-8E4D-49FD19BF607F" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
+    <dmn:decisionTable id="_069122D6-D52A-416F-AF4B-6941FCB02862" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
       <dmn:input id="_bf7fc56f-ea82-464e-a541-f3221dc07e78">
-        <dmn:inputExpression id="_CD64F691-69E0-43B7-AF8D-C3F69FA79CA9" typeRef="feel:number">
+        <dmn:inputExpression id="_E0766330-AC5C-4E08-8FD7-1F53C50CC54E" typeRef="number">
           <dmn:text>Age</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:input id="_bb73bf86-b399-490a-a635-c6f2c04ff75d">
-        <dmn:inputExpression id="_46BD5D82-3265-44FA-9A02-E478FF508803" typeRef="feel:string">
+        <dmn:inputExpression id="_1B90EBCA-7131-4489-BCAD-5986036407CB" typeRef="string">
           <dmn:text>RiskCategory</dmn:text>
         </dmn:inputExpression>
-        <dmn:inputValues id="_BA474AF5-1308-4915-A252-1DB45DD5D57F">
+        <dmn:inputValues id="_966E64DC-F972-465D-BA48-01C909F2FE56">
           <dmn:text>"High", "Low", "Medium"</dmn:text>
         </dmn:inputValues>
       </dmn:input>
       <dmn:input id="_af5e5c2a-5124-4277-9409-d07421dcb5a4">
-        <dmn:inputExpression id="_0926D996-A39B-4D58-A090-9518194FDD71" typeRef="feel:boolean">
+        <dmn:inputExpression id="_0418EFF3-A5A9-458A-B09C-1EC986F27904" typeRef="boolean">
           <dmn:text>isAffordable</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:output id="_bffba7a1-f0a2-4679-b6e2-50e27bb27968">
-        <dmn:outputValues id="_5A5E695D-448E-44E8-8A15-0DFA40E16CE2">
+        <dmn:outputValues id="_030849AF-D4CE-40AA-A750-7561EF563262">
           <dmn:text>"Approved", "Declined"</dmn:text>
         </dmn:outputValues>
       </dmn:output>
@@ -110,24 +118,24 @@
   </dmn:decision>
   <dmn:inputData id="_41effb45-b3c4-46ac-b1da-122b3e428a98" name="Age">
     <dmn:extensionElements/>
-    <dmn:variable id="_9B969F73-6E91-4381-8DFD-539DF0F15A05" name="Age" typeRef="feel:number"/>
+    <dmn:variable id="_037225E9-72ED-42B7-8F2B-D52818F5E917" name="Age" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" name="RiskCategory">
     <dmn:extensionElements/>
-    <dmn:variable id="_402AE57C-426F-4492-BB0C-BE5511E44FDC" name="RiskCategory" typeRef="feel:string"/>
+    <dmn:variable id="_F38112FF-6CC0-467D-80D4-496FC4B4280D" name="RiskCategory" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_8ff18665-84e9-49f2-a8df-8981b1844549" name="isAffordable">
     <dmn:extensionElements/>
-    <dmn:variable id="_A7F1284A-4DB8-4AC5-BAFA-258E40EE6212" name="isAffordable" typeRef="feel:boolean"/>
+    <dmn:variable id="_F3CC9F7B-9F0D-4901-A2AC-B24C07326BF6" name="isAffordable" typeRef="boolean"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_B0AAF69F-65D1-44F6-B845-9F2F360C010B" name="DRG">
+    <dmndi:DMNDiagram id="_77F33A41-9594-458D-A3B1-3DB0A249554F" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_E1A5DC6E-F799-41B1-8E4D-49FD19BF607F"/>
+          <kie:ComponentWidths dmnElementRef="_069122D6-D52A-416F-AF4B-6941FCB02862"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="tns:_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -136,7 +144,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -145,7 +153,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -154,7 +162,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -163,15 +171,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+      <dmndi:DMNEdge id="dmnedge-drg-_11F06FEE-B38B-4784-A208-8920DC68C44E" dmnElementRef="_11F06FEE-B38B-4784-A208-8920DC68C44E">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98">
+      <dmndi:DMNEdge id="dmnedge-drg-_B2A0A5F3-A2C3-494E-BD2A-B4539D35F5F2" dmnElementRef="_B2A0A5F3-A2C3-494E-BD2A-B4539D35F5F2">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549">
+      <dmndi:DMNEdge id="dmnedge-drg-_D1374317-C07B-4CE0-83B0-DBF9E2CD24EF" dmnElementRef="_D1374317-C07B-4CE0-83B0-DBF9E2CD24EF">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-literal-invocation.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-literal-invocation.dmn
@@ -1,63 +1,70 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11" name="literal invocation1" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11" name="literal invocation1" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="_f909c1d5-36e4-4f71-8392-fe3b14ddb6f7" name="tLoan" isCollection="false">
     <dmn:itemComponent id="_579041dc-2bad-42b4-9650-b2cf39175ecc" name="amount" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_353c0e6f-b344-451e-944e-bec76817b29a" name="rate" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_c7b4a252-df93-4407-8bef-9d30d94125b6" name="term" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decision id="d_MonthlyPayment" name="MonthlyPayment">
     <dmn:extensionElements/>
-    <dmn:variable id="_EA33D775-C448-4359-8A5E-22F9300AAF42" name="MonthlyPayment" typeRef="feel:number"/>
-    <dmn:informationRequirement id="i_Loan">
+    <dmn:variable id="_58C8B4C5-68E2-4456-A5A6-CF50AD214ADB" name="MonthlyPayment" typeRef="number"/>
+    <dmn:informationRequirement id="_376E38BC-CBB2-41F7-BE25-F91093774325">
       <dmn:requiredInput href="#i_Loan"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_fee">
+    <dmn:informationRequirement id="_C18E6ABA-89E3-49F8-9851-E6792FFBA10B">
       <dmn:requiredInput href="#i_fee"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_PMT">
+    <dmn:knowledgeRequirement id="_90853A2C-BB99-4F41-B7AF-FFED0C9CF667">
       <dmn:requiredKnowledge href="#b_PMT"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_4F349813-4BD2-44F8-948B-C5DBDFF0F08A">
+    <dmn:literalExpression id="_B14BDA6B-8492-47B0-96C4-F289DF9FB6A3">
       <dmn:text>PMT(Loan.amount, Loan.rate, Loan.term)+fee</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="b_PMT" name="PMT">
     <dmn:extensionElements/>
-    <dmn:variable id="_F5CF1FD0-FF1C-496A-AF85-12DE3AF5EAEB" name="PMT" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_D00CF981-F50B-4132-9B95-7D6F0F203E00" kind="FEEL">
-      <dmn:formalParameter id="_7F33C424-6A96-43AD-8B99-A28A05A5A12C" name="p" typeRef="feel:number"/>
-      <dmn:formalParameter id="_EFFCD396-DB1D-4F7B-BD47-735E9394FBA0" name="r" typeRef="feel:number"/>
-      <dmn:formalParameter id="_691D2E42-990F-42AA-97EB-6BA0F319DA11" name="n" typeRef="feel:number"/>
-      <dmn:literalExpression id="_2B97F5BA-9F6C-4DBF-B4E6-CD9EF4C5C087" expressionLanguage="FEEL">
+    <dmn:variable id="_42A43045-7FD4-4D6E-B7C6-0B4A1BE8F047" name="PMT" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_5137ABEE-2272-44C1-8D5C-BBA8A15E84D7" kind="FEEL">
+      <dmn:formalParameter id="_FF5FC324-5D1D-4C17-89D4-B75726EEFF4F" name="p" typeRef="number"/>
+      <dmn:formalParameter id="_200F4C4B-B154-4F41-8FF1-0F9C7396ACCD" name="r" typeRef="number"/>
+      <dmn:formalParameter id="_47A46328-4E6D-4003-808F-9AC3C2F5A62A" name="n" typeRef="number"/>
+      <dmn:literalExpression id="_CBDDC4B4-594F-43BC-8915-7E6657EC3326" expressionLanguage="FEEL">
         <dmn:text>(p*r/12)/(1-(1+r/12)**-n)</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:inputData id="i_Loan" name="Loan">
     <dmn:extensionElements/>
-    <dmn:variable id="_00552942-DBDE-4C81-AD96-BDDF10168F44" name="Loan" typeRef="tns:tLoan"/>
+    <dmn:variable id="_65EC3546-E870-4551-BE91-A26CC3BBCBB4" name="Loan" typeRef="tLoan"/>
   </dmn:inputData>
   <dmn:inputData id="i_fee" name="fee">
     <dmn:extensionElements/>
-    <dmn:variable id="_E3191BB1-CB71-44D4-9ED3-7F079311A1F2" name="fee" typeRef="feel:number"/>
+    <dmn:variable id="_D9C16DE0-E1D4-4CF4-BE81-48C7975DB7DD" name="fee" typeRef="number"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_F11F6596-3146-4038-8765-57DED87217B7" name="DRG">
+    <dmndi:DMNDiagram id="_83F05F0E-84DD-4870-9D81-BD297EDBAAC5" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_4F349813-4BD2-44F8-948B-C5DBDFF0F08A"/>
-          <kie:ComponentWidths dmnElementRef="_2B97F5BA-9F6C-4DBF-B4E6-CD9EF4C5C087"/>
-          <kie:ComponentWidths dmnElementRef="_D00CF981-F50B-4132-9B95-7D6F0F203E00"/>
+          <kie:ComponentWidths dmnElementRef="_B14BDA6B-8492-47B0-96C4-F289DF9FB6A3"/>
+          <kie:ComponentWidths dmnElementRef="_CBDDC4B4-594F-43BC-8915-7E6657EC3326"/>
+          <kie:ComponentWidths dmnElementRef="_5137ABEE-2272-44C1-8D5C-BBA8A15E84D7"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-d_MonthlyPayment" dmnElementRef="tns:d_MonthlyPayment" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_MonthlyPayment" dmnElementRef="d_MonthlyPayment" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -66,7 +73,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_PMT" dmnElementRef="tns:b_PMT" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_PMT" dmnElementRef="b_PMT" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -75,7 +82,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_Loan" dmnElementRef="tns:i_Loan" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_Loan" dmnElementRef="i_Loan" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -84,7 +91,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_fee" dmnElementRef="tns:i_fee" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_fee" dmnElementRef="i_fee" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -93,15 +100,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-i_Loan" dmnElementRef="tns:i_Loan">
+      <dmndi:DMNEdge id="dmnedge-drg-_376E38BC-CBB2-41F7-BE25-F91093774325" dmnElementRef="_376E38BC-CBB2-41F7-BE25-F91093774325">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-i_fee" dmnElementRef="tns:i_fee">
+      <dmndi:DMNEdge id="dmnedge-drg-_C18E6ABA-89E3-49F8-9851-E6792FFBA10B" dmnElementRef="_C18E6ABA-89E3-49F8-9851-E6792FFBA10B">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_PMT" dmnElementRef="tns:b_PMT">
+      <dmndi:DMNEdge id="dmnedge-drg-_90853A2C-BB99-4F41-B7AF-FFED0C9CF667" dmnElementRef="_90853A2C-BB99-4F41-B7AF-FFED0C9CF667">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-simpletable-A.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-simpletable-A.dmn
@@ -1,39 +1,47 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_6cb03678-38e5-4ee3-826b-d6622c738563" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_6cb03678-38e5-4ee3-826b-d6622c738563" name="simple A table" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_6cb03678-38e5-4ee3-826b-d6622c738563">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_6cb03678-38e5-4ee3-826b-d6622c738563"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_6cb03678-38e5-4ee3-826b-d6622c738563" name="simple A table" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_6cb03678-38e5-4ee3-826b-d6622c738563">
   <dmn:extensionElements/>
   <dmn:decision id="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" name="Approval Status">
     <dmn:extensionElements/>
-    <dmn:variable id="_831A29A7-8170-4128-A52B-D579ED5F932C" name="Approval Status" typeRef="feel:string"/>
-    <dmn:informationRequirement id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+    <dmn:variable id="_AC5B3303-081A-4EEF-ACCA-A9BB56405EDD" name="Approval Status" typeRef="string"/>
+    <dmn:informationRequirement id="_0D92E037-76AF-4224-B01D-792F707BD782">
       <dmn:requiredInput href="#_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_41effb45-b3c4-46ac-b1da-122b3e428a98">
+    <dmn:informationRequirement id="_5623E3A1-9F87-4F6F-9ED7-B7D807B75ADE">
       <dmn:requiredInput href="#_41effb45-b3c4-46ac-b1da-122b3e428a98"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8ff18665-84e9-49f2-a8df-8981b1844549">
+    <dmn:informationRequirement id="_DB80BA13-2097-47F8-BB99-B383D983F3B8">
       <dmn:requiredInput href="#_8ff18665-84e9-49f2-a8df-8981b1844549"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_A4D9EA45-FD14-40C0-A3B3-1E673D7241B3" hitPolicy="ANY" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
+    <dmn:decisionTable id="_0BA5AEFA-2ADB-4146-9F3A-7A9E76B5FF47" hitPolicy="ANY" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
       <dmn:input id="_62d2bb2d-dcf4-49fc-a96a-0c11dd6dee70">
-        <dmn:inputExpression id="_CBF36520-1444-4DDC-B273-4E89541FCF59" typeRef="feel:number">
+        <dmn:inputExpression id="_105DAB86-B98A-4D88-A881-700DE405C6B4" typeRef="number">
           <dmn:text>Age</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:input id="_d924d584-b27a-4288-921d-04e0ede1096d">
-        <dmn:inputExpression id="_87A1D5B5-DCA8-40FD-A362-514D21F9C8EE" typeRef="feel:string">
+        <dmn:inputExpression id="_245640CB-C812-474B-BAC0-DDE056B13284" typeRef="string">
           <dmn:text>RiskCategory</dmn:text>
         </dmn:inputExpression>
-        <dmn:inputValues id="_3FFBC335-73E3-415A-B694-0D36DDC0033A">
+        <dmn:inputValues id="_6809BD7E-7AED-4031-8818-C159E218CF99">
           <dmn:text>"High", "Low", "Medium"</dmn:text>
         </dmn:inputValues>
       </dmn:input>
       <dmn:input id="_bfebcb06-fc90-490f-a060-5bfd3d12fdb9">
-        <dmn:inputExpression id="_59F692B1-9BAA-4436-ACA9-073DE1AF8F62" typeRef="feel:boolean">
+        <dmn:inputExpression id="_7DA6588F-5A78-4EFA-BA3D-2D90A46BE33A" typeRef="boolean">
           <dmn:text>isAffordable</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:output id="_ad9c87b6-994e-4009-9118-7a2e861912e9">
-        <dmn:outputValues id="_5FF7D5E7-E85C-40F6-B0DE-3BB1A7AA78E4">
+        <dmn:outputValues id="_96F16F39-8F44-4D52-8A6B-762E5F463118">
           <dmn:text>"Approved", "Declined"</dmn:text>
         </dmn:outputValues>
       </dmn:output>
@@ -110,24 +118,24 @@
   </dmn:decision>
   <dmn:inputData id="_41effb45-b3c4-46ac-b1da-122b3e428a98" name="Age">
     <dmn:extensionElements/>
-    <dmn:variable id="_8D802A22-416C-421A-B88E-297AF539B74C" name="Age" typeRef="feel:number"/>
+    <dmn:variable id="_3264BD63-072E-4DB0-9115-186FA4D8D625" name="Age" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" name="RiskCategory">
     <dmn:extensionElements/>
-    <dmn:variable id="_C73186C2-3505-408B-8D05-D79CEFA160A6" name="RiskCategory" typeRef="feel:string"/>
+    <dmn:variable id="_C26B9B72-0CFE-4C0B-8292-2FD238815A69" name="RiskCategory" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_8ff18665-84e9-49f2-a8df-8981b1844549" name="isAffordable">
     <dmn:extensionElements/>
-    <dmn:variable id="_C65050E6-D64D-4B43-BD5A-C3128659089C" name="isAffordable" typeRef="feel:boolean"/>
+    <dmn:variable id="_8F1B3E07-034F-4AAC-92ED-88E0B8CE69A9" name="isAffordable" typeRef="boolean"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_C9C3DEAC-C525-4AAB-8004-88B7A293F8C7" name="DRG">
+    <dmndi:DMNDiagram id="_4E42D1F5-8A24-4388-AE77-BD836F25CCB1" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_A4D9EA45-FD14-40C0-A3B3-1E673D7241B3"/>
+          <kie:ComponentWidths dmnElementRef="_0BA5AEFA-2ADB-4146-9F3A-7A9E76B5FF47"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="tns:_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -136,7 +144,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -145,7 +153,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -154,7 +162,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -163,15 +171,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+      <dmndi:DMNEdge id="dmnedge-drg-_0D92E037-76AF-4224-B01D-792F707BD782" dmnElementRef="_0D92E037-76AF-4224-B01D-792F707BD782">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98">
+      <dmndi:DMNEdge id="dmnedge-drg-_5623E3A1-9F87-4F6F-9ED7-B7D807B75ADE" dmnElementRef="_5623E3A1-9F87-4F6F-9ED7-B7D807B75ADE">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549">
+      <dmndi:DMNEdge id="dmnedge-drg-_DB80BA13-2097-47F8-BB99-B383D983F3B8" dmnElementRef="_DB80BA13-2097-47F8-BB99-B383D983F3B8">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-join.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-join.dmn
@@ -1,67 +1,74 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_16bf03c7-8f3d-46d0-a921-6e335ccc7e29" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_16bf03c7-8f3d-46d0-a921-6e335ccc7e29" name="join01" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_16bf03c7-8f3d-46d0-a921-6e335ccc7e29">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_16bf03c7-8f3d-46d0-a921-6e335ccc7e29"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_16bf03c7-8f3d-46d0-a921-6e335ccc7e29" name="join01" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_16bf03c7-8f3d-46d0-a921-6e335ccc7e29">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tEmployeeTable" name="tEmployeeTable" isCollection="true">
     <dmn:itemComponent id="_008f96e5-b82b-4105-ab8f-52673390c75f" name="id" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_657371a7-e0a9-4f4c-987d-35cd10e2918b" name="name" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_fa7afb54-265e-4244-97bf-4789c48e3629" name="deptNum" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_df562869-8cda-4a15-a37d-e121a4f7abac" name="mgrName" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tDeptTable" name="tDeptTable" isCollection="true">
     <dmn:itemComponent id="_f7e37827-f9ab-4fb1-b07e-9e4367242e65" name="number" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_fd0110de-a09b-4167-a5fe-103308ad6d0b" name="name" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_ee4e552c-4e8d-4a0c-8451-bae3eb2d4bd9" name="manager" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decision id="_24c9e583-a87c-462d-ade3-be545e228abd" name="Join">
     <dmn:extensionElements/>
-    <dmn:variable id="_F2E49A83-0BD2-48F6-859C-55628B4F41E4" name="Join" typeRef="feel:string"/>
-    <dmn:informationRequirement id="_7985579c-554c-4d98-aad6-c9dbacff726b">
+    <dmn:variable id="_BF0575EB-A958-47EC-8A5E-C4C32BFCDA17" name="Join" typeRef="string"/>
+    <dmn:informationRequirement id="_E61EBDBF-6A03-4BE4-8564-4F9CCD658818">
       <dmn:requiredInput href="#_7985579c-554c-4d98-aad6-c9dbacff726b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_35b4f57c-e574-4963-a149-83cc0030e809">
+    <dmn:informationRequirement id="_FA11668E-868E-4F46-8F97-50B1D4C09BE8">
       <dmn:requiredInput href="#_35b4f57c-e574-4963-a149-83cc0030e809"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_7b08bda2-fcf4-44e8-8022-08d9043e1dee">
+    <dmn:informationRequirement id="_A4A3386A-F250-4D4B-A7C8-CCEA0D6585B2">
       <dmn:requiredInput href="#_7b08bda2-fcf4-44e8-8022-08d9043e1dee"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_0013C70B-421E-4BDA-8105-73385A444E6A">
+    <dmn:literalExpression id="_104C1855-2CC7-4F4E-8634-B82969430A58">
       <dmn:text>DeptTable[number = EmployeeTable[name=LastName].deptNum[1]].manager[1]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_7985579c-554c-4d98-aad6-c9dbacff726b" name="EmployeeTable">
     <dmn:extensionElements/>
-    <dmn:variable id="_45A882CB-7FF6-400F-AC4A-D96534396218" name="EmployeeTable" typeRef="tns:tEmployeeTable"/>
+    <dmn:variable id="_4D298886-56B0-496B-B600-048073D7CFAD" name="EmployeeTable" typeRef="tEmployeeTable"/>
   </dmn:inputData>
   <dmn:inputData id="_35b4f57c-e574-4963-a149-83cc0030e809" name="DeptTable">
     <dmn:extensionElements/>
-    <dmn:variable id="_AC06A530-3D83-44EE-9280-E0214213BCEE" name="DeptTable" typeRef="tns:tDeptTable"/>
+    <dmn:variable id="_7FD12F78-649D-4CE7-94D8-A71976965BAD" name="DeptTable" typeRef="tDeptTable"/>
   </dmn:inputData>
   <dmn:inputData id="_7b08bda2-fcf4-44e8-8022-08d9043e1dee" name="LastName">
     <dmn:extensionElements/>
-    <dmn:variable id="_3856218E-8C93-40C6-825D-9837ABAB444D" name="LastName" typeRef="feel:string"/>
+    <dmn:variable id="_C9A3D30E-961A-4E76-8F14-32612DBD6132" name="LastName" typeRef="string"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_D5B58594-E68D-4AAB-8C16-96203DE3F21D" name="DRG">
+    <dmndi:DMNDiagram id="_5B6FA7CA-633B-45B0-9586-19826022BA97" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_0013C70B-421E-4BDA-8105-73385A444E6A"/>
+          <kie:ComponentWidths dmnElementRef="_104C1855-2CC7-4F4E-8634-B82969430A58"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_24c9e583-a87c-462d-ade3-be545e228abd" dmnElementRef="tns:_24c9e583-a87c-462d-ade3-be545e228abd" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_24c9e583-a87c-462d-ade3-be545e228abd" dmnElementRef="_24c9e583-a87c-462d-ade3-be545e228abd" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -70,7 +77,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7985579c-554c-4d98-aad6-c9dbacff726b" dmnElementRef="tns:_7985579c-554c-4d98-aad6-c9dbacff726b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7985579c-554c-4d98-aad6-c9dbacff726b" dmnElementRef="_7985579c-554c-4d98-aad6-c9dbacff726b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -79,7 +86,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_35b4f57c-e574-4963-a149-83cc0030e809" dmnElementRef="tns:_35b4f57c-e574-4963-a149-83cc0030e809" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_35b4f57c-e574-4963-a149-83cc0030e809" dmnElementRef="_35b4f57c-e574-4963-a149-83cc0030e809" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -88,7 +95,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7b08bda2-fcf4-44e8-8022-08d9043e1dee" dmnElementRef="tns:_7b08bda2-fcf4-44e8-8022-08d9043e1dee" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7b08bda2-fcf4-44e8-8022-08d9043e1dee" dmnElementRef="_7b08bda2-fcf4-44e8-8022-08d9043e1dee" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -97,15 +104,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_7985579c-554c-4d98-aad6-c9dbacff726b" dmnElementRef="tns:_7985579c-554c-4d98-aad6-c9dbacff726b">
+      <dmndi:DMNEdge id="dmnedge-drg-_E61EBDBF-6A03-4BE4-8564-4F9CCD658818" dmnElementRef="_E61EBDBF-6A03-4BE4-8564-4F9CCD658818">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_35b4f57c-e574-4963-a149-83cc0030e809" dmnElementRef="tns:_35b4f57c-e574-4963-a149-83cc0030e809">
+      <dmndi:DMNEdge id="dmnedge-drg-_FA11668E-868E-4F46-8F97-50B1D4C09BE8" dmnElementRef="_FA11668E-868E-4F46-8F97-50B1D4C09BE8">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7b08bda2-fcf4-44e8-8022-08d9043e1dee" dmnElementRef="tns:_7b08bda2-fcf4-44e8-8022-08d9043e1dee">
+      <dmndi:DMNEdge id="dmnedge-drg-_A4A3386A-F250-4D4B-A7C8-CCEA0D6585B2" dmnElementRef="_A4A3386A-F250-4D4B-A7C8-CCEA0D6585B2">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-simpletable-P1.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-simpletable-P1.dmn
@@ -1,39 +1,47 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_791b8e95-b7a7-40e7-9dd1-5ff12364f340" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_791b8e95-b7a7-40e7-9dd1-5ff12364f340" name="simple P table 1" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_791b8e95-b7a7-40e7-9dd1-5ff12364f340">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_791b8e95-b7a7-40e7-9dd1-5ff12364f340"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_791b8e95-b7a7-40e7-9dd1-5ff12364f340" name="simple P table 1" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_791b8e95-b7a7-40e7-9dd1-5ff12364f340">
   <dmn:extensionElements/>
   <dmn:decision id="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" name="Approval Status">
     <dmn:extensionElements/>
-    <dmn:variable id="_EC54796F-4F74-4800-B3CA-64394C4F6CE1" name="Approval Status" typeRef="feel:string"/>
-    <dmn:informationRequirement id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+    <dmn:variable id="_E2C0D7F8-4A73-409A-8AE1-DC7199DEB4A2" name="Approval Status" typeRef="string"/>
+    <dmn:informationRequirement id="_B4EC322E-ABB3-4EE4-B5EC-BA7CE4CE9152">
       <dmn:requiredInput href="#_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_41effb45-b3c4-46ac-b1da-122b3e428a98">
+    <dmn:informationRequirement id="_C5BD4042-CB34-4BBB-B64E-A8246958DFD9">
       <dmn:requiredInput href="#_41effb45-b3c4-46ac-b1da-122b3e428a98"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8ff18665-84e9-49f2-a8df-8981b1844549">
+    <dmn:informationRequirement id="_FF3E58D7-BEE1-4AA4-AD14-D404647D46BD">
       <dmn:requiredInput href="#_8ff18665-84e9-49f2-a8df-8981b1844549"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_03AF0BE5-165F-4A81-BED1-B3309880E8B3" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
+    <dmn:decisionTable id="_548F6F5D-EF82-491D-B5FA-794C1EE59EA3" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
       <dmn:input id="_f64e79ef-12df-471a-8830-18dd1060e8f0">
-        <dmn:inputExpression id="_A3E11F6B-5164-45EB-9420-0A3FCB23EAB0" typeRef="feel:number">
+        <dmn:inputExpression id="_F4ECFF79-1EC2-4BC6-ACB9-84EBCC2689C1" typeRef="number">
           <dmn:text>Age</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:input id="_066896e9-14c6-4684-a6a7-1036057c69ae">
-        <dmn:inputExpression id="_104DDFD1-6A47-473D-851E-59AF328A268F" typeRef="feel:string">
+        <dmn:inputExpression id="_0C966235-AA11-4105-A5BC-F9B9F37A906D" typeRef="string">
           <dmn:text>RiskCategory</dmn:text>
         </dmn:inputExpression>
-        <dmn:inputValues id="_10D7761F-B749-4CDA-ABE9-E66C0166A0E5">
+        <dmn:inputValues id="_45CE8E85-D28E-431A-9CDA-256A23F18079">
           <dmn:text>"High", "Low", "Medium"</dmn:text>
         </dmn:inputValues>
       </dmn:input>
       <dmn:input id="_11764a00-cb22-4e5b-8e52-cbcd2a4d3971">
-        <dmn:inputExpression id="_2574AF2A-2AFC-48F0-AAA4-2AE8B67466E0" typeRef="feel:boolean">
+        <dmn:inputExpression id="_C6CFF9E4-4AD4-43A4-90AE-A7565F144303" typeRef="boolean">
           <dmn:text>isAffordable</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:output id="_c8adc49f-998f-48b8-bd79-746d9c3d25b3">
-        <dmn:outputValues id="_8D97D16A-ACE1-45BA-B6FE-07EB6E8CBD4C">
+        <dmn:outputValues id="_90B2B8C4-97B9-4BED-8817-29314B7B35A4">
           <dmn:text>"Approved", "Declined"</dmn:text>
         </dmn:outputValues>
       </dmn:output>
@@ -110,24 +118,24 @@
   </dmn:decision>
   <dmn:inputData id="_41effb45-b3c4-46ac-b1da-122b3e428a98" name="Age">
     <dmn:extensionElements/>
-    <dmn:variable id="_E4DD66E1-87AD-45D5-BCFF-1747C6DB6F1B" name="Age" typeRef="feel:number"/>
+    <dmn:variable id="_F3015E05-5C7A-4C6C-A05B-7B180B2B8D50" name="Age" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" name="RiskCategory">
     <dmn:extensionElements/>
-    <dmn:variable id="_D1C1DBF5-4626-4C19-BFB8-597A83AB9FE8" name="RiskCategory" typeRef="feel:string"/>
+    <dmn:variable id="_8C7FAD27-FD29-4197-BFB5-B7DB2DC390C1" name="RiskCategory" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_8ff18665-84e9-49f2-a8df-8981b1844549" name="isAffordable">
     <dmn:extensionElements/>
-    <dmn:variable id="_BF2BFA8D-1ED0-45CF-A809-0C20C7D78019" name="isAffordable" typeRef="feel:boolean"/>
+    <dmn:variable id="_DAB3B73D-CC58-447F-87F9-A2F1D3B22480" name="isAffordable" typeRef="boolean"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_EE1C1C77-1144-4F75-BAB9-4FE4864C5941" name="DRG">
+    <dmndi:DMNDiagram id="_E8ECBCBC-FFF3-4B02-9317-85C67AFA1C4D" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_03AF0BE5-165F-4A81-BED1-B3309880E8B3"/>
+          <kie:ComponentWidths dmnElementRef="_548F6F5D-EF82-491D-B5FA-794C1EE59EA3"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="tns:_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -136,7 +144,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -145,7 +153,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -154,7 +162,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -163,15 +171,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+      <dmndi:DMNEdge id="dmnedge-drg-_B4EC322E-ABB3-4EE4-B5EC-BA7CE4CE9152" dmnElementRef="_B4EC322E-ABB3-4EE4-B5EC-BA7CE4CE9152">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98">
+      <dmndi:DMNEdge id="dmnedge-drg-_C5BD4042-CB34-4BBB-B64E-A8246958DFD9" dmnElementRef="_C5BD4042-CB34-4BBB-B64E-A8246958DFD9">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549">
+      <dmndi:DMNEdge id="dmnedge-drg-_FF3E58D7-BEE1-4AA4-AD14-D404647D46BD" dmnElementRef="_FF3E58D7-BEE1-4AA4-AD14-D404647D46BD">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-date-time.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-date-time.dmn
@@ -1,79 +1,86 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_69430b3e-17b8-430d-b760-c505bf6469f9" name="dateTime Table 58" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_69430b3e-17b8-430d-b760-c505bf6469f9" name="dateTime Table 58" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_69430b3e-17b8-430d-b760-c505bf6469f9">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tDateTimeComponents" name="tDateTimeComponents" isCollection="false">
     <dmn:itemComponent id="_df05a420-dbc5-48cf-be85-4b41702c4f33" name="Year" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_3e119228-7599-47e5-aa96-182e5ff66034" name="Month" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_d5d22cac-3276-4dfd-9aee-353aa47bf2d4" name="Day" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_63defe21-0369-438e-b879-27df2bcf475e" name="Hour" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_1ebad337-b2da-49ed-8ab2-b308d78e1b2f" name="Minute" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_4666a2d0-63b2-4822-b5b4-e266f4cca3d1" name="Second" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tDateVariants" name="tDateVariants" isCollection="false">
     <dmn:itemComponent id="_02d44cc2-24ac-4f64-a61f-7044684dc438" name="fromString" isCollection="false">
-      <dmn:typeRef>feel:date</dmn:typeRef>
+      <dmn:typeRef>date</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_13da5f5e-8fdd-4a33-9500-ceeaaeaccc91" name="fromDateTime" isCollection="false">
-      <dmn:typeRef>feel:date</dmn:typeRef>
+      <dmn:typeRef>date</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_c4e03aa1-d8f3-4ffa-aab2-42a17a4fb707" name="fromYearMonthDay" isCollection="false">
-      <dmn:typeRef>feel:date</dmn:typeRef>
+      <dmn:typeRef>date</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:inputData id="_74a9c3ad-a813-444e-88ee-8a91096ee233" name="dateString">
     <dmn:extensionElements/>
-    <dmn:variable id="_E6E45DBF-A97D-4D91-9F7F-BA576A132498" name="dateString" typeRef="feel:string"/>
+    <dmn:variable id="_BCD06D06-362D-4D00-9192-E04ED2C9EB6E" name="dateString" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_e5705a69-0114-4f64-8aca-22500a533a51" name="timeString">
     <dmn:extensionElements/>
-    <dmn:variable id="_ADDA0EEC-4AC1-4038-BFA0-9E2483270AA1" name="timeString" typeRef="feel:string"/>
+    <dmn:variable id="_0DA35EF8-6C7F-4723-BBC2-1F3F8E066896" name="timeString" typeRef="string"/>
   </dmn:inputData>
   <dmn:decision id="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda" name="Date">
     <dmn:extensionElements/>
-    <dmn:variable id="_AE35F04E-217F-405C-9619-D8B08EDA2D35" name="Date" typeRef="tns:tDateVariants"/>
-    <dmn:informationRequirement id="_74a9c3ad-a813-444e-88ee-8a91096ee233">
+    <dmn:variable id="_FBF8AEC0-86A1-458D-8030-45D0DD9F127C" name="Date" typeRef="tDateVariants"/>
+    <dmn:informationRequirement id="_2F32C1AB-DE32-4CCD-B9AA-6B4E04C7821A">
       <dmn:requiredInput href="#_74a9c3ad-a813-444e-88ee-8a91096ee233"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_178690e3-8936-4914-a735-6243a29b6068">
+    <dmn:informationRequirement id="_6DADBF64-C403-4708-860B-1EF8133EA368">
       <dmn:requiredInput href="#_178690e3-8936-4914-a735-6243a29b6068"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_e3143b2d-e150-422e-8163-d3e4461988f4">
+    <dmn:informationRequirement id="_57CB86DC-FF64-45FA-A07A-99A717753730">
       <dmn:requiredInput href="#_e3143b2d-e150-422e-8163-d3e4461988f4"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_ec0d9542-257d-401b-ac6b-ce927014cf25">
+    <dmn:informationRequirement id="_4EAD7C78-93CC-448C-BB07-D4A83929B5E8">
       <dmn:requiredInput href="#_ec0d9542-257d-401b-ac6b-ce927014cf25"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_dfbb843a-bd34-4099-b700-0d9ca5b38d6a">
+    <dmn:informationRequirement id="_764D785F-89BC-4054-9C5D-D81B884D7582">
       <dmn:requiredDecision href="#_dfbb843a-bd34-4099-b700-0d9ca5b38d6a"/>
     </dmn:informationRequirement>
-    <dmn:context id="_6537FA94-F2CB-4BC9-AB51-6640C47C31A1">
+    <dmn:context id="_6E4DEFBD-1A16-4248-BB64-B5880BF88790">
       <dmn:contextEntry>
-        <dmn:variable id="_E46469CF-F138-4368-9E8F-7D4FFD6D45CF" name="fromString" typeRef="feel:date"/>
-        <dmn:literalExpression id="_8E1A47E9-3420-4651-AA51-1E229A344359">
+        <dmn:variable id="_365055C4-EC1D-453B-BEBE-94BBD0B1AD66" name="fromString" typeRef="date"/>
+        <dmn:literalExpression id="_B75D4B9F-247B-4840-A3A0-6A0F57DC024A">
           <dmn:text>date(dateString)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_C354959D-C2E4-46D3-A5DB-CFC3C9BA6224" name="fromDateTime" typeRef="feel:date"/>
-        <dmn:literalExpression id="_19A1B0BE-CE81-482C-A942-7D7DFFD8E4AB">
+        <dmn:variable id="_58B88126-415C-46DC-94E6-F00D8F64098D" name="fromDateTime" typeRef="date"/>
+        <dmn:literalExpression id="_DDF791BB-B9A2-400D-9BFD-417A037FD393">
           <dmn:text>date(Date-Time)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_C8DD26D5-8CBD-4EA7-A016-18C3EF475C77" name="fromYearMonthDay" typeRef="feel:date"/>
-        <dmn:literalExpression id="_4B5FFDCE-EE26-43E2-B540-492E7140CBBE">
+        <dmn:variable id="_8824F08B-4DC1-4EDD-B633-2B9E449D6C5B" name="fromYearMonthDay" typeRef="date"/>
+        <dmn:literalExpression id="_7525B26E-F7ED-4B1F-A379-A88DE0DE1F59">
           <dmn:text>date(Year,Month,Day)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
@@ -81,288 +88,288 @@
   </dmn:decision>
   <dmn:decision id="_dfbb843a-bd34-4099-b700-0d9ca5b38d6a" name="Date-Time">
     <dmn:extensionElements/>
-    <dmn:variable id="_2C3160B9-D782-4390-B488-CF68E3491D2B" name="Date-Time" typeRef="feel:dateTime"/>
-    <dmn:informationRequirement id="_c796f29d-d800-4239-b9f6-d4d72f77b183">
+    <dmn:variable id="_49A2005C-B1E5-4715-B264-EEE56487F55B" name="Date-Time" typeRef="dateTime"/>
+    <dmn:informationRequirement id="_B9F18756-FA08-4F4D-873E-1F3904825503">
       <dmn:requiredInput href="#_c796f29d-d800-4239-b9f6-d4d72f77b183"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_6F27E152-BC2B-48C6-9F20-CCC9F4B71A5B">
+    <dmn:literalExpression id="_431096EB-C3C9-413B-AEB8-5522EF84A06D">
       <dmn:text>date and time(dateTimeString)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_9e8acf47-790a-4741-8ebb-e8a22a30744c" name="Time">
     <dmn:extensionElements/>
-    <dmn:variable id="_1BE427E6-713D-4124-99B9-C08DF5AC1881" name="Time" typeRef="feel:time"/>
-    <dmn:informationRequirement id="_e5705a69-0114-4f64-8aca-22500a533a51">
+    <dmn:variable id="_5E68F8E7-770C-44D1-A223-14EE237F1281" name="Time" typeRef="time"/>
+    <dmn:informationRequirement id="_6A05094C-71B1-44DC-A3D6-DB4CBCF44354">
       <dmn:requiredInput href="#_e5705a69-0114-4f64-8aca-22500a533a51"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_0177AE88-B961-497B-9414-FB3C2CE54C6E">
+    <dmn:literalExpression id="_E0268B4B-B777-4F02-8807-0878563D2447">
       <dmn:text>time(timeString)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_178690e3-8936-4914-a735-6243a29b6068" name="Year">
     <dmn:extensionElements/>
-    <dmn:variable id="_5A0968CF-8221-4745-AE67-61A67E7590A3" name="Year" typeRef="feel:number"/>
+    <dmn:variable id="_C3778375-08DA-4507-BEDF-E25DA91CB2F5" name="Year" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_e3143b2d-e150-422e-8163-d3e4461988f4" name="Month">
     <dmn:extensionElements/>
-    <dmn:variable id="_1D692B3E-07F6-435A-AA6A-B92150A52AC9" name="Month" typeRef="feel:number"/>
+    <dmn:variable id="_D0946DC0-0F6F-45BA-95B7-CC7CDE93C539" name="Month" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_ec0d9542-257d-401b-ac6b-ce927014cf25" name="Day">
     <dmn:extensionElements/>
-    <dmn:variable id="_F13C7138-4357-4B0F-B458-ACD4A0426D1C" name="Day" typeRef="feel:number"/>
+    <dmn:variable id="_E78ED4A9-FD8E-4355-A832-73379C6C395B" name="Day" typeRef="number"/>
   </dmn:inputData>
   <dmn:decision id="_7df22028-4b5b-4594-89c7-a80b8aec526f" name="Date-Time2">
     <dmn:extensionElements/>
-    <dmn:variable id="_B3A034A9-E78C-4B49-B311-764AC0D42913" name="Date-Time2" typeRef="feel:dateTime"/>
-    <dmn:informationRequirement id="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda">
+    <dmn:variable id="_BCBC2EE2-684A-409F-90D6-88B8BA7EED71" name="Date-Time2" typeRef="dateTime"/>
+    <dmn:informationRequirement id="_6E31E108-B3CB-4CA7-9B16-BDFC57A0A169">
       <dmn:requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_9e8acf47-790a-4741-8ebb-e8a22a30744c">
+    <dmn:informationRequirement id="_1209E44E-C0C7-476C-B19B-EBC83C7EE3A7">
       <dmn:requiredDecision href="#_9e8acf47-790a-4741-8ebb-e8a22a30744c"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_720CC67C-FF76-4E7E-B2F2-859A6B5D4F3E">
+    <dmn:literalExpression id="_A102464D-F722-4EAB-B070-D7E5F6847B8C">
       <dmn:text>date and time(Date.fromString,Time)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_1f2b08ce-3c6b-4e22-a747-8d9f378e9035" name="Time2">
     <dmn:extensionElements/>
-    <dmn:variable id="_04D55B69-FC38-4EA5-8219-43192FA083E4" name="Time2" typeRef="feel:time"/>
-    <dmn:informationRequirement id="_7df22028-4b5b-4594-89c7-a80b8aec526f">
+    <dmn:variable id="_FAC1B143-4FA2-4129-A459-DCE2FB6BA399" name="Time2" typeRef="time"/>
+    <dmn:informationRequirement id="_DA0BCAE3-C5E0-4ECB-BE52-D59408C90579">
       <dmn:requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_425812B3-EAE4-46F8-88C1-4389C5DCEC9D">
+    <dmn:literalExpression id="_849CF137-1E64-424A-838D-B1C3BB80062A">
       <dmn:text>time(Date-Time2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_c796f29d-d800-4239-b9f6-d4d72f77b183" name="dateTimeString">
     <dmn:extensionElements/>
-    <dmn:variable id="_EEA7365F-6028-457C-A7C5-210B3BA6FE38" name="dateTimeString" typeRef="feel:string"/>
+    <dmn:variable id="_AFEAFB4A-6B53-48E0-9472-FAF0FDD4DFD8" name="dateTimeString" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_0dffa0f8-4c84-401e-8403-94c201fbd976" name="Hours">
     <dmn:extensionElements/>
-    <dmn:variable id="_DC141034-01A4-4EF9-8FE3-AF946860DE45" name="Hours" typeRef="feel:number"/>
+    <dmn:variable id="_4D0AA170-B59D-47B0-A825-7F6A363257AD" name="Hours" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_03d8f475-0a28-4c67-8fc5-51d9b1f54781" name="Minutes">
     <dmn:extensionElements/>
-    <dmn:variable id="_8E17FC6B-CBBC-43B0-9679-A39D49CAEB4A" name="Minutes" typeRef="feel:number"/>
+    <dmn:variable id="_B58AC468-4A6E-4097-A558-6D67E5896CD3" name="Minutes" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_9225dbc5-fe5c-4fa9-b97c-0a41265abf20" name="Seconds">
     <dmn:extensionElements/>
-    <dmn:variable id="_A4B27815-9B13-421E-88CC-AD33F3F4C686" name="Seconds" typeRef="feel:number"/>
+    <dmn:variable id="_7A4BF707-6184-469C-8BA8-759CF8AE4613" name="Seconds" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_b133cbd3-884d-4cf9-a750-81d949d17e31" name="Timezone">
     <dmn:extensionElements/>
-    <dmn:variable id="_26DB436E-C1E6-4081-9334-B138684B193C" name="Timezone" typeRef="feel:dayTimeDuration"/>
+    <dmn:variable id="_BDFD4797-2BE1-44ED-8832-FF0C46CD5427" name="Timezone" typeRef="dayTimeDuration"/>
   </dmn:inputData>
   <dmn:decision id="_463b1a36-2505-413a-8056-f6a5efc2b52e" name="Time3">
     <dmn:extensionElements/>
-    <dmn:variable id="_3934E9B2-86FE-4C71-8A79-B3FBFEE23F52" name="Time3" typeRef="feel:time"/>
-    <dmn:informationRequirement id="_0dffa0f8-4c84-401e-8403-94c201fbd976">
+    <dmn:variable id="_DBE05CB9-FD2A-4E16-AE0D-0044C6CD5118" name="Time3" typeRef="time"/>
+    <dmn:informationRequirement id="_8FF88619-083D-456D-ABDC-B447A83D3A0B">
       <dmn:requiredInput href="#_0dffa0f8-4c84-401e-8403-94c201fbd976"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_03d8f475-0a28-4c67-8fc5-51d9b1f54781">
+    <dmn:informationRequirement id="_F0D243DA-BA7A-42F5-BD1C-81E4949F786A">
       <dmn:requiredInput href="#_03d8f475-0a28-4c67-8fc5-51d9b1f54781"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_9225dbc5-fe5c-4fa9-b97c-0a41265abf20">
+    <dmn:informationRequirement id="_EFF0B589-D5C9-456D-AAEB-BA30D81F23F2">
       <dmn:requiredInput href="#_9225dbc5-fe5c-4fa9-b97c-0a41265abf20"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_b133cbd3-884d-4cf9-a750-81d949d17e31">
+    <dmn:informationRequirement id="_D8364D7C-A568-439C-970C-4C827013C4BD">
       <dmn:requiredInput href="#_b133cbd3-884d-4cf9-a750-81d949d17e31"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E8F0EF7B-1734-4C3A-BECE-227D09FAD121">
+    <dmn:literalExpression id="_19F59E11-F3CC-4B4B-9290-77608FD4590D">
       <dmn:text>time(Hours,Minutes,Seconds,Timezone)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_6f8bf858-eed1-4f41-93f2-73431540f91f" name="durationString">
     <dmn:extensionElements/>
-    <dmn:variable id="_A84D72BD-EC0C-48ED-8DB6-EFD6B6E4B1AE" name="durationString" typeRef="feel:string"/>
+    <dmn:variable id="_5F5190C8-7A28-4B16-B972-483BD43231EA" name="durationString" typeRef="string"/>
   </dmn:inputData>
   <dmn:decision id="_972ecd98-1c70-4f0c-909c-786f23c61dbb" name="dtDuration1">
     <dmn:extensionElements/>
-    <dmn:variable id="_F0260B51-2A0B-4801-90DC-62CE2CB2718B" name="dtDuration1" typeRef="feel:dayTimeDuration"/>
-    <dmn:informationRequirement id="_6f8bf858-eed1-4f41-93f2-73431540f91f">
+    <dmn:variable id="_A18B2145-2085-484E-975A-F4BD21355CCA" name="dtDuration1" typeRef="dayTimeDuration"/>
+    <dmn:informationRequirement id="_F4FC7369-10DB-457A-82AF-3A42D9E55D63">
       <dmn:requiredInput href="#_6f8bf858-eed1-4f41-93f2-73431540f91f"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_87BAA48C-81F2-4DF6-9B94-E9EF13DD3896">
+    <dmn:literalExpression id="_02A89FD8-94A0-4DF8-AE77-6F9B164B2A2A">
       <dmn:text>duration(durationString)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_a2c48b03-6e72-4846-99cc-02f3747c6867" name="dtDuration2">
     <dmn:extensionElements/>
-    <dmn:variable id="_D48ACA48-3633-4266-8B75-E96C4B41E785" name="dtDuration2" typeRef="feel:dayTimeDuration"/>
-    <dmn:informationRequirement id="_7df22028-4b5b-4594-89c7-a80b8aec526f">
+    <dmn:variable id="_0C8F46FD-0E19-49CD-87F1-C26433E520CB" name="dtDuration2" typeRef="dayTimeDuration"/>
+    <dmn:informationRequirement id="_048023B4-1E6B-4C5D-8D25-624A5FA1B22A">
       <dmn:requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_dfbb843a-bd34-4099-b700-0d9ca5b38d6a">
+    <dmn:informationRequirement id="_F8E68AB4-E621-468C-8619-63A72972F1F1">
       <dmn:requiredDecision href="#_dfbb843a-bd34-4099-b700-0d9ca5b38d6a"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_CD3FA8E2-98AC-4219-9A19-7CFA65CA8522">
+    <dmn:literalExpression id="_9A3CFBD4-4C56-424F-8F95-98873A1023FD">
       <dmn:text>Date-Time - Date-Time2</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_d96a8f03-5cee-42ca-8646-4383ad5ecee2" name="oneHour">
     <dmn:extensionElements/>
-    <dmn:variable id="_59041749-B271-46F3-A675-06809F9BA566" name="oneHour" typeRef="feel:dayTimeDuration"/>
+    <dmn:variable id="_9922D152-B821-4206-8F0A-22E9B5883BC3" name="oneHour" typeRef="dayTimeDuration"/>
   </dmn:inputData>
   <dmn:decision id="_634e7bf4-782f-43f0-8b4f-cd8a3146da38" name="hoursInDuration">
     <dmn:extensionElements/>
-    <dmn:variable id="_90F3B5CE-8FE4-43BA-AA4F-6ECB63E0E72B" name="hoursInDuration" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_d96a8f03-5cee-42ca-8646-4383ad5ecee2">
+    <dmn:variable id="_76854143-F213-4288-9383-23B8C69D4BC5" name="hoursInDuration" typeRef="number"/>
+    <dmn:informationRequirement id="_96962293-59EB-49F5-B1DF-01C484A06BA4">
       <dmn:requiredInput href="#_d96a8f03-5cee-42ca-8646-4383ad5ecee2"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_a2c48b03-6e72-4846-99cc-02f3747c6867">
+    <dmn:informationRequirement id="_1C4BB9F4-4569-46BD-AE8F-2E8A99127AF5">
       <dmn:requiredDecision href="#_a2c48b03-6e72-4846-99cc-02f3747c6867"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_5E74E4F8-CCEF-49B6-80B6-2A94CDB10F32">
+    <dmn:literalExpression id="_A8215450-CEFC-43E4-A63A-9951431997FD">
       <dmn:text>dtDuration2 / oneHour</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_14f9f361-8c3c-455b-9c97-fe15201e3b5e" name="sumDurations">
     <dmn:extensionElements/>
-    <dmn:variable id="_8F52B735-E8AE-4E78-B7C9-873DEBD6A5E7" name="sumDurations" typeRef="feel:dayTimeDuration"/>
-    <dmn:informationRequirement id="_a2c48b03-6e72-4846-99cc-02f3747c6867">
+    <dmn:variable id="_282E771E-B4C9-44A7-A8F9-C88474CAE0CB" name="sumDurations" typeRef="dayTimeDuration"/>
+    <dmn:informationRequirement id="_68B86AE9-272F-4654-85A5-09A6FDB93564">
       <dmn:requiredDecision href="#_a2c48b03-6e72-4846-99cc-02f3747c6867"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_972ecd98-1c70-4f0c-909c-786f23c61dbb">
+    <dmn:informationRequirement id="_A1EAE063-BD35-4D7C-AD55-ECEF8413A798">
       <dmn:requiredDecision href="#_972ecd98-1c70-4f0c-909c-786f23c61dbb"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_619A7C30-BEBC-4C26-9572-4AD1B9FC66A3">
+    <dmn:literalExpression id="_368C2695-056E-4C82-B4C7-BA9A7200E80C">
       <dmn:text>dtDuration1 + dtDuration2</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_cbac111e-ca71-4fac-a921-175ffd767055" name="ymDuration2">
     <dmn:extensionElements/>
-    <dmn:variable id="_9DAC9730-D04B-4001-B7F1-BF91410F4FC7" name="ymDuration2" typeRef="feel:yearMonthDuration"/>
-    <dmn:informationRequirement id="_7df22028-4b5b-4594-89c7-a80b8aec526f">
+    <dmn:variable id="_DCB6414C-2849-474D-9508-C6386D01922C" name="ymDuration2" typeRef="yearMonthDuration"/>
+    <dmn:informationRequirement id="_70678B25-C5A4-4CEB-BFBD-74A0E624318B">
       <dmn:requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_dfbb843a-bd34-4099-b700-0d9ca5b38d6a">
+    <dmn:informationRequirement id="_54EB4B5D-1D44-413A-8254-7C08A8D6D40A">
       <dmn:requiredDecision href="#_dfbb843a-bd34-4099-b700-0d9ca5b38d6a"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_7536FBA2-0513-4F9A-9F65-A581BF7332B3">
+    <dmn:literalExpression id="_D12143BE-455F-4D2C-A2F7-DA3DB5B7F871">
       <dmn:text>years and months duration(Date-Time2,Date-Time)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_04c6bedc-bc63-464f-8e61-c039d24a47bf" name="cDay">
     <dmn:extensionElements/>
-    <dmn:variable id="_2BBCC200-9A49-406A-B8E2-F28F9B39735C" name="cDay" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda">
+    <dmn:variable id="_4FB1A19A-E581-4AF2-8B46-0E1F6A9F460E" name="cDay" typeRef="number"/>
+    <dmn:informationRequirement id="_DEFC6019-7DC9-475E-8E2B-47C32790672F">
       <dmn:requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_F6148C2C-FFE3-4024-AF05-743F39CD318D">
+    <dmn:literalExpression id="_0057AD4E-413E-4090-8F18-F927621EEE2F">
       <dmn:text>Date.fromString.day</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_dc18ebe0-6762-4734-aeb3-ed4fb861865c" name="cYear">
     <dmn:extensionElements/>
-    <dmn:variable id="_367A5CA4-C98E-46AD-B048-7D5A15F0B6F7" name="cYear" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda">
+    <dmn:variable id="_08EBE0FA-A77C-451F-AADC-0D81554A3C7B" name="cYear" typeRef="number"/>
+    <dmn:informationRequirement id="_FBE0E4DA-8F54-45C8-926B-7F27AEB01A03">
       <dmn:requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_934FEFCD-D8EE-4DE1-8DD9-4DF19660BC2B">
+    <dmn:literalExpression id="_7A6BDE99-9853-4F72-B882-0BC0B519A9E5">
       <dmn:text>Date.fromString.year</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_2cf37ed0-590d-4f97-b58b-46eaa424b965" name="cMonth">
     <dmn:extensionElements/>
-    <dmn:variable id="_FB690155-ED63-4D27-A957-ACAC3207FBC9" name="cMonth" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda">
+    <dmn:variable id="_EA783F2F-13D2-432F-B437-4DD98EED566E" name="cMonth" typeRef="number"/>
+    <dmn:informationRequirement id="_E08C050E-A63E-4A55-8D54-F7FC7FBBA502">
       <dmn:requiredDecision href="#_bd547a08-c157-47ca-84d4-ac6f3d5bdeda"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_DD4471B5-8C06-48EB-AE1F-C68AFE6CEEE5">
+    <dmn:literalExpression id="_903146BD-A3A5-47D4-849A-8E02ECFB8CF9">
       <dmn:text>Date.fromString.month</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_087e3f57-8ea6-4857-a080-fadc5a1dd9e8" name="cHour">
     <dmn:extensionElements/>
-    <dmn:variable id="_825DBC71-C25E-44A0-91E7-5FE568450743" name="cHour" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_7df22028-4b5b-4594-89c7-a80b8aec526f">
+    <dmn:variable id="_89EF9304-2242-40FF-B1CC-A284AD41A942" name="cHour" typeRef="number"/>
+    <dmn:informationRequirement id="_5C2F3B54-3BE0-46D2-9042-8F49AA65EF68">
       <dmn:requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_CC7A4D6F-BF83-41CF-AADA-2509F0560591">
+    <dmn:literalExpression id="_D891D530-8703-4597-9C5F-2CB4070A9911">
       <dmn:text>Date-Time2.hour</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_6836a944-7f7b-4c98-8a7a-a573494110fd" name="cMinute">
     <dmn:extensionElements/>
-    <dmn:variable id="_8E88879D-131F-4106-B524-211F74C63D80" name="cMinute" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_7df22028-4b5b-4594-89c7-a80b8aec526f">
+    <dmn:variable id="_6AB0AF0D-3A0E-4CDE-9F13-3851AE612466" name="cMinute" typeRef="number"/>
+    <dmn:informationRequirement id="_BB8EDC72-B01A-4673-95C8-4DF51FCF7D67">
       <dmn:requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_5803A3ED-A92C-4BE5-9522-A904F5009D30">
+    <dmn:literalExpression id="_AE24B902-E5C4-426F-96C4-19F95085ADAA">
       <dmn:text>Date-Time2.minute</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_4af88a8f-92e4-4f2d-bde1-e8a36b27e5bf" name="cSecond">
     <dmn:extensionElements/>
-    <dmn:variable id="_E1D86059-11F6-4C87-92E0-1CF5CFA11B42" name="cSecond" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_7df22028-4b5b-4594-89c7-a80b8aec526f">
+    <dmn:variable id="_4B2B56DE-6DBB-4D1C-99AA-18881D852981" name="cSecond" typeRef="number"/>
+    <dmn:informationRequirement id="_15692DF4-8248-4D5E-86F0-C3A84D65CF90">
       <dmn:requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_0B8DE7EB-C979-483B-B4A3-7B94A9CB81AE">
+    <dmn:literalExpression id="_72E30AFB-5ED3-4FCE-8910-0C6B015BE42C">
       <dmn:text>Date-Time2.second</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_81f97dd0-29ea-4bab-9540-b70a2fdf8ff3" name="cTimezone">
     <dmn:extensionElements/>
-    <dmn:variable id="_E4AE9121-23FA-41DB-A3D9-E93E7EFF17A8" name="cTimezone" typeRef="feel:dayTimeDuration"/>
-    <dmn:informationRequirement id="_7df22028-4b5b-4594-89c7-a80b8aec526f">
+    <dmn:variable id="_363DF571-220D-47A3-86EF-15D126AAAABF" name="cTimezone" typeRef="dayTimeDuration"/>
+    <dmn:informationRequirement id="_22101F33-1394-41F7-8D62-9815F12E9CF6">
       <dmn:requiredDecision href="#_7df22028-4b5b-4594-89c7-a80b8aec526f"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_59B91482-A39A-4A04-84AF-9300F8BB7964">
+    <dmn:literalExpression id="_865AE7AB-C430-4700-8987-2D1E46AD5859">
       <dmn:text>Date-Time2.timezone</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_91fb395d-8173-4ed3-95f7-f790bd3967ab" name="years">
     <dmn:extensionElements/>
-    <dmn:variable id="_E45E1439-51B9-4437-9968-B94223D8ED4F" name="years" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_cbac111e-ca71-4fac-a921-175ffd767055">
+    <dmn:variable id="_027317E9-2610-4EB0-9AD0-4F3A11F07D74" name="years" typeRef="number"/>
+    <dmn:informationRequirement id="_7AE36E0E-098B-4AC4-9567-40BFB87445E5">
       <dmn:requiredDecision href="#_cbac111e-ca71-4fac-a921-175ffd767055"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_B4BA79D9-CE8C-49ED-A952-70282BA4B914">
+    <dmn:literalExpression id="_058922D6-CE9A-4967-9C0B-115FCAE057DB">
       <dmn:text>ymDuration2.years</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" name="seconds">
     <dmn:extensionElements/>
-    <dmn:variable id="_19124985-F7B2-49DC-9B4D-AABEBE92FE59" name="seconds" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_972ecd98-1c70-4f0c-909c-786f23c61dbb">
+    <dmn:variable id="_86A8C7FC-F03C-4EB9-B319-69F053D8F975" name="seconds" typeRef="number"/>
+    <dmn:informationRequirement id="_BC847ABC-AA07-467F-BC2B-F6E248A2170E">
       <dmn:requiredDecision href="#_972ecd98-1c70-4f0c-909c-786f23c61dbb"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_363A53B0-40F6-4B71-9186-2D85FBDF560F">
+    <dmn:literalExpression id="_3BD839F2-7D86-4E30-9F4E-FA7715DA7BB4">
       <dmn:text>dtDuration1.seconds</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_97E877E2-D741-49B3-88FA-A1371188C256" name="DRG">
+    <dmndi:DMNDiagram id="_A93B463D-C604-4EF8-A723-31D0CA8E9029" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_6537FA94-F2CB-4BC9-AB51-6640C47C31A1"/>
-          <kie:ComponentWidths dmnElementRef="_8E1A47E9-3420-4651-AA51-1E229A344359"/>
-          <kie:ComponentWidths dmnElementRef="_19A1B0BE-CE81-482C-A942-7D7DFFD8E4AB"/>
-          <kie:ComponentWidths dmnElementRef="_4B5FFDCE-EE26-43E2-B540-492E7140CBBE"/>
-          <kie:ComponentWidths dmnElementRef="_6F27E152-BC2B-48C6-9F20-CCC9F4B71A5B"/>
-          <kie:ComponentWidths dmnElementRef="_0177AE88-B961-497B-9414-FB3C2CE54C6E"/>
-          <kie:ComponentWidths dmnElementRef="_720CC67C-FF76-4E7E-B2F2-859A6B5D4F3E"/>
-          <kie:ComponentWidths dmnElementRef="_425812B3-EAE4-46F8-88C1-4389C5DCEC9D"/>
-          <kie:ComponentWidths dmnElementRef="_E8F0EF7B-1734-4C3A-BECE-227D09FAD121"/>
-          <kie:ComponentWidths dmnElementRef="_87BAA48C-81F2-4DF6-9B94-E9EF13DD3896"/>
-          <kie:ComponentWidths dmnElementRef="_CD3FA8E2-98AC-4219-9A19-7CFA65CA8522"/>
-          <kie:ComponentWidths dmnElementRef="_5E74E4F8-CCEF-49B6-80B6-2A94CDB10F32"/>
-          <kie:ComponentWidths dmnElementRef="_619A7C30-BEBC-4C26-9572-4AD1B9FC66A3"/>
-          <kie:ComponentWidths dmnElementRef="_7536FBA2-0513-4F9A-9F65-A581BF7332B3"/>
-          <kie:ComponentWidths dmnElementRef="_F6148C2C-FFE3-4024-AF05-743F39CD318D"/>
-          <kie:ComponentWidths dmnElementRef="_934FEFCD-D8EE-4DE1-8DD9-4DF19660BC2B"/>
-          <kie:ComponentWidths dmnElementRef="_DD4471B5-8C06-48EB-AE1F-C68AFE6CEEE5"/>
-          <kie:ComponentWidths dmnElementRef="_CC7A4D6F-BF83-41CF-AADA-2509F0560591"/>
-          <kie:ComponentWidths dmnElementRef="_5803A3ED-A92C-4BE5-9522-A904F5009D30"/>
-          <kie:ComponentWidths dmnElementRef="_0B8DE7EB-C979-483B-B4A3-7B94A9CB81AE"/>
-          <kie:ComponentWidths dmnElementRef="_59B91482-A39A-4A04-84AF-9300F8BB7964"/>
-          <kie:ComponentWidths dmnElementRef="_B4BA79D9-CE8C-49ED-A952-70282BA4B914"/>
-          <kie:ComponentWidths dmnElementRef="_363A53B0-40F6-4B71-9186-2D85FBDF560F"/>
+          <kie:ComponentWidths dmnElementRef="_6E4DEFBD-1A16-4248-BB64-B5880BF88790"/>
+          <kie:ComponentWidths dmnElementRef="_B75D4B9F-247B-4840-A3A0-6A0F57DC024A"/>
+          <kie:ComponentWidths dmnElementRef="_DDF791BB-B9A2-400D-9BFD-417A037FD393"/>
+          <kie:ComponentWidths dmnElementRef="_7525B26E-F7ED-4B1F-A379-A88DE0DE1F59"/>
+          <kie:ComponentWidths dmnElementRef="_431096EB-C3C9-413B-AEB8-5522EF84A06D"/>
+          <kie:ComponentWidths dmnElementRef="_E0268B4B-B777-4F02-8807-0878563D2447"/>
+          <kie:ComponentWidths dmnElementRef="_A102464D-F722-4EAB-B070-D7E5F6847B8C"/>
+          <kie:ComponentWidths dmnElementRef="_849CF137-1E64-424A-838D-B1C3BB80062A"/>
+          <kie:ComponentWidths dmnElementRef="_19F59E11-F3CC-4B4B-9290-77608FD4590D"/>
+          <kie:ComponentWidths dmnElementRef="_02A89FD8-94A0-4DF8-AE77-6F9B164B2A2A"/>
+          <kie:ComponentWidths dmnElementRef="_9A3CFBD4-4C56-424F-8F95-98873A1023FD"/>
+          <kie:ComponentWidths dmnElementRef="_A8215450-CEFC-43E4-A63A-9951431997FD"/>
+          <kie:ComponentWidths dmnElementRef="_368C2695-056E-4C82-B4C7-BA9A7200E80C"/>
+          <kie:ComponentWidths dmnElementRef="_D12143BE-455F-4D2C-A2F7-DA3DB5B7F871"/>
+          <kie:ComponentWidths dmnElementRef="_0057AD4E-413E-4090-8F18-F927621EEE2F"/>
+          <kie:ComponentWidths dmnElementRef="_7A6BDE99-9853-4F72-B882-0BC0B519A9E5"/>
+          <kie:ComponentWidths dmnElementRef="_903146BD-A3A5-47D4-849A-8E02ECFB8CF9"/>
+          <kie:ComponentWidths dmnElementRef="_D891D530-8703-4597-9C5F-2CB4070A9911"/>
+          <kie:ComponentWidths dmnElementRef="_AE24B902-E5C4-426F-96C4-19F95085ADAA"/>
+          <kie:ComponentWidths dmnElementRef="_72E30AFB-5ED3-4FCE-8910-0C6B015BE42C"/>
+          <kie:ComponentWidths dmnElementRef="_865AE7AB-C430-4700-8987-2D1E46AD5859"/>
+          <kie:ComponentWidths dmnElementRef="_058922D6-CE9A-4967-9C0B-115FCAE057DB"/>
+          <kie:ComponentWidths dmnElementRef="_3BD839F2-7D86-4E30-9F4E-FA7715DA7BB4"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_74a9c3ad-a813-444e-88ee-8a91096ee233" dmnElementRef="tns:_74a9c3ad-a813-444e-88ee-8a91096ee233" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_74a9c3ad-a813-444e-88ee-8a91096ee233" dmnElementRef="_74a9c3ad-a813-444e-88ee-8a91096ee233" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -371,7 +378,7 @@
         <dc:Bounds x="663" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_e5705a69-0114-4f64-8aca-22500a533a51" dmnElementRef="tns:_e5705a69-0114-4f64-8aca-22500a533a51" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_e5705a69-0114-4f64-8aca-22500a533a51" dmnElementRef="_e5705a69-0114-4f64-8aca-22500a533a51" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -380,7 +387,7 @@
         <dc:Bounds x="1013" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bd547a08-c157-47ca-84d4-ac6f3d5bdeda" dmnElementRef="tns:_bd547a08-c157-47ca-84d4-ac6f3d5bdeda" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_bd547a08-c157-47ca-84d4-ac6f3d5bdeda" dmnElementRef="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -389,7 +396,7 @@
         <dc:Bounds x="1013" y="575" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_dfbb843a-bd34-4099-b700-0d9ca5b38d6a" dmnElementRef="tns:_dfbb843a-bd34-4099-b700-0d9ca5b38d6a" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_dfbb843a-bd34-4099-b700-0d9ca5b38d6a" dmnElementRef="_dfbb843a-bd34-4099-b700-0d9ca5b38d6a" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -398,7 +405,7 @@
         <dc:Bounds x="838" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_9e8acf47-790a-4741-8ebb-e8a22a30744c" dmnElementRef="tns:_9e8acf47-790a-4741-8ebb-e8a22a30744c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_9e8acf47-790a-4741-8ebb-e8a22a30744c" dmnElementRef="_9e8acf47-790a-4741-8ebb-e8a22a30744c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -407,7 +414,7 @@
         <dc:Bounds x="1188" y="575" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_178690e3-8936-4914-a735-6243a29b6068" dmnElementRef="tns:_178690e3-8936-4914-a735-6243a29b6068" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_178690e3-8936-4914-a735-6243a29b6068" dmnElementRef="_178690e3-8936-4914-a735-6243a29b6068" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -416,7 +423,7 @@
         <dc:Bounds x="1188" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_e3143b2d-e150-422e-8163-d3e4461988f4" dmnElementRef="tns:_e3143b2d-e150-422e-8163-d3e4461988f4" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_e3143b2d-e150-422e-8163-d3e4461988f4" dmnElementRef="_e3143b2d-e150-422e-8163-d3e4461988f4" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -425,7 +432,7 @@
         <dc:Bounds x="1363" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ec0d9542-257d-401b-ac6b-ce927014cf25" dmnElementRef="tns:_ec0d9542-257d-401b-ac6b-ce927014cf25" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_ec0d9542-257d-401b-ac6b-ce927014cf25" dmnElementRef="_ec0d9542-257d-401b-ac6b-ce927014cf25" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -434,7 +441,7 @@
         <dc:Bounds x="1538" y="750" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7df22028-4b5b-4594-89c7-a80b8aec526f" dmnElementRef="tns:_7df22028-4b5b-4594-89c7-a80b8aec526f" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7df22028-4b5b-4594-89c7-a80b8aec526f" dmnElementRef="_7df22028-4b5b-4594-89c7-a80b8aec526f" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -443,7 +450,7 @@
         <dc:Bounds x="1013" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_1f2b08ce-3c6b-4e22-a747-8d9f378e9035" dmnElementRef="tns:_1f2b08ce-3c6b-4e22-a747-8d9f378e9035" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1f2b08ce-3c6b-4e22-a747-8d9f378e9035" dmnElementRef="_1f2b08ce-3c6b-4e22-a747-8d9f378e9035" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -452,7 +459,7 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c796f29d-d800-4239-b9f6-d4d72f77b183" dmnElementRef="tns:_c796f29d-d800-4239-b9f6-d4d72f77b183" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c796f29d-d800-4239-b9f6-d4d72f77b183" dmnElementRef="_c796f29d-d800-4239-b9f6-d4d72f77b183" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -461,7 +468,7 @@
         <dc:Bounds x="1100" y="925" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_0dffa0f8-4c84-401e-8403-94c201fbd976" dmnElementRef="tns:_0dffa0f8-4c84-401e-8403-94c201fbd976" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_0dffa0f8-4c84-401e-8403-94c201fbd976" dmnElementRef="_0dffa0f8-4c84-401e-8403-94c201fbd976" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -470,7 +477,7 @@
         <dc:Bounds x="1013" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_03d8f475-0a28-4c67-8fc5-51d9b1f54781" dmnElementRef="tns:_03d8f475-0a28-4c67-8fc5-51d9b1f54781" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_03d8f475-0a28-4c67-8fc5-51d9b1f54781" dmnElementRef="_03d8f475-0a28-4c67-8fc5-51d9b1f54781" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -479,7 +486,7 @@
         <dc:Bounds x="1188" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_9225dbc5-fe5c-4fa9-b97c-0a41265abf20" dmnElementRef="tns:_9225dbc5-fe5c-4fa9-b97c-0a41265abf20" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_9225dbc5-fe5c-4fa9-b97c-0a41265abf20" dmnElementRef="_9225dbc5-fe5c-4fa9-b97c-0a41265abf20" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -488,7 +495,7 @@
         <dc:Bounds x="1363" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_b133cbd3-884d-4cf9-a750-81d949d17e31" dmnElementRef="tns:_b133cbd3-884d-4cf9-a750-81d949d17e31" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_b133cbd3-884d-4cf9-a750-81d949d17e31" dmnElementRef="_b133cbd3-884d-4cf9-a750-81d949d17e31" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -497,7 +504,7 @@
         <dc:Bounds x="1538" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_463b1a36-2505-413a-8056-f6a5efc2b52e" dmnElementRef="tns:_463b1a36-2505-413a-8056-f6a5efc2b52e" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_463b1a36-2505-413a-8056-f6a5efc2b52e" dmnElementRef="_463b1a36-2505-413a-8056-f6a5efc2b52e" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -506,7 +513,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_6f8bf858-eed1-4f41-93f2-73431540f91f" dmnElementRef="tns:_6f8bf858-eed1-4f41-93f2-73431540f91f" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_6f8bf858-eed1-4f41-93f2-73431540f91f" dmnElementRef="_6f8bf858-eed1-4f41-93f2-73431540f91f" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -515,7 +522,7 @@
         <dc:Bounds x="1188" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_972ecd98-1c70-4f0c-909c-786f23c61dbb" dmnElementRef="tns:_972ecd98-1c70-4f0c-909c-786f23c61dbb" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_972ecd98-1c70-4f0c-909c-786f23c61dbb" dmnElementRef="_972ecd98-1c70-4f0c-909c-786f23c61dbb" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -524,7 +531,7 @@
         <dc:Bounds x="838" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_a2c48b03-6e72-4846-99cc-02f3747c6867" dmnElementRef="tns:_a2c48b03-6e72-4846-99cc-02f3747c6867" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_a2c48b03-6e72-4846-99cc-02f3747c6867" dmnElementRef="_a2c48b03-6e72-4846-99cc-02f3747c6867" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -533,7 +540,7 @@
         <dc:Bounds x="488" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d96a8f03-5cee-42ca-8646-4383ad5ecee2" dmnElementRef="tns:_d96a8f03-5cee-42ca-8646-4383ad5ecee2" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d96a8f03-5cee-42ca-8646-4383ad5ecee2" dmnElementRef="_d96a8f03-5cee-42ca-8646-4383ad5ecee2" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -542,7 +549,7 @@
         <dc:Bounds x="1713" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_634e7bf4-782f-43f0-8b4f-cd8a3146da38" dmnElementRef="tns:_634e7bf4-782f-43f0-8b4f-cd8a3146da38" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_634e7bf4-782f-43f0-8b4f-cd8a3146da38" dmnElementRef="_634e7bf4-782f-43f0-8b4f-cd8a3146da38" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -551,7 +558,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_14f9f361-8c3c-455b-9c97-fe15201e3b5e" dmnElementRef="tns:_14f9f361-8c3c-455b-9c97-fe15201e3b5e" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_14f9f361-8c3c-455b-9c97-fe15201e3b5e" dmnElementRef="_14f9f361-8c3c-455b-9c97-fe15201e3b5e" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -560,7 +567,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_cbac111e-ca71-4fac-a921-175ffd767055" dmnElementRef="tns:_cbac111e-ca71-4fac-a921-175ffd767055" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_cbac111e-ca71-4fac-a921-175ffd767055" dmnElementRef="_cbac111e-ca71-4fac-a921-175ffd767055" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -569,7 +576,7 @@
         <dc:Bounds x="663" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_04c6bedc-bc63-464f-8e61-c039d24a47bf" dmnElementRef="tns:_04c6bedc-bc63-464f-8e61-c039d24a47bf" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_04c6bedc-bc63-464f-8e61-c039d24a47bf" dmnElementRef="_04c6bedc-bc63-464f-8e61-c039d24a47bf" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -578,7 +585,7 @@
         <dc:Bounds x="1100" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_dc18ebe0-6762-4734-aeb3-ed4fb861865c" dmnElementRef="tns:_dc18ebe0-6762-4734-aeb3-ed4fb861865c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_dc18ebe0-6762-4734-aeb3-ed4fb861865c" dmnElementRef="_dc18ebe0-6762-4734-aeb3-ed4fb861865c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -587,7 +594,7 @@
         <dc:Bounds x="1625" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2cf37ed0-590d-4f97-b58b-46eaa424b965" dmnElementRef="tns:_2cf37ed0-590d-4f97-b58b-46eaa424b965" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_2cf37ed0-590d-4f97-b58b-46eaa424b965" dmnElementRef="_2cf37ed0-590d-4f97-b58b-46eaa424b965" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -596,7 +603,7 @@
         <dc:Bounds x="1975" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_087e3f57-8ea6-4857-a080-fadc5a1dd9e8" dmnElementRef="tns:_087e3f57-8ea6-4857-a080-fadc5a1dd9e8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_087e3f57-8ea6-4857-a080-fadc5a1dd9e8" dmnElementRef="_087e3f57-8ea6-4857-a080-fadc5a1dd9e8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -605,7 +612,7 @@
         <dc:Bounds x="925" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_6836a944-7f7b-4c98-8a7a-a573494110fd" dmnElementRef="tns:_6836a944-7f7b-4c98-8a7a-a573494110fd" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_6836a944-7f7b-4c98-8a7a-a573494110fd" dmnElementRef="_6836a944-7f7b-4c98-8a7a-a573494110fd" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -614,7 +621,7 @@
         <dc:Bounds x="1275" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4af88a8f-92e4-4f2d-bde1-e8a36b27e5bf" dmnElementRef="tns:_4af88a8f-92e4-4f2d-bde1-e8a36b27e5bf" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4af88a8f-92e4-4f2d-bde1-e8a36b27e5bf" dmnElementRef="_4af88a8f-92e4-4f2d-bde1-e8a36b27e5bf" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -623,7 +630,7 @@
         <dc:Bounds x="1800" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_81f97dd0-29ea-4bab-9540-b70a2fdf8ff3" dmnElementRef="tns:_81f97dd0-29ea-4bab-9540-b70a2fdf8ff3" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_81f97dd0-29ea-4bab-9540-b70a2fdf8ff3" dmnElementRef="_81f97dd0-29ea-4bab-9540-b70a2fdf8ff3" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -632,7 +639,7 @@
         <dc:Bounds x="2150" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_91fb395d-8173-4ed3-95f7-f790bd3967ab" dmnElementRef="tns:_91fb395d-8173-4ed3-95f7-f790bd3967ab" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_91fb395d-8173-4ed3-95f7-f790bd3967ab" dmnElementRef="_91fb395d-8173-4ed3-95f7-f790bd3967ab" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -641,7 +648,7 @@
         <dc:Bounds x="750" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" dmnElementRef="tns:_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" dmnElementRef="_c2f1a1ae-1403-43a2-b176-dedf3da51e6b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -650,81 +657,133 @@
         <dc:Bounds x="1450" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_74a9c3ad-a813-444e-88ee-8a91096ee233" dmnElementRef="tns:_74a9c3ad-a813-444e-88ee-8a91096ee233">
+      <dmndi:DMNEdge id="dmnedge-drg-_2F32C1AB-DE32-4CCD-B9AA-6B4E04C7821A" dmnElementRef="_2F32C1AB-DE32-4CCD-B9AA-6B4E04C7821A">
         <di:waypoint x="663" y="750"/>
         <di:waypoint x="1013" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_178690e3-8936-4914-a735-6243a29b6068" dmnElementRef="tns:_178690e3-8936-4914-a735-6243a29b6068">
+      <dmndi:DMNEdge id="dmnedge-drg-_6DADBF64-C403-4708-860B-1EF8133EA368" dmnElementRef="_6DADBF64-C403-4708-860B-1EF8133EA368">
         <di:waypoint x="1188" y="750"/>
         <di:waypoint x="1013" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_e3143b2d-e150-422e-8163-d3e4461988f4" dmnElementRef="tns:_e3143b2d-e150-422e-8163-d3e4461988f4">
+      <dmndi:DMNEdge id="dmnedge-drg-_57CB86DC-FF64-45FA-A07A-99A717753730" dmnElementRef="_57CB86DC-FF64-45FA-A07A-99A717753730">
         <di:waypoint x="1363" y="750"/>
         <di:waypoint x="1013" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_ec0d9542-257d-401b-ac6b-ce927014cf25" dmnElementRef="tns:_ec0d9542-257d-401b-ac6b-ce927014cf25">
+      <dmndi:DMNEdge id="dmnedge-drg-_4EAD7C78-93CC-448C-BB07-D4A83929B5E8" dmnElementRef="_4EAD7C78-93CC-448C-BB07-D4A83929B5E8">
         <di:waypoint x="1538" y="750"/>
         <di:waypoint x="1013" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_dfbb843a-bd34-4099-b700-0d9ca5b38d6a" dmnElementRef="tns:_dfbb843a-bd34-4099-b700-0d9ca5b38d6a">
+      <dmndi:DMNEdge id="dmnedge-drg-_764D785F-89BC-4054-9C5D-D81B884D7582" dmnElementRef="_764D785F-89BC-4054-9C5D-D81B884D7582">
         <di:waypoint x="838" y="750"/>
         <di:waypoint x="1013" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c796f29d-d800-4239-b9f6-d4d72f77b183" dmnElementRef="tns:_c796f29d-d800-4239-b9f6-d4d72f77b183">
+      <dmndi:DMNEdge id="dmnedge-drg-_B9F18756-FA08-4F4D-873E-1F3904825503" dmnElementRef="_B9F18756-FA08-4F4D-873E-1F3904825503">
         <di:waypoint x="1100" y="925"/>
         <di:waypoint x="838" y="750"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_e5705a69-0114-4f64-8aca-22500a533a51" dmnElementRef="tns:_e5705a69-0114-4f64-8aca-22500a533a51">
+      <dmndi:DMNEdge id="dmnedge-drg-_6A05094C-71B1-44DC-A3D6-DB4CBCF44354" dmnElementRef="_6A05094C-71B1-44DC-A3D6-DB4CBCF44354">
         <di:waypoint x="1013" y="750"/>
         <di:waypoint x="1188" y="575"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_bd547a08-c157-47ca-84d4-ac6f3d5bdeda" dmnElementRef="tns:_bd547a08-c157-47ca-84d4-ac6f3d5bdeda">
+      <dmndi:DMNEdge id="dmnedge-drg-_6E31E108-B3CB-4CA7-9B16-BDFC57A0A169" dmnElementRef="_6E31E108-B3CB-4CA7-9B16-BDFC57A0A169">
         <di:waypoint x="1013" y="575"/>
         <di:waypoint x="1013" y="400"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_9e8acf47-790a-4741-8ebb-e8a22a30744c" dmnElementRef="tns:_9e8acf47-790a-4741-8ebb-e8a22a30744c">
+      <dmndi:DMNEdge id="dmnedge-drg-_1209E44E-C0C7-476C-B19B-EBC83C7EE3A7" dmnElementRef="_1209E44E-C0C7-476C-B19B-EBC83C7EE3A7">
         <di:waypoint x="1188" y="575"/>
         <di:waypoint x="1013" y="400"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7df22028-4b5b-4594-89c7-a80b8aec526f" dmnElementRef="tns:_7df22028-4b5b-4594-89c7-a80b8aec526f">
+      <dmndi:DMNEdge id="dmnedge-drg-_DA0BCAE3-C5E0-4ECB-BE52-D59408C90579" dmnElementRef="_DA0BCAE3-C5E0-4ECB-BE52-D59408C90579">
         <di:waypoint x="1013" y="400"/>
         <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_0dffa0f8-4c84-401e-8403-94c201fbd976" dmnElementRef="tns:_0dffa0f8-4c84-401e-8403-94c201fbd976">
+      <dmndi:DMNEdge id="dmnedge-drg-_8FF88619-083D-456D-ABDC-B447A83D3A0B" dmnElementRef="_8FF88619-083D-456D-ABDC-B447A83D3A0B">
         <di:waypoint x="1013" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_03d8f475-0a28-4c67-8fc5-51d9b1f54781" dmnElementRef="tns:_03d8f475-0a28-4c67-8fc5-51d9b1f54781">
+      <dmndi:DMNEdge id="dmnedge-drg-_F0D243DA-BA7A-42F5-BD1C-81E4949F786A" dmnElementRef="_F0D243DA-BA7A-42F5-BD1C-81E4949F786A">
         <di:waypoint x="1188" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_9225dbc5-fe5c-4fa9-b97c-0a41265abf20" dmnElementRef="tns:_9225dbc5-fe5c-4fa9-b97c-0a41265abf20">
+      <dmndi:DMNEdge id="dmnedge-drg-_EFF0B589-D5C9-456D-AAEB-BA30D81F23F2" dmnElementRef="_EFF0B589-D5C9-456D-AAEB-BA30D81F23F2">
         <di:waypoint x="1363" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_b133cbd3-884d-4cf9-a750-81d949d17e31" dmnElementRef="tns:_b133cbd3-884d-4cf9-a750-81d949d17e31">
+      <dmndi:DMNEdge id="dmnedge-drg-_D8364D7C-A568-439C-970C-4C827013C4BD" dmnElementRef="_D8364D7C-A568-439C-970C-4C827013C4BD">
         <di:waypoint x="1538" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_6f8bf858-eed1-4f41-93f2-73431540f91f" dmnElementRef="tns:_6f8bf858-eed1-4f41-93f2-73431540f91f">
+      <dmndi:DMNEdge id="dmnedge-drg-_F4FC7369-10DB-457A-82AF-3A42D9E55D63" dmnElementRef="_F4FC7369-10DB-457A-82AF-3A42D9E55D63">
         <di:waypoint x="1188" y="400"/>
         <di:waypoint x="838" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_d96a8f03-5cee-42ca-8646-4383ad5ecee2" dmnElementRef="tns:_d96a8f03-5cee-42ca-8646-4383ad5ecee2">
+      <dmndi:DMNEdge id="dmnedge-drg-_048023B4-1E6B-4C5D-8D25-624A5FA1B22A" dmnElementRef="_048023B4-1E6B-4C5D-8D25-624A5FA1B22A">
+        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="488" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F8E68AB4-E621-468C-8619-63A72972F1F1" dmnElementRef="_F8E68AB4-E621-468C-8619-63A72972F1F1">
+        <di:waypoint x="838" y="750"/>
+        <di:waypoint x="488" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_96962293-59EB-49F5-B1DF-01C484A06BA4" dmnElementRef="_96962293-59EB-49F5-B1DF-01C484A06BA4">
         <di:waypoint x="1713" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_a2c48b03-6e72-4846-99cc-02f3747c6867" dmnElementRef="tns:_a2c48b03-6e72-4846-99cc-02f3747c6867">
+      <dmndi:DMNEdge id="dmnedge-drg-_1C4BB9F4-4569-46BD-AE8F-2E8A99127AF5" dmnElementRef="_1C4BB9F4-4569-46BD-AE8F-2E8A99127AF5">
         <di:waypoint x="488" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_972ecd98-1c70-4f0c-909c-786f23c61dbb" dmnElementRef="tns:_972ecd98-1c70-4f0c-909c-786f23c61dbb">
+      <dmndi:DMNEdge id="dmnedge-drg-_68B86AE9-272F-4654-85A5-09A6FDB93564" dmnElementRef="_68B86AE9-272F-4654-85A5-09A6FDB93564">
+        <di:waypoint x="488" y="225"/>
+        <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_A1EAE063-BD35-4D7C-AD55-ECEF8413A798" dmnElementRef="_A1EAE063-BD35-4D7C-AD55-ECEF8413A798">
         <di:waypoint x="838" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_cbac111e-ca71-4fac-a921-175ffd767055" dmnElementRef="tns:_cbac111e-ca71-4fac-a921-175ffd767055">
+      <dmndi:DMNEdge id="dmnedge-drg-_70678B25-C5A4-4CEB-BFBD-74A0E624318B" dmnElementRef="_70678B25-C5A4-4CEB-BFBD-74A0E624318B">
+        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="663" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_54EB4B5D-1D44-413A-8254-7C08A8D6D40A" dmnElementRef="_54EB4B5D-1D44-413A-8254-7C08A8D6D40A">
+        <di:waypoint x="838" y="750"/>
+        <di:waypoint x="663" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_DEFC6019-7DC9-475E-8E2B-47C32790672F" dmnElementRef="_DEFC6019-7DC9-475E-8E2B-47C32790672F">
+        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="1100" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_FBE0E4DA-8F54-45C8-926B-7F27AEB01A03" dmnElementRef="_FBE0E4DA-8F54-45C8-926B-7F27AEB01A03">
+        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="1625" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E08C050E-A63E-4A55-8D54-F7FC7FBBA502" dmnElementRef="_E08C050E-A63E-4A55-8D54-F7FC7FBBA502">
+        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="1975" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_5C2F3B54-3BE0-46D2-9042-8F49AA65EF68" dmnElementRef="_5C2F3B54-3BE0-46D2-9042-8F49AA65EF68">
+        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="925" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_BB8EDC72-B01A-4673-95C8-4DF51FCF7D67" dmnElementRef="_BB8EDC72-B01A-4673-95C8-4DF51FCF7D67">
+        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="1275" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_15692DF4-8248-4D5E-86F0-C3A84D65CF90" dmnElementRef="_15692DF4-8248-4D5E-86F0-C3A84D65CF90">
+        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_22101F33-1394-41F7-8D62-9815F12E9CF6" dmnElementRef="_22101F33-1394-41F7-8D62-9815F12E9CF6">
+        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="2150" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_7AE36E0E-098B-4AC4-9567-40BFB87445E5" dmnElementRef="_7AE36E0E-098B-4AC4-9567-40BFB87445E5">
         <di:waypoint x="663" y="225"/>
         <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_BC847ABC-AA07-467F-BC2B-F6E248A2170E" dmnElementRef="_BC847ABC-AA07-467F-BC2B-F6E248A2170E">
+        <di:waypoint x="838" y="225"/>
+        <di:waypoint x="1450" y="50"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-simpletable-P2.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-simpletable-P2.dmn
@@ -1,39 +1,47 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_501f6033-f4bc-4823-99aa-edaf29ac2e0b" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_501f6033-f4bc-4823-99aa-edaf29ac2e0b" name="simple P table 2" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_501f6033-f4bc-4823-99aa-edaf29ac2e0b">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_501f6033-f4bc-4823-99aa-edaf29ac2e0b"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_501f6033-f4bc-4823-99aa-edaf29ac2e0b" name="simple P table 2" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_501f6033-f4bc-4823-99aa-edaf29ac2e0b">
   <dmn:extensionElements/>
   <dmn:decision id="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" name="Approval Status">
     <dmn:extensionElements/>
-    <dmn:variable id="_96321322-82C5-4490-A031-D0EE11178E80" name="Approval Status" typeRef="feel:string"/>
-    <dmn:informationRequirement id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+    <dmn:variable id="_D9732D69-F936-4BF8-A75B-AD0BB4F19ADD" name="Approval Status" typeRef="string"/>
+    <dmn:informationRequirement id="_55E54DF9-9380-4382-B422-E2129E5FCCC3">
       <dmn:requiredInput href="#_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_41effb45-b3c4-46ac-b1da-122b3e428a98">
+    <dmn:informationRequirement id="_F2A78307-E242-416D-B94E-6D7C42B2B88D">
       <dmn:requiredInput href="#_41effb45-b3c4-46ac-b1da-122b3e428a98"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8ff18665-84e9-49f2-a8df-8981b1844549">
+    <dmn:informationRequirement id="_9C92B4C7-AD66-405D-B1A6-C6F0344F148F">
       <dmn:requiredInput href="#_8ff18665-84e9-49f2-a8df-8981b1844549"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_F46284D5-29EB-4FDE-B0C4-DA53BE263DF0" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
+    <dmn:decisionTable id="_9AAA52C6-A92C-4F22-885C-A83507CF1DE3" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="Approval Status">
       <dmn:input id="_f64e79ef-12df-471a-8830-18dd1060e8f0">
-        <dmn:inputExpression id="_1C644125-562F-48D2-8C1C-D93566371EB1" typeRef="feel:number">
+        <dmn:inputExpression id="_4B8D0F61-A2A9-49FE-9A48-525DC3235544" typeRef="number">
           <dmn:text>Age</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:input id="_066896e9-14c6-4684-a6a7-1036057c69ae">
-        <dmn:inputExpression id="_C9FC1C49-6035-40FE-9EC4-0A95CFA0357E" typeRef="feel:string">
+        <dmn:inputExpression id="_82B440B3-8AFB-41DD-807D-4C471D69DFC3" typeRef="string">
           <dmn:text>RiskCategory</dmn:text>
         </dmn:inputExpression>
-        <dmn:inputValues id="_B3708BBE-4B4C-494A-89D3-9D5E2F2FA76B">
+        <dmn:inputValues id="_EE1F0542-6D74-4CA4-9491-14F0FA1BA354">
           <dmn:text>"High", "Low", "Medium"</dmn:text>
         </dmn:inputValues>
       </dmn:input>
       <dmn:input id="_11764a00-cb22-4e5b-8e52-cbcd2a4d3971">
-        <dmn:inputExpression id="_6EF3C202-B498-4041-B1BA-9778A5A5959A" typeRef="feel:boolean">
+        <dmn:inputExpression id="_454C11B3-CCD1-4D1A-9D62-7327CAF3793E" typeRef="boolean">
           <dmn:text>isAffordable</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:output id="_c8adc49f-998f-48b8-bd79-746d9c3d25b3">
-        <dmn:outputValues id="_411231BC-9A0B-4DDA-B09C-49E98F29CDB3">
+        <dmn:outputValues id="_1CE97E10-DF04-4C3C-901F-49E756E5389C">
           <dmn:text>"Approved", "Declined"</dmn:text>
         </dmn:outputValues>
       </dmn:output>
@@ -76,24 +84,24 @@
   </dmn:decision>
   <dmn:inputData id="_41effb45-b3c4-46ac-b1da-122b3e428a98" name="Age">
     <dmn:extensionElements/>
-    <dmn:variable id="_59D62904-C8A9-435E-8D96-D38282C31AA9" name="Age" typeRef="feel:number"/>
+    <dmn:variable id="_6F8C7D31-0EAC-4E3C-92BA-A5FEF383F6CC" name="Age" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" name="RiskCategory">
     <dmn:extensionElements/>
-    <dmn:variable id="_77EA2196-8ED1-41DA-83E7-622E5A52E933" name="RiskCategory" typeRef="feel:string"/>
+    <dmn:variable id="_02EA7B29-2764-4E01-B63C-69D401144C70" name="RiskCategory" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_8ff18665-84e9-49f2-a8df-8981b1844549" name="isAffordable">
     <dmn:extensionElements/>
-    <dmn:variable id="_DA5119DE-2E6B-4053-828D-A7DF3C4792F7" name="isAffordable" typeRef="feel:boolean"/>
+    <dmn:variable id="_97F1BDB6-09C8-44A8-A8F9-64C2EDD81C8E" name="isAffordable" typeRef="boolean"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_437A20C7-CDFC-472A-9D4F-80F0F1097CB1" name="DRG">
+    <dmndi:DMNDiagram id="_20C1C3DC-883D-4ECD-B003-AF817B387BE7" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_F46284D5-29EB-4FDE-B0C4-DA53BE263DF0"/>
+          <kie:ComponentWidths dmnElementRef="_9AAA52C6-A92C-4F22-885C-A83507CF1DE3"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="tns:_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -102,7 +110,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -111,7 +119,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -120,7 +128,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -129,15 +137,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+      <dmndi:DMNEdge id="dmnedge-drg-_55E54DF9-9380-4382-B422-E2129E5FCCC3" dmnElementRef="_55E54DF9-9380-4382-B422-E2129E5FCCC3">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98">
+      <dmndi:DMNEdge id="dmnedge-drg-_F2A78307-E242-416D-B94E-6D7C42B2B88D" dmnElementRef="_F2A78307-E242-416D-B94E-6D7C42B2B88D">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549">
+      <dmndi:DMNEdge id="dmnedge-drg-_9C92B4C7-AD66-405D-B1A6-C6F0344F148F" dmnElementRef="_9C92B4C7-AD66-405D-B1A6-C6F0344F148F">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-LX-arithmetic.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-LX-arithmetic.dmn
@@ -1,39 +1,47 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_1fedf2c0-0f4a-470c-bc66-a15528e8a49a" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_1fedf2c0-0f4a-470c-bc66-a15528e8a49a" name="literal - arithmetic" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_1fedf2c0-0f4a-470c-bc66-a15528e8a49a">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_1fedf2c0-0f4a-470c-bc66-a15528e8a49a"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_1fedf2c0-0f4a-470c-bc66-a15528e8a49a" name="literal - arithmetic" expressionLanguage="http://www.omg.org/spec/FEEL/20140401" typeLanguage="http://www.omg.org/spec/FEEL/20140401" namespace="http://www.trisotech.com/definitions/_1fedf2c0-0f4a-470c-bc66-a15528e8a49a">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tLoan" name="tLoan" isCollection="false">
     <dmn:itemComponent id="_561947e6-180a-416e-aa22-5e8e5d650624" name="principal" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_c1751fa0-4da6-4cb5-a234-45765d6b35ac" name="rate" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_006e0a06-26a6-42e1-9b3c-4b2502a567fe" name="termMonths" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decision id="_ebf02591-49c6-448d-9f76-6358b0e011c3" name="payment">
     <dmn:extensionElements/>
-    <dmn:variable id="_0874FCD1-94B3-402E-A901-B293D6FF1650" name="payment" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a">
+    <dmn:variable id="_B6CBED5C-B419-4975-BDA3-3C5804E5D292" name="payment" typeRef="number"/>
+    <dmn:informationRequirement id="_20E384BE-C605-46FC-9A3E-5846770B92BE">
       <dmn:requiredInput href="#_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_5C6BE3E2-EC4A-4FE2-9137-3B8201C4BA56">
+    <dmn:literalExpression id="_5DA034E1-BBFC-4643-B3A2-120FE2FF200A">
       <dmn:text>(loan.principal*loan.rate/12)/(1-(1+loan.rate/12)**-loan.termMonths)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a" name="loan">
     <dmn:extensionElements/>
-    <dmn:variable id="_CF302539-4EFB-4797-B095-412AACA2CE89" name="loan" typeRef="tns:tLoan"/>
+    <dmn:variable id="_0014BF56-748F-4A8B-818A-17A1DBBAE8AC" name="loan" typeRef="tLoan"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_F791E8D9-FF36-4C47-B915-AC15E62C5C5B" name="DRG">
+    <dmndi:DMNDiagram id="_EF00C7A2-1BD8-43DD-BA27-57022C0F1EAE" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_5C6BE3E2-EC4A-4FE2-9137-3B8201C4BA56"/>
+          <kie:ComponentWidths dmnElementRef="_5DA034E1-BBFC-4643-B3A2-120FE2FF200A"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_ebf02591-49c6-448d-9f76-6358b0e011c3" dmnElementRef="tns:_ebf02591-49c6-448d-9f76-6358b0e011c3" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_ebf02591-49c6-448d-9f76-6358b0e011c3" dmnElementRef="_ebf02591-49c6-448d-9f76-6358b0e011c3" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -42,7 +50,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a" dmnElementRef="tns:_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a" dmnElementRef="_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -51,7 +59,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a" dmnElementRef="tns:_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a">
+      <dmndi:DMNEdge id="dmnedge-drg-_20E384BE-C605-46FC-9A3E-5846770B92BE" dmnElementRef="_20E384BE-C605-46FC-9A3E-5846770B92BE">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-listGen.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-listGen.dmn
@@ -1,66 +1,73 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_95e3405c-eac4-4398-9de1-ca40c213f4ae" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_95e3405c-eac4-4398-9de1-ca40c213f4ae" name="listGen" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_95e3405c-eac4-4398-9de1-ca40c213f4ae">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_95e3405c-eac4-4398-9de1-ca40c213f4ae"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_95e3405c-eac4-4398-9de1-ca40c213f4ae" name="listGen" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_95e3405c-eac4-4398-9de1-ca40c213f4ae">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tStringList" name="tStringList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:decision id="_102c003f-ec24-47a9-bfa1-36d05f1452f6" name="listGen1">
     <dmn:extensionElements/>
-    <dmn:variable id="_E54ACDC0-1099-4E72-A9BB-E6D492CDE766" name="listGen1" typeRef="tns:tStringList"/>
-    <dmn:literalExpression id="_B5F7C3F3-E9AB-45C8-9D48-5D95CD3D13E1">
+    <dmn:variable id="_58F92A40-E70D-4BBA-AD83-DE5915C16A6F" name="listGen1" typeRef="tStringList"/>
+    <dmn:literalExpression id="_B6D45464-6D7B-4DDF-8ABF-F85BAE0193EC">
       <dmn:text>["a","b","c"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_018d53fc-1aef-4e1b-b418-c0fb7c36753b" name="a">
     <dmn:extensionElements/>
-    <dmn:variable id="_6C61A94F-0AE0-4B4F-A591-DB27198164F2" name="a" typeRef="feel:string"/>
+    <dmn:variable id="_5FE4D441-FDD4-4541-B9D0-D6110E026E95" name="a" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_7cd90c11-7224-41eb-95b0-109c0d5930c3" name="b">
     <dmn:extensionElements/>
-    <dmn:variable id="_0E3F990F-FC45-4C6F-993A-EC72FF5EE401" name="b" typeRef="feel:string"/>
+    <dmn:variable id="_1AFE801E-35AD-4A6A-8FAC-1237A94F47DD" name="b" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_2b11df48-aba7-435d-a2ea-e10da78fb70e" name="c">
     <dmn:extensionElements/>
-    <dmn:variable id="_59B12C9A-AFA4-4E09-ABAB-524345D83C59" name="c" typeRef="feel:string"/>
+    <dmn:variable id="_79DDDE13-1CF6-4950-8DEE-0E05C303FE8C" name="c" typeRef="string"/>
   </dmn:inputData>
   <dmn:decision id="_2504224f-d1c3-43cb-9216-8f9d4ffdfd72" name="listGen2">
     <dmn:extensionElements/>
-    <dmn:variable id="_AECA05F8-275C-461F-864F-4A4728C8112E" name="listGen2" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_018d53fc-1aef-4e1b-b418-c0fb7c36753b">
+    <dmn:variable id="_8BE65D87-050D-4C1D-88D5-A8C1E5B0C9EC" name="listGen2" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_90001B99-B640-4269-A5F7-D8FC7F461BCE">
       <dmn:requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_7cd90c11-7224-41eb-95b0-109c0d5930c3">
+    <dmn:informationRequirement id="_B85B5184-D999-4A7C-B2F2-42618AAE08F3">
       <dmn:requiredInput href="#_7cd90c11-7224-41eb-95b0-109c0d5930c3"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_2b11df48-aba7-435d-a2ea-e10da78fb70e">
+    <dmn:informationRequirement id="_B4D2DE48-59A0-4FF9-B4D9-DD336C9A3290">
       <dmn:requiredInput href="#_2b11df48-aba7-435d-a2ea-e10da78fb70e"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_381AAA8D-7E61-485A-9178-70E31D6F24DA">
+    <dmn:literalExpression id="_A2A1C8C8-4A77-4992-9E6E-C7A2E7233073">
       <dmn:text>[a,b,c]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_5786c8b8-bea1-4b1f-9f7b-71be3f4ffbcc" name="listGen3">
     <dmn:extensionElements/>
-    <dmn:variable id="_F70A3D1D-760B-463F-A508-6C924E167439" name="listGen3" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_7cd90c11-7224-41eb-95b0-109c0d5930c3">
+    <dmn:variable id="_750A7A3C-9107-402A-8D6F-AA9034F3E91B" name="listGen3" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_C2850877-39A0-4452-9E47-99C14CF8F62B">
       <dmn:requiredInput href="#_7cd90c11-7224-41eb-95b0-109c0d5930c3"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_2b11df48-aba7-435d-a2ea-e10da78fb70e">
+    <dmn:informationRequirement id="_35AE3DF4-C0A2-4FD3-B851-188A63E7C280">
       <dmn:requiredInput href="#_2b11df48-aba7-435d-a2ea-e10da78fb70e"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_24772703-45C2-4F4B-99F8-A3186DEB7D17">
+    <dmn:literalExpression id="_E2911EEE-EF1F-4D0C-8056-00AD58A3762B">
       <dmn:text>["a",b,c]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_ca299168-4590-4040-bb10-beb7d1a6932b" name="listGen4">
     <dmn:extensionElements/>
-    <dmn:variable id="_11EF5FCE-91A9-400F-874D-B30E92BC1AC0" name="listGen4" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_2b11df48-aba7-435d-a2ea-e10da78fb70e">
+    <dmn:variable id="_B1CE481E-300C-4BA3-890C-F2ED0ED267BA" name="listGen4" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_9A278924-5DEE-4531-BCBE-C8D4B1C6BFDE">
       <dmn:requiredInput href="#_2b11df48-aba7-435d-a2ea-e10da78fb70e"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_360FEA63-E4C5-49EF-BEF2-78D62EAD33F9" hitPolicy="COLLECT" preferredOrientation="Rule-as-Row" outputLabel="listGen4">
+    <dmn:decisionTable id="_393BECF0-B8C8-423A-8155-B73C5D05ABF2" hitPolicy="COLLECT" preferredOrientation="Rule-as-Row" outputLabel="listGen4">
       <dmn:input id="_d435103a-6330-42c5-8c2a-837980ab3c80">
-        <dmn:inputExpression id="_84DD0875-6990-4CC8-B335-D1DE06EE1CAC" typeRef="feel:string">
+        <dmn:inputExpression id="_532B02C8-2845-434D-8BC3-7FFC757CC5D5" typeRef="string">
           <dmn:text>c</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
@@ -103,29 +110,29 @@
   </dmn:decision>
   <dmn:decision id="_4a428274-6c5f-4c4c-ac86-1e81df943704" name="listGen5">
     <dmn:extensionElements/>
-    <dmn:variable id="_00CB191D-1842-4855-87F1-1D080F63141A" name="listGen5" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_018d53fc-1aef-4e1b-b418-c0fb7c36753b">
+    <dmn:variable id="_61FDAD15-2FBB-4E37-BC45-FB03DE024ED6" name="listGen5" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_8CC21103-A65A-4B29-85F9-B24156FFB465">
       <dmn:requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_7cd90c11-7224-41eb-95b0-109c0d5930c3">
+    <dmn:informationRequirement id="_50B314AE-978F-4DA6-8D1B-94BBBA8C956B">
       <dmn:requiredInput href="#_7cd90c11-7224-41eb-95b0-109c0d5930c3"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_2b11df48-aba7-435d-a2ea-e10da78fb70e">
+    <dmn:informationRequirement id="_7E7242AF-9607-402C-98D3-6E9EA45BDFBB">
       <dmn:requiredInput href="#_2b11df48-aba7-435d-a2ea-e10da78fb70e"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_7A6B68DB-B219-4388-A72D-CE148232E8D3" hitPolicy="COLLECT" preferredOrientation="Rule-as-Row" outputLabel="listGen5">
+    <dmn:decisionTable id="_A4BCD199-EDF3-4D35-A812-82CAA621D3A1" hitPolicy="COLLECT" preferredOrientation="Rule-as-Row" outputLabel="listGen5">
       <dmn:input id="_495db22e-f4ea-449a-87cd-c11a7a141c53">
-        <dmn:inputExpression id="_F54539E3-C07E-454C-B0B3-46965A32057A" typeRef="feel:string">
+        <dmn:inputExpression id="_52775F18-3634-4470-A70F-92CAA217B0FD" typeRef="string">
           <dmn:text>a</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:input id="_f9f46efa-ba77-4c41-b12e-dd77e88341ef">
-        <dmn:inputExpression id="_D1AAF000-8D4D-430B-AB07-D46F06B2A785" typeRef="feel:string">
+        <dmn:inputExpression id="_E01C6CFE-AB4B-4764-B5EC-048FCD572197" typeRef="string">
           <dmn:text>b</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:input id="_7805245a-fedd-4df9-be31-1d9d5b4ab7f5">
-        <dmn:inputExpression id="_46F83417-AA37-493C-BE28-C7DED2E39B82" typeRef="feel:string">
+        <dmn:inputExpression id="_9877BFBE-36A4-4847-BDF2-A5425BAC63A8" typeRef="string">
           <dmn:text>c</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
@@ -186,87 +193,87 @@
   </dmn:decision>
   <dmn:inputData id="_c51e77a1-30a4-4f23-9054-6c359bf80e9f" name="wx">
     <dmn:extensionElements/>
-    <dmn:variable id="_B7E4DD31-CEDB-4022-AD8E-25138296620D" name="wx" typeRef="tns:tStringList"/>
+    <dmn:variable id="_64C615F3-A965-4F1E-9994-3C24317DA6AD" name="wx" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:decision id="_50554bc6-d4e1-468b-a620-db2d35da5a0b" name="listGen6">
     <dmn:extensionElements/>
-    <dmn:variable id="_9F71CF59-66F9-496F-AB7A-5BDE38C3C787" name="listGen6" typeRef="tns:tStringList"/>
-    <dmn:literalExpression id="_9880F8DA-B3F2-46CB-A72F-00FDFF535A1C">
+    <dmn:variable id="_375EA0E0-D496-4938-8B70-1E536AB0CF0A" name="listGen6" typeRef="tStringList"/>
+    <dmn:literalExpression id="_21461172-260B-4DB2-84B1-DD5A88E4EF0A">
       <dmn:text>[["w","x"],"y","z"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_6d3062b2-55d4-4299-aeb2-a5e97e03daec" name="listGen7">
     <dmn:extensionElements/>
-    <dmn:variable id="_A293933F-F7AC-4BA0-B22A-0D973E7286B6" name="listGen7" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_c51e77a1-30a4-4f23-9054-6c359bf80e9f">
+    <dmn:variable id="_E81856CE-A0CF-4D99-BD9E-2512C5C2867E" name="listGen7" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_72B80600-F881-47D3-A768-BEEA284C2D57">
       <dmn:requiredInput href="#_c51e77a1-30a4-4f23-9054-6c359bf80e9f"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_7004165B-8E7D-49E1-B195-89A04747EF38">
+    <dmn:literalExpression id="_8E9A59A0-A935-4D2F-814B-A30318C06545">
       <dmn:text>[wx,"y","z"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_bd8b0287-1ff4-4c13-b0ef-68cff151cabd" name="listGen8">
     <dmn:extensionElements/>
-    <dmn:variable id="_E640BFA2-F94C-44B2-A96E-3793096FC8D9" name="listGen8" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_018d53fc-1aef-4e1b-b418-c0fb7c36753b">
+    <dmn:variable id="_4A97E6AF-EBA1-49B6-9F71-265E2242933F" name="listGen8" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_E8A9271A-C81B-4E4F-8E9B-674A3D10A8EB">
       <dmn:requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_7cd90c11-7224-41eb-95b0-109c0d5930c3">
+    <dmn:informationRequirement id="_12EF5810-5150-4289-803C-67E1C922ED5B">
       <dmn:requiredInput href="#_7cd90c11-7224-41eb-95b0-109c0d5930c3"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_50554bc6-d4e1-468b-a620-db2d35da5a0b">
+    <dmn:informationRequirement id="_B6E70DC8-CE1F-4790-A7A7-5EE1E69788F7">
       <dmn:requiredDecision href="#_50554bc6-d4e1-468b-a620-db2d35da5a0b"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_A4FCFD47-13B3-46EB-B03E-387F2B2196AC">
+    <dmn:literalExpression id="_3EBBE24B-1C7D-467E-BB8C-61D7B9123EA6">
       <dmn:text>[a,b,listGen6]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_64ccac33-c22b-454d-b763-5a77ffd38678" name="listGen9">
     <dmn:extensionElements/>
-    <dmn:variable id="_A17E219B-15EF-4EC8-ACC6-5D4C0B31CCA4" name="listGen9" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_018d53fc-1aef-4e1b-b418-c0fb7c36753b">
+    <dmn:variable id="_2A55A986-0A6A-47AD-A645-69C246D1A499" name="listGen9" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_34DB8E67-29F0-4A6A-8B25-C533E4313ECF">
       <dmn:requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_7cd90c11-7224-41eb-95b0-109c0d5930c3">
+    <dmn:informationRequirement id="_F0938126-C5A9-44A7-A2B2-F52B485711D1">
       <dmn:requiredInput href="#_7cd90c11-7224-41eb-95b0-109c0d5930c3"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_6d3062b2-55d4-4299-aeb2-a5e97e03daec">
+    <dmn:informationRequirement id="_8086369C-58DE-487A-BFAB-7C9E9ABED146">
       <dmn:requiredDecision href="#_6d3062b2-55d4-4299-aeb2-a5e97e03daec"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_45BC5A25-8404-4B31-AD3F-28E505B0D7C7">
+    <dmn:literalExpression id="_CE46D5D8-3CA4-4B60-BA44-2EF3953BAE50">
       <dmn:text>[a,b,listGen7]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_9d464a01-5230-4270-88b6-f8e08d03e10b" name="listGen10">
     <dmn:extensionElements/>
-    <dmn:variable id="_26739EAB-DE99-4656-9D03-7526A753ADE2" name="listGen10" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_6d3062b2-55d4-4299-aeb2-a5e97e03daec">
+    <dmn:variable id="_74016576-4DDC-4643-B7B2-AD47154026BE" name="listGen10" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_34B0C881-E125-4D93-95C5-646B38DB12EA">
       <dmn:requiredDecision href="#_6d3062b2-55d4-4299-aeb2-a5e97e03daec"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_ca299168-4590-4040-bb10-beb7d1a6932b">
+    <dmn:informationRequirement id="_0F38AE74-7574-4834-AF08-74FB580BFA8E">
       <dmn:requiredDecision href="#_ca299168-4590-4040-bb10-beb7d1a6932b"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_2A0C102B-B988-40CF-8DBC-66A4FA3B795D">
+    <dmn:literalExpression id="_A171E4B2-0E3B-4C48-89EF-BF9AF9BE7C60">
       <dmn:text>[listGen4,listGen7]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_00E1AAAB-7615-468C-9831-EEEA4EEE09DB" name="DRG">
+    <dmndi:DMNDiagram id="_494F69E1-B965-405E-99AE-85B2C8B3833F" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_B5F7C3F3-E9AB-45C8-9D48-5D95CD3D13E1"/>
-          <kie:ComponentWidths dmnElementRef="_381AAA8D-7E61-485A-9178-70E31D6F24DA"/>
-          <kie:ComponentWidths dmnElementRef="_24772703-45C2-4F4B-99F8-A3186DEB7D17"/>
-          <kie:ComponentWidths dmnElementRef="_360FEA63-E4C5-49EF-BEF2-78D62EAD33F9"/>
-          <kie:ComponentWidths dmnElementRef="_7A6B68DB-B219-4388-A72D-CE148232E8D3"/>
-          <kie:ComponentWidths dmnElementRef="_9880F8DA-B3F2-46CB-A72F-00FDFF535A1C"/>
-          <kie:ComponentWidths dmnElementRef="_7004165B-8E7D-49E1-B195-89A04747EF38"/>
-          <kie:ComponentWidths dmnElementRef="_A4FCFD47-13B3-46EB-B03E-387F2B2196AC"/>
-          <kie:ComponentWidths dmnElementRef="_45BC5A25-8404-4B31-AD3F-28E505B0D7C7"/>
-          <kie:ComponentWidths dmnElementRef="_2A0C102B-B988-40CF-8DBC-66A4FA3B795D"/>
+          <kie:ComponentWidths dmnElementRef="_B6D45464-6D7B-4DDF-8ABF-F85BAE0193EC"/>
+          <kie:ComponentWidths dmnElementRef="_A2A1C8C8-4A77-4992-9E6E-C7A2E7233073"/>
+          <kie:ComponentWidths dmnElementRef="_E2911EEE-EF1F-4D0C-8056-00AD58A3762B"/>
+          <kie:ComponentWidths dmnElementRef="_393BECF0-B8C8-423A-8155-B73C5D05ABF2"/>
+          <kie:ComponentWidths dmnElementRef="_A4BCD199-EDF3-4D35-A812-82CAA621D3A1"/>
+          <kie:ComponentWidths dmnElementRef="_21461172-260B-4DB2-84B1-DD5A88E4EF0A"/>
+          <kie:ComponentWidths dmnElementRef="_8E9A59A0-A935-4D2F-814B-A30318C06545"/>
+          <kie:ComponentWidths dmnElementRef="_3EBBE24B-1C7D-467E-BB8C-61D7B9123EA6"/>
+          <kie:ComponentWidths dmnElementRef="_CE46D5D8-3CA4-4B60-BA44-2EF3953BAE50"/>
+          <kie:ComponentWidths dmnElementRef="_A171E4B2-0E3B-4C48-89EF-BF9AF9BE7C60"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_102c003f-ec24-47a9-bfa1-36d05f1452f6" dmnElementRef="tns:_102c003f-ec24-47a9-bfa1-36d05f1452f6" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_102c003f-ec24-47a9-bfa1-36d05f1452f6" dmnElementRef="_102c003f-ec24-47a9-bfa1-36d05f1452f6" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -275,7 +282,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_018d53fc-1aef-4e1b-b418-c0fb7c36753b" dmnElementRef="tns:_018d53fc-1aef-4e1b-b418-c0fb7c36753b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_018d53fc-1aef-4e1b-b418-c0fb7c36753b" dmnElementRef="_018d53fc-1aef-4e1b-b418-c0fb7c36753b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -284,7 +291,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7cd90c11-7224-41eb-95b0-109c0d5930c3" dmnElementRef="tns:_7cd90c11-7224-41eb-95b0-109c0d5930c3" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7cd90c11-7224-41eb-95b0-109c0d5930c3" dmnElementRef="_7cd90c11-7224-41eb-95b0-109c0d5930c3" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -293,7 +300,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2b11df48-aba7-435d-a2ea-e10da78fb70e" dmnElementRef="tns:_2b11df48-aba7-435d-a2ea-e10da78fb70e" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_2b11df48-aba7-435d-a2ea-e10da78fb70e" dmnElementRef="_2b11df48-aba7-435d-a2ea-e10da78fb70e" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -302,7 +309,7 @@
         <dc:Bounds x="488" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2504224f-d1c3-43cb-9216-8f9d4ffdfd72" dmnElementRef="tns:_2504224f-d1c3-43cb-9216-8f9d4ffdfd72" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_2504224f-d1c3-43cb-9216-8f9d4ffdfd72" dmnElementRef="_2504224f-d1c3-43cb-9216-8f9d4ffdfd72" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -311,7 +318,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_5786c8b8-bea1-4b1f-9f7b-71be3f4ffbcc" dmnElementRef="tns:_5786c8b8-bea1-4b1f-9f7b-71be3f4ffbcc" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_5786c8b8-bea1-4b1f-9f7b-71be3f4ffbcc" dmnElementRef="_5786c8b8-bea1-4b1f-9f7b-71be3f4ffbcc" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -320,7 +327,7 @@
         <dc:Bounds x="925" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ca299168-4590-4040-bb10-beb7d1a6932b" dmnElementRef="tns:_ca299168-4590-4040-bb10-beb7d1a6932b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_ca299168-4590-4040-bb10-beb7d1a6932b" dmnElementRef="_ca299168-4590-4040-bb10-beb7d1a6932b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -329,7 +336,7 @@
         <dc:Bounds x="575" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4a428274-6c5f-4c4c-ac86-1e81df943704" dmnElementRef="tns:_4a428274-6c5f-4c4c-ac86-1e81df943704" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4a428274-6c5f-4c4c-ac86-1e81df943704" dmnElementRef="_4a428274-6c5f-4c4c-ac86-1e81df943704" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -338,7 +345,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c51e77a1-30a4-4f23-9054-6c359bf80e9f" dmnElementRef="tns:_c51e77a1-30a4-4f23-9054-6c359bf80e9f" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c51e77a1-30a4-4f23-9054-6c359bf80e9f" dmnElementRef="_c51e77a1-30a4-4f23-9054-6c359bf80e9f" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -347,7 +354,7 @@
         <dc:Bounds x="663" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_50554bc6-d4e1-468b-a620-db2d35da5a0b" dmnElementRef="tns:_50554bc6-d4e1-468b-a620-db2d35da5a0b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_50554bc6-d4e1-468b-a620-db2d35da5a0b" dmnElementRef="_50554bc6-d4e1-468b-a620-db2d35da5a0b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -356,7 +363,7 @@
         <dc:Bounds x="925" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_6d3062b2-55d4-4299-aeb2-a5e97e03daec" dmnElementRef="tns:_6d3062b2-55d4-4299-aeb2-a5e97e03daec" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_6d3062b2-55d4-4299-aeb2-a5e97e03daec" dmnElementRef="_6d3062b2-55d4-4299-aeb2-a5e97e03daec" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -365,7 +372,7 @@
         <dc:Bounds x="750" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bd8b0287-1ff4-4c13-b0ef-68cff151cabd" dmnElementRef="tns:_bd8b0287-1ff4-4c13-b0ef-68cff151cabd" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_bd8b0287-1ff4-4c13-b0ef-68cff151cabd" dmnElementRef="_bd8b0287-1ff4-4c13-b0ef-68cff151cabd" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -374,7 +381,7 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_64ccac33-c22b-454d-b763-5a77ffd38678" dmnElementRef="tns:_64ccac33-c22b-454d-b763-5a77ffd38678" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_64ccac33-c22b-454d-b763-5a77ffd38678" dmnElementRef="_64ccac33-c22b-454d-b763-5a77ffd38678" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -383,7 +390,7 @@
         <dc:Bounds x="750" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_9d464a01-5230-4270-88b6-f8e08d03e10b" dmnElementRef="tns:_9d464a01-5230-4270-88b6-f8e08d03e10b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_9d464a01-5230-4270-88b6-f8e08d03e10b" dmnElementRef="_9d464a01-5230-4270-88b6-f8e08d03e10b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -392,31 +399,75 @@
         <dc:Bounds x="1100" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_018d53fc-1aef-4e1b-b418-c0fb7c36753b" dmnElementRef="tns:_018d53fc-1aef-4e1b-b418-c0fb7c36753b">
+      <dmndi:DMNEdge id="dmnedge-drg-_90001B99-B640-4269-A5F7-D8FC7F461BCE" dmnElementRef="_90001B99-B640-4269-A5F7-D8FC7F461BCE">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7cd90c11-7224-41eb-95b0-109c0d5930c3" dmnElementRef="tns:_7cd90c11-7224-41eb-95b0-109c0d5930c3">
+      <dmndi:DMNEdge id="dmnedge-drg-_B85B5184-D999-4A7C-B2F2-42618AAE08F3" dmnElementRef="_B85B5184-D999-4A7C-B2F2-42618AAE08F3">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2b11df48-aba7-435d-a2ea-e10da78fb70e" dmnElementRef="tns:_2b11df48-aba7-435d-a2ea-e10da78fb70e">
+      <dmndi:DMNEdge id="dmnedge-drg-_B4D2DE48-59A0-4FF9-B4D9-DD336C9A3290" dmnElementRef="_B4D2DE48-59A0-4FF9-B4D9-DD336C9A3290">
         <di:waypoint x="488" y="400"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c51e77a1-30a4-4f23-9054-6c359bf80e9f" dmnElementRef="tns:_c51e77a1-30a4-4f23-9054-6c359bf80e9f">
+      <dmndi:DMNEdge id="dmnedge-drg-_C2850877-39A0-4452-9E47-99C14CF8F62B" dmnElementRef="_C2850877-39A0-4452-9E47-99C14CF8F62B">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="925" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_35AE3DF4-C0A2-4FD3-B851-188A63E7C280" dmnElementRef="_35AE3DF4-C0A2-4FD3-B851-188A63E7C280">
+        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="925" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_9A278924-5DEE-4531-BCBE-C8D4B1C6BFDE" dmnElementRef="_9A278924-5DEE-4531-BCBE-C8D4B1C6BFDE">
+        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="575" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8CC21103-A65A-4B29-85F9-B24156FFB465" dmnElementRef="_8CC21103-A65A-4B29-85F9-B24156FFB465">
+        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_50B314AE-978F-4DA6-8D1B-94BBBA8C956B" dmnElementRef="_50B314AE-978F-4DA6-8D1B-94BBBA8C956B">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_7E7242AF-9607-402C-98D3-6E9EA45BDFBB" dmnElementRef="_7E7242AF-9607-402C-98D3-6E9EA45BDFBB">
+        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_72B80600-F881-47D3-A768-BEEA284C2D57" dmnElementRef="_72B80600-F881-47D3-A768-BEEA284C2D57">
         <di:waypoint x="663" y="400"/>
         <di:waypoint x="750" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_50554bc6-d4e1-468b-a620-db2d35da5a0b" dmnElementRef="tns:_50554bc6-d4e1-468b-a620-db2d35da5a0b">
+      <dmndi:DMNEdge id="dmnedge-drg-_E8A9271A-C81B-4E4F-8E9B-674A3D10A8EB" dmnElementRef="_E8A9271A-C81B-4E4F-8E9B-674A3D10A8EB">
+        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_12EF5810-5150-4289-803C-67E1C922ED5B" dmnElementRef="_12EF5810-5150-4289-803C-67E1C922ED5B">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_B6E70DC8-CE1F-4790-A7A7-5EE1E69788F7" dmnElementRef="_B6E70DC8-CE1F-4790-A7A7-5EE1E69788F7">
         <di:waypoint x="925" y="225"/>
         <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_6d3062b2-55d4-4299-aeb2-a5e97e03daec" dmnElementRef="tns:_6d3062b2-55d4-4299-aeb2-a5e97e03daec">
+      <dmndi:DMNEdge id="dmnedge-drg-_34DB8E67-29F0-4A6A-8B25-C533E4313ECF" dmnElementRef="_34DB8E67-29F0-4A6A-8B25-C533E4313ECF">
+        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F0938126-C5A9-44A7-A2B2-F52B485711D1" dmnElementRef="_F0938126-C5A9-44A7-A2B2-F52B485711D1">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8086369C-58DE-487A-BFAB-7C9E9ABED146" dmnElementRef="_8086369C-58DE-487A-BFAB-7C9E9ABED146">
         <di:waypoint x="750" y="225"/>
         <di:waypoint x="750" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_ca299168-4590-4040-bb10-beb7d1a6932b" dmnElementRef="tns:_ca299168-4590-4040-bb10-beb7d1a6932b">
+      <dmndi:DMNEdge id="dmnedge-drg-_34B0C881-E125-4D93-95C5-646B38DB12EA" dmnElementRef="_34B0C881-E125-4D93-95C5-646B38DB12EA">
+        <di:waypoint x="750" y="225"/>
+        <di:waypoint x="1100" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_0F38AE74-7574-4834-AF08-74FB580BFA8E" dmnElementRef="_0F38AE74-7574-4834-AF08-74FB580BFA8E">
         <di:waypoint x="575" y="225"/>
         <di:waypoint x="1100" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-append-flatten.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-append-flatten.dmn
@@ -1,143 +1,150 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_9d6beae5-6a61-44a7-bbcf-09bcce989739" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_9d6beae5-6a61-44a7-bbcf-09bcce989739" name="flatten" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_9d6beae5-6a61-44a7-bbcf-09bcce989739">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_9d6beae5-6a61-44a7-bbcf-09bcce989739"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_9d6beae5-6a61-44a7-bbcf-09bcce989739" name="flatten" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_9d6beae5-6a61-44a7-bbcf-09bcce989739">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tStringList" name="tStringList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tNestedList" name="tNestedList" isCollection="true">
-    <dmn:typeRef>tns:tStringList</dmn:typeRef>
+    <dmn:typeRef>tStringList</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="_1296434e-6902-40fc-9a93-07c35dda7ec8" name="simpleList">
     <dmn:extensionElements/>
-    <dmn:variable id="_F3AC5870-C41B-4CE9-95F5-5888A0583AEC" name="simpleList" typeRef="tns:tStringList"/>
+    <dmn:variable id="_BFF38A04-4155-4DFF-93C1-D08B8FF31A8B" name="simpleList" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:inputData id="_4e72e88f-2239-43b8-9944-4893daf84127" name="nestedList">
     <dmn:extensionElements/>
-    <dmn:variable id="_E6949CE2-91BB-4AD4-984A-F8A0AFB1CA4B" name="nestedList" typeRef="tns:tNestedList"/>
+    <dmn:variable id="_4CA25664-26E0-4001-AFE2-0FEF34E9042B" name="nestedList" typeRef="tNestedList"/>
   </dmn:inputData>
   <dmn:decision id="_1bd696ab-0181-49e0-bb15-d090219c4943" name="literalSimpleList">
     <dmn:extensionElements/>
-    <dmn:variable id="_0CC7626B-B969-43BA-87E7-8B1CCCEB81E5" name="literalSimpleList" typeRef="tns:tStringList"/>
-    <dmn:literalExpression id="_EEBBBA6C-EFD0-42E3-80C3-99872C7809B4">
+    <dmn:variable id="_C554968B-57C3-4F60-86C1-A796101D8276" name="literalSimpleList" typeRef="tStringList"/>
+    <dmn:literalExpression id="_66F8D70A-97A2-47F5-9A5D-ABA9BFB38173">
       <dmn:text>["a","b","c"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_d6152254-7ad2-4aeb-90a0-16b962a11257" name="literalNestedList">
     <dmn:extensionElements/>
-    <dmn:variable id="_DD3CD27B-6E56-4A9A-A292-3DF0AAF9DCBF" name="literalNestedList" typeRef="tns:tNestedList"/>
-    <dmn:literalExpression id="_B26D2BA1-BA41-4769-AAC3-907E08E1265D">
+    <dmn:variable id="_5206001E-120B-4D01-BE9F-B19E5CC0A455" name="literalNestedList" typeRef="tNestedList"/>
+    <dmn:literalExpression id="_4D233219-DCA2-4FA5-BB59-7466B9266F93">
       <dmn:text>[["w","x"],"y","z"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_f6e97b3b-d13c-47b5-b679-36cf46d4f904" name="append1">
     <dmn:extensionElements/>
-    <dmn:variable id="_BAD77E51-D8AB-46A5-910D-598CFCF71FEA" name="append1" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1bd696ab-0181-49e0-bb15-d090219c4943">
+    <dmn:variable id="_3D583AFB-C2B4-4430-82C6-E89C761F6EE6" name="append1" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_DC8BB6F1-15E9-477F-949D-85789FEDE037">
       <dmn:requiredDecision href="#_1bd696ab-0181-49e0-bb15-d090219c4943"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1296434e-6902-40fc-9a93-07c35dda7ec8">
+    <dmn:informationRequirement id="_1650A2A7-AAB0-4AC0-9AAA-C52F1AA529EE">
       <dmn:requiredInput href="#_1296434e-6902-40fc-9a93-07c35dda7ec8"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_647932FD-B46D-4C43-84EB-4AEB37130EDC">
+    <dmn:literalExpression id="_8B273125-A1F5-4B9D-A19F-15B8CAA6D2A6">
       <dmn:text>append(simpleList,literalSimpleList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_bf18b7c7-5f20-48a2-bd27-527c82cf0855" name="append2">
     <dmn:extensionElements/>
-    <dmn:variable id="_354EAAAF-447B-4BE6-AA53-D88266641D8E" name="append2" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1296434e-6902-40fc-9a93-07c35dda7ec8">
+    <dmn:variable id="_D55BF934-AB8D-4E13-8CEA-37857F684F1F" name="append2" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_249291EE-1BA4-4BBB-94EA-459423745C1F">
       <dmn:requiredInput href="#_1296434e-6902-40fc-9a93-07c35dda7ec8"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4e72e88f-2239-43b8-9944-4893daf84127">
+    <dmn:informationRequirement id="_6177772C-8AD9-4A51-AEB6-55CF1856B23D">
       <dmn:requiredInput href="#_4e72e88f-2239-43b8-9944-4893daf84127"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_24591980-9559-40A2-A5B3-DF54C08017E7">
+    <dmn:literalExpression id="_8A3C839D-D7E6-427D-9D35-111BA0D568E8">
       <dmn:text>append(simpleList,nestedList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_877fd216-703c-4b2f-8197-9f3ed144ff4d" name="append3">
     <dmn:extensionElements/>
-    <dmn:variable id="_1ABBC07B-FEBF-4ED7-9334-6C48A19247BA" name="append3" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1bd696ab-0181-49e0-bb15-d090219c4943">
+    <dmn:variable id="_B0036E8B-C29E-4AC3-BA1D-715ABF54D3BF" name="append3" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_E7E53982-BAF4-4BB5-B39E-FF7C19DBD82F">
       <dmn:requiredDecision href="#_1bd696ab-0181-49e0-bb15-d090219c4943"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4e72e88f-2239-43b8-9944-4893daf84127">
+    <dmn:informationRequirement id="_5E7432DD-5A54-43D3-812F-6F2E489207DE">
       <dmn:requiredInput href="#_4e72e88f-2239-43b8-9944-4893daf84127"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E04D392F-CF6E-4304-BA19-C8D889760C64">
+    <dmn:literalExpression id="_B2AC8BC8-260A-4F15-8F44-417FD0BF034A">
       <dmn:text>append(literalSimpleList,nestedList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_cf4db6c6-da6b-42fe-8f85-110f8d711111" name="append4">
     <dmn:extensionElements/>
-    <dmn:variable id="_E9F5D690-208F-437E-AD93-984E1E4E1685" name="append4" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1bd696ab-0181-49e0-bb15-d090219c4943">
+    <dmn:variable id="_4C612D55-EDDC-4D2B-BD0A-8BD371F7C961" name="append4" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_C9C38B25-13E6-42D9-9535-9161D3EE2512">
       <dmn:requiredDecision href="#_1bd696ab-0181-49e0-bb15-d090219c4943"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_d6152254-7ad2-4aeb-90a0-16b962a11257">
+    <dmn:informationRequirement id="_13720F79-7269-4427-B680-EA6686042CDA">
       <dmn:requiredDecision href="#_d6152254-7ad2-4aeb-90a0-16b962a11257"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_395A542C-45DB-49BE-92F4-CD5E331FE30F">
+    <dmn:literalExpression id="_03CE2D3B-89D6-4076-914B-9043CD30CA87">
       <dmn:text>append(literalSimpleList,literalNestedList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_84459bf0-7e3a-4897-8f0d-5abb51b1d564" name="flatten1">
     <dmn:extensionElements/>
-    <dmn:variable id="_9AAB1CAA-9401-46B1-B2AF-D278F106F915" name="flatten1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_f6e97b3b-d13c-47b5-b679-36cf46d4f904">
+    <dmn:variable id="_BCC2CE5E-8BD4-495D-A338-E95E31A27A8F" name="flatten1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_A2407C26-3494-4482-9A03-205705246BF0">
       <dmn:requiredDecision href="#_f6e97b3b-d13c-47b5-b679-36cf46d4f904"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_65FE14A2-E492-4FAE-9C21-1D6101D0AC32">
+    <dmn:literalExpression id="_FB77E03E-6CB6-407A-9376-5394596E34CA">
       <dmn:text>flatten(append1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_18ea4eb1-e7dd-45fa-a7b1-c2288bb48054" name="flatten2">
     <dmn:extensionElements/>
-    <dmn:variable id="_29E8F76D-499E-4A38-AA93-BA861D253425" name="flatten2" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_bf18b7c7-5f20-48a2-bd27-527c82cf0855">
+    <dmn:variable id="_04660C04-6338-426E-9842-8807EF538F02" name="flatten2" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_50E496E4-933F-45DA-B024-9ED020D1352B">
       <dmn:requiredDecision href="#_bf18b7c7-5f20-48a2-bd27-527c82cf0855"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_B39D8436-5F22-46A9-951D-59867FBD4ED9">
+    <dmn:literalExpression id="_CCC06B26-4A29-4E9B-BCDD-4285391E0B98">
       <dmn:text>flatten(append2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_c225c17f-276b-47c1-be56-f1153752eb70" name="flatten3">
     <dmn:extensionElements/>
-    <dmn:variable id="_BD015BB8-5353-4CBB-9B9D-D78CBA73513B" name="flatten3" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_877fd216-703c-4b2f-8197-9f3ed144ff4d">
+    <dmn:variable id="_8EA32EED-44D7-4EAD-AF7C-4A217F6DD38C" name="flatten3" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_5C5DCDA0-0DDD-4A9F-A7C7-76146A276559">
       <dmn:requiredDecision href="#_877fd216-703c-4b2f-8197-9f3ed144ff4d"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_0F843334-B18E-448A-8C9A-F6FE4B702ED0">
+    <dmn:literalExpression id="_48613705-94A6-48BE-8781-CEB5321EBE1A">
       <dmn:text>flatten(append3)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_f513bcdc-7e96-4680-8893-d04ee04c61a8" name="flatten4">
     <dmn:extensionElements/>
-    <dmn:variable id="_AEE3A7D1-1041-4EE6-B389-CB7314831A56" name="flatten4" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_cf4db6c6-da6b-42fe-8f85-110f8d711111">
+    <dmn:variable id="_CEBC1AC8-AF5D-4405-8C86-748C37696EA8" name="flatten4" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_05F0CD22-DF7B-4684-941F-04392FEDBBCC">
       <dmn:requiredDecision href="#_cf4db6c6-da6b-42fe-8f85-110f8d711111"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_C273731B-6D1F-491A-A694-41E53E9679DB">
+    <dmn:literalExpression id="_47A115B1-D60E-4949-BE9A-A736FC100A01">
       <dmn:text>flatten(append4)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_216BFB29-A951-47E1-94DC-9F4191913A98" name="DRG">
+    <dmndi:DMNDiagram id="_36DD120D-F561-45D6-B6DF-CCBE6B297993" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_EEBBBA6C-EFD0-42E3-80C3-99872C7809B4"/>
-          <kie:ComponentWidths dmnElementRef="_B26D2BA1-BA41-4769-AAC3-907E08E1265D"/>
-          <kie:ComponentWidths dmnElementRef="_647932FD-B46D-4C43-84EB-4AEB37130EDC"/>
-          <kie:ComponentWidths dmnElementRef="_24591980-9559-40A2-A5B3-DF54C08017E7"/>
-          <kie:ComponentWidths dmnElementRef="_E04D392F-CF6E-4304-BA19-C8D889760C64"/>
-          <kie:ComponentWidths dmnElementRef="_395A542C-45DB-49BE-92F4-CD5E331FE30F"/>
-          <kie:ComponentWidths dmnElementRef="_65FE14A2-E492-4FAE-9C21-1D6101D0AC32"/>
-          <kie:ComponentWidths dmnElementRef="_B39D8436-5F22-46A9-951D-59867FBD4ED9"/>
-          <kie:ComponentWidths dmnElementRef="_0F843334-B18E-448A-8C9A-F6FE4B702ED0"/>
-          <kie:ComponentWidths dmnElementRef="_C273731B-6D1F-491A-A694-41E53E9679DB"/>
+          <kie:ComponentWidths dmnElementRef="_66F8D70A-97A2-47F5-9A5D-ABA9BFB38173"/>
+          <kie:ComponentWidths dmnElementRef="_4D233219-DCA2-4FA5-BB59-7466B9266F93"/>
+          <kie:ComponentWidths dmnElementRef="_8B273125-A1F5-4B9D-A19F-15B8CAA6D2A6"/>
+          <kie:ComponentWidths dmnElementRef="_8A3C839D-D7E6-427D-9D35-111BA0D568E8"/>
+          <kie:ComponentWidths dmnElementRef="_B2AC8BC8-260A-4F15-8F44-417FD0BF034A"/>
+          <kie:ComponentWidths dmnElementRef="_03CE2D3B-89D6-4076-914B-9043CD30CA87"/>
+          <kie:ComponentWidths dmnElementRef="_FB77E03E-6CB6-407A-9376-5394596E34CA"/>
+          <kie:ComponentWidths dmnElementRef="_CCC06B26-4A29-4E9B-BCDD-4285391E0B98"/>
+          <kie:ComponentWidths dmnElementRef="_48613705-94A6-48BE-8781-CEB5321EBE1A"/>
+          <kie:ComponentWidths dmnElementRef="_47A115B1-D60E-4949-BE9A-A736FC100A01"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_1296434e-6902-40fc-9a93-07c35dda7ec8" dmnElementRef="tns:_1296434e-6902-40fc-9a93-07c35dda7ec8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1296434e-6902-40fc-9a93-07c35dda7ec8" dmnElementRef="_1296434e-6902-40fc-9a93-07c35dda7ec8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -146,7 +153,7 @@
         <dc:Bounds x="50" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4e72e88f-2239-43b8-9944-4893daf84127" dmnElementRef="tns:_4e72e88f-2239-43b8-9944-4893daf84127" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4e72e88f-2239-43b8-9944-4893daf84127" dmnElementRef="_4e72e88f-2239-43b8-9944-4893daf84127" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -155,7 +162,7 @@
         <dc:Bounds x="225" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_1bd696ab-0181-49e0-bb15-d090219c4943" dmnElementRef="tns:_1bd696ab-0181-49e0-bb15-d090219c4943" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1bd696ab-0181-49e0-bb15-d090219c4943" dmnElementRef="_1bd696ab-0181-49e0-bb15-d090219c4943" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -164,7 +171,7 @@
         <dc:Bounds x="400" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d6152254-7ad2-4aeb-90a0-16b962a11257" dmnElementRef="tns:_d6152254-7ad2-4aeb-90a0-16b962a11257" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d6152254-7ad2-4aeb-90a0-16b962a11257" dmnElementRef="_d6152254-7ad2-4aeb-90a0-16b962a11257" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -173,7 +180,7 @@
         <dc:Bounds x="575" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_f6e97b3b-d13c-47b5-b679-36cf46d4f904" dmnElementRef="tns:_f6e97b3b-d13c-47b5-b679-36cf46d4f904" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_f6e97b3b-d13c-47b5-b679-36cf46d4f904" dmnElementRef="_f6e97b3b-d13c-47b5-b679-36cf46d4f904" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -182,7 +189,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bf18b7c7-5f20-48a2-bd27-527c82cf0855" dmnElementRef="tns:_bf18b7c7-5f20-48a2-bd27-527c82cf0855" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_bf18b7c7-5f20-48a2-bd27-527c82cf0855" dmnElementRef="_bf18b7c7-5f20-48a2-bd27-527c82cf0855" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -191,7 +198,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_877fd216-703c-4b2f-8197-9f3ed144ff4d" dmnElementRef="tns:_877fd216-703c-4b2f-8197-9f3ed144ff4d" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_877fd216-703c-4b2f-8197-9f3ed144ff4d" dmnElementRef="_877fd216-703c-4b2f-8197-9f3ed144ff4d" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -200,7 +207,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_cf4db6c6-da6b-42fe-8f85-110f8d711111" dmnElementRef="tns:_cf4db6c6-da6b-42fe-8f85-110f8d711111" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_cf4db6c6-da6b-42fe-8f85-110f8d711111" dmnElementRef="_cf4db6c6-da6b-42fe-8f85-110f8d711111" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -209,7 +216,7 @@
         <dc:Bounds x="575" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_84459bf0-7e3a-4897-8f0d-5abb51b1d564" dmnElementRef="tns:_84459bf0-7e3a-4897-8f0d-5abb51b1d564" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_84459bf0-7e3a-4897-8f0d-5abb51b1d564" dmnElementRef="_84459bf0-7e3a-4897-8f0d-5abb51b1d564" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -218,7 +225,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_18ea4eb1-e7dd-45fa-a7b1-c2288bb48054" dmnElementRef="tns:_18ea4eb1-e7dd-45fa-a7b1-c2288bb48054" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_18ea4eb1-e7dd-45fa-a7b1-c2288bb48054" dmnElementRef="_18ea4eb1-e7dd-45fa-a7b1-c2288bb48054" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -227,7 +234,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c225c17f-276b-47c1-be56-f1153752eb70" dmnElementRef="tns:_c225c17f-276b-47c1-be56-f1153752eb70" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c225c17f-276b-47c1-be56-f1153752eb70" dmnElementRef="_c225c17f-276b-47c1-be56-f1153752eb70" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -236,7 +243,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_f513bcdc-7e96-4680-8893-d04ee04c61a8" dmnElementRef="tns:_f513bcdc-7e96-4680-8893-d04ee04c61a8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_f513bcdc-7e96-4680-8893-d04ee04c61a8" dmnElementRef="_f513bcdc-7e96-4680-8893-d04ee04c61a8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -245,35 +252,51 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_1bd696ab-0181-49e0-bb15-d090219c4943" dmnElementRef="tns:_1bd696ab-0181-49e0-bb15-d090219c4943">
+      <dmndi:DMNEdge id="dmnedge-drg-_DC8BB6F1-15E9-477F-949D-85789FEDE037" dmnElementRef="_DC8BB6F1-15E9-477F-949D-85789FEDE037">
         <di:waypoint x="400" y="400"/>
         <di:waypoint x="50" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1296434e-6902-40fc-9a93-07c35dda7ec8" dmnElementRef="tns:_1296434e-6902-40fc-9a93-07c35dda7ec8">
+      <dmndi:DMNEdge id="dmnedge-drg-_1650A2A7-AAB0-4AC0-9AAA-C52F1AA529EE" dmnElementRef="_1650A2A7-AAB0-4AC0-9AAA-C52F1AA529EE">
         <di:waypoint x="50" y="400"/>
         <di:waypoint x="50" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_4e72e88f-2239-43b8-9944-4893daf84127" dmnElementRef="tns:_4e72e88f-2239-43b8-9944-4893daf84127">
+      <dmndi:DMNEdge id="dmnedge-drg-_249291EE-1BA4-4BBB-94EA-459423745C1F" dmnElementRef="_249291EE-1BA4-4BBB-94EA-459423745C1F">
+        <di:waypoint x="50" y="400"/>
+        <di:waypoint x="225" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_6177772C-8AD9-4A51-AEB6-55CF1856B23D" dmnElementRef="_6177772C-8AD9-4A51-AEB6-55CF1856B23D">
         <di:waypoint x="225" y="400"/>
         <di:waypoint x="225" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_d6152254-7ad2-4aeb-90a0-16b962a11257" dmnElementRef="tns:_d6152254-7ad2-4aeb-90a0-16b962a11257">
+      <dmndi:DMNEdge id="dmnedge-drg-_E7E53982-BAF4-4BB5-B39E-FF7C19DBD82F" dmnElementRef="_E7E53982-BAF4-4BB5-B39E-FF7C19DBD82F">
+        <di:waypoint x="400" y="400"/>
+        <di:waypoint x="400" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_5E7432DD-5A54-43D3-812F-6F2E489207DE" dmnElementRef="_5E7432DD-5A54-43D3-812F-6F2E489207DE">
+        <di:waypoint x="225" y="400"/>
+        <di:waypoint x="400" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C9C38B25-13E6-42D9-9535-9161D3EE2512" dmnElementRef="_C9C38B25-13E6-42D9-9535-9161D3EE2512">
+        <di:waypoint x="400" y="400"/>
+        <di:waypoint x="575" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_13720F79-7269-4427-B680-EA6686042CDA" dmnElementRef="_13720F79-7269-4427-B680-EA6686042CDA">
         <di:waypoint x="575" y="400"/>
         <di:waypoint x="575" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_f6e97b3b-d13c-47b5-b679-36cf46d4f904" dmnElementRef="tns:_f6e97b3b-d13c-47b5-b679-36cf46d4f904">
+      <dmndi:DMNEdge id="dmnedge-drg-_A2407C26-3494-4482-9A03-205705246BF0" dmnElementRef="_A2407C26-3494-4482-9A03-205705246BF0">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_bf18b7c7-5f20-48a2-bd27-527c82cf0855" dmnElementRef="tns:_bf18b7c7-5f20-48a2-bd27-527c82cf0855">
+      <dmndi:DMNEdge id="dmnedge-drg-_50E496E4-933F-45DA-B024-9ED020D1352B" dmnElementRef="_50E496E4-933F-45DA-B024-9ED020D1352B">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_877fd216-703c-4b2f-8197-9f3ed144ff4d" dmnElementRef="tns:_877fd216-703c-4b2f-8197-9f3ed144ff4d">
+      <dmndi:DMNEdge id="dmnedge-drg-_5C5DCDA0-0DDD-4A9F-A7C7-76146A276559" dmnElementRef="_5C5DCDA0-0DDD-4A9F-A7C7-76146A276559">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_cf4db6c6-da6b-42fe-8f85-110f8d711111" dmnElementRef="tns:_cf4db6c6-da6b-42fe-8f85-110f8d711111">
+      <dmndi:DMNEdge id="dmnedge-drg-_05F0CD22-DF7B-4684-941F-04392FEDBBCC" dmnElementRef="_05F0CD22-DF7B-4684-941F-04392FEDBBCC">
         <di:waypoint x="575" y="225"/>
         <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-invocation-arithmetic.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-invocation-arithmetic.dmn
@@ -1,63 +1,70 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11" name="literal invocation1" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11" name="literal invocation1" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_cb28c255-91cd-4c01-ac7b-1a9cb1ecdb11">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="_f909c1d5-36e4-4f71-8392-fe3b14ddb6f7" name="tLoan" isCollection="false">
     <dmn:itemComponent id="_579041dc-2bad-42b4-9650-b2cf39175ecc" name="amount" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_353c0e6f-b344-451e-944e-bec76817b29a" name="rate" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_c7b4a252-df93-4407-8bef-9d30d94125b6" name="term" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decision id="d_MonthlyPayment" name="MonthlyPayment">
     <dmn:extensionElements/>
-    <dmn:variable id="_B3BDAF71-BAD5-437B-B581-0125F9507CC2" name="MonthlyPayment" typeRef="feel:number"/>
-    <dmn:informationRequirement id="i_Loan">
+    <dmn:variable id="_4FFFEFB9-953A-4631-9531-3187B50E291C" name="MonthlyPayment" typeRef="number"/>
+    <dmn:informationRequirement id="_1586A9BA-0E4F-44FA-8D90-5A83736E9C42">
       <dmn:requiredInput href="#i_Loan"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_fee">
+    <dmn:informationRequirement id="_43F559D8-AD98-4081-9637-096BA73C4D9B">
       <dmn:requiredInput href="#i_fee"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_PMT">
+    <dmn:knowledgeRequirement id="_64BA75A4-AFEC-4589-B421-80A4A782C152">
       <dmn:requiredKnowledge href="#b_PMT"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_A8F27F57-3F2B-4264-B91B-458C8C2F7614">
+    <dmn:literalExpression id="_109E6DD8-5ACB-40BC-9F83-372AE01E0E7E">
       <dmn:text>PMT(Loan.amount, Loan.rate, Loan.term)+fee</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="b_PMT" name="PMT">
     <dmn:extensionElements/>
-    <dmn:variable id="_7B96D811-4DD9-4968-9F2A-59803AB5C4E5" name="PMT" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_562B1D42-7AC4-4244-BDBC-5835AC71F1F5" kind="FEEL">
-      <dmn:formalParameter id="_E6FC0C55-21F8-4958-99E0-036CB692BB81" name="p" typeRef="feel:number"/>
-      <dmn:formalParameter id="_038D1871-1672-4354-923C-1E2726596F76" name="r" typeRef="feel:number"/>
-      <dmn:formalParameter id="_BE13F8DB-34F8-470A-838C-79D24C2CD0D4" name="n" typeRef="feel:number"/>
-      <dmn:literalExpression id="_07E60D98-4790-4FBA-91BD-2663E7FB0B37" expressionLanguage="http://www.omg.org/spec/FEEL/20140401">
+    <dmn:variable id="_12FDC74C-BAC6-4F4F-B293-60AFBC9B9D00" name="PMT" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_A7A74352-67DA-4D88-A06D-3428D451FE74" kind="FEEL">
+      <dmn:formalParameter id="_264CC6F3-8A51-4826-9994-3697B5C18AB9" name="p" typeRef="number"/>
+      <dmn:formalParameter id="_4D629EF2-CDFA-4AE7-8730-A75CFD8E5260" name="r" typeRef="number"/>
+      <dmn:formalParameter id="_F62F1496-C6CF-4CAA-9E17-1D24B25CE424" name="n" typeRef="number"/>
+      <dmn:literalExpression id="_30DC38E7-5758-42D2-933D-692EC8A55527" expressionLanguage="http://www.omg.org/spec/FEEL/20140401">
         <dmn:text>(p*r/12)/(1-(1+r/12)**-n)</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:inputData id="i_Loan" name="Loan">
     <dmn:extensionElements/>
-    <dmn:variable id="_1F0AF0E0-F6EA-4F1B-9D8D-BEF02F1DFB0E" name="Loan" typeRef="tns:tLoan"/>
+    <dmn:variable id="_185D72BF-A731-4E21-A96C-1A388A4727F4" name="Loan" typeRef="tLoan"/>
   </dmn:inputData>
   <dmn:inputData id="i_fee" name="fee">
     <dmn:extensionElements/>
-    <dmn:variable id="_D27F1A1F-9E8D-4234-A353-4ED1AF3F894E" name="fee" typeRef="feel:number"/>
+    <dmn:variable id="_28F3EC26-1F4F-4B74-9711-4D8B5F71E92B" name="fee" typeRef="number"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_4868299F-B5A8-4361-88BF-04D9CA4A0720" name="DRG">
+    <dmndi:DMNDiagram id="_234DEAD1-9A77-4106-93A1-FC2A27013CED" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_A8F27F57-3F2B-4264-B91B-458C8C2F7614"/>
-          <kie:ComponentWidths dmnElementRef="_07E60D98-4790-4FBA-91BD-2663E7FB0B37"/>
-          <kie:ComponentWidths dmnElementRef="_562B1D42-7AC4-4244-BDBC-5835AC71F1F5"/>
+          <kie:ComponentWidths dmnElementRef="_109E6DD8-5ACB-40BC-9F83-372AE01E0E7E"/>
+          <kie:ComponentWidths dmnElementRef="_30DC38E7-5758-42D2-933D-692EC8A55527"/>
+          <kie:ComponentWidths dmnElementRef="_A7A74352-67DA-4D88-A06D-3428D451FE74"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-d_MonthlyPayment" dmnElementRef="tns:d_MonthlyPayment" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-d_MonthlyPayment" dmnElementRef="d_MonthlyPayment" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -66,7 +73,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-b_PMT" dmnElementRef="tns:b_PMT" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-b_PMT" dmnElementRef="b_PMT" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -75,7 +82,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_Loan" dmnElementRef="tns:i_Loan" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_Loan" dmnElementRef="i_Loan" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -84,7 +91,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_fee" dmnElementRef="tns:i_fee" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-i_fee" dmnElementRef="i_fee" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -93,15 +100,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-i_Loan" dmnElementRef="tns:i_Loan">
+      <dmndi:DMNEdge id="dmnedge-drg-_1586A9BA-0E4F-44FA-8D90-5A83736E9C42" dmnElementRef="_1586A9BA-0E4F-44FA-8D90-5A83736E9C42">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-i_fee" dmnElementRef="tns:i_fee">
+      <dmndi:DMNEdge id="dmnedge-drg-_43F559D8-AD98-4081-9637-096BA73C4D9B" dmnElementRef="_43F559D8-AD98-4081-9637-096BA73C4D9B">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_PMT" dmnElementRef="tns:b_PMT">
+      <dmndi:DMNEdge id="dmnedge-drg-_64BA75A4-AFEC-4589-B421-80A4A782C152" dmnElementRef="_64BA75A4-AFEC-4589-B421-80A4A782C152">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-concatenate.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-concatenate.dmn
@@ -1,99 +1,106 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_e14a67c7-c9a2-4fd6-84fb-63722d1454d4" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_e14a67c7-c9a2-4fd6-84fb-63722d1454d4" name="concatenate" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_e14a67c7-c9a2-4fd6-84fb-63722d1454d4">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_e14a67c7-c9a2-4fd6-84fb-63722d1454d4"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_e14a67c7-c9a2-4fd6-84fb-63722d1454d4" name="concatenate" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_e14a67c7-c9a2-4fd6-84fb-63722d1454d4">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tStringList" name="tStringList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tNestedList" name="tNestedList" isCollection="true">
-    <dmn:typeRef>tns:tStringList</dmn:typeRef>
+    <dmn:typeRef>tStringList</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="_1296434e-6902-40fc-9a93-07c35dda7ec8" name="simpleList">
     <dmn:extensionElements/>
-    <dmn:variable id="_0C126D4F-D9F4-4C93-B475-73DC8E1C4A1C" name="simpleList" typeRef="tns:tStringList"/>
+    <dmn:variable id="_8DA7775C-85FD-44F7-BB4D-C694DB3E5CAB" name="simpleList" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:inputData id="_4e72e88f-2239-43b8-9944-4893daf84127" name="nestedList">
     <dmn:extensionElements/>
-    <dmn:variable id="_8E678F5C-4B42-4059-9AC0-72ED28CEF530" name="nestedList" typeRef="tns:tNestedList"/>
+    <dmn:variable id="_0D670E89-1BED-45C9-9A8D-6AA507CC5E0C" name="nestedList" typeRef="tNestedList"/>
   </dmn:inputData>
   <dmn:decision id="_1bd696ab-0181-49e0-bb15-d090219c4943" name="literalSimpleList">
     <dmn:extensionElements/>
-    <dmn:variable id="_CDBFB10C-EC94-44BA-9166-D3AFD4440E0A" name="literalSimpleList" typeRef="tns:tStringList"/>
-    <dmn:literalExpression id="_572C91FB-BD05-4F0F-A683-8C8952624B1D">
+    <dmn:variable id="_3807BB72-41AC-46AD-8D41-9E1E72C0CA59" name="literalSimpleList" typeRef="tStringList"/>
+    <dmn:literalExpression id="_010436EF-064E-43BE-8B36-34FA7B5F87A5">
       <dmn:text>["a","b","c"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_d6152254-7ad2-4aeb-90a0-16b962a11257" name="literalNestedList">
     <dmn:extensionElements/>
-    <dmn:variable id="_127C2104-9C22-4ACD-B205-F9B36C075D20" name="literalNestedList" typeRef="tns:tNestedList"/>
-    <dmn:literalExpression id="_ACB1DD4D-F461-46CC-988B-A04DF631C90B">
+    <dmn:variable id="_62157D57-E22A-4681-A5CF-5E96A4EFE162" name="literalNestedList" typeRef="tNestedList"/>
+    <dmn:literalExpression id="_41335DE8-B890-4778-8488-560FDF892A04">
       <dmn:text>[["w","x"],"y","z"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_f6e97b3b-d13c-47b5-b679-36cf46d4f904" name="concatenate1">
     <dmn:extensionElements/>
-    <dmn:variable id="_65B88808-F55E-441A-9157-2ACE7D5998CA" name="concatenate1" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1bd696ab-0181-49e0-bb15-d090219c4943">
+    <dmn:variable id="_C92A884F-9E5C-4082-84C2-7245EBCFC742" name="concatenate1" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_A8F03B01-78C4-4AB7-BC40-D1F14CA5C24F">
       <dmn:requiredDecision href="#_1bd696ab-0181-49e0-bb15-d090219c4943"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1296434e-6902-40fc-9a93-07c35dda7ec8">
+    <dmn:informationRequirement id="_9B20674C-2B73-4FA0-8DF6-864D05661025">
       <dmn:requiredInput href="#_1296434e-6902-40fc-9a93-07c35dda7ec8"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_77E8FFC9-9209-425B-AB90-4D77AEF3E51C">
+    <dmn:literalExpression id="_26A512C6-4CF9-4102-9F0B-9D9F1731F78C">
       <dmn:text>concatenate(simpleList,literalSimpleList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_bf18b7c7-5f20-48a2-bd27-527c82cf0855" name="concatenate2">
     <dmn:extensionElements/>
-    <dmn:variable id="_A3D595D4-D94F-4F52-BE90-41B1997215DA" name="concatenate2" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1296434e-6902-40fc-9a93-07c35dda7ec8">
+    <dmn:variable id="_D6446E7C-73DC-4934-9A03-F51337529F98" name="concatenate2" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_7ADC3B69-1CCC-4C93-9AC5-3F095C82CD48">
       <dmn:requiredInput href="#_1296434e-6902-40fc-9a93-07c35dda7ec8"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4e72e88f-2239-43b8-9944-4893daf84127">
+    <dmn:informationRequirement id="_98D0D74A-9098-4B63-BC52-1AEE91CA347C">
       <dmn:requiredInput href="#_4e72e88f-2239-43b8-9944-4893daf84127"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_FE742264-2874-4D5E-BEC0-3E2387A73497">
+    <dmn:literalExpression id="_002AA0E6-B321-4023-B722-02080C40509B">
       <dmn:text>concatenate(simpleList,nestedList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_877fd216-703c-4b2f-8197-9f3ed144ff4d" name="concatenate3">
     <dmn:extensionElements/>
-    <dmn:variable id="_2A81516A-BA28-4E0E-89AF-C1154FA5A9CC" name="concatenate3" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1bd696ab-0181-49e0-bb15-d090219c4943">
+    <dmn:variable id="_ABECDB4D-C273-4121-AF14-71DB3BA2FBD5" name="concatenate3" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_74DE7B09-2B2F-4539-9119-4E742B2F2057">
       <dmn:requiredDecision href="#_1bd696ab-0181-49e0-bb15-d090219c4943"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4e72e88f-2239-43b8-9944-4893daf84127">
+    <dmn:informationRequirement id="_E4BF5584-3304-4092-8232-73E2E736CE2F">
       <dmn:requiredInput href="#_4e72e88f-2239-43b8-9944-4893daf84127"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_469E346B-C96F-433E-8F9A-DDB6438F44FF">
+    <dmn:literalExpression id="_C99DAF9F-0CB1-48B1-AA84-77E0CAAF480C">
       <dmn:text>concatenate(literalSimpleList,nestedList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_cf4db6c6-da6b-42fe-8f85-110f8d711111" name="concatenate4">
     <dmn:extensionElements/>
-    <dmn:variable id="_ADE8B581-E354-45D5-988A-D714E910F781" name="concatenate4" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_1bd696ab-0181-49e0-bb15-d090219c4943">
+    <dmn:variable id="_24CDC909-3E7F-487B-A082-98D7BC73E536" name="concatenate4" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_D85AC2E1-60E8-469B-96C1-EFD2305A5FA2">
       <dmn:requiredDecision href="#_1bd696ab-0181-49e0-bb15-d090219c4943"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_d6152254-7ad2-4aeb-90a0-16b962a11257">
+    <dmn:informationRequirement id="_ABF45914-CD7A-424F-8421-1539737570E4">
       <dmn:requiredDecision href="#_d6152254-7ad2-4aeb-90a0-16b962a11257"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_509320C2-5E47-4499-8CEC-421A8F6C6E88">
+    <dmn:literalExpression id="_E6938C8F-9961-431E-B3A6-271CE461C86F">
       <dmn:text>concatenate(literalSimpleList,literalNestedList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_5403C8B2-1104-4022-8189-DEB90EC7E92D" name="DRG">
+    <dmndi:DMNDiagram id="_B945F7A0-2680-42A9-B9A7-DDD63A871910" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_572C91FB-BD05-4F0F-A683-8C8952624B1D"/>
-          <kie:ComponentWidths dmnElementRef="_ACB1DD4D-F461-46CC-988B-A04DF631C90B"/>
-          <kie:ComponentWidths dmnElementRef="_77E8FFC9-9209-425B-AB90-4D77AEF3E51C"/>
-          <kie:ComponentWidths dmnElementRef="_FE742264-2874-4D5E-BEC0-3E2387A73497"/>
-          <kie:ComponentWidths dmnElementRef="_469E346B-C96F-433E-8F9A-DDB6438F44FF"/>
-          <kie:ComponentWidths dmnElementRef="_509320C2-5E47-4499-8CEC-421A8F6C6E88"/>
+          <kie:ComponentWidths dmnElementRef="_010436EF-064E-43BE-8B36-34FA7B5F87A5"/>
+          <kie:ComponentWidths dmnElementRef="_41335DE8-B890-4778-8488-560FDF892A04"/>
+          <kie:ComponentWidths dmnElementRef="_26A512C6-4CF9-4102-9F0B-9D9F1731F78C"/>
+          <kie:ComponentWidths dmnElementRef="_002AA0E6-B321-4023-B722-02080C40509B"/>
+          <kie:ComponentWidths dmnElementRef="_C99DAF9F-0CB1-48B1-AA84-77E0CAAF480C"/>
+          <kie:ComponentWidths dmnElementRef="_E6938C8F-9961-431E-B3A6-271CE461C86F"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_1296434e-6902-40fc-9a93-07c35dda7ec8" dmnElementRef="tns:_1296434e-6902-40fc-9a93-07c35dda7ec8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1296434e-6902-40fc-9a93-07c35dda7ec8" dmnElementRef="_1296434e-6902-40fc-9a93-07c35dda7ec8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -102,7 +109,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4e72e88f-2239-43b8-9944-4893daf84127" dmnElementRef="tns:_4e72e88f-2239-43b8-9944-4893daf84127" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4e72e88f-2239-43b8-9944-4893daf84127" dmnElementRef="_4e72e88f-2239-43b8-9944-4893daf84127" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -111,7 +118,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_1bd696ab-0181-49e0-bb15-d090219c4943" dmnElementRef="tns:_1bd696ab-0181-49e0-bb15-d090219c4943" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1bd696ab-0181-49e0-bb15-d090219c4943" dmnElementRef="_1bd696ab-0181-49e0-bb15-d090219c4943" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -120,7 +127,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d6152254-7ad2-4aeb-90a0-16b962a11257" dmnElementRef="tns:_d6152254-7ad2-4aeb-90a0-16b962a11257" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d6152254-7ad2-4aeb-90a0-16b962a11257" dmnElementRef="_d6152254-7ad2-4aeb-90a0-16b962a11257" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -129,7 +136,7 @@
         <dc:Bounds x="575" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_f6e97b3b-d13c-47b5-b679-36cf46d4f904" dmnElementRef="tns:_f6e97b3b-d13c-47b5-b679-36cf46d4f904" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_f6e97b3b-d13c-47b5-b679-36cf46d4f904" dmnElementRef="_f6e97b3b-d13c-47b5-b679-36cf46d4f904" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -138,7 +145,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bf18b7c7-5f20-48a2-bd27-527c82cf0855" dmnElementRef="tns:_bf18b7c7-5f20-48a2-bd27-527c82cf0855" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_bf18b7c7-5f20-48a2-bd27-527c82cf0855" dmnElementRef="_bf18b7c7-5f20-48a2-bd27-527c82cf0855" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -147,7 +154,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_877fd216-703c-4b2f-8197-9f3ed144ff4d" dmnElementRef="tns:_877fd216-703c-4b2f-8197-9f3ed144ff4d" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_877fd216-703c-4b2f-8197-9f3ed144ff4d" dmnElementRef="_877fd216-703c-4b2f-8197-9f3ed144ff4d" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -156,7 +163,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_cf4db6c6-da6b-42fe-8f85-110f8d711111" dmnElementRef="tns:_cf4db6c6-da6b-42fe-8f85-110f8d711111" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_cf4db6c6-da6b-42fe-8f85-110f8d711111" dmnElementRef="_cf4db6c6-da6b-42fe-8f85-110f8d711111" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -165,19 +172,35 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_1bd696ab-0181-49e0-bb15-d090219c4943" dmnElementRef="tns:_1bd696ab-0181-49e0-bb15-d090219c4943">
+      <dmndi:DMNEdge id="dmnedge-drg-_A8F03B01-78C4-4AB7-BC40-D1F14CA5C24F" dmnElementRef="_A8F03B01-78C4-4AB7-BC40-D1F14CA5C24F">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1296434e-6902-40fc-9a93-07c35dda7ec8" dmnElementRef="tns:_1296434e-6902-40fc-9a93-07c35dda7ec8">
+      <dmndi:DMNEdge id="dmnedge-drg-_9B20674C-2B73-4FA0-8DF6-864D05661025" dmnElementRef="_9B20674C-2B73-4FA0-8DF6-864D05661025">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_4e72e88f-2239-43b8-9944-4893daf84127" dmnElementRef="tns:_4e72e88f-2239-43b8-9944-4893daf84127">
+      <dmndi:DMNEdge id="dmnedge-drg-_7ADC3B69-1CCC-4C93-9AC5-3F095C82CD48" dmnElementRef="_7ADC3B69-1CCC-4C93-9AC5-3F095C82CD48">
+        <di:waypoint x="50" y="225"/>
+        <di:waypoint x="50" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_98D0D74A-9098-4B63-BC52-1AEE91CA347C" dmnElementRef="_98D0D74A-9098-4B63-BC52-1AEE91CA347C">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_d6152254-7ad2-4aeb-90a0-16b962a11257" dmnElementRef="tns:_d6152254-7ad2-4aeb-90a0-16b962a11257">
+      <dmndi:DMNEdge id="dmnedge-drg-_74DE7B09-2B2F-4539-9119-4E742B2F2057" dmnElementRef="_74DE7B09-2B2F-4539-9119-4E742B2F2057">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E4BF5584-3304-4092-8232-73E2E736CE2F" dmnElementRef="_E4BF5584-3304-4092-8232-73E2E736CE2F">
+        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_D85AC2E1-60E8-469B-96C1-EFD2305A5FA2" dmnElementRef="_D85AC2E1-60E8-469B-96C1-EFD2305A5FA2">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_ABF45914-CD7A-424F-8421-1539737570E4" dmnElementRef="_ABF45914-CD7A-424F-8421-1539737570E4">
         <di:waypoint x="575" y="225"/>
         <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-multi-output-U.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-multi-output-U.dmn
@@ -1,58 +1,65 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_a3ebbd98-af09-42f3-9099-4ae2204a1f54" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_a3ebbd98-af09-42f3-9099-4ae2204a1f54" name="multi-output-table" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_a3ebbd98-af09-42f3-9099-4ae2204a1f54">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_a3ebbd98-af09-42f3-9099-4ae2204a1f54"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_a3ebbd98-af09-42f3-9099-4ae2204a1f54" name="multi-output-table" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_a3ebbd98-af09-42f3-9099-4ae2204a1f54">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tApproval" name="tApproval" isCollection="false">
     <dmn:itemComponent id="_20dfeb44-1c36-43cf-8819-63ce36819e90" name="Status" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_858ef6e6-69ca-4b50-a654-10f4b981f43c" name="Rate" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decision id="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" name="Approval">
     <dmn:extensionElements/>
-    <dmn:variable id="_91047FAA-5A69-4F30-87FC-AB0F2996EE30" name="Approval" typeRef="tns:tApproval"/>
-    <dmn:informationRequirement id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+    <dmn:variable id="_294D6E9F-29ED-464D-9A81-39DE73148EB9" name="Approval" typeRef="tApproval"/>
+    <dmn:informationRequirement id="_CD737D33-2E3A-4BF0-AB07-CF0D63524322">
       <dmn:requiredInput href="#_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_41effb45-b3c4-46ac-b1da-122b3e428a98">
+    <dmn:informationRequirement id="_6CEE9A57-9C03-463A-BBA4-06016C929C1B">
       <dmn:requiredInput href="#_41effb45-b3c4-46ac-b1da-122b3e428a98"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8ff18665-84e9-49f2-a8df-8981b1844549">
+    <dmn:informationRequirement id="_4B41B69F-671B-404B-9C0E-1BE27DCCA197">
       <dmn:requiredInput href="#_8ff18665-84e9-49f2-a8df-8981b1844549"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_1402292B-1C74-42BA-A954-6F24CE6B19CC" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Approval">
+    <dmn:decisionTable id="_49183A5F-66D4-4169-BFE6-ED645FFF060A" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="Approval">
       <dmn:input id="_bf7fc56f-ea82-464e-a541-f3221dc07e78">
-        <dmn:inputExpression id="_E29E1A54-8CD6-47FB-997F-1F36E2D140A8" typeRef="feel:number">
+        <dmn:inputExpression id="_D5E3A8DB-27FD-40FA-9513-13B8710985A9" typeRef="number">
           <dmn:text>Age</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:input id="_bb73bf86-b399-490a-a635-c6f2c04ff75d">
-        <dmn:inputExpression id="_7E28C76C-33FB-4B74-9233-0A5EC5FC3AF7" typeRef="feel:string">
+        <dmn:inputExpression id="_2DD79E45-9B32-4502-9506-F3D9822F8D03" typeRef="string">
           <dmn:text>RiskCategory</dmn:text>
         </dmn:inputExpression>
-        <dmn:inputValues id="_0789D6CF-ADA4-4B52-94C2-DE9ECE693251">
+        <dmn:inputValues id="_580B8896-05BE-4FFE-BA0E-E7E2D3FF6DAE">
           <dmn:text>"High", "Low", "Medium"</dmn:text>
         </dmn:inputValues>
       </dmn:input>
       <dmn:input id="_af5e5c2a-5124-4277-9409-d07421dcb5a4">
-        <dmn:inputExpression id="_9422EB1B-AC53-4BC7-9F03-34F03F788E11" typeRef="feel:boolean">
+        <dmn:inputExpression id="_25B6773A-EC50-456E-9849-3958182C932E" typeRef="boolean">
           <dmn:text>isAffordable</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
-      <dmn:output id="_bffba7a1-f0a2-4679-b6e2-50e27bb27968" name="Status" typeRef="feel:string">
-        <dmn:outputValues id="_12D3A764-0396-4E9F-88A3-9FBAA0A08641">
+      <dmn:output id="_bffba7a1-f0a2-4679-b6e2-50e27bb27968" name="Status" typeRef="string">
+        <dmn:outputValues id="_3822BE02-3E85-4B45-8014-C1ECC550CBD4">
           <dmn:text>"Approved", "Declined"</dmn:text>
         </dmn:outputValues>
-        <dmn:defaultOutputEntry id="_AE6CD7DB-9245-4C16-BFCA-16E47FD2D2EC">
+        <dmn:defaultOutputEntry id="_8470C46B-5E02-47A6-B746-5CE5A15E7E42">
           <dmn:text>"Declined"</dmn:text>
         </dmn:defaultOutputEntry>
       </dmn:output>
-      <dmn:output id="_f07f9e98-3a1e-4add-a200-7cee75b550b3" name="Rate" typeRef="feel:string">
-        <dmn:outputValues id="_B49BCF9B-5932-4B6A-89A2-245C77AAEB4A">
+      <dmn:output id="_f07f9e98-3a1e-4add-a200-7cee75b550b3" name="Rate" typeRef="string">
+        <dmn:outputValues id="_D67981C6-916E-4620-9B45-F6DB4562DC49">
           <dmn:text>"Best", "Standard"</dmn:text>
         </dmn:outputValues>
-        <dmn:defaultOutputEntry id="_7255BE6D-5354-4B8E-8421-44AF0E1F4CD6">
+        <dmn:defaultOutputEntry id="_683B2E50-FB11-43C9-BCEC-69092911F840">
           <dmn:text>"Standard"</dmn:text>
         </dmn:defaultOutputEntry>
       </dmn:output>
@@ -161,24 +168,24 @@
   </dmn:decision>
   <dmn:inputData id="_41effb45-b3c4-46ac-b1da-122b3e428a98" name="Age">
     <dmn:extensionElements/>
-    <dmn:variable id="_C8CA8281-DAD4-4186-9E23-093A05932B62" name="Age" typeRef="feel:number"/>
+    <dmn:variable id="_F20AA3D8-1E86-47A0-8830-E7B02FA19A6C" name="Age" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" name="RiskCategory">
     <dmn:extensionElements/>
-    <dmn:variable id="_4D4464EF-3A71-4A8B-8AA2-06504DCA7116" name="RiskCategory" typeRef="feel:string"/>
+    <dmn:variable id="_F2C7CB73-C804-427A-B193-09774F099261" name="RiskCategory" typeRef="string"/>
   </dmn:inputData>
   <dmn:inputData id="_8ff18665-84e9-49f2-a8df-8981b1844549" name="isAffordable">
     <dmn:extensionElements/>
-    <dmn:variable id="_905254D9-6021-4534-8F7D-7E8237AE92FE" name="isAffordable" typeRef="feel:boolean"/>
+    <dmn:variable id="_91A66A00-7AB7-4085-9D59-3E7C44CE1595" name="isAffordable" typeRef="boolean"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_16CD362C-3FF8-495E-AA56-7D32E7DEB4FB" name="DRG">
+    <dmndi:DMNDiagram id="_5BCC4586-5756-4D49-9766-C14BD6029497" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_1402292B-1C74-42BA-A954-6F24CE6B19CC"/>
+          <kie:ComponentWidths dmnElementRef="_49183A5F-66D4-4169-BFE6-ED645FFF060A"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="tns:_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" dmnElementRef="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -187,7 +194,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="_41effb45-b3c4-46ac-b1da-122b3e428a98" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -196,7 +203,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -205,7 +212,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="_8ff18665-84e9-49f2-a8df-8981b1844549" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -214,15 +221,15 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17" dmnElementRef="tns:_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17">
+      <dmndi:DMNEdge id="dmnedge-drg-_CD737D33-2E3A-4BF0-AB07-CF0D63524322" dmnElementRef="_CD737D33-2E3A-4BF0-AB07-CF0D63524322">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_41effb45-b3c4-46ac-b1da-122b3e428a98" dmnElementRef="tns:_41effb45-b3c4-46ac-b1da-122b3e428a98">
+      <dmndi:DMNEdge id="dmnedge-drg-_6CEE9A57-9C03-463A-BBA4-06016C929C1B" dmnElementRef="_6CEE9A57-9C03-463A-BBA4-06016C929C1B">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8ff18665-84e9-49f2-a8df-8981b1844549" dmnElementRef="tns:_8ff18665-84e9-49f2-a8df-8981b1844549">
+      <dmndi:DMNEdge id="dmnedge-drg-_4B41B69F-671B-404B-9C0E-1BE27DCCA197" dmnElementRef="_4B41B69F-671B-404B-9C0E-1BE27DCCA197">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0011-insert-remove.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0011-insert-remove.dmn
@@ -1,115 +1,122 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_6029a6d3-d2f1-484b-a99d-4bedb5858a3e" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_6029a6d3-d2f1-484b-a99d-4bedb5858a3e" name="insert-remove" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_6029a6d3-d2f1-484b-a99d-4bedb5858a3e">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_6029a6d3-d2f1-484b-a99d-4bedb5858a3e"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_6029a6d3-d2f1-484b-a99d-4bedb5858a3e" name="insert-remove" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_6029a6d3-d2f1-484b-a99d-4bedb5858a3e">
   <dmn:extensionElements/>
-  <dmn:itemDefinition id="_0C5DEE47-65FC-430D-A444-2B0B77084157" name="tStringList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+  <dmn:itemDefinition id="_F1559F96-96D0-4BD3-8B74-287E68393FA7" name="tStringList" isCollection="true">
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_814209A5-0C4E-4037-B32A-68CD71C2BE2E" name="tNestedList" isCollection="true">
-    <dmn:typeRef>tns:tStringList</dmn:typeRef>
+  <dmn:itemDefinition id="_217E2DF9-EC5E-4D55-8AFA-463768CD010B" name="tNestedList" isCollection="true">
+    <dmn:typeRef>tStringList</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="_8713a7d7-bae7-484e-b1d5-788b3979d659" name="simpleList">
     <dmn:extensionElements/>
-    <dmn:variable id="_827DA116-4588-4D17-83BC-99E349EC7023" name="simpleList" typeRef="tns:tStringList"/>
+    <dmn:variable id="_6D7FEF84-4A3D-40E8-882D-65315119A7BB" name="simpleList" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:inputData id="_722095a4-3116-4d71-b225-58795b3ec654" name="nestedList">
     <dmn:extensionElements/>
-    <dmn:variable id="_E27F8255-51E5-4A74-AE29-7E564952AA52" name="nestedList" typeRef="tns:tNestedList"/>
+    <dmn:variable id="_CC6D98F6-A468-4EB8-A70A-2AC65D8275C6" name="nestedList" typeRef="tNestedList"/>
   </dmn:inputData>
   <dmn:inputData id="_4688d5d9-3a03-4377-89e3-9ccd50e1624e" name="position">
     <dmn:extensionElements/>
-    <dmn:variable id="_90F021C4-9037-45F3-9C93-1CD540A8B528" name="position" typeRef="feel:number"/>
+    <dmn:variable id="_7C752C53-2C9C-45F2-BE4A-F28703E0C45D" name="position" typeRef="number"/>
   </dmn:inputData>
   <dmn:decision id="_7a7f2263-5d9b-4a18-aee8-43783f417b07" name="literalNestedList">
     <dmn:extensionElements/>
-    <dmn:variable id="_9675D3F6-1157-46D5-B82B-EBC263133077" name="literalNestedList" typeRef="tns:tNestedList"/>
-    <dmn:literalExpression id="_EC1AB047-8F71-4014-88FE-984336B4C403">
+    <dmn:variable id="_F7E2528D-5841-4216-84E9-7DFED9C6FCCC" name="literalNestedList" typeRef="tNestedList"/>
+    <dmn:literalExpression id="_98E86E98-A857-4AE8-8C45-99C5E58E2134">
       <dmn:text>[["a","b"],["b","c"]]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_c169428e-2a57-42d2-a26d-cf22039da762" name="remove1">
     <dmn:extensionElements/>
-    <dmn:variable id="_24D5F8F1-73A8-4F49-8514-1C6F590CC60A" name="remove1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_8713a7d7-bae7-484e-b1d5-788b3979d659">
+    <dmn:variable id="_33AD5E82-4B8E-44B5-BC3E-FC0576210DD2" name="remove1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_CB7C0187-B762-4F37-9C1C-838FB99FE465">
       <dmn:requiredInput href="#_8713a7d7-bae7-484e-b1d5-788b3979d659"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4688d5d9-3a03-4377-89e3-9ccd50e1624e">
+    <dmn:informationRequirement id="_0E8DF44E-83DF-4A98-B953-FBABEC9D163C">
       <dmn:requiredInput href="#_4688d5d9-3a03-4377-89e3-9ccd50e1624e"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_878C6C44-1124-4C73-973D-6523CD5801A7">
+    <dmn:literalExpression id="_9432E04F-76F2-41CC-9AB1-460ED2EE6B6D">
       <dmn:text>remove(simpleList,position)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_12fdd98a-00da-47af-80e6-f70906e359c0" name="insert2">
     <dmn:extensionElements/>
-    <dmn:variable id="_E315D619-A5F4-46A5-AE0F-7E94884CC4EE" name="insert2" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_7a7f2263-5d9b-4a18-aee8-43783f417b07">
+    <dmn:variable id="_FA95A52C-AEA4-40E1-87D1-3EE01AD12A32" name="insert2" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_BD02C8E3-F6E2-4C67-BC4D-EAF2CEAA45EF">
       <dmn:requiredDecision href="#_7a7f2263-5d9b-4a18-aee8-43783f417b07"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4688d5d9-3a03-4377-89e3-9ccd50e1624e">
+    <dmn:informationRequirement id="_987ACA10-B886-44AE-8C2F-C92E4E2F6BB0">
       <dmn:requiredInput href="#_4688d5d9-3a03-4377-89e3-9ccd50e1624e"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8713a7d7-bae7-484e-b1d5-788b3979d659">
+    <dmn:informationRequirement id="_B48403D5-C9A1-4E90-9E53-D2917FB111D2">
       <dmn:requiredInput href="#_8713a7d7-bae7-484e-b1d5-788b3979d659"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_CADA59D8-B143-46C7-A234-C25860AD12B9">
+    <dmn:literalExpression id="_BCAF595D-E610-4C3E-9201-BC6CD154840E">
       <dmn:text>insert before(literalNestedList,position,simpleList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_93786c60-d986-4c40-b836-4b2f0bc218ce" name="remove2">
     <dmn:extensionElements/>
-    <dmn:variable id="_4714BD87-AED5-4E36-99A6-2954C7B8BE13" name="remove2" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_4688d5d9-3a03-4377-89e3-9ccd50e1624e">
+    <dmn:variable id="_D30FEC6B-9F66-4C2A-87CF-0A19901B8F50" name="remove2" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_DD92436D-E9DE-4E5D-87C3-24F82EC515C3">
       <dmn:requiredInput href="#_4688d5d9-3a03-4377-89e3-9ccd50e1624e"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_7a7f2263-5d9b-4a18-aee8-43783f417b07">
+    <dmn:informationRequirement id="_B933CCFE-EB52-4BFC-9E66-150C222600EE">
       <dmn:requiredDecision href="#_7a7f2263-5d9b-4a18-aee8-43783f417b07"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_6BEC0BC6-B312-47F8-9FB5-8F83E7EF0472">
+    <dmn:literalExpression id="_4719D1B9-917E-4DEE-9D6D-55B53ED31E3E">
       <dmn:text>remove(literalNestedList,position)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_d1465880-49ca-4182-ae74-7670fc834f2c" name="insert1">
     <dmn:extensionElements/>
-    <dmn:variable id="_36166F1D-F36C-44D4-AB3E-D14DB48C9C34" name="insert1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_8713a7d7-bae7-484e-b1d5-788b3979d659">
+    <dmn:variable id="_FA39CE07-7D8E-496A-ADB1-D0A105423099" name="insert1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_B5609C47-42C8-475C-97E4-1D063D154165">
       <dmn:requiredInput href="#_8713a7d7-bae7-484e-b1d5-788b3979d659"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4688d5d9-3a03-4377-89e3-9ccd50e1624e">
+    <dmn:informationRequirement id="_420E0234-CF1C-4400-BF12-8EF06DBE3CF7">
       <dmn:requiredInput href="#_4688d5d9-3a03-4377-89e3-9ccd50e1624e"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_864ACC73-B3A5-4BCC-AF83-D84E3ED209A9">
+    <dmn:literalExpression id="_94B92FE8-D3F0-4CCB-860E-D228BF1D69AB">
       <dmn:text>insert before(simpleList,position,"x")</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_d6beae1e-c23f-4fdb-8c63-6c9835337eff" name="insert3">
     <dmn:extensionElements/>
-    <dmn:variable id="_D0F0E254-3C69-4792-84C3-D9C716B2F2B2" name="insert3" typeRef="tns:tNestedList"/>
-    <dmn:informationRequirement id="_722095a4-3116-4d71-b225-58795b3ec654">
+    <dmn:variable id="_9347C678-9DDB-4C19-8E2B-87D5B4B31E39" name="insert3" typeRef="tNestedList"/>
+    <dmn:informationRequirement id="_A7D3476D-2D4E-461D-9ADC-1D5227235198">
       <dmn:requiredInput href="#_722095a4-3116-4d71-b225-58795b3ec654"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4688d5d9-3a03-4377-89e3-9ccd50e1624e">
+    <dmn:informationRequirement id="_4C219646-1242-4C8B-9D9A-91BCF122AA12">
       <dmn:requiredInput href="#_4688d5d9-3a03-4377-89e3-9ccd50e1624e"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8713a7d7-bae7-484e-b1d5-788b3979d659">
+    <dmn:informationRequirement id="_8FDA7786-5311-419C-8256-055218D18BE5">
       <dmn:requiredInput href="#_8713a7d7-bae7-484e-b1d5-788b3979d659"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_9B281F15-341A-47A3-8D18-46B81262C531">
+    <dmn:literalExpression id="_EF42A85D-0058-43D8-ADBF-700BB3F172F6">
       <dmn:text>insert before(nestedList,position,simpleList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_9ECAB98E-7399-4441-BD9D-4918F42F952D" name="DRG">
+    <dmndi:DMNDiagram id="_A2A1BE39-1540-43D3-8005-79C60AF2185B" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_EC1AB047-8F71-4014-88FE-984336B4C403"/>
-          <kie:ComponentWidths dmnElementRef="_878C6C44-1124-4C73-973D-6523CD5801A7"/>
-          <kie:ComponentWidths dmnElementRef="_CADA59D8-B143-46C7-A234-C25860AD12B9"/>
-          <kie:ComponentWidths dmnElementRef="_6BEC0BC6-B312-47F8-9FB5-8F83E7EF0472"/>
-          <kie:ComponentWidths dmnElementRef="_864ACC73-B3A5-4BCC-AF83-D84E3ED209A9"/>
-          <kie:ComponentWidths dmnElementRef="_9B281F15-341A-47A3-8D18-46B81262C531"/>
+          <kie:ComponentWidths dmnElementRef="_98E86E98-A857-4AE8-8C45-99C5E58E2134"/>
+          <kie:ComponentWidths dmnElementRef="_9432E04F-76F2-41CC-9AB1-460ED2EE6B6D"/>
+          <kie:ComponentWidths dmnElementRef="_BCAF595D-E610-4C3E-9201-BC6CD154840E"/>
+          <kie:ComponentWidths dmnElementRef="_4719D1B9-917E-4DEE-9D6D-55B53ED31E3E"/>
+          <kie:ComponentWidths dmnElementRef="_94B92FE8-D3F0-4CCB-860E-D228BF1D69AB"/>
+          <kie:ComponentWidths dmnElementRef="_EF42A85D-0058-43D8-ADBF-700BB3F172F6"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_8713a7d7-bae7-484e-b1d5-788b3979d659" dmnElementRef="tns:_8713a7d7-bae7-484e-b1d5-788b3979d659" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_8713a7d7-bae7-484e-b1d5-788b3979d659" dmnElementRef="_8713a7d7-bae7-484e-b1d5-788b3979d659" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -118,7 +125,7 @@
         <dc:Bounds x="313" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_722095a4-3116-4d71-b225-58795b3ec654" dmnElementRef="tns:_722095a4-3116-4d71-b225-58795b3ec654" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_722095a4-3116-4d71-b225-58795b3ec654" dmnElementRef="_722095a4-3116-4d71-b225-58795b3ec654" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -127,7 +134,7 @@
         <dc:Bounds x="138" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4688d5d9-3a03-4377-89e3-9ccd50e1624e" dmnElementRef="tns:_4688d5d9-3a03-4377-89e3-9ccd50e1624e" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4688d5d9-3a03-4377-89e3-9ccd50e1624e" dmnElementRef="_4688d5d9-3a03-4377-89e3-9ccd50e1624e" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -136,7 +143,7 @@
         <dc:Bounds x="488" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7a7f2263-5d9b-4a18-aee8-43783f417b07" dmnElementRef="tns:_7a7f2263-5d9b-4a18-aee8-43783f417b07" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7a7f2263-5d9b-4a18-aee8-43783f417b07" dmnElementRef="_7a7f2263-5d9b-4a18-aee8-43783f417b07" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -145,7 +152,7 @@
         <dc:Bounds x="663" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c169428e-2a57-42d2-a26d-cf22039da762" dmnElementRef="tns:_c169428e-2a57-42d2-a26d-cf22039da762" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c169428e-2a57-42d2-a26d-cf22039da762" dmnElementRef="_c169428e-2a57-42d2-a26d-cf22039da762" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -154,7 +161,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_12fdd98a-00da-47af-80e6-f70906e359c0" dmnElementRef="tns:_12fdd98a-00da-47af-80e6-f70906e359c0" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_12fdd98a-00da-47af-80e6-f70906e359c0" dmnElementRef="_12fdd98a-00da-47af-80e6-f70906e359c0" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -163,7 +170,7 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_93786c60-d986-4c40-b836-4b2f0bc218ce" dmnElementRef="tns:_93786c60-d986-4c40-b836-4b2f0bc218ce" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_93786c60-d986-4c40-b836-4b2f0bc218ce" dmnElementRef="_93786c60-d986-4c40-b836-4b2f0bc218ce" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -172,7 +179,7 @@
         <dc:Bounds x="750" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d1465880-49ca-4182-ae74-7670fc834f2c" dmnElementRef="tns:_d1465880-49ca-4182-ae74-7670fc834f2c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d1465880-49ca-4182-ae74-7670fc834f2c" dmnElementRef="_d1465880-49ca-4182-ae74-7670fc834f2c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -181,7 +188,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d6beae1e-c23f-4fdb-8c63-6c9835337eff" dmnElementRef="tns:_d6beae1e-c23f-4fdb-8c63-6c9835337eff" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d6beae1e-c23f-4fdb-8c63-6c9835337eff" dmnElementRef="_d6beae1e-c23f-4fdb-8c63-6c9835337eff" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -190,20 +197,52 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_8713a7d7-bae7-484e-b1d5-788b3979d659" dmnElementRef="tns:_8713a7d7-bae7-484e-b1d5-788b3979d659">
+      <dmndi:DMNEdge id="dmnedge-drg-_CB7C0187-B762-4F37-9C1C-838FB99FE465" dmnElementRef="_CB7C0187-B762-4F37-9C1C-838FB99FE465">
         <di:waypoint x="313" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_4688d5d9-3a03-4377-89e3-9ccd50e1624e" dmnElementRef="tns:_4688d5d9-3a03-4377-89e3-9ccd50e1624e">
+      <dmndi:DMNEdge id="dmnedge-drg-_0E8DF44E-83DF-4A98-B953-FBABEC9D163C" dmnElementRef="_0E8DF44E-83DF-4A98-B953-FBABEC9D163C">
         <di:waypoint x="488" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7a7f2263-5d9b-4a18-aee8-43783f417b07" dmnElementRef="tns:_7a7f2263-5d9b-4a18-aee8-43783f417b07">
+      <dmndi:DMNEdge id="dmnedge-drg-_BD02C8E3-F6E2-4C67-BC4D-EAF2CEAA45EF" dmnElementRef="_BD02C8E3-F6E2-4C67-BC4D-EAF2CEAA45EF">
         <di:waypoint x="663" y="225"/>
         <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_722095a4-3116-4d71-b225-58795b3ec654" dmnElementRef="tns:_722095a4-3116-4d71-b225-58795b3ec654">
+      <dmndi:DMNEdge id="dmnedge-drg-_987ACA10-B886-44AE-8C2F-C92E4E2F6BB0" dmnElementRef="_987ACA10-B886-44AE-8C2F-C92E4E2F6BB0">
+        <di:waypoint x="488" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_B48403D5-C9A1-4E90-9E53-D2917FB111D2" dmnElementRef="_B48403D5-C9A1-4E90-9E53-D2917FB111D2">
+        <di:waypoint x="313" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_DD92436D-E9DE-4E5D-87C3-24F82EC515C3" dmnElementRef="_DD92436D-E9DE-4E5D-87C3-24F82EC515C3">
+        <di:waypoint x="488" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_B933CCFE-EB52-4BFC-9E66-150C222600EE" dmnElementRef="_B933CCFE-EB52-4BFC-9E66-150C222600EE">
+        <di:waypoint x="663" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_B5609C47-42C8-475C-97E4-1D063D154165" dmnElementRef="_B5609C47-42C8-475C-97E4-1D063D154165">
+        <di:waypoint x="313" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_420E0234-CF1C-4400-BF12-8EF06DBE3CF7" dmnElementRef="_420E0234-CF1C-4400-BF12-8EF06DBE3CF7">
+        <di:waypoint x="488" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_A7D3476D-2D4E-461D-9ADC-1D5227235198" dmnElementRef="_A7D3476D-2D4E-461D-9ADC-1D5227235198">
         <di:waypoint x="138" y="225"/>
+        <di:waypoint x="50" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_4C219646-1242-4C8B-9D9A-91BCF122AA12" dmnElementRef="_4C219646-1242-4C8B-9D9A-91BCF122AA12">
+        <di:waypoint x="488" y="225"/>
+        <di:waypoint x="50" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8FDA7786-5311-419C-8256-055218D18BE5" dmnElementRef="_8FDA7786-5311-419C-8256-055218D18BE5">
+        <di:waypoint x="313" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0012-list-functions.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0012-list-functions.dmn
@@ -1,292 +1,299 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_c0858816-af7b-40a1-8aa7-6e11b8761215" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_c0858816-af7b-40a1-8aa7-6e11b8761215" name="listFunctions" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_c0858816-af7b-40a1-8aa7-6e11b8761215">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_c0858816-af7b-40a1-8aa7-6e11b8761215"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_c0858816-af7b-40a1-8aa7-6e11b8761215" name="listFunctions" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_c0858816-af7b-40a1-8aa7-6e11b8761215">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tStringList" name="tStringList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tNumList" name="tNumList" isCollection="true">
-    <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:typeRef>number</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tListOfLists" name="tListOfLists" isCollection="true">
-    <dmn:typeRef>tns:tStringList</dmn:typeRef>
+    <dmn:typeRef>tStringList</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8" name="list1">
     <dmn:extensionElements/>
-    <dmn:variable id="_1C4F55F9-154E-4A99-8CCB-F21CE4235021" name="list1" typeRef="tns:tStringList"/>
+    <dmn:variable id="_64852E91-4F79-4D23-A9C4-0C7D898EB4B1" name="list1" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:inputData id="_82d66f50-2d47-4849-b5fd-da179e0fec66" name="list2">
     <dmn:extensionElements/>
-    <dmn:variable id="_C3942BF0-4332-487C-99FA-590233BD3600" name="list2" typeRef="tns:tStringList"/>
+    <dmn:variable id="_F2A0D6F0-165C-440B-9D97-1945E8F2D9D7" name="list2" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:inputData id="_1bbe9689-bd70-45d4-ab30-f3887cf46b28" name="string1">
     <dmn:extensionElements/>
-    <dmn:variable id="_A06B16E8-B98C-4F89-9516-993F73A8F337" name="string1" typeRef="feel:string"/>
+    <dmn:variable id="_A7A977CC-79E8-4267-B340-5E9C4C968387" name="string1" typeRef="string"/>
   </dmn:inputData>
   <dmn:decision id="_99f9f3b2-b956-4a95-82c4-7384c6237a98" name="listContainsList">
     <dmn:extensionElements/>
-    <dmn:variable id="_74FA7684-0591-43A5-875B-9CAB98875A5C" name="listContainsList" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
+    <dmn:variable id="_FF06C1FD-0B3D-47DE-9064-AC1095BAB0E7" name="listContainsList" typeRef="boolean"/>
+    <dmn:informationRequirement id="_0B8E53C3-715E-4B91-AADD-B51145B9D200">
       <dmn:requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
+    <dmn:informationRequirement id="_F8DD4F61-8B94-4C66-8E68-3D17A26A7F94">
       <dmn:requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_DFDF7B38-394A-47AD-B524-BA340A3D7FAF">
+    <dmn:literalExpression id="_2C1CF2DA-830C-4908-A01F-612C4B018BF4">
       <dmn:text>list contains(list1,list2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_75384b82-eb58-4d5b-8e9a-82b14e3f68f4" name="listContains">
     <dmn:extensionElements/>
-    <dmn:variable id="_4570AE98-1F72-4F28-B9ED-1B0E45C319A0" name="listContains" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
+    <dmn:variable id="_DA37990A-D27E-430B-A5F7-B25AFC457A21" name="listContains" typeRef="boolean"/>
+    <dmn:informationRequirement id="_C8CAD9F5-2D9F-4D60-BD1F-0AFF13910F84">
       <dmn:requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1bbe9689-bd70-45d4-ab30-f3887cf46b28">
+    <dmn:informationRequirement id="_63F410CF-F442-4E4F-89D2-246F13FEA6F3">
       <dmn:requiredInput href="#_1bbe9689-bd70-45d4-ab30-f3887cf46b28"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_B606B947-432A-420F-A37A-0C31391E88D0">
+    <dmn:literalExpression id="_5C16F50A-8825-45B4-BA1C-8687C18D7D2A">
       <dmn:text>list contains(list2,string1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_a9bc7b65-ddf7-4336-85e8-67833bb1e10e" name="count1">
     <dmn:extensionElements/>
-    <dmn:variable id="_69383BE7-6E90-4168-9284-7B1AE98D32DD" name="count1" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
+    <dmn:variable id="_05B36813-A818-406B-A19E-649BBCD2D8FD" name="count1" typeRef="number"/>
+    <dmn:informationRequirement id="_7C9A0B31-D9FD-484E-9F04-E549C586182E">
       <dmn:requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_41C06541-5C77-433A-8BFC-3AD59D50A2CB">
+    <dmn:literalExpression id="_395D2AAE-707C-46BD-AC5F-C9D38FD23C24">
       <dmn:text>count(list1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_7322b523-9698-4037-86cc-bcca6ca3f9f6" name="min1">
     <dmn:extensionElements/>
-    <dmn:variable id="_A0800B45-89DC-4646-9E19-C4D4F56320E3" name="min1" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_b894ee22-f795-46f7-b713-77d69d07ae22">
+    <dmn:variable id="_24B3C102-95F3-43EA-A3EE-D20C8AB9CFF1" name="min1" typeRef="number"/>
+    <dmn:informationRequirement id="_FB1E8D41-8698-4B69-A00A-D4BEC9ADA278">
       <dmn:requiredInput href="#_b894ee22-f795-46f7-b713-77d69d07ae22"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_049538DE-BCC0-461D-8522-1D044A67BBE9">
+    <dmn:literalExpression id="_9F2E205E-9BC3-48C8-ADD5-0E93E4F2FD57">
       <dmn:text>min(numList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_b894ee22-f795-46f7-b713-77d69d07ae22" name="numList">
     <dmn:extensionElements/>
-    <dmn:variable id="_744F9043-B4A4-474B-847B-292A3D949682" name="numList" typeRef="tns:tNumList"/>
+    <dmn:variable id="_AE30F7CD-F7A0-4AAE-B3F3-30B47028AB1B" name="numList" typeRef="tNumList"/>
   </dmn:inputData>
   <dmn:decision id="_d6b2c4a0-a147-44a1-a9f4-3575f1bb5695" name="sum1">
     <dmn:extensionElements/>
-    <dmn:variable id="_F7DA59F2-6AC6-4171-9903-59CB2B029ED2" name="sum1" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_b894ee22-f795-46f7-b713-77d69d07ae22">
+    <dmn:variable id="_47768C1F-297D-4940-B2FB-5A907904846B" name="sum1" typeRef="number"/>
+    <dmn:informationRequirement id="_B8984900-4BC1-4DB1-A5E5-CFD12B881E31">
       <dmn:requiredInput href="#_b894ee22-f795-46f7-b713-77d69d07ae22"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_0DD6C11E-ADB4-4BCE-8FE1-E22B4D62BAA5">
+    <dmn:literalExpression id="_C9FC3E31-A911-4C9F-83A2-7C76507FEEC9">
       <dmn:text>sum(numList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_c7e617bc-5928-4e8a-a700-4fb498c50508" name="mean1">
     <dmn:extensionElements/>
-    <dmn:variable id="_FDEBE968-C988-4C28-82C5-EB96E45BF526" name="mean1" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_b894ee22-f795-46f7-b713-77d69d07ae22">
+    <dmn:variable id="_B6C186BA-9536-4E72-B6CD-4DD2ED34DCFE" name="mean1" typeRef="number"/>
+    <dmn:informationRequirement id="_3C3B2C77-E3F8-449E-969D-83A918ABB839">
       <dmn:requiredInput href="#_b894ee22-f795-46f7-b713-77d69d07ae22"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_34B2B390-000C-4F50-ACBF-55417A1E12C5">
+    <dmn:literalExpression id="_21F8654A-BE75-46BE-955B-9CFB14DC24DC">
       <dmn:text>mean(numList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_25cfe558-925d-438a-8863-983ed1c12f26" name="num1">
     <dmn:extensionElements/>
-    <dmn:variable id="_F438F5B6-2FF1-4219-BD19-8A9D1F7ED7AE" name="num1" typeRef="feel:number"/>
+    <dmn:variable id="_A7055572-B75A-4D82-A8C6-266F74EE9A5D" name="num1" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_2bfdc253-0033-40fd-94e5-4726aca95933" name="num2">
     <dmn:extensionElements/>
-    <dmn:variable id="_2AA0A933-8392-4535-BA5F-26570F15EDD4" name="num2" typeRef="feel:number"/>
+    <dmn:variable id="_F6B16625-EBD7-4F87-9A91-B2ED36D7BE3B" name="num2" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_c8de2ba0-25c1-4820-973a-417105f4eb5e" name="num3">
     <dmn:extensionElements/>
-    <dmn:variable id="_076876FB-1B0F-4963-93D7-482481A6D167" name="num3" typeRef="feel:number"/>
+    <dmn:variable id="_F3B2C213-BDCA-4F35-BBFF-C5E9782BF0DF" name="num3" typeRef="number"/>
   </dmn:inputData>
   <dmn:decision id="_cc131883-6380-47f1-8a4d-9026cd05e1fa" name="mean2">
     <dmn:extensionElements/>
-    <dmn:variable id="_D0B12C96-7687-4755-8D05-59E226FA2B14" name="mean2" typeRef="feel:number"/>
-    <dmn:informationRequirement id="_25cfe558-925d-438a-8863-983ed1c12f26">
+    <dmn:variable id="_971ABDCD-9CB2-4205-9F0C-298F3176E3EB" name="mean2" typeRef="number"/>
+    <dmn:informationRequirement id="_023F682D-3B8B-4791-BB24-D5DCACD120D3">
       <dmn:requiredInput href="#_25cfe558-925d-438a-8863-983ed1c12f26"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_2bfdc253-0033-40fd-94e5-4726aca95933">
+    <dmn:informationRequirement id="_08ED6657-FD97-4B43-9000-CC8C8F774723">
       <dmn:requiredInput href="#_2bfdc253-0033-40fd-94e5-4726aca95933"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_c8de2ba0-25c1-4820-973a-417105f4eb5e">
+    <dmn:informationRequirement id="_4AA4FF0F-152C-422D-BB55-1D7F5B8A1028">
       <dmn:requiredInput href="#_c8de2ba0-25c1-4820-973a-417105f4eb5e"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_384C8A33-03A3-4130-A7F9-FA20D6115BB6">
+    <dmn:literalExpression id="_9E0404DD-57B8-4698-9DFF-8EE7FCF265C3">
       <dmn:text>mean(num1,num2,num3)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_95e0ad53-c08f-46af-baa0-9c36d69002f5" name="sublist12">
     <dmn:extensionElements/>
-    <dmn:variable id="_06126D39-9B29-4E2D-AC59-BF5A50F700E8" name="sublist12" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
+    <dmn:variable id="_5F8C5AB9-5744-4B7C-813C-42762F394D5D" name="sublist12" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_6BB243D1-CD29-4E9B-A9EC-A2B8F4307389">
       <dmn:requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_5DE71869-4C84-4CC0-B0C4-EC3C2DC8A621">
+    <dmn:literalExpression id="_5016FD7F-FAD4-4F4B-BADC-78D7F307D98E">
       <dmn:text>sublist(list1,1,2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_85f6330f-dcaa-47ca-96bb-1c0228da911f" name="sublistLast">
     <dmn:extensionElements/>
-    <dmn:variable id="_B0853BE6-9072-403A-8054-B6B357A179C9" name="sublistLast" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
+    <dmn:variable id="_C1839A37-E1D3-4C96-9FD6-1D08E0769681" name="sublistLast" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_0189AC2D-32B6-4F53-989C-777CDE9C26FA">
       <dmn:requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_C1C87965-7552-455D-95CD-9AC366108EC9">
+    <dmn:literalExpression id="_9D440E46-66F0-4A91-83FE-95C50A74DBFB">
       <dmn:text>sublist(list1,-1,1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_845ea241-587e-43d8-a563-a1dd18693afe" name="append1">
     <dmn:extensionElements/>
-    <dmn:variable id="_68C53395-511A-43BE-8456-76ED2431F36D" name="append1" typeRef="tns:tNumList"/>
-    <dmn:informationRequirement id="_b894ee22-f795-46f7-b713-77d69d07ae22">
+    <dmn:variable id="_70CFDA07-D29F-4488-8552-321C822DB451" name="append1" typeRef="tNumList"/>
+    <dmn:informationRequirement id="_1DDECF3D-923D-4FD6-B986-5DF741A2AC27">
       <dmn:requiredInput href="#_b894ee22-f795-46f7-b713-77d69d07ae22"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_25cfe558-925d-438a-8863-983ed1c12f26">
+    <dmn:informationRequirement id="_2073B4D3-5194-4DFE-9B00-F49BEAA9BB1D">
       <dmn:requiredInput href="#_25cfe558-925d-438a-8863-983ed1c12f26"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_2bfdc253-0033-40fd-94e5-4726aca95933">
+    <dmn:informationRequirement id="_3EF05BAB-32DA-4ECA-89ED-F65F17D2F131">
       <dmn:requiredInput href="#_2bfdc253-0033-40fd-94e5-4726aca95933"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E5B0E27A-E3A5-418D-9B7A-0D0AA037858A">
+    <dmn:literalExpression id="_CA0DA437-CF7B-4F8E-B1B1-C08FE91D6545">
       <dmn:text>append(numList,num1,num2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9" name="concatenate1">
     <dmn:extensionElements/>
-    <dmn:variable id="_2775E66F-C445-46E9-86E3-9EC0B0BEC523" name="concatenate1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
+    <dmn:variable id="_BDB86EE3-B365-4144-BCC3-61275EA51468" name="concatenate1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_337E6258-101B-43FF-A27A-C218BA4C648F">
       <dmn:requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
+    <dmn:informationRequirement id="_CE99705F-D615-4A78-AC5B-1B05B5FF54F9">
       <dmn:requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E8FA67BC-B64F-4E6F-ACE5-095161B79C92">
+    <dmn:literalExpression id="_919E5F9D-1B16-47F2-8C69-9DDF79EC1C56">
       <dmn:text>concatenate(list1,list2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_2064fd78-72aa-4851-9813-8d56674b3936" name="insertBefore1">
     <dmn:extensionElements/>
-    <dmn:variable id="_D5A6574A-37BB-4E47-A393-3DC9194686E1" name="insertBefore1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
+    <dmn:variable id="_5F136EA0-30ED-4A69-83A4-9BD5F2C68F39" name="insertBefore1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_1637F3CE-D35E-42DB-9D41-35FCA3BF541A">
       <dmn:requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1bbe9689-bd70-45d4-ab30-f3887cf46b28">
+    <dmn:informationRequirement id="_5DA1D048-7F04-4DDE-A228-DB7F2D742895">
       <dmn:requiredInput href="#_1bbe9689-bd70-45d4-ab30-f3887cf46b28"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E1A0B9B2-F98C-48C7-81DE-A199C4C6F16E">
+    <dmn:literalExpression id="_10D7E169-3D9D-44B3-8896-35C507B6E8D2">
       <dmn:text>insert before(list2,2,string1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_ffd2b93c-2bca-4979-9a65-357ca8ba92ff" name="remove2nd">
     <dmn:extensionElements/>
-    <dmn:variable id="_4F491B96-E814-4B8E-972A-7724ABA6BACD" name="remove2nd" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
+    <dmn:variable id="_E582CA53-C08D-4C05-BA41-185ECA68A9AF" name="remove2nd" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_0962F364-B2A7-4738-9DC1-ECEC77CA1ACC">
       <dmn:requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_A28EF549-9C28-4801-B444-6F0AFA3A5B4D">
+    <dmn:literalExpression id="_F8A45069-EB53-4968-A19B-CC3D447B85F7">
       <dmn:text>remove(list2,2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_673c3497-f8e7-4340-827d-99d8d08664db" name="reverse1">
     <dmn:extensionElements/>
-    <dmn:variable id="_4A484CF0-EF3B-42E2-9E70-3C7EA5C8575F" name="reverse1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9">
+    <dmn:variable id="_23F9186F-F9E6-41A1-BB57-3D1A907D29B7" name="reverse1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_AD261C65-88B9-4C37-AE6F-2433FCEE5404">
       <dmn:requiredDecision href="#_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_5FBB6586-7CE6-4DBC-9ED5-6220135B71B5">
+    <dmn:literalExpression id="_14491A71-F313-4A22-8C43-987919EDF256">
       <dmn:text>reverse(concatenate1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_d12d9a82-b182-4c15-9fce-d22cdc53dbc4" name="appendListItem">
     <dmn:extensionElements/>
-    <dmn:variable id="_76126AD0-73B2-48AA-8253-1A6D08F55E9A" name="appendListItem" typeRef="tns:tListOfLists"/>
-    <dmn:informationRequirement id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
+    <dmn:variable id="_E922F641-F0F3-433E-9F23-63341F39F272" name="appendListItem" typeRef="tListOfLists"/>
+    <dmn:informationRequirement id="_FFD5D0CF-3E1A-46F6-B8D4-25FCE3F93886">
       <dmn:requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
+    <dmn:informationRequirement id="_08922177-D594-4891-ACEE-81BEBEAECD46">
       <dmn:requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_86FE3C56-116D-4577-9FEB-75975DF9BCF5">
+    <dmn:literalExpression id="_0EBD2C5C-B818-4E51-B8EB-CE0A07F8E5F1">
       <dmn:text>append(list1,list2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_3c7aef83-002c-4c61-9297-e822a7d4e829" name="indexOf1">
     <dmn:extensionElements/>
-    <dmn:variable id="_F737848B-5FD7-4E23-AD90-14512F12FE25" name="indexOf1" typeRef="tns:tNumList"/>
-    <dmn:informationRequirement id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
+    <dmn:variable id="_0231671D-E41A-49B0-A0CE-1DEADB355F2D" name="indexOf1" typeRef="tNumList"/>
+    <dmn:informationRequirement id="_6DB7FDEE-331B-4BEB-A3A0-33A10A5B07F4">
       <dmn:requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1bbe9689-bd70-45d4-ab30-f3887cf46b28">
+    <dmn:informationRequirement id="_6537A260-A595-4232-91AA-922FF10FEDAC">
       <dmn:requiredInput href="#_1bbe9689-bd70-45d4-ab30-f3887cf46b28"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E03C51A1-3A38-4C47-98D6-34786CCA9956">
+    <dmn:literalExpression id="_69AC549A-4CD9-4E51-A845-BA0116927C1C">
       <dmn:text>index of(list2,string1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_0dee9e3c-ef4e-4853-b182-bdf8bff1d20b" name="union1">
     <dmn:extensionElements/>
-    <dmn:variable id="_4FFC61E2-D8DE-4CA2-A98C-F24E930C24B5" name="union1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9">
+    <dmn:variable id="_F06667D6-94D1-4889-85F7-45F0BD0BE9D0" name="union1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_DD1D4DC9-6E72-457B-B5C5-6D0D1994C6E1">
       <dmn:requiredDecision href="#_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_2064fd78-72aa-4851-9813-8d56674b3936">
+    <dmn:informationRequirement id="_F8DD31F2-C579-4A4D-9BED-116B5F893EE6">
       <dmn:requiredDecision href="#_2064fd78-72aa-4851-9813-8d56674b3936"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_3DE9BF84-D3A0-4221-992E-62CA26C53823">
+    <dmn:literalExpression id="_4A688960-BC0A-47A1-9478-49D0D03F3DAE">
       <dmn:text>union(insertBefore1,concatenate1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_0bbaa2a8-b265-49d4-9540-28b1bddac540" name="distinctVals">
     <dmn:extensionElements/>
-    <dmn:variable id="_D0F50559-7279-47D3-98C7-6F6F52E3982D" name="distinctVals" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_2064fd78-72aa-4851-9813-8d56674b3936">
+    <dmn:variable id="_D3DBE2A9-CCA7-4E23-94C5-5FE1B0262E8C" name="distinctVals" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_4F8AF385-4195-4F00-85B5-A9C7C7E0B998">
       <dmn:requiredDecision href="#_2064fd78-72aa-4851-9813-8d56674b3936"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_4ED16A00-BB5A-40EB-829D-F9E69958B0BE">
+    <dmn:literalExpression id="_E65E25B4-7D3F-48FF-9ACD-30001FB0AB4C">
       <dmn:text>distinct values(insertBefore1)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_ef7d1df2-8a1c-47cf-ae2e-928f71e2c460" name="flatten1">
     <dmn:extensionElements/>
-    <dmn:variable id="_C51EC83D-6D50-4480-A7D6-DFEC7927A325" name="flatten1" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_d12d9a82-b182-4c15-9fce-d22cdc53dbc4">
+    <dmn:variable id="_5BA5F52A-5121-4594-832B-5A21565D4CDB" name="flatten1" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_9F8C5723-4AFB-4678-8510-99A1131674D7">
       <dmn:requiredDecision href="#_d12d9a82-b182-4c15-9fce-d22cdc53dbc4"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_475FAB49-667A-426C-AEB6-B9E4221858BB">
+    <dmn:literalExpression id="_8553D0CE-32F5-4E17-8CFD-A710AE017477">
       <dmn:text>flatten(appendListItem)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_15FF7739-CF80-4658-B845-9CBAC9B0562E" name="DRG">
+    <dmndi:DMNDiagram id="_9466B3C3-1367-4991-A62F-6C65A03F7676" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_DFDF7B38-394A-47AD-B524-BA340A3D7FAF"/>
-          <kie:ComponentWidths dmnElementRef="_B606B947-432A-420F-A37A-0C31391E88D0"/>
-          <kie:ComponentWidths dmnElementRef="_41C06541-5C77-433A-8BFC-3AD59D50A2CB"/>
-          <kie:ComponentWidths dmnElementRef="_049538DE-BCC0-461D-8522-1D044A67BBE9"/>
-          <kie:ComponentWidths dmnElementRef="_0DD6C11E-ADB4-4BCE-8FE1-E22B4D62BAA5"/>
-          <kie:ComponentWidths dmnElementRef="_34B2B390-000C-4F50-ACBF-55417A1E12C5"/>
-          <kie:ComponentWidths dmnElementRef="_384C8A33-03A3-4130-A7F9-FA20D6115BB6"/>
-          <kie:ComponentWidths dmnElementRef="_5DE71869-4C84-4CC0-B0C4-EC3C2DC8A621"/>
-          <kie:ComponentWidths dmnElementRef="_C1C87965-7552-455D-95CD-9AC366108EC9"/>
-          <kie:ComponentWidths dmnElementRef="_E5B0E27A-E3A5-418D-9B7A-0D0AA037858A"/>
-          <kie:ComponentWidths dmnElementRef="_E8FA67BC-B64F-4E6F-ACE5-095161B79C92"/>
-          <kie:ComponentWidths dmnElementRef="_E1A0B9B2-F98C-48C7-81DE-A199C4C6F16E"/>
-          <kie:ComponentWidths dmnElementRef="_A28EF549-9C28-4801-B444-6F0AFA3A5B4D"/>
-          <kie:ComponentWidths dmnElementRef="_5FBB6586-7CE6-4DBC-9ED5-6220135B71B5"/>
-          <kie:ComponentWidths dmnElementRef="_86FE3C56-116D-4577-9FEB-75975DF9BCF5"/>
-          <kie:ComponentWidths dmnElementRef="_E03C51A1-3A38-4C47-98D6-34786CCA9956"/>
-          <kie:ComponentWidths dmnElementRef="_3DE9BF84-D3A0-4221-992E-62CA26C53823"/>
-          <kie:ComponentWidths dmnElementRef="_4ED16A00-BB5A-40EB-829D-F9E69958B0BE"/>
-          <kie:ComponentWidths dmnElementRef="_475FAB49-667A-426C-AEB6-B9E4221858BB"/>
+          <kie:ComponentWidths dmnElementRef="_2C1CF2DA-830C-4908-A01F-612C4B018BF4"/>
+          <kie:ComponentWidths dmnElementRef="_5C16F50A-8825-45B4-BA1C-8687C18D7D2A"/>
+          <kie:ComponentWidths dmnElementRef="_395D2AAE-707C-46BD-AC5F-C9D38FD23C24"/>
+          <kie:ComponentWidths dmnElementRef="_9F2E205E-9BC3-48C8-ADD5-0E93E4F2FD57"/>
+          <kie:ComponentWidths dmnElementRef="_C9FC3E31-A911-4C9F-83A2-7C76507FEEC9"/>
+          <kie:ComponentWidths dmnElementRef="_21F8654A-BE75-46BE-955B-9CFB14DC24DC"/>
+          <kie:ComponentWidths dmnElementRef="_9E0404DD-57B8-4698-9DFF-8EE7FCF265C3"/>
+          <kie:ComponentWidths dmnElementRef="_5016FD7F-FAD4-4F4B-BADC-78D7F307D98E"/>
+          <kie:ComponentWidths dmnElementRef="_9D440E46-66F0-4A91-83FE-95C50A74DBFB"/>
+          <kie:ComponentWidths dmnElementRef="_CA0DA437-CF7B-4F8E-B1B1-C08FE91D6545"/>
+          <kie:ComponentWidths dmnElementRef="_919E5F9D-1B16-47F2-8C69-9DDF79EC1C56"/>
+          <kie:ComponentWidths dmnElementRef="_10D7E169-3D9D-44B3-8896-35C507B6E8D2"/>
+          <kie:ComponentWidths dmnElementRef="_F8A45069-EB53-4968-A19B-CC3D447B85F7"/>
+          <kie:ComponentWidths dmnElementRef="_14491A71-F313-4A22-8C43-987919EDF256"/>
+          <kie:ComponentWidths dmnElementRef="_0EBD2C5C-B818-4E51-B8EB-CE0A07F8E5F1"/>
+          <kie:ComponentWidths dmnElementRef="_69AC549A-4CD9-4E51-A845-BA0116927C1C"/>
+          <kie:ComponentWidths dmnElementRef="_4A688960-BC0A-47A1-9478-49D0D03F3DAE"/>
+          <kie:ComponentWidths dmnElementRef="_E65E25B4-7D3F-48FF-9ACD-30001FB0AB4C"/>
+          <kie:ComponentWidths dmnElementRef="_8553D0CE-32F5-4E17-8CFD-A710AE017477"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_86f5e710-a139-4cd5-8ac4-90b4671a75b8" dmnElementRef="tns:_86f5e710-a139-4cd5-8ac4-90b4671a75b8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_86f5e710-a139-4cd5-8ac4-90b4671a75b8" dmnElementRef="_86f5e710-a139-4cd5-8ac4-90b4671a75b8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -295,7 +302,7 @@
         <dc:Bounds x="1187" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_82d66f50-2d47-4849-b5fd-da179e0fec66" dmnElementRef="tns:_82d66f50-2d47-4849-b5fd-da179e0fec66" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_82d66f50-2d47-4849-b5fd-da179e0fec66" dmnElementRef="_82d66f50-2d47-4849-b5fd-da179e0fec66" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -304,7 +311,7 @@
         <dc:Bounds x="1362" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_1bbe9689-bd70-45d4-ab30-f3887cf46b28" dmnElementRef="tns:_1bbe9689-bd70-45d4-ab30-f3887cf46b28" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_1bbe9689-bd70-45d4-ab30-f3887cf46b28" dmnElementRef="_1bbe9689-bd70-45d4-ab30-f3887cf46b28" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -313,7 +320,7 @@
         <dc:Bounds x="1537" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_99f9f3b2-b956-4a95-82c4-7384c6237a98" dmnElementRef="tns:_99f9f3b2-b956-4a95-82c4-7384c6237a98" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_99f9f3b2-b956-4a95-82c4-7384c6237a98" dmnElementRef="_99f9f3b2-b956-4a95-82c4-7384c6237a98" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -322,7 +329,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_75384b82-eb58-4d5b-8e9a-82b14e3f68f4" dmnElementRef="tns:_75384b82-eb58-4d5b-8e9a-82b14e3f68f4" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_75384b82-eb58-4d5b-8e9a-82b14e3f68f4" dmnElementRef="_75384b82-eb58-4d5b-8e9a-82b14e3f68f4" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -331,7 +338,7 @@
         <dc:Bounds x="1625" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_a9bc7b65-ddf7-4336-85e8-67833bb1e10e" dmnElementRef="tns:_a9bc7b65-ddf7-4336-85e8-67833bb1e10e" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_a9bc7b65-ddf7-4336-85e8-67833bb1e10e" dmnElementRef="_a9bc7b65-ddf7-4336-85e8-67833bb1e10e" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -340,7 +347,7 @@
         <dc:Bounds x="1275" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7322b523-9698-4037-86cc-bcca6ca3f9f6" dmnElementRef="tns:_7322b523-9698-4037-86cc-bcca6ca3f9f6" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7322b523-9698-4037-86cc-bcca6ca3f9f6" dmnElementRef="_7322b523-9698-4037-86cc-bcca6ca3f9f6" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -349,7 +356,7 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_b894ee22-f795-46f7-b713-77d69d07ae22" dmnElementRef="tns:_b894ee22-f795-46f7-b713-77d69d07ae22" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_b894ee22-f795-46f7-b713-77d69d07ae22" dmnElementRef="_b894ee22-f795-46f7-b713-77d69d07ae22" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -358,7 +365,7 @@
         <dc:Bounds x="1362" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d6b2c4a0-a147-44a1-a9f4-3575f1bb5695" dmnElementRef="tns:_d6b2c4a0-a147-44a1-a9f4-3575f1bb5695" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d6b2c4a0-a147-44a1-a9f4-3575f1bb5695" dmnElementRef="_d6b2c4a0-a147-44a1-a9f4-3575f1bb5695" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -367,7 +374,7 @@
         <dc:Bounds x="750" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c7e617bc-5928-4e8a-a700-4fb498c50508" dmnElementRef="tns:_c7e617bc-5928-4e8a-a700-4fb498c50508" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c7e617bc-5928-4e8a-a700-4fb498c50508" dmnElementRef="_c7e617bc-5928-4e8a-a700-4fb498c50508" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -376,7 +383,7 @@
         <dc:Bounds x="925" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_25cfe558-925d-438a-8863-983ed1c12f26" dmnElementRef="tns:_25cfe558-925d-438a-8863-983ed1c12f26" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_25cfe558-925d-438a-8863-983ed1c12f26" dmnElementRef="_25cfe558-925d-438a-8863-983ed1c12f26" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -385,7 +392,7 @@
         <dc:Bounds x="837" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2bfdc253-0033-40fd-94e5-4726aca95933" dmnElementRef="tns:_2bfdc253-0033-40fd-94e5-4726aca95933" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_2bfdc253-0033-40fd-94e5-4726aca95933" dmnElementRef="_2bfdc253-0033-40fd-94e5-4726aca95933" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -394,7 +401,7 @@
         <dc:Bounds x="1012" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c8de2ba0-25c1-4820-973a-417105f4eb5e" dmnElementRef="tns:_c8de2ba0-25c1-4820-973a-417105f4eb5e" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c8de2ba0-25c1-4820-973a-417105f4eb5e" dmnElementRef="_c8de2ba0-25c1-4820-973a-417105f4eb5e" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -403,7 +410,7 @@
         <dc:Bounds x="1712" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_cc131883-6380-47f1-8a4d-9026cd05e1fa" dmnElementRef="tns:_cc131883-6380-47f1-8a4d-9026cd05e1fa" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_cc131883-6380-47f1-8a4d-9026cd05e1fa" dmnElementRef="_cc131883-6380-47f1-8a4d-9026cd05e1fa" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -412,7 +419,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_95e0ad53-c08f-46af-baa0-9c36d69002f5" dmnElementRef="tns:_95e0ad53-c08f-46af-baa0-9c36d69002f5" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_95e0ad53-c08f-46af-baa0-9c36d69002f5" dmnElementRef="_95e0ad53-c08f-46af-baa0-9c36d69002f5" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -421,7 +428,7 @@
         <dc:Bounds x="1975" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_85f6330f-dcaa-47ca-96bb-1c0228da911f" dmnElementRef="tns:_85f6330f-dcaa-47ca-96bb-1c0228da911f" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_85f6330f-dcaa-47ca-96bb-1c0228da911f" dmnElementRef="_85f6330f-dcaa-47ca-96bb-1c0228da911f" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -430,7 +437,7 @@
         <dc:Bounds x="2325" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_845ea241-587e-43d8-a563-a1dd18693afe" dmnElementRef="tns:_845ea241-587e-43d8-a563-a1dd18693afe" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_845ea241-587e-43d8-a563-a1dd18693afe" dmnElementRef="_845ea241-587e-43d8-a563-a1dd18693afe" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -439,7 +446,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9" dmnElementRef="tns:_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9" dmnElementRef="_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -448,7 +455,7 @@
         <dc:Bounds x="1187" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2064fd78-72aa-4851-9813-8d56674b3936" dmnElementRef="tns:_2064fd78-72aa-4851-9813-8d56674b3936" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_2064fd78-72aa-4851-9813-8d56674b3936" dmnElementRef="_2064fd78-72aa-4851-9813-8d56674b3936" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -457,7 +464,7 @@
         <dc:Bounds x="1537" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ffd2b93c-2bca-4979-9a65-357ca8ba92ff" dmnElementRef="tns:_ffd2b93c-2bca-4979-9a65-357ca8ba92ff" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_ffd2b93c-2bca-4979-9a65-357ca8ba92ff" dmnElementRef="_ffd2b93c-2bca-4979-9a65-357ca8ba92ff" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -466,7 +473,7 @@
         <dc:Bounds x="2675" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_673c3497-f8e7-4340-827d-99d8d08664db" dmnElementRef="tns:_673c3497-f8e7-4340-827d-99d8d08664db" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_673c3497-f8e7-4340-827d-99d8d08664db" dmnElementRef="_673c3497-f8e7-4340-827d-99d8d08664db" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -475,7 +482,7 @@
         <dc:Bounds x="1450" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d12d9a82-b182-4c15-9fce-d22cdc53dbc4" dmnElementRef="tns:_d12d9a82-b182-4c15-9fce-d22cdc53dbc4" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d12d9a82-b182-4c15-9fce-d22cdc53dbc4" dmnElementRef="_d12d9a82-b182-4c15-9fce-d22cdc53dbc4" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -484,7 +491,7 @@
         <dc:Bounds x="1887" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_3c7aef83-002c-4c61-9297-e822a7d4e829" dmnElementRef="tns:_3c7aef83-002c-4c61-9297-e822a7d4e829" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_3c7aef83-002c-4c61-9297-e822a7d4e829" dmnElementRef="_3c7aef83-002c-4c61-9297-e822a7d4e829" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -493,7 +500,7 @@
         <dc:Bounds x="1800" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_0dee9e3c-ef4e-4853-b182-bdf8bff1d20b" dmnElementRef="tns:_0dee9e3c-ef4e-4853-b182-bdf8bff1d20b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_0dee9e3c-ef4e-4853-b182-bdf8bff1d20b" dmnElementRef="_0dee9e3c-ef4e-4853-b182-bdf8bff1d20b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -502,7 +509,7 @@
         <dc:Bounds x="1100" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_0bbaa2a8-b265-49d4-9540-28b1bddac540" dmnElementRef="tns:_0bbaa2a8-b265-49d4-9540-28b1bddac540" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_0bbaa2a8-b265-49d4-9540-28b1bddac540" dmnElementRef="_0bbaa2a8-b265-49d4-9540-28b1bddac540" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -511,7 +518,7 @@
         <dc:Bounds x="2150" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ef7d1df2-8a1c-47cf-ae2e-928f71e2c460" dmnElementRef="tns:_ef7d1df2-8a1c-47cf-ae2e-928f71e2c460" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_ef7d1df2-8a1c-47cf-ae2e-928f71e2c460" dmnElementRef="_ef7d1df2-8a1c-47cf-ae2e-928f71e2c460" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -520,43 +527,123 @@
         <dc:Bounds x="2500" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_86f5e710-a139-4cd5-8ac4-90b4671a75b8" dmnElementRef="tns:_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
+      <dmndi:DMNEdge id="dmnedge-drg-_0B8E53C3-715E-4B91-AADD-B51145B9D200" dmnElementRef="_0B8E53C3-715E-4B91-AADD-B51145B9D200">
         <di:waypoint x="1187" y="400"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_82d66f50-2d47-4849-b5fd-da179e0fec66" dmnElementRef="tns:_82d66f50-2d47-4849-b5fd-da179e0fec66">
+      <dmndi:DMNEdge id="dmnedge-drg-_F8DD4F61-8B94-4C66-8E68-3D17A26A7F94" dmnElementRef="_F8DD4F61-8B94-4C66-8E68-3D17A26A7F94">
         <di:waypoint x="1362" y="400"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1bbe9689-bd70-45d4-ab30-f3887cf46b28" dmnElementRef="tns:_1bbe9689-bd70-45d4-ab30-f3887cf46b28">
+      <dmndi:DMNEdge id="dmnedge-drg-_C8CAD9F5-2D9F-4D60-BD1F-0AFF13910F84" dmnElementRef="_C8CAD9F5-2D9F-4D60-BD1F-0AFF13910F84">
+        <di:waypoint x="1362" y="400"/>
+        <di:waypoint x="1625" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_63F410CF-F442-4E4F-89D2-246F13FEA6F3" dmnElementRef="_63F410CF-F442-4E4F-89D2-246F13FEA6F3">
         <di:waypoint x="1537" y="400"/>
         <di:waypoint x="1625" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_b894ee22-f795-46f7-b713-77d69d07ae22" dmnElementRef="tns:_b894ee22-f795-46f7-b713-77d69d07ae22">
+      <dmndi:DMNEdge id="dmnedge-drg-_7C9A0B31-D9FD-484E-9F04-E549C586182E" dmnElementRef="_7C9A0B31-D9FD-484E-9F04-E549C586182E">
+        <di:waypoint x="1187" y="400"/>
+        <di:waypoint x="1275" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_FB1E8D41-8698-4B69-A00A-D4BEC9ADA278" dmnElementRef="_FB1E8D41-8698-4B69-A00A-D4BEC9ADA278">
         <di:waypoint x="1362" y="225"/>
         <di:waypoint x="575" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_25cfe558-925d-438a-8863-983ed1c12f26" dmnElementRef="tns:_25cfe558-925d-438a-8863-983ed1c12f26">
+      <dmndi:DMNEdge id="dmnedge-drg-_B8984900-4BC1-4DB1-A5E5-CFD12B881E31" dmnElementRef="_B8984900-4BC1-4DB1-A5E5-CFD12B881E31">
+        <di:waypoint x="1362" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_3C3B2C77-E3F8-449E-969D-83A918ABB839" dmnElementRef="_3C3B2C77-E3F8-449E-969D-83A918ABB839">
+        <di:waypoint x="1362" y="225"/>
+        <di:waypoint x="925" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_023F682D-3B8B-4791-BB24-D5DCACD120D3" dmnElementRef="_023F682D-3B8B-4791-BB24-D5DCACD120D3">
         <di:waypoint x="837" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2bfdc253-0033-40fd-94e5-4726aca95933" dmnElementRef="tns:_2bfdc253-0033-40fd-94e5-4726aca95933">
+      <dmndi:DMNEdge id="dmnedge-drg-_08ED6657-FD97-4B43-9000-CC8C8F774723" dmnElementRef="_08ED6657-FD97-4B43-9000-CC8C8F774723">
         <di:waypoint x="1012" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c8de2ba0-25c1-4820-973a-417105f4eb5e" dmnElementRef="tns:_c8de2ba0-25c1-4820-973a-417105f4eb5e">
+      <dmndi:DMNEdge id="dmnedge-drg-_4AA4FF0F-152C-422D-BB55-1D7F5B8A1028" dmnElementRef="_4AA4FF0F-152C-422D-BB55-1D7F5B8A1028">
         <di:waypoint x="1712" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9" dmnElementRef="tns:_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9">
+      <dmndi:DMNEdge id="dmnedge-drg-_6BB243D1-CD29-4E9B-A9EC-A2B8F4307389" dmnElementRef="_6BB243D1-CD29-4E9B-A9EC-A2B8F4307389">
+        <di:waypoint x="1187" y="400"/>
+        <di:waypoint x="1975" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_0189AC2D-32B6-4F53-989C-777CDE9C26FA" dmnElementRef="_0189AC2D-32B6-4F53-989C-777CDE9C26FA">
+        <di:waypoint x="1187" y="400"/>
+        <di:waypoint x="2325" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_1DDECF3D-923D-4FD6-B986-5DF741A2AC27" dmnElementRef="_1DDECF3D-923D-4FD6-B986-5DF741A2AC27">
+        <di:waypoint x="1362" y="225"/>
+        <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_2073B4D3-5194-4DFE-9B00-F49BEAA9BB1D" dmnElementRef="_2073B4D3-5194-4DFE-9B00-F49BEAA9BB1D">
+        <di:waypoint x="837" y="225"/>
+        <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_3EF05BAB-32DA-4ECA-89ED-F65F17D2F131" dmnElementRef="_3EF05BAB-32DA-4ECA-89ED-F65F17D2F131">
+        <di:waypoint x="1012" y="225"/>
+        <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_337E6258-101B-43FF-A27A-C218BA4C648F" dmnElementRef="_337E6258-101B-43FF-A27A-C218BA4C648F">
+        <di:waypoint x="1187" y="400"/>
+        <di:waypoint x="1187" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_CE99705F-D615-4A78-AC5B-1B05B5FF54F9" dmnElementRef="_CE99705F-D615-4A78-AC5B-1B05B5FF54F9">
+        <di:waypoint x="1362" y="400"/>
+        <di:waypoint x="1187" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_1637F3CE-D35E-42DB-9D41-35FCA3BF541A" dmnElementRef="_1637F3CE-D35E-42DB-9D41-35FCA3BF541A">
+        <di:waypoint x="1362" y="400"/>
+        <di:waypoint x="1537" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_5DA1D048-7F04-4DDE-A228-DB7F2D742895" dmnElementRef="_5DA1D048-7F04-4DDE-A228-DB7F2D742895">
+        <di:waypoint x="1537" y="400"/>
+        <di:waypoint x="1537" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_0962F364-B2A7-4738-9DC1-ECEC77CA1ACC" dmnElementRef="_0962F364-B2A7-4738-9DC1-ECEC77CA1ACC">
+        <di:waypoint x="1362" y="400"/>
+        <di:waypoint x="2675" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_AD261C65-88B9-4C37-AE6F-2433FCEE5404" dmnElementRef="_AD261C65-88B9-4C37-AE6F-2433FCEE5404">
         <di:waypoint x="1187" y="225"/>
         <di:waypoint x="1450" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2064fd78-72aa-4851-9813-8d56674b3936" dmnElementRef="tns:_2064fd78-72aa-4851-9813-8d56674b3936">
+      <dmndi:DMNEdge id="dmnedge-drg-_FFD5D0CF-3E1A-46F6-B8D4-25FCE3F93886" dmnElementRef="_FFD5D0CF-3E1A-46F6-B8D4-25FCE3F93886">
+        <di:waypoint x="1187" y="400"/>
+        <di:waypoint x="1887" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_08922177-D594-4891-ACEE-81BEBEAECD46" dmnElementRef="_08922177-D594-4891-ACEE-81BEBEAECD46">
+        <di:waypoint x="1362" y="400"/>
+        <di:waypoint x="1887" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_6DB7FDEE-331B-4BEB-A3A0-33A10A5B07F4" dmnElementRef="_6DB7FDEE-331B-4BEB-A3A0-33A10A5B07F4">
+        <di:waypoint x="1362" y="400"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_6537A260-A595-4232-91AA-922FF10FEDAC" dmnElementRef="_6537A260-A595-4232-91AA-922FF10FEDAC">
+        <di:waypoint x="1537" y="400"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_DD1D4DC9-6E72-457B-B5C5-6D0D1994C6E1" dmnElementRef="_DD1D4DC9-6E72-457B-B5C5-6D0D1994C6E1">
+        <di:waypoint x="1187" y="225"/>
+        <di:waypoint x="1100" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F8DD31F2-C579-4A4D-9BED-116B5F893EE6" dmnElementRef="_F8DD31F2-C579-4A4D-9BED-116B5F893EE6">
         <di:waypoint x="1537" y="225"/>
         <di:waypoint x="1100" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_d12d9a82-b182-4c15-9fce-d22cdc53dbc4" dmnElementRef="tns:_d12d9a82-b182-4c15-9fce-d22cdc53dbc4">
+      <dmndi:DMNEdge id="dmnedge-drg-_4F8AF385-4195-4F00-85B5-A9C7C7E0B998" dmnElementRef="_4F8AF385-4195-4F00-85B5-A9C7C7E0B998">
+        <di:waypoint x="1537" y="225"/>
+        <di:waypoint x="2150" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_9F8C5723-4AFB-4678-8510-99A1131674D7" dmnElementRef="_9F8C5723-4AFB-4678-8510-99A1131674D7">
         <di:waypoint x="1887" y="225"/>
         <di:waypoint x="2500" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0013-sort.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0013-sort.dmn
@@ -1,81 +1,88 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_ac1acfdd-6baa-4f30-9cac-5d23957b4217" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_ac1acfdd-6baa-4f30-9cac-5d23957b4217" name="sort" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_ac1acfdd-6baa-4f30-9cac-5d23957b4217">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_ac1acfdd-6baa-4f30-9cac-5d23957b4217"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_ac1acfdd-6baa-4f30-9cac-5d23957b4217" name="sort" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_ac1acfdd-6baa-4f30-9cac-5d23957b4217">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tNumList" name="tNumList" isCollection="true">
-    <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:typeRef>number</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tRow" name="tRow" isCollection="false">
     <dmn:itemComponent id="_bed80fb2-293a-4db0-b261-e58a1311dfd0" name="col1" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_88c1de9d-6c23-4ea2-9bf9-f7cb06d43ebe" name="col2" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_a63e8581-e650-47e5-bd6a-b8cb0f5b3fb7" name="col3" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_fed04cbf-6aee-43ed-b218-d0fffca51693" name="col4" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tTable" name="tTable" isCollection="true">
-    <dmn:typeRef>tns:tRow</dmn:typeRef>
+    <dmn:typeRef>tRow</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tStringList" name="tStringList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="_d8747cda-26be-46c8-98ee-78f64efbf730" name="listA">
     <dmn:extensionElements/>
-    <dmn:variable id="_7143901C-D8BE-4ABE-9F13-750917BF00D3" name="listA" typeRef="tns:tNumList"/>
+    <dmn:variable id="_AF00CF5D-9D18-45F0-803A-2636691A32D2" name="listA" typeRef="tNumList"/>
   </dmn:inputData>
   <dmn:inputData id="_f8197899-44af-4ec5-9453-26da073a2be3" name="tableB">
     <dmn:extensionElements/>
-    <dmn:variable id="_FCE32E35-1321-43CA-83BC-742A338F1560" name="tableB" typeRef="tns:tTable"/>
+    <dmn:variable id="_D5E20ED5-1BE1-48A4-AD9C-FF34861B71AE" name="tableB" typeRef="tTable"/>
   </dmn:inputData>
   <dmn:decision id="_c6416c42-328a-410c-a083-859b82771690" name="sort1">
     <dmn:extensionElements/>
-    <dmn:variable id="_A766A6D9-B0FC-447C-9D25-02DD0F69E3BC" name="sort1" typeRef="tns:tNumList"/>
-    <dmn:informationRequirement id="_d8747cda-26be-46c8-98ee-78f64efbf730">
+    <dmn:variable id="_75F6B431-515D-4816-8008-A0246770F140" name="sort1" typeRef="tNumList"/>
+    <dmn:informationRequirement id="_B003E907-840B-4CFD-85AF-FD3525E3BABD">
       <dmn:requiredInput href="#_d8747cda-26be-46c8-98ee-78f64efbf730"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_6BAF6362-BDD0-4C70-B19D-8D20E55DFD2E">
+    <dmn:literalExpression id="_17A219E1-1860-4E09-A729-9BC085821C4E">
       <dmn:text>sort(listA, function(x,y) x&gt;y)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_d8ef1de9-9387-4389-ab83-cbf9dafc419b" name="sort2">
     <dmn:extensionElements/>
-    <dmn:variable id="_F4261A49-0761-497A-8C08-FD5FC3E3C467" name="sort2" typeRef="tns:tTable"/>
-    <dmn:informationRequirement id="_f8197899-44af-4ec5-9453-26da073a2be3">
+    <dmn:variable id="_E1CA35A1-2BFB-484C-938A-C685F3A7E302" name="sort2" typeRef="tTable"/>
+    <dmn:informationRequirement id="_2C9BC426-23D2-4164-BFAE-EF0DF8B9FE5E">
       <dmn:requiredInput href="#_f8197899-44af-4ec5-9453-26da073a2be3"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E4A2CAD9-2F2F-4C44-90FD-F960FFEB7AFA">
+    <dmn:literalExpression id="_1D60798F-62BC-4416-A336-C54984B99051">
       <dmn:text>sort(tableB, function(x,y) x.col2&lt;y.col2)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_7471008b-e8c7-4205-8e17-586ff41e7205" name="stringList">
     <dmn:extensionElements/>
-    <dmn:variable id="_A07B35EA-ACD1-4704-8C56-A4561861580A" name="stringList" typeRef="tns:tStringList"/>
+    <dmn:variable id="_2E8B534E-875A-459D-93BB-031B8A1F7247" name="stringList" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:decision id="_4ff4b8ff-4379-477a-a016-f7d1741d2036" name="sort3">
     <dmn:extensionElements/>
-    <dmn:variable id="_C77398A4-9F25-4FD6-972D-A9710AD99C3C" name="sort3" typeRef="tns:tStringList"/>
-    <dmn:informationRequirement id="_7471008b-e8c7-4205-8e17-586ff41e7205">
+    <dmn:variable id="_276EC98F-BA8F-4725-9A8A-25B0EB55F099" name="sort3" typeRef="tStringList"/>
+    <dmn:informationRequirement id="_EA6FCAE6-75D7-4A14-9CE6-10DEEBCD6B90">
       <dmn:requiredInput href="#_7471008b-e8c7-4205-8e17-586ff41e7205"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_D8416EE8-AEC6-4093-A5E2-D591874F5978">
+    <dmn:literalExpression id="_DADE1F38-E56C-4D59-AFE6-CE3CF91AF583">
       <dmn:text>sort(stringList, function(x,y) x&lt;y)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_C5029F17-5FE7-4A25-8FC1-F85C230EFF15" name="DRG">
+    <dmndi:DMNDiagram id="_5D1B1CB4-45B7-4519-BDC0-72921315883E" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_6BAF6362-BDD0-4C70-B19D-8D20E55DFD2E"/>
-          <kie:ComponentWidths dmnElementRef="_E4A2CAD9-2F2F-4C44-90FD-F960FFEB7AFA"/>
-          <kie:ComponentWidths dmnElementRef="_D8416EE8-AEC6-4093-A5E2-D591874F5978"/>
+          <kie:ComponentWidths dmnElementRef="_17A219E1-1860-4E09-A729-9BC085821C4E"/>
+          <kie:ComponentWidths dmnElementRef="_1D60798F-62BC-4416-A336-C54984B99051"/>
+          <kie:ComponentWidths dmnElementRef="_DADE1F38-E56C-4D59-AFE6-CE3CF91AF583"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_d8747cda-26be-46c8-98ee-78f64efbf730" dmnElementRef="tns:_d8747cda-26be-46c8-98ee-78f64efbf730" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d8747cda-26be-46c8-98ee-78f64efbf730" dmnElementRef="_d8747cda-26be-46c8-98ee-78f64efbf730" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -84,7 +91,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_f8197899-44af-4ec5-9453-26da073a2be3" dmnElementRef="tns:_f8197899-44af-4ec5-9453-26da073a2be3" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_f8197899-44af-4ec5-9453-26da073a2be3" dmnElementRef="_f8197899-44af-4ec5-9453-26da073a2be3" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -93,7 +100,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c6416c42-328a-410c-a083-859b82771690" dmnElementRef="tns:_c6416c42-328a-410c-a083-859b82771690" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c6416c42-328a-410c-a083-859b82771690" dmnElementRef="_c6416c42-328a-410c-a083-859b82771690" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -102,7 +109,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d8ef1de9-9387-4389-ab83-cbf9dafc419b" dmnElementRef="tns:_d8ef1de9-9387-4389-ab83-cbf9dafc419b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d8ef1de9-9387-4389-ab83-cbf9dafc419b" dmnElementRef="_d8ef1de9-9387-4389-ab83-cbf9dafc419b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -111,7 +118,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7471008b-e8c7-4205-8e17-586ff41e7205" dmnElementRef="tns:_7471008b-e8c7-4205-8e17-586ff41e7205" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7471008b-e8c7-4205-8e17-586ff41e7205" dmnElementRef="_7471008b-e8c7-4205-8e17-586ff41e7205" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -120,7 +127,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4ff4b8ff-4379-477a-a016-f7d1741d2036" dmnElementRef="tns:_4ff4b8ff-4379-477a-a016-f7d1741d2036" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4ff4b8ff-4379-477a-a016-f7d1741d2036" dmnElementRef="_4ff4b8ff-4379-477a-a016-f7d1741d2036" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -129,15 +136,15 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_d8747cda-26be-46c8-98ee-78f64efbf730" dmnElementRef="tns:_d8747cda-26be-46c8-98ee-78f64efbf730">
+      <dmndi:DMNEdge id="dmnedge-drg-_B003E907-840B-4CFD-85AF-FD3525E3BABD" dmnElementRef="_B003E907-840B-4CFD-85AF-FD3525E3BABD">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_f8197899-44af-4ec5-9453-26da073a2be3" dmnElementRef="tns:_f8197899-44af-4ec5-9453-26da073a2be3">
+      <dmndi:DMNEdge id="dmnedge-drg-_2C9BC426-23D2-4164-BFAE-EF0DF8B9FE5E" dmnElementRef="_2C9BC426-23D2-4164-BFAE-EF0DF8B9FE5E">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7471008b-e8c7-4205-8e17-586ff41e7205" dmnElementRef="tns:_7471008b-e8c7-4205-8e17-586ff41e7205">
+      <dmndi:DMNEdge id="dmnedge-drg-_EA6FCAE6-75D7-4A14-9CE6-10DEEBCD6B90" dmnElementRef="_EA6FCAE6-75D7-4A14-9CE6-10DEEBCD6B90">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0014-loan-comparison.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0014-loan-comparison.dmn
@@ -1,214 +1,222 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_56c7d4a5-e6db-4bba-ac5f-dc082a16f719" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_56c7d4a5-e6db-4bba-ac5f-dc082a16f719" name="loanComparison" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_56c7d4a5-e6db-4bba-ac5f-dc082a16f719">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_56c7d4a5-e6db-4bba-ac5f-dc082a16f719"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_56c7d4a5-e6db-4bba-ac5f-dc082a16f719" name="loanComparison" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_56c7d4a5-e6db-4bba-ac5f-dc082a16f719">
   <dmn:extensionElements/>
-  <dmn:itemDefinition id="_AF6547AD-B94D-4B53-BF8D-1EBB47DD6CCA" name="tLoanProduct" isCollection="false">
+  <dmn:itemDefinition id="_1DF3027C-E5D7-48BF-B693-DF15C3BAA932" name="tLoanProduct" isCollection="false">
     <dmn:itemComponent id="_e4e050fd-9198-4b62-8f99-15cb2a0a2373" name="lenderName" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_dc34919e-c7d1-4aab-b6d1-4be1174f6fd2" name="rate" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_9ca2f88a-3845-4b8d-864f-b86718eaa54d" name="points" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_5b870440-9692-4e81-959f-f2347c1768c9" name="fee" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_15F7B43B-FA51-4BD9-A626-765B7F91FB35" name="tLoanTable" isCollection="true">
-    <dmn:typeRef>tns:tLoanProduct</dmn:typeRef>
+  <dmn:itemDefinition id="_C1E491D2-6A0E-4C31-9E5A-4123B8AEBA57" name="tLoanTable" isCollection="true">
+    <dmn:typeRef>tLoanProduct</dmn:typeRef>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_8C00C9B7-A8D2-44E2-853D-E769AB632555" name="tMetric" isCollection="false">
+  <dmn:itemDefinition id="_7EED6080-2698-4468-ADD4-DAB009D039AF" name="tMetric" isCollection="false">
     <dmn:itemComponent id="_59994d58-3220-4cc6-8d91-783a008ac472" name="lenderName" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_63d8c69d-2431-43f5-bfa3-a014a6d2363e" name="rate" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_be9eaeb3-8d52-4d99-9d0a-325c15fa6b74" name="points" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_2a9fe07c-d72b-4f8b-9995-e1b194dd5aa9" name="fee" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_333f9092-d8a7-4e75-973d-82f30569e432" name="loanAmt" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_790093df-4886-405a-8ad6-34de25812bdc" name="downPmtAmt" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_8f37cdc9-ff7a-4b8c-8849-c0b6a6cbb960" name="paymentAmt" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_3f4568e7-be52-4ce2-8704-be14aa6cd1d5" name="equity36moPct" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_B2F91B5D-777F-4AE3-8198-0B97F20715C4" name="tMetrics" isCollection="true">
-    <dmn:typeRef>tns:tMetric</dmn:typeRef>
+  <dmn:itemDefinition id="_75BA5279-CCA5-423A-80C0-6B84C5F75966" name="tMetrics" isCollection="true">
+    <dmn:typeRef>tMetric</dmn:typeRef>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_9B898E80-E3E0-46F3-BC9F-C250E1B46795" name="tRankedProducts" isCollection="false">
+  <dmn:itemDefinition id="_5435726D-47ED-4619-923E-A6C54DC05301" name="tRankedProducts" isCollection="false">
     <dmn:itemComponent id="_0ee333d1-03fc-4a77-8798-d0b351a19a36" name="metricsTable" isCollection="false">
-      <dmn:typeRef>tns:tMetrics</dmn:typeRef>
+      <dmn:typeRef>tMetrics</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_f0790a52-d95d-466a-bc51-5766c046c717" name="rankByRate" isCollection="false">
-      <dmn:typeRef>tns:tMetrics</dmn:typeRef>
+      <dmn:typeRef>tMetrics</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_d54127c6-8418-45df-89da-2f84bedae37c" name="rankByDownPmt" isCollection="false">
-      <dmn:typeRef>tns:tMetrics</dmn:typeRef>
+      <dmn:typeRef>tMetrics</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_7f98fed9-552a-4b57-99de-495cb96e8484" name="rankByMonthlyPmt" isCollection="false">
-      <dmn:typeRef>tns:tMetrics</dmn:typeRef>
+      <dmn:typeRef>tMetrics</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_897183a6-2ca8-4437-b21d-8ba90555a9e0" name="rankByEquityPct" isCollection="false">
-      <dmn:typeRef>tns:tMetrics</dmn:typeRef>
+      <dmn:typeRef>tMetrics</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decision id="_c5dd7a17-b588-4daf-8c9b-677e65ce87be" name="Bankrates">
     <dmn:extensionElements/>
-    <dmn:variable id="_FB28FC6C-9D10-4785-AC7A-597C815EEA2F" name="Bankrates" typeRef="tns:tLoanTable"/>
-    <dmn:relation id="_F9A4056C-65FA-4002-AAD2-A0ABA94F7A71">
+    <dmn:variable id="_2FA2C423-9B69-4C78-85DE-919B81EF08D1" name="Bankrates" typeRef="tLoanTable"/>
+    <dmn:relation id="_1DF555FB-D937-4A5D-8EDC-4B38A6250743">
       <dmn:column id="_23af7b70-cc60-4d84-8e5f-60d5a4ebfe86" name="lenderName"/>
       <dmn:column id="_11fb4b39-53a6-4670-90c7-7f1b21bf3936" name="rate"/>
       <dmn:column id="_505d19fa-b5b3-4adc-8aca-5ecc1b58d4f5" name="points"/>
       <dmn:column id="_e9ed23a8-88c6-4cb0-a1f3-2a895999ef06" name="fee"/>
       <dmn:row id="_bc21b674-23cc-440d-b505-32d5f799e281">
-        <dmn:literalExpression id="_40A6B5CE-2E45-495B-9AE7-BDF3D1C1D5E1">
+        <dmn:literalExpression id="_1B1D9DF9-7A0A-4F52-B136-606CBC6D6887">
           <dmn:text>"Oceans Capital"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_7EAE2169-97BD-4987-9849-944DF332E7A8">
+        <dmn:literalExpression id="_64C244A6-AC34-4969-8C4D-D9A8A2C3B996">
           <dmn:text>.03500</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_830B02EA-26EC-4B6A-99EB-A97906016229">
+        <dmn:literalExpression id="_E910BF7C-EC84-4324-9DD5-8FEAE48D5090">
           <dmn:text>0</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_EF0A1F86-EDAD-4E31-9593-BCAEE82B7934">
+        <dmn:literalExpression id="_337DFEE7-CA4C-4D29-B3A5-37AC363ED108">
           <dmn:text>0</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_6f3eb485-dddc-40f0-a153-8c989dc4b68d">
-        <dmn:literalExpression id="_F8FAA367-6E59-4D7D-A2FD-F487A8F52BE4">
+        <dmn:literalExpression id="_8DF0FB96-8446-4437-9807-70407F2151B6">
           <dmn:text>"eClick Lending"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_4C0AA6D1-ADC2-4686-A764-8A6EAF3A5C45">
+        <dmn:literalExpression id="_0B01FF93-2F83-4FD7-8EB8-D5FF4A8C0277">
           <dmn:text>.03200</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_88B5A821-855B-4F22-B63F-1D5483C5FA17">
+        <dmn:literalExpression id="_F8993C34-6FA3-4262-B5DB-FC6930AA349F">
           <dmn:text>1.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_D479EF2A-B4DE-43A7-9AA1-3BFF4FC89FDA">
+        <dmn:literalExpression id="_85C7AD0C-5D96-455A-B6DA-8756EB335625">
           <dmn:text>2700</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_36362bb9-5cd1-4b55-8ce2-a8cf02f6bed0">
-        <dmn:literalExpression id="_B4CCD593-10C0-4B9E-A4BD-4AFFDB1F02CB">
+        <dmn:literalExpression id="_6AC0DD5F-9230-4AB0-B0B6-16624ADBFC3D">
           <dmn:text>"eClickLending"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_CD9CFE11-C862-40F9-A129-EE6F040139A9">
+        <dmn:literalExpression id="_F8C70D78-715B-4A1B-A56D-2B39B8145884">
           <dmn:text>.03375</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_1C8FCF1A-3A16-44C9-A11A-723617BA5767">
+        <dmn:literalExpression id="_3EC48D54-2879-4E52-9C98-2C0940AEDCE5">
           <dmn:text>0.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_A5A7261E-059A-4095-8D51-EA9BA55A0480">
+        <dmn:literalExpression id="_E8CEF60F-13CB-43C2-97F5-4F2D2A12BF49">
           <dmn:text>1200</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_922a8c6b-2bf0-4453-b1d2-1242c5527dce">
-        <dmn:literalExpression id="_948666A6-61C4-4348-9712-60380809B1BD">
+        <dmn:literalExpression id="_BE062BA6-500F-42FC-ABE3-4B0879669E60">
           <dmn:text>"AimLoan"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_F8033E29-4DB2-4480-8D23-AA755586BB58">
+        <dmn:literalExpression id="_91892B76-7EDC-4FD3-A681-EF621329916A">
           <dmn:text>.03000</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_D1BFC2A7-4D62-4182-B764-AD60915D9D0B">
+        <dmn:literalExpression id="_FB19BB74-AE5B-47CC-9B11-C7BCF9C29C23">
           <dmn:text>1.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_A6DD0656-9D6E-4E8D-98E2-A246DDC1E030">
+        <dmn:literalExpression id="_F29E0A1B-82EC-4760-BC50-07B4715E33EE">
           <dmn:text>3966</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_72d72621-d6aa-4c78-a6ee-b0086b27ea3a">
-        <dmn:literalExpression id="_25EB561C-1D5A-4FAA-AC95-57223E477A51">
+        <dmn:literalExpression id="_00C4DAEF-CFA8-44F6-934C-D7ED6FC036D2">
           <dmn:text>"Home Loans Today"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_DBFB13B4-B6EE-4095-9BA5-46CCB7E8848F">
+        <dmn:literalExpression id="_4BB883D3-7134-415E-B2BE-C72CAEFFED7F">
           <dmn:text>.03125</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_E939129F-1BCE-41D4-99C7-CEBB19385DE8">
+        <dmn:literalExpression id="_0892370F-163D-49D3-869F-ED21DBC4A986">
           <dmn:text>1.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_8FAE46EE-2C2E-4BBA-A57B-9FACF5479B2E">
+        <dmn:literalExpression id="_50598652-BE27-483F-A9EC-3D9719E092FD">
           <dmn:text>285</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_4fd60510-7767-4cd9-9f5e-9783b9e6f688">
-        <dmn:literalExpression id="_9FB45238-2252-4AD7-AE10-302211A10663">
+        <dmn:literalExpression id="_4D94CC2C-B5B4-46A1-8C43-4A74023C1F15">
           <dmn:text>"Sebonic"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_490E5199-9C1C-413F-BEF6-61462633A667">
+        <dmn:literalExpression id="_450F34A8-11A6-45B4-83BA-505C9A060E21">
           <dmn:text>.03125</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_6BAAF23D-F2D3-43B3-9780-A1D7CD445D83">
+        <dmn:literalExpression id="_26861A54-CE84-4598-9AC2-7B9EE74453E2">
           <dmn:text>0.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_CE24F48E-1760-4682-91D4-FBAC061CFFA8">
+        <dmn:literalExpression id="_2595493D-EFAD-403C-B68F-B77383157692">
           <dmn:text>4028</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_4a2aca46-7331-445b-b378-beb0a4b7064f">
-        <dmn:literalExpression id="_04BFA932-5AD9-4019-AECC-AABC3014B4CE">
+        <dmn:literalExpression id="_499AFD59-FE4A-42E4-B79C-22A1F98470AA">
           <dmn:text>"AimLoan"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_CA255327-2E3C-4547-B644-524F9874A069">
+        <dmn:literalExpression id="_6D0F4AB1-D9E1-4CC0-A42A-6829EFEDBA84">
           <dmn:text>.03125</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_65761C4B-0687-4750-8B74-FE765D9D2B1E">
+        <dmn:literalExpression id="_B85FC7CD-6686-4B9D-A251-CEE744413B80">
           <dmn:text>0.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_1784A1B1-4107-4E87-A6A6-07E3FD110C8C">
+        <dmn:literalExpression id="_E7D52F84-229C-4286-8992-1C86FAEC5A26">
           <dmn:text>4317</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_3b1b71e2-7084-4869-bb08-52d5ad2bcf1e">
-        <dmn:literalExpression id="_37D03ABD-7392-479E-A64D-713783A38C35">
+        <dmn:literalExpression id="_34C345C8-0957-41C8-AC1B-62FC729DA1E3">
           <dmn:text>"eRates Mortgage"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_611E0069-3571-4578-8061-F3959B15B3B5">
+        <dmn:literalExpression id="_6AA424CB-B287-4A7E-BA6C-90622D8B20BD">
           <dmn:text>.03125</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_D8561DDE-E4BF-460E-9393-1780F4DBAB08">
+        <dmn:literalExpression id="_ABAAE3BA-0EDA-4FC6-B2EB-B2466EA58F16">
           <dmn:text>1.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_FBBB0DA2-8749-42AA-A8E5-40CF6EABF534">
+        <dmn:literalExpression id="_93F7207F-BA2F-4F28-8615-8F9C15094DDF">
           <dmn:text>2518</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_d0e4ef04-9127-4931-b802-a0d4128a78c9">
-        <dmn:literalExpression id="_50793495-BE94-469C-BF4C-093F957AF4E6">
+        <dmn:literalExpression id="_8189227B-F307-4E85-9597-E174128A81C7">
           <dmn:text>"Home Loans Today"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_A066BA6B-061D-40A1-822D-6D1556D12702">
+        <dmn:literalExpression id="_EDF72F44-1A0C-4DD5-98D6-644C27B33E11">
           <dmn:text>.03250</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_009E3BC8-451A-401A-9931-431EEA2D9F70">
+        <dmn:literalExpression id="_A8F9206F-D086-461F-8D66-C182451AA7B0">
           <dmn:text>0.1</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_4DA98CAF-770A-4AFD-B221-E33C63F372E3">
+        <dmn:literalExpression id="_319DC76B-9B32-4E08-9567-855E5CA601ED">
           <dmn:text>822</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_a254dd15-1c62-4f4f-9ce2-83f6bfbcb487">
-        <dmn:literalExpression id="_E1F4F061-FB40-4EAB-B276-5F1099F47084">
+        <dmn:literalExpression id="_0FB6EF1D-15E0-452B-A010-C6D993EE6F5D">
           <dmn:text>"AimLoan"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_62539908-A96C-466D-BDB1-5D7A9647325A">
+        <dmn:literalExpression id="_3FCA4C0C-693A-4DCB-8467-8121AA9987DF">
           <dmn:text>.03250</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_D34A9949-BB93-42DD-AADC-1837D7FFEFFA">
+        <dmn:literalExpression id="_63ADF70D-2EA0-49CD-AFA4-DFCCC7A663FB">
           <dmn:text>0</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_A31230C9-BA82-450E-92C1-A89DC43DDCF5">
+        <dmn:literalExpression id="_7CF549B0-D03F-4C41-8A7A-F9CBBDC661A7">
           <dmn:text>1995</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
@@ -216,48 +224,48 @@
   </dmn:decision>
   <dmn:inputData id="_67c50a4c-3002-4d0a-9acf-4c76cb0364fa" name="RequestedAmt">
     <dmn:extensionElements/>
-    <dmn:variable id="_01E7B2AF-3A55-486F-8F6C-32E5E97FD422" name="RequestedAmt" typeRef="feel:number"/>
+    <dmn:variable id="_0800A219-FD90-4E8E-BA95-2564E231655C" name="RequestedAmt" typeRef="number"/>
   </dmn:inputData>
   <dmn:decision id="_715940be-0f5d-4701-8155-fcba85874aa1" name="RankedProducts">
     <dmn:extensionElements/>
-    <dmn:variable id="_2B666123-6EA6-4DBF-BC62-88D9068A81C4" name="RankedProducts" typeRef="tns:tRankedProducts"/>
-    <dmn:informationRequirement id="_67c50a4c-3002-4d0a-9acf-4c76cb0364fa">
+    <dmn:variable id="_5ED3401E-7689-415D-897C-BBB1E8973F5B" name="RankedProducts" typeRef="tRankedProducts"/>
+    <dmn:informationRequirement id="_608B07F5-FDE8-4AD2-8816-DC77F980FA2C">
       <dmn:requiredInput href="#_67c50a4c-3002-4d0a-9acf-4c76cb0364fa"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_c5dd7a17-b588-4daf-8c9b-677e65ce87be">
+    <dmn:informationRequirement id="_7057F3DB-00F4-4613-BFD9-5CECB3119503">
       <dmn:requiredDecision href="#_c5dd7a17-b588-4daf-8c9b-677e65ce87be"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_83059f2e-2862-45a9-97a7-71ffaa860586">
+    <dmn:knowledgeRequirement id="_E3757580-2571-47EB-B428-989DED1434F3">
       <dmn:requiredKnowledge href="#_83059f2e-2862-45a9-97a7-71ffaa860586"/>
     </dmn:knowledgeRequirement>
-    <dmn:context id="_9E525FB1-0CDC-4D03-A6D7-4A9D97488C78">
+    <dmn:context id="_9E76BE47-7581-4D87-A3BA-81FA2A9C8BB1">
       <dmn:contextEntry>
-        <dmn:variable id="_9F716717-3890-4DD6-9430-598F1C43448D" name="metricsTable" typeRef="tns:tMetrics"/>
-        <dmn:literalExpression id="_F3279A5D-AB9C-4515-A26B-1A7F680D5364">
+        <dmn:variable id="_32570EA7-6777-45B9-9BDC-36A1CA08D4EB" name="metricsTable" typeRef="tMetrics"/>
+        <dmn:literalExpression id="_877F1EB7-E054-4523-946E-3EA7B9D58940">
           <dmn:text>for i in Bankrates return FinancialMetrics(i,RequestedAmt)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_991835C6-1EC9-43FA-BEF2-B79325088F2C" name="rankByRate" typeRef="tns:tMetrics"/>
-        <dmn:literalExpression id="_8932296B-4D6E-4759-8259-4F408629965E">
+        <dmn:variable id="_8BDDC5C2-50B7-4D93-846B-1D0CC514FE7E" name="rankByRate" typeRef="tMetrics"/>
+        <dmn:literalExpression id="_782861F6-4BD7-4E37-8888-0A007F6B5F90">
           <dmn:text>sort(metricsTable, function(x,y) x.rate&lt;y.rate)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_53FBD7CE-B489-4469-8953-3EF2E8748B45" name="rankByDownPmt" typeRef="tns:tMetrics"/>
-        <dmn:literalExpression id="_37D6B095-8C9A-45E3-8301-FCCCC383677F">
+        <dmn:variable id="_777C2078-31E5-4093-BBBF-F2DAFFA413DD" name="rankByDownPmt" typeRef="tMetrics"/>
+        <dmn:literalExpression id="_DD1D2890-5263-48FC-B86F-1751161BF3AB">
           <dmn:text>sort(metricsTable, function(x,y) x.downPmtAmt&lt;y.downPmtAmt)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_F83EBF50-5CC6-449E-A009-9C265973983A" name="rankByMonthlyPmt" typeRef="tns:tMetrics"/>
-        <dmn:literalExpression id="_E6B3A2E6-181F-4B23-A2AC-023DF7EC58DF">
+        <dmn:variable id="_42ED7AB0-8351-4C4E-B3ED-59348B8D9937" name="rankByMonthlyPmt" typeRef="tMetrics"/>
+        <dmn:literalExpression id="_BEE7285A-D2F7-4B3B-B65B-A2BD98C33135">
           <dmn:text>sort(metricsTable, function(x,y) x.paymentAmt&lt;y.paymentAmt)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_84F198DB-2B5C-4FE3-B98C-33D06FFFF129" name="rankByEquityPct" typeRef="tns:tMetrics"/>
-        <dmn:literalExpression id="_2107E96A-9255-496E-A18D-98429F3224F9">
+        <dmn:variable id="_3B0F8ABB-26C5-4A78-9C55-3C3F04EE3E86" name="rankByEquityPct" typeRef="tMetrics"/>
+        <dmn:literalExpression id="_0D69BA37-338C-44AC-91AF-7EF51029E5E3">
           <dmn:text>sort(metricsTable, function(x,y) x.equity36moPct&gt;y.equity36moPct)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
@@ -265,161 +273,161 @@
   </dmn:decision>
   <dmn:businessKnowledgeModel id="_83059f2e-2862-45a9-97a7-71ffaa860586" name="FinancialMetrics">
     <dmn:extensionElements/>
-    <dmn:variable id="_5B5264CB-9EF5-4230-B7A4-67C3F8CE59B6" name="FinancialMetrics" typeRef="tns:tMetrics"/>
-    <dmn:encapsulatedLogic id="_6F77BB1F-CC82-4BF7-9098-180528DAF3C8" kind="FEEL">
-      <dmn:formalParameter id="_581FBAB0-8A92-4A0D-A0E1-AF438640890D" name="product" typeRef="tns:tLoanProduct"/>
-      <dmn:formalParameter id="_8C4AE4A2-AF78-4AA3-93BB-4274E089107E" name="requestedAmt" typeRef="feel:number"/>
-      <dmn:context id="_BD0E69D1-4D74-403D-B1F6-5B23BB7B2895">
+    <dmn:variable id="_416324F7-9F4A-4709-B132-116C5C0CC0AF" name="FinancialMetrics" typeRef="tMetrics"/>
+    <dmn:encapsulatedLogic id="_8772BB2C-4644-4174-A271-59F9544B991A" kind="FEEL">
+      <dmn:formalParameter id="_9B638B68-EAFC-448C-9E8E-368D8E062D91" name="product" typeRef="tLoanProduct"/>
+      <dmn:formalParameter id="_CAE20F36-10E4-4FDC-9FEE-A82407D37459" name="requestedAmt" typeRef="number"/>
+      <dmn:context id="_46673250-1A65-4EF5-9C23-DA559D39E746">
         <dmn:contextEntry>
-          <dmn:variable id="_5210410F-1C36-4C2B-B716-CC8385BBE07B" name="lenderName" typeRef="feel:string"/>
-          <dmn:literalExpression id="_DC5F0F71-E3FA-4AFC-9F7E-26309A2CA1B2">
+          <dmn:variable id="_DAD7E879-3646-4FC2-B509-536F0DBF307D" name="lenderName" typeRef="string"/>
+          <dmn:literalExpression id="_05941C74-67CF-4CCF-AD20-38FDF4EA3892">
             <dmn:text>product.lenderName</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_708FB7B1-4504-4BE6-AD47-749A53BBAD2E" name="rate" typeRef="feel:number"/>
-          <dmn:literalExpression id="_DC84D766-7498-4CE7-9345-A81C3BE30734">
+          <dmn:variable id="_797D752C-C17D-468E-8788-0B0F1354DCB9" name="rate" typeRef="number"/>
+          <dmn:literalExpression id="_B5DE32AD-CA22-4B23-B40C-8F8ECC4BB0F3">
             <dmn:text>product.rate</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_49308805-F5A7-429C-8604-BC3A15EB1E54" name="points" typeRef="feel:number"/>
-          <dmn:literalExpression id="_C1D637D2-0003-49FD-B2DF-0DF0F8F5313E">
+          <dmn:variable id="_2743AEDE-E462-45CC-AFCA-02613341EEE8" name="points" typeRef="number"/>
+          <dmn:literalExpression id="_67E4AA85-FF72-48C6-A41A-586CB86B6A3D">
             <dmn:text>product.points</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_1572D846-E764-4055-B5F6-921C707878D7" name="fee" typeRef="feel:number"/>
-          <dmn:literalExpression id="_2EBBC9BB-1E1A-4DA4-B240-990EA135449F">
+          <dmn:variable id="_27848B23-80DB-42D8-9F7E-089CF6EC5C37" name="fee" typeRef="number"/>
+          <dmn:literalExpression id="_030C87AC-F0FF-42F0-86DD-DE2A2A17683C">
             <dmn:text>product.fee</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_B5D42F68-5356-4E24-8825-110BD7E7A236" name="loanAmt" typeRef="feel:number"/>
-          <dmn:literalExpression id="_4AF47FA3-2527-45B0-AF77-40D0A57AD4F5">
+          <dmn:variable id="_BE39E471-737A-424A-A322-8F1D67337DCE" name="loanAmt" typeRef="number"/>
+          <dmn:literalExpression id="_EA6C9F53-7A7F-4922-91F8-0DA02E83A610">
             <dmn:text>requestedAmt*(1+points/100)+fee</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_58CF7409-6D10-4B8A-8BD5-8DBE73FA7993" name="downPmtAmt" typeRef="feel:number"/>
-          <dmn:literalExpression id="_8A364143-E167-45F7-B824-AB4BAFA6CE65">
+          <dmn:variable id="_B347EC9E-E53F-4EF9-8D19-1AE34D93D665" name="downPmtAmt" typeRef="number"/>
+          <dmn:literalExpression id="_AD57FD3B-DF6C-452D-BADE-8A3FAA1259C4">
             <dmn:text>0.2*loanAmt</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_1DE254C0-83D5-4D2C-808C-FC0A3121A1FA" name="paymentAmt" typeRef="feel:number"/>
-          <dmn:literalExpression id="_CC1B1923-5702-4582-912D-FD7C51DF1D8C">
+          <dmn:variable id="_24E5D54F-B08B-4EB1-BD83-92F53BB48D9F" name="paymentAmt" typeRef="number"/>
+          <dmn:literalExpression id="_D9F6F60A-0903-4A89-B00D-E4E277637400">
             <dmn:text>monthlyPayment(loanAmt,rate,360)</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_CD3E39AA-1F42-41D1-BDE5-21739790A616" name="equity36moPct" typeRef="feel:number"/>
-          <dmn:literalExpression id="_0D1C7372-9323-4E85-A4BA-CDDDCDFDFDF1">
+          <dmn:variable id="_860924B8-C81B-484E-AD30-49244EF727A7" name="equity36moPct" typeRef="number"/>
+          <dmn:literalExpression id="_F9088A7D-8704-464E-9DCE-8C2D373691C6">
             <dmn:text>1 - equity36Mo(loanAmt,rate,36,paymentAmt)/requestedAmt*0.8</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
       </dmn:context>
     </dmn:encapsulatedLogic>
-    <dmn:knowledgeRequirement id="_8702e1b6-213b-4f75-bf56-99ac3835cde7">
+    <dmn:knowledgeRequirement id="_FE9BECB0-836E-4D5D-9CC4-1CAFAE5F9340">
       <dmn:requiredKnowledge href="#_8702e1b6-213b-4f75-bf56-99ac3835cde7"/>
     </dmn:knowledgeRequirement>
-    <dmn:knowledgeRequirement id="_daec318a-135b-4d54-9e7f-85af3aa662f7">
+    <dmn:knowledgeRequirement id="_69F0F987-6AE9-45F4-91E6-D179D0BA49C4">
       <dmn:requiredKnowledge href="#_daec318a-135b-4d54-9e7f-85af3aa662f7"/>
     </dmn:knowledgeRequirement>
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="_8702e1b6-213b-4f75-bf56-99ac3835cde7" name="monthlyPayment">
     <dmn:extensionElements/>
-    <dmn:variable id="_B506C225-599A-462C-9F63-EA0898246AF2" name="monthlyPayment" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_253D214A-0686-4226-ABEA-1015EFD9D7E5" kind="FEEL">
-      <dmn:formalParameter id="_01CB9687-4A60-473E-A161-3033F1A01611" name="p" typeRef="feel:number"/>
-      <dmn:formalParameter id="_94795336-54D0-489B-A69A-F6C7EB685409" name="r" typeRef="feel:number"/>
-      <dmn:formalParameter id="_2AD73608-AF82-4798-B9E6-DAD88ACAD303" name="n" typeRef="feel:number"/>
-      <dmn:literalExpression id="_194D97FA-6F8E-40D3-A618-63AC2105AE0E" expressionLanguage="FEEL">
+    <dmn:variable id="_A15A6F47-FE29-4DA6-B74C-BC0C6E349565" name="monthlyPayment" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_2927F71D-C56B-4BD8-8488-2524149799FB" kind="FEEL">
+      <dmn:formalParameter id="_D0DE68A1-F345-422F-BBA9-A13CCA91C75B" name="p" typeRef="number"/>
+      <dmn:formalParameter id="_E409F809-0827-41EA-B2B5-5F4CA904E5E5" name="r" typeRef="number"/>
+      <dmn:formalParameter id="_D4BB362D-0B7C-4742-AE3F-340FDE6F3FC4" name="n" typeRef="number"/>
+      <dmn:literalExpression id="_B67AF0FF-D2C1-43E6-936E-0DE650F09A04" expressionLanguage="FEEL">
         <dmn:text>p*r/12/(1-(1+r/12)**-n)</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="_daec318a-135b-4d54-9e7f-85af3aa662f7" name="equity36Mo">
     <dmn:extensionElements/>
-    <dmn:variable id="_DB27E207-1169-47B5-970C-E4C64C035EEB" name="equity36Mo" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_FC1FA78C-CCEE-4271-B5C6-A4F1390AF799" kind="FEEL">
-      <dmn:formalParameter id="_611B0AB6-EC1A-4B57-AF3F-C09E456220D4" name="p" typeRef="feel:number"/>
-      <dmn:formalParameter id="_0786993A-9A03-4DF2-9966-53D338E9DEF3" name="r" typeRef="feel:number"/>
-      <dmn:formalParameter id="_8D5BFC76-0E4D-41B5-AFC5-ACB52EC9E265" name="n" typeRef="feel:number"/>
-      <dmn:formalParameter id="_AAA5A49F-CB75-410F-A3B6-57C767F22DE2" name="pmt" typeRef="feel:number"/>
-      <dmn:literalExpression id="_6FF67FE2-4171-41EC-9E0A-6ADD9D054735" expressionLanguage="FEEL">
+    <dmn:variable id="_1BB585FB-1A6B-484F-8379-1EAA257DBD9E" name="equity36Mo" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_7F139AF4-123B-4494-9597-C4DE063DE530" kind="FEEL">
+      <dmn:formalParameter id="_C81E667A-E855-4F0A-B071-16F3B13AB927" name="p" typeRef="number"/>
+      <dmn:formalParameter id="_90EAAAD5-EBEA-47D3-803D-4F047478A082" name="r" typeRef="number"/>
+      <dmn:formalParameter id="_F02CFCED-97F2-4C14-BE89-A48DD4391B19" name="n" typeRef="number"/>
+      <dmn:formalParameter id="_B700D1CA-0787-473C-9518-B7156ADA2BAC" name="pmt" typeRef="number"/>
+      <dmn:literalExpression id="_19E769D0-0A0F-457A-BEAF-256C9A761ADC" expressionLanguage="FEEL">
         <dmn:text>p*(1+r/12)**n - pmt*(-1+(1+r/12)**n)/r</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_EFE5B5FE-9F33-4558-B296-6ACAD1E3EBE3" name="DRG">
+    <dmndi:DMNDiagram id="_11F3B119-FDBD-4B1A-868A-3DD4B7096071" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_F9A4056C-65FA-4002-AAD2-A0ABA94F7A71"/>
-          <kie:ComponentWidths dmnElementRef="_40A6B5CE-2E45-495B-9AE7-BDF3D1C1D5E1"/>
-          <kie:ComponentWidths dmnElementRef="_7EAE2169-97BD-4987-9849-944DF332E7A8"/>
-          <kie:ComponentWidths dmnElementRef="_830B02EA-26EC-4B6A-99EB-A97906016229"/>
-          <kie:ComponentWidths dmnElementRef="_EF0A1F86-EDAD-4E31-9593-BCAEE82B7934"/>
-          <kie:ComponentWidths dmnElementRef="_F8FAA367-6E59-4D7D-A2FD-F487A8F52BE4"/>
-          <kie:ComponentWidths dmnElementRef="_4C0AA6D1-ADC2-4686-A764-8A6EAF3A5C45"/>
-          <kie:ComponentWidths dmnElementRef="_88B5A821-855B-4F22-B63F-1D5483C5FA17"/>
-          <kie:ComponentWidths dmnElementRef="_D479EF2A-B4DE-43A7-9AA1-3BFF4FC89FDA"/>
-          <kie:ComponentWidths dmnElementRef="_B4CCD593-10C0-4B9E-A4BD-4AFFDB1F02CB"/>
-          <kie:ComponentWidths dmnElementRef="_CD9CFE11-C862-40F9-A129-EE6F040139A9"/>
-          <kie:ComponentWidths dmnElementRef="_1C8FCF1A-3A16-44C9-A11A-723617BA5767"/>
-          <kie:ComponentWidths dmnElementRef="_A5A7261E-059A-4095-8D51-EA9BA55A0480"/>
-          <kie:ComponentWidths dmnElementRef="_948666A6-61C4-4348-9712-60380809B1BD"/>
-          <kie:ComponentWidths dmnElementRef="_F8033E29-4DB2-4480-8D23-AA755586BB58"/>
-          <kie:ComponentWidths dmnElementRef="_D1BFC2A7-4D62-4182-B764-AD60915D9D0B"/>
-          <kie:ComponentWidths dmnElementRef="_A6DD0656-9D6E-4E8D-98E2-A246DDC1E030"/>
-          <kie:ComponentWidths dmnElementRef="_25EB561C-1D5A-4FAA-AC95-57223E477A51"/>
-          <kie:ComponentWidths dmnElementRef="_DBFB13B4-B6EE-4095-9BA5-46CCB7E8848F"/>
-          <kie:ComponentWidths dmnElementRef="_E939129F-1BCE-41D4-99C7-CEBB19385DE8"/>
-          <kie:ComponentWidths dmnElementRef="_8FAE46EE-2C2E-4BBA-A57B-9FACF5479B2E"/>
-          <kie:ComponentWidths dmnElementRef="_9FB45238-2252-4AD7-AE10-302211A10663"/>
-          <kie:ComponentWidths dmnElementRef="_490E5199-9C1C-413F-BEF6-61462633A667"/>
-          <kie:ComponentWidths dmnElementRef="_6BAAF23D-F2D3-43B3-9780-A1D7CD445D83"/>
-          <kie:ComponentWidths dmnElementRef="_CE24F48E-1760-4682-91D4-FBAC061CFFA8"/>
-          <kie:ComponentWidths dmnElementRef="_04BFA932-5AD9-4019-AECC-AABC3014B4CE"/>
-          <kie:ComponentWidths dmnElementRef="_CA255327-2E3C-4547-B644-524F9874A069"/>
-          <kie:ComponentWidths dmnElementRef="_65761C4B-0687-4750-8B74-FE765D9D2B1E"/>
-          <kie:ComponentWidths dmnElementRef="_1784A1B1-4107-4E87-A6A6-07E3FD110C8C"/>
-          <kie:ComponentWidths dmnElementRef="_37D03ABD-7392-479E-A64D-713783A38C35"/>
-          <kie:ComponentWidths dmnElementRef="_611E0069-3571-4578-8061-F3959B15B3B5"/>
-          <kie:ComponentWidths dmnElementRef="_D8561DDE-E4BF-460E-9393-1780F4DBAB08"/>
-          <kie:ComponentWidths dmnElementRef="_FBBB0DA2-8749-42AA-A8E5-40CF6EABF534"/>
-          <kie:ComponentWidths dmnElementRef="_50793495-BE94-469C-BF4C-093F957AF4E6"/>
-          <kie:ComponentWidths dmnElementRef="_A066BA6B-061D-40A1-822D-6D1556D12702"/>
-          <kie:ComponentWidths dmnElementRef="_009E3BC8-451A-401A-9931-431EEA2D9F70"/>
-          <kie:ComponentWidths dmnElementRef="_4DA98CAF-770A-4AFD-B221-E33C63F372E3"/>
-          <kie:ComponentWidths dmnElementRef="_E1F4F061-FB40-4EAB-B276-5F1099F47084"/>
-          <kie:ComponentWidths dmnElementRef="_62539908-A96C-466D-BDB1-5D7A9647325A"/>
-          <kie:ComponentWidths dmnElementRef="_D34A9949-BB93-42DD-AADC-1837D7FFEFFA"/>
-          <kie:ComponentWidths dmnElementRef="_A31230C9-BA82-450E-92C1-A89DC43DDCF5"/>
-          <kie:ComponentWidths dmnElementRef="_9E525FB1-0CDC-4D03-A6D7-4A9D97488C78"/>
-          <kie:ComponentWidths dmnElementRef="_F3279A5D-AB9C-4515-A26B-1A7F680D5364"/>
-          <kie:ComponentWidths dmnElementRef="_8932296B-4D6E-4759-8259-4F408629965E"/>
-          <kie:ComponentWidths dmnElementRef="_37D6B095-8C9A-45E3-8301-FCCCC383677F"/>
-          <kie:ComponentWidths dmnElementRef="_E6B3A2E6-181F-4B23-A2AC-023DF7EC58DF"/>
-          <kie:ComponentWidths dmnElementRef="_2107E96A-9255-496E-A18D-98429F3224F9"/>
-          <kie:ComponentWidths dmnElementRef="_BD0E69D1-4D74-403D-B1F6-5B23BB7B2895"/>
-          <kie:ComponentWidths dmnElementRef="_DC5F0F71-E3FA-4AFC-9F7E-26309A2CA1B2"/>
-          <kie:ComponentWidths dmnElementRef="_DC84D766-7498-4CE7-9345-A81C3BE30734"/>
-          <kie:ComponentWidths dmnElementRef="_C1D637D2-0003-49FD-B2DF-0DF0F8F5313E"/>
-          <kie:ComponentWidths dmnElementRef="_2EBBC9BB-1E1A-4DA4-B240-990EA135449F"/>
-          <kie:ComponentWidths dmnElementRef="_4AF47FA3-2527-45B0-AF77-40D0A57AD4F5"/>
-          <kie:ComponentWidths dmnElementRef="_8A364143-E167-45F7-B824-AB4BAFA6CE65"/>
-          <kie:ComponentWidths dmnElementRef="_CC1B1923-5702-4582-912D-FD7C51DF1D8C"/>
-          <kie:ComponentWidths dmnElementRef="_0D1C7372-9323-4E85-A4BA-CDDDCDFDFDF1"/>
-          <kie:ComponentWidths dmnElementRef="_6F77BB1F-CC82-4BF7-9098-180528DAF3C8"/>
-          <kie:ComponentWidths dmnElementRef="_194D97FA-6F8E-40D3-A618-63AC2105AE0E"/>
-          <kie:ComponentWidths dmnElementRef="_253D214A-0686-4226-ABEA-1015EFD9D7E5"/>
-          <kie:ComponentWidths dmnElementRef="_6FF67FE2-4171-41EC-9E0A-6ADD9D054735"/>
-          <kie:ComponentWidths dmnElementRef="_FC1FA78C-CCEE-4271-B5C6-A4F1390AF799"/>
+          <kie:ComponentWidths dmnElementRef="_1DF555FB-D937-4A5D-8EDC-4B38A6250743"/>
+          <kie:ComponentWidths dmnElementRef="_1B1D9DF9-7A0A-4F52-B136-606CBC6D6887"/>
+          <kie:ComponentWidths dmnElementRef="_64C244A6-AC34-4969-8C4D-D9A8A2C3B996"/>
+          <kie:ComponentWidths dmnElementRef="_E910BF7C-EC84-4324-9DD5-8FEAE48D5090"/>
+          <kie:ComponentWidths dmnElementRef="_337DFEE7-CA4C-4D29-B3A5-37AC363ED108"/>
+          <kie:ComponentWidths dmnElementRef="_8DF0FB96-8446-4437-9807-70407F2151B6"/>
+          <kie:ComponentWidths dmnElementRef="_0B01FF93-2F83-4FD7-8EB8-D5FF4A8C0277"/>
+          <kie:ComponentWidths dmnElementRef="_F8993C34-6FA3-4262-B5DB-FC6930AA349F"/>
+          <kie:ComponentWidths dmnElementRef="_85C7AD0C-5D96-455A-B6DA-8756EB335625"/>
+          <kie:ComponentWidths dmnElementRef="_6AC0DD5F-9230-4AB0-B0B6-16624ADBFC3D"/>
+          <kie:ComponentWidths dmnElementRef="_F8C70D78-715B-4A1B-A56D-2B39B8145884"/>
+          <kie:ComponentWidths dmnElementRef="_3EC48D54-2879-4E52-9C98-2C0940AEDCE5"/>
+          <kie:ComponentWidths dmnElementRef="_E8CEF60F-13CB-43C2-97F5-4F2D2A12BF49"/>
+          <kie:ComponentWidths dmnElementRef="_BE062BA6-500F-42FC-ABE3-4B0879669E60"/>
+          <kie:ComponentWidths dmnElementRef="_91892B76-7EDC-4FD3-A681-EF621329916A"/>
+          <kie:ComponentWidths dmnElementRef="_FB19BB74-AE5B-47CC-9B11-C7BCF9C29C23"/>
+          <kie:ComponentWidths dmnElementRef="_F29E0A1B-82EC-4760-BC50-07B4715E33EE"/>
+          <kie:ComponentWidths dmnElementRef="_00C4DAEF-CFA8-44F6-934C-D7ED6FC036D2"/>
+          <kie:ComponentWidths dmnElementRef="_4BB883D3-7134-415E-B2BE-C72CAEFFED7F"/>
+          <kie:ComponentWidths dmnElementRef="_0892370F-163D-49D3-869F-ED21DBC4A986"/>
+          <kie:ComponentWidths dmnElementRef="_50598652-BE27-483F-A9EC-3D9719E092FD"/>
+          <kie:ComponentWidths dmnElementRef="_4D94CC2C-B5B4-46A1-8C43-4A74023C1F15"/>
+          <kie:ComponentWidths dmnElementRef="_450F34A8-11A6-45B4-83BA-505C9A060E21"/>
+          <kie:ComponentWidths dmnElementRef="_26861A54-CE84-4598-9AC2-7B9EE74453E2"/>
+          <kie:ComponentWidths dmnElementRef="_2595493D-EFAD-403C-B68F-B77383157692"/>
+          <kie:ComponentWidths dmnElementRef="_499AFD59-FE4A-42E4-B79C-22A1F98470AA"/>
+          <kie:ComponentWidths dmnElementRef="_6D0F4AB1-D9E1-4CC0-A42A-6829EFEDBA84"/>
+          <kie:ComponentWidths dmnElementRef="_B85FC7CD-6686-4B9D-A251-CEE744413B80"/>
+          <kie:ComponentWidths dmnElementRef="_E7D52F84-229C-4286-8992-1C86FAEC5A26"/>
+          <kie:ComponentWidths dmnElementRef="_34C345C8-0957-41C8-AC1B-62FC729DA1E3"/>
+          <kie:ComponentWidths dmnElementRef="_6AA424CB-B287-4A7E-BA6C-90622D8B20BD"/>
+          <kie:ComponentWidths dmnElementRef="_ABAAE3BA-0EDA-4FC6-B2EB-B2466EA58F16"/>
+          <kie:ComponentWidths dmnElementRef="_93F7207F-BA2F-4F28-8615-8F9C15094DDF"/>
+          <kie:ComponentWidths dmnElementRef="_8189227B-F307-4E85-9597-E174128A81C7"/>
+          <kie:ComponentWidths dmnElementRef="_EDF72F44-1A0C-4DD5-98D6-644C27B33E11"/>
+          <kie:ComponentWidths dmnElementRef="_A8F9206F-D086-461F-8D66-C182451AA7B0"/>
+          <kie:ComponentWidths dmnElementRef="_319DC76B-9B32-4E08-9567-855E5CA601ED"/>
+          <kie:ComponentWidths dmnElementRef="_0FB6EF1D-15E0-452B-A010-C6D993EE6F5D"/>
+          <kie:ComponentWidths dmnElementRef="_3FCA4C0C-693A-4DCB-8467-8121AA9987DF"/>
+          <kie:ComponentWidths dmnElementRef="_63ADF70D-2EA0-49CD-AFA4-DFCCC7A663FB"/>
+          <kie:ComponentWidths dmnElementRef="_7CF549B0-D03F-4C41-8A7A-F9CBBDC661A7"/>
+          <kie:ComponentWidths dmnElementRef="_9E76BE47-7581-4D87-A3BA-81FA2A9C8BB1"/>
+          <kie:ComponentWidths dmnElementRef="_877F1EB7-E054-4523-946E-3EA7B9D58940"/>
+          <kie:ComponentWidths dmnElementRef="_782861F6-4BD7-4E37-8888-0A007F6B5F90"/>
+          <kie:ComponentWidths dmnElementRef="_DD1D2890-5263-48FC-B86F-1751161BF3AB"/>
+          <kie:ComponentWidths dmnElementRef="_BEE7285A-D2F7-4B3B-B65B-A2BD98C33135"/>
+          <kie:ComponentWidths dmnElementRef="_0D69BA37-338C-44AC-91AF-7EF51029E5E3"/>
+          <kie:ComponentWidths dmnElementRef="_46673250-1A65-4EF5-9C23-DA559D39E746"/>
+          <kie:ComponentWidths dmnElementRef="_05941C74-67CF-4CCF-AD20-38FDF4EA3892"/>
+          <kie:ComponentWidths dmnElementRef="_B5DE32AD-CA22-4B23-B40C-8F8ECC4BB0F3"/>
+          <kie:ComponentWidths dmnElementRef="_67E4AA85-FF72-48C6-A41A-586CB86B6A3D"/>
+          <kie:ComponentWidths dmnElementRef="_030C87AC-F0FF-42F0-86DD-DE2A2A17683C"/>
+          <kie:ComponentWidths dmnElementRef="_EA6C9F53-7A7F-4922-91F8-0DA02E83A610"/>
+          <kie:ComponentWidths dmnElementRef="_AD57FD3B-DF6C-452D-BADE-8A3FAA1259C4"/>
+          <kie:ComponentWidths dmnElementRef="_D9F6F60A-0903-4A89-B00D-E4E277637400"/>
+          <kie:ComponentWidths dmnElementRef="_F9088A7D-8704-464E-9DCE-8C2D373691C6"/>
+          <kie:ComponentWidths dmnElementRef="_8772BB2C-4644-4174-A271-59F9544B991A"/>
+          <kie:ComponentWidths dmnElementRef="_B67AF0FF-D2C1-43E6-936E-0DE650F09A04"/>
+          <kie:ComponentWidths dmnElementRef="_2927F71D-C56B-4BD8-8488-2524149799FB"/>
+          <kie:ComponentWidths dmnElementRef="_19E769D0-0A0F-457A-BEAF-256C9A761ADC"/>
+          <kie:ComponentWidths dmnElementRef="_7F139AF4-123B-4494-9597-C4DE063DE530"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_c5dd7a17-b588-4daf-8c9b-677e65ce87be" dmnElementRef="tns:_c5dd7a17-b588-4daf-8c9b-677e65ce87be" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c5dd7a17-b588-4daf-8c9b-677e65ce87be" dmnElementRef="_c5dd7a17-b588-4daf-8c9b-677e65ce87be" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -428,7 +436,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_67c50a4c-3002-4d0a-9acf-4c76cb0364fa" dmnElementRef="tns:_67c50a4c-3002-4d0a-9acf-4c76cb0364fa" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_67c50a4c-3002-4d0a-9acf-4c76cb0364fa" dmnElementRef="_67c50a4c-3002-4d0a-9acf-4c76cb0364fa" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -437,7 +445,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_715940be-0f5d-4701-8155-fcba85874aa1" dmnElementRef="tns:_715940be-0f5d-4701-8155-fcba85874aa1" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_715940be-0f5d-4701-8155-fcba85874aa1" dmnElementRef="_715940be-0f5d-4701-8155-fcba85874aa1" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -446,7 +454,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_83059f2e-2862-45a9-97a7-71ffaa860586" dmnElementRef="tns:_83059f2e-2862-45a9-97a7-71ffaa860586" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_83059f2e-2862-45a9-97a7-71ffaa860586" dmnElementRef="_83059f2e-2862-45a9-97a7-71ffaa860586" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -455,7 +463,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8702e1b6-213b-4f75-bf56-99ac3835cde7" dmnElementRef="tns:_8702e1b6-213b-4f75-bf56-99ac3835cde7" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_8702e1b6-213b-4f75-bf56-99ac3835cde7" dmnElementRef="_8702e1b6-213b-4f75-bf56-99ac3835cde7" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -464,7 +472,7 @@
         <dc:Bounds x="138" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_daec318a-135b-4d54-9e7f-85af3aa662f7" dmnElementRef="tns:_daec318a-135b-4d54-9e7f-85af3aa662f7" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_daec318a-135b-4d54-9e7f-85af3aa662f7" dmnElementRef="_daec318a-135b-4d54-9e7f-85af3aa662f7" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -473,23 +481,23 @@
         <dc:Bounds x="313" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_67c50a4c-3002-4d0a-9acf-4c76cb0364fa" dmnElementRef="tns:_67c50a4c-3002-4d0a-9acf-4c76cb0364fa">
+      <dmndi:DMNEdge id="dmnedge-drg-_608B07F5-FDE8-4AD2-8816-DC77F980FA2C" dmnElementRef="_608B07F5-FDE8-4AD2-8816-DC77F980FA2C">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c5dd7a17-b588-4daf-8c9b-677e65ce87be" dmnElementRef="tns:_c5dd7a17-b588-4daf-8c9b-677e65ce87be">
+      <dmndi:DMNEdge id="dmnedge-drg-_7057F3DB-00F4-4613-BFD9-5CECB3119503" dmnElementRef="_7057F3DB-00F4-4613-BFD9-5CECB3119503">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_83059f2e-2862-45a9-97a7-71ffaa860586" dmnElementRef="tns:_83059f2e-2862-45a9-97a7-71ffaa860586">
+      <dmndi:DMNEdge id="dmnedge-drg-_E3757580-2571-47EB-B428-989DED1434F3" dmnElementRef="_E3757580-2571-47EB-B428-989DED1434F3">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8702e1b6-213b-4f75-bf56-99ac3835cde7" dmnElementRef="tns:_8702e1b6-213b-4f75-bf56-99ac3835cde7">
+      <dmndi:DMNEdge id="dmnedge-drg-_FE9BECB0-836E-4D5D-9CC4-1CAFAE5F9340" dmnElementRef="_FE9BECB0-836E-4D5D-9CC4-1CAFAE5F9340">
         <di:waypoint x="138" y="400"/>
         <di:waypoint x="400" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_daec318a-135b-4d54-9e7f-85af3aa662f7" dmnElementRef="tns:_daec318a-135b-4d54-9e7f-85af3aa662f7">
+      <dmndi:DMNEdge id="dmnedge-drg-_69F0F987-6AE9-45F4-91E6-D179D0BA49C4" dmnElementRef="_69F0F987-6AE9-45F4-91E6-D179D0BA49C4">
         <di:waypoint x="313" y="400"/>
         <di:waypoint x="400" y="225"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0015-all-any.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0015-all-any.dmn
@@ -1,101 +1,108 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" name="and-or" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" name="and-or" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tBoolList" name="tBoolList" isCollection="true">
-    <dmn:typeRef>feel:boolean</dmn:typeRef>
+    <dmn:typeRef>boolean</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:decision id="_a1f1c9c1-11b3-4fee-b26a-fbbd69014e78" name="and1">
     <dmn:extensionElements/>
-    <dmn:variable id="_6D1D37B1-E8F0-46AD-9D8F-B41B28CD2E9E" name="and1" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_efe62f90-4da2-45ff-9298-741d39b24e3b">
+    <dmn:variable id="_EEA698D9-47D6-4925-B3FB-A85E6EAFB992" name="and1" typeRef="boolean"/>
+    <dmn:informationRequirement id="_6486B965-86B8-4E00-8170-8FAC4E9B235D">
       <dmn:requiredInput href="#_efe62f90-4da2-45ff-9298-741d39b24e3b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_c780afbe-9905-419c-aed4-04b6158e0074">
+    <dmn:informationRequirement id="_8B3EFA94-D611-4E3E-9A93-1FA67E02DFCB">
       <dmn:requiredInput href="#_c780afbe-9905-419c-aed4-04b6158e0074"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_457ae2e3-529f-4b75-9d0d-f01c9cb23796">
+    <dmn:informationRequirement id="_DB37385A-2322-4D50-8402-CC8B9162951F">
       <dmn:requiredInput href="#_457ae2e3-529f-4b75-9d0d-f01c9cb23796"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_D0E81C1F-62F9-4062-8E1D-742C828F3659">
+    <dmn:literalExpression id="_B774EBAA-BE74-44A8-B868-D598DB2787D7">
       <dmn:text>all([a&gt;b,a&gt;c])</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_734e64a3-2733-453a-af1b-dce9f6995edb" name="and2">
     <dmn:extensionElements/>
-    <dmn:variable id="_76CC791F-A4E4-4E45-8861-2284FE7E2872" name="and2" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_065cfe42-f9c4-4218-801d-09a111945833">
+    <dmn:variable id="_82D51E9D-562F-43C4-B295-F9E4A0DA2E22" name="and2" typeRef="boolean"/>
+    <dmn:informationRequirement id="_221D6962-1175-4F00-9A7A-C799BB291AA9">
       <dmn:requiredDecision href="#_065cfe42-f9c4-4218-801d-09a111945833"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_6335B61B-B72A-47F8-B261-4B4F052B3617">
+    <dmn:literalExpression id="_4C1AB497-D826-4ECB-AB52-B3BC0405280F">
       <dmn:text>all(literalList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_7b646a38-8b7a-441a-a807-17f7700087b8" name="or1">
     <dmn:extensionElements/>
-    <dmn:variable id="_BAA38D22-CF7A-462C-999F-8BE499C54578" name="or1" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_efe62f90-4da2-45ff-9298-741d39b24e3b">
+    <dmn:variable id="_B5A72A90-2AED-43E1-8FB1-FCC74DCA3D57" name="or1" typeRef="boolean"/>
+    <dmn:informationRequirement id="_C027248F-BB76-4D69-B677-F4341EE018F8">
       <dmn:requiredInput href="#_efe62f90-4da2-45ff-9298-741d39b24e3b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_c780afbe-9905-419c-aed4-04b6158e0074">
+    <dmn:informationRequirement id="_930A457B-8313-4553-BEBD-8CBFE69F0ADF">
       <dmn:requiredInput href="#_c780afbe-9905-419c-aed4-04b6158e0074"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_457ae2e3-529f-4b75-9d0d-f01c9cb23796">
+    <dmn:informationRequirement id="_CF568108-11D7-4CF0-BB25-2346ABC3CB48">
       <dmn:requiredInput href="#_457ae2e3-529f-4b75-9d0d-f01c9cb23796"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_C02C3B62-2906-4D40-A0EA-7BE69EF3E6B0">
+    <dmn:literalExpression id="_7FF4DCFF-0A83-40A9-8B4E-F115DB500FFD">
       <dmn:text>any([a&gt;b,a&gt;c])</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_30439de7-21fd-4e54-800c-b94e1f714f0d" name="or2">
     <dmn:extensionElements/>
-    <dmn:variable id="_8D789921-E17F-438B-9387-257712D5ECB9" name="or2" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_065cfe42-f9c4-4218-801d-09a111945833">
+    <dmn:variable id="_AD4CBA6E-3CEE-4986-83C1-CCDD85200ED1" name="or2" typeRef="boolean"/>
+    <dmn:informationRequirement id="_F0ECBE06-AE77-4FFD-8F40-8827112B97D8">
       <dmn:requiredDecision href="#_065cfe42-f9c4-4218-801d-09a111945833"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_C31C7C3B-0DC2-4145-BD92-825B7158E600">
+    <dmn:literalExpression id="_1CB8619B-3382-4475-93C7-FD68FD201DD9">
       <dmn:text>any(literalList)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_065cfe42-f9c4-4218-801d-09a111945833" name="literalList">
     <dmn:extensionElements/>
-    <dmn:variable id="_ED003972-BC8B-4459-B465-879F73787662" name="literalList" typeRef="tns:tBoolList"/>
-    <dmn:informationRequirement id="_efe62f90-4da2-45ff-9298-741d39b24e3b">
+    <dmn:variable id="_2443EEA3-5112-4496-8E08-38CA2C2583F1" name="literalList" typeRef="tBoolList"/>
+    <dmn:informationRequirement id="_89449474-A844-423A-858E-EFDEC2CE300B">
       <dmn:requiredInput href="#_efe62f90-4da2-45ff-9298-741d39b24e3b"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_c780afbe-9905-419c-aed4-04b6158e0074">
+    <dmn:informationRequirement id="_C97D00A0-79E0-4867-8A3E-D73E17205245">
       <dmn:requiredInput href="#_c780afbe-9905-419c-aed4-04b6158e0074"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_457ae2e3-529f-4b75-9d0d-f01c9cb23796">
+    <dmn:informationRequirement id="_2BBFDEB0-FC15-43A1-920A-43FD27DD770F">
       <dmn:requiredInput href="#_457ae2e3-529f-4b75-9d0d-f01c9cb23796"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_E7C7E7F3-2536-4BEB-A887-7A03E9281881">
+    <dmn:literalExpression id="_8FEB6114-7880-47F5-88AE-FE6E48C40D5E">
       <dmn:text>[a&gt;b,a&gt;c]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_efe62f90-4da2-45ff-9298-741d39b24e3b" name="a">
     <dmn:extensionElements/>
-    <dmn:variable id="_9A685A18-2CC7-4E6D-920D-8B07907393B5" name="a" typeRef="feel:number"/>
+    <dmn:variable id="_DAB6EB12-6F2E-420B-9623-E75667D6A7D3" name="a" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_c780afbe-9905-419c-aed4-04b6158e0074" name="b">
     <dmn:extensionElements/>
-    <dmn:variable id="_260C98BB-EEF7-4E23-A18F-6E8552D2A300" name="b" typeRef="feel:number"/>
+    <dmn:variable id="_2D52F315-3EFE-4817-9CA9-08F9637CD2C8" name="b" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_457ae2e3-529f-4b75-9d0d-f01c9cb23796" name="c">
     <dmn:extensionElements/>
-    <dmn:variable id="_FDD73356-6874-4A42-9F25-99F0F841D4A4" name="c" typeRef="feel:number"/>
+    <dmn:variable id="_F46E7D5D-A265-474B-8BA6-0600B251D97F" name="c" typeRef="number"/>
   </dmn:inputData>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_36667DE9-E7DA-4F9C-9D32-402825503500" name="DRG">
+    <dmndi:DMNDiagram id="_B1999CFE-5E95-4B3D-962F-C19FD7AD1294" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_D0E81C1F-62F9-4062-8E1D-742C828F3659"/>
-          <kie:ComponentWidths dmnElementRef="_6335B61B-B72A-47F8-B261-4B4F052B3617"/>
-          <kie:ComponentWidths dmnElementRef="_C02C3B62-2906-4D40-A0EA-7BE69EF3E6B0"/>
-          <kie:ComponentWidths dmnElementRef="_C31C7C3B-0DC2-4145-BD92-825B7158E600"/>
-          <kie:ComponentWidths dmnElementRef="_E7C7E7F3-2536-4BEB-A887-7A03E9281881"/>
+          <kie:ComponentWidths dmnElementRef="_B774EBAA-BE74-44A8-B868-D598DB2787D7"/>
+          <kie:ComponentWidths dmnElementRef="_4C1AB497-D826-4ECB-AB52-B3BC0405280F"/>
+          <kie:ComponentWidths dmnElementRef="_7FF4DCFF-0A83-40A9-8B4E-F115DB500FFD"/>
+          <kie:ComponentWidths dmnElementRef="_1CB8619B-3382-4475-93C7-FD68FD201DD9"/>
+          <kie:ComponentWidths dmnElementRef="_8FEB6114-7880-47F5-88AE-FE6E48C40D5E"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_a1f1c9c1-11b3-4fee-b26a-fbbd69014e78" dmnElementRef="tns:_a1f1c9c1-11b3-4fee-b26a-fbbd69014e78" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_a1f1c9c1-11b3-4fee-b26a-fbbd69014e78" dmnElementRef="_a1f1c9c1-11b3-4fee-b26a-fbbd69014e78" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -104,7 +111,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_734e64a3-2733-453a-af1b-dce9f6995edb" dmnElementRef="tns:_734e64a3-2733-453a-af1b-dce9f6995edb" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_734e64a3-2733-453a-af1b-dce9f6995edb" dmnElementRef="_734e64a3-2733-453a-af1b-dce9f6995edb" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -113,7 +120,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_7b646a38-8b7a-441a-a807-17f7700087b8" dmnElementRef="tns:_7b646a38-8b7a-441a-a807-17f7700087b8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_7b646a38-8b7a-441a-a807-17f7700087b8" dmnElementRef="_7b646a38-8b7a-441a-a807-17f7700087b8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -122,7 +129,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_30439de7-21fd-4e54-800c-b94e1f714f0d" dmnElementRef="tns:_30439de7-21fd-4e54-800c-b94e1f714f0d" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_30439de7-21fd-4e54-800c-b94e1f714f0d" dmnElementRef="_30439de7-21fd-4e54-800c-b94e1f714f0d" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -131,7 +138,7 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_065cfe42-f9c4-4218-801d-09a111945833" dmnElementRef="tns:_065cfe42-f9c4-4218-801d-09a111945833" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_065cfe42-f9c4-4218-801d-09a111945833" dmnElementRef="_065cfe42-f9c4-4218-801d-09a111945833" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -140,7 +147,7 @@
         <dc:Bounds x="312" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_efe62f90-4da2-45ff-9298-741d39b24e3b" dmnElementRef="tns:_efe62f90-4da2-45ff-9298-741d39b24e3b" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_efe62f90-4da2-45ff-9298-741d39b24e3b" dmnElementRef="_efe62f90-4da2-45ff-9298-741d39b24e3b" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -149,7 +156,7 @@
         <dc:Bounds x="137" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_c780afbe-9905-419c-aed4-04b6158e0074" dmnElementRef="tns:_c780afbe-9905-419c-aed4-04b6158e0074" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_c780afbe-9905-419c-aed4-04b6158e0074" dmnElementRef="_c780afbe-9905-419c-aed4-04b6158e0074" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -158,7 +165,7 @@
         <dc:Bounds x="312" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_457ae2e3-529f-4b75-9d0d-f01c9cb23796" dmnElementRef="tns:_457ae2e3-529f-4b75-9d0d-f01c9cb23796" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_457ae2e3-529f-4b75-9d0d-f01c9cb23796" dmnElementRef="_457ae2e3-529f-4b75-9d0d-f01c9cb23796" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -167,21 +174,49 @@
         <dc:Bounds x="487" y="400" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_efe62f90-4da2-45ff-9298-741d39b24e3b" dmnElementRef="tns:_efe62f90-4da2-45ff-9298-741d39b24e3b">
+      <dmndi:DMNEdge id="dmnedge-drg-_6486B965-86B8-4E00-8170-8FAC4E9B235D" dmnElementRef="_6486B965-86B8-4E00-8170-8FAC4E9B235D">
         <di:waypoint x="137" y="400"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_c780afbe-9905-419c-aed4-04b6158e0074" dmnElementRef="tns:_c780afbe-9905-419c-aed4-04b6158e0074">
+      <dmndi:DMNEdge id="dmnedge-drg-_8B3EFA94-D611-4E3E-9A93-1FA67E02DFCB" dmnElementRef="_8B3EFA94-D611-4E3E-9A93-1FA67E02DFCB">
         <di:waypoint x="312" y="400"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_457ae2e3-529f-4b75-9d0d-f01c9cb23796" dmnElementRef="tns:_457ae2e3-529f-4b75-9d0d-f01c9cb23796">
+      <dmndi:DMNEdge id="dmnedge-drg-_DB37385A-2322-4D50-8402-CC8B9162951F" dmnElementRef="_DB37385A-2322-4D50-8402-CC8B9162951F">
         <di:waypoint x="487" y="400"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_065cfe42-f9c4-4218-801d-09a111945833" dmnElementRef="tns:_065cfe42-f9c4-4218-801d-09a111945833">
+      <dmndi:DMNEdge id="dmnedge-drg-_221D6962-1175-4F00-9A7A-C799BB291AA9" dmnElementRef="_221D6962-1175-4F00-9A7A-C799BB291AA9">
         <di:waypoint x="312" y="225"/>
         <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C027248F-BB76-4D69-B677-F4341EE018F8" dmnElementRef="_C027248F-BB76-4D69-B677-F4341EE018F8">
+        <di:waypoint x="137" y="400"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_930A457B-8313-4553-BEBD-8CBFE69F0ADF" dmnElementRef="_930A457B-8313-4553-BEBD-8CBFE69F0ADF">
+        <di:waypoint x="312" y="400"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_CF568108-11D7-4CF0-BB25-2346ABC3CB48" dmnElementRef="_CF568108-11D7-4CF0-BB25-2346ABC3CB48">
+        <di:waypoint x="487" y="400"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F0ECBE06-AE77-4FFD-8F40-8827112B97D8" dmnElementRef="_F0ECBE06-AE77-4FFD-8F40-8827112B97D8">
+        <di:waypoint x="312" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_89449474-A844-423A-858E-EFDEC2CE300B" dmnElementRef="_89449474-A844-423A-858E-EFDEC2CE300B">
+        <di:waypoint x="137" y="400"/>
+        <di:waypoint x="312" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C97D00A0-79E0-4867-8A3E-D73E17205245" dmnElementRef="_C97D00A0-79E0-4867-8A3E-D73E17205245">
+        <di:waypoint x="312" y="400"/>
+        <di:waypoint x="312" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_2BBFDEB0-FC15-43A1-920A-43FD27DD770F" dmnElementRef="_2BBFDEB0-FC15-43A1-920A-43FD27DD770F">
+        <di:waypoint x="487" y="400"/>
+        <di:waypoint x="312" y="225"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0016-some-every.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0016-some-every.dmn
@@ -1,48 +1,55 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_d7643a02-a8fc-4a6f-a8a9-5c2881afea70" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_d7643a02-a8fc-4a6f-a8a9-5c2881afea70" name="some-every" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_d7643a02-a8fc-4a6f-a8a9-5c2881afea70">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_d7643a02-a8fc-4a6f-a8a9-5c2881afea70"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_d7643a02-a8fc-4a6f-a8a9-5c2881afea70" name="some-every" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_d7643a02-a8fc-4a6f-a8a9-5c2881afea70">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tItemPrice" name="tItemPrice" isCollection="false">
     <dmn:itemComponent id="_de166af3-e625-4572-bc70-cb3c3aa01ca8" name="itemName" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_d68f500e-3997-409e-8152-d454c34487d8" name="price" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tPriceTable" name="tPriceTable" isCollection="true">
-    <dmn:typeRef>tns:tItemPrice</dmn:typeRef>
+    <dmn:typeRef>tItemPrice</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="_87bb4ba6-43bb-4fc5-a120-0c15c3901278" name="priceTable2">
     <dmn:extensionElements/>
-    <dmn:variable id="_5821888D-B594-4AF3-B3F7-651D49E46C7B" name="priceTable2" typeRef="tns:tPriceTable"/>
+    <dmn:variable id="_B00ABFCE-FC67-4C45-BF80-5C1AB134AA35" name="priceTable2" typeRef="tPriceTable"/>
   </dmn:inputData>
   <dmn:decision id="_a471e76a-64b1-44af-9ede-623f6c15b72e" name="priceTable1">
     <dmn:extensionElements/>
-    <dmn:variable id="_7555A317-3131-4491-B94B-6FA29A3F0777" name="priceTable1" typeRef="tns:tPriceTable"/>
-    <dmn:relation id="_7A09A1D4-666F-49AF-BBC1-C0C6BF8BD4A4">
+    <dmn:variable id="_C503FC51-F58F-47FF-9532-BFFD0BB784BC" name="priceTable1" typeRef="tPriceTable"/>
+    <dmn:relation id="_2DBA3010-56A4-4B39-9B6E-5D0D08AA0042">
       <dmn:column id="_b27cab6a-61cb-493c-9d68-b945a7a725f1" name="itemName"/>
       <dmn:column id="_379f9074-2bd8-496d-8077-c8713d006504" name="price"/>
       <dmn:row id="_bb0e1dff-05cd-49c2-9e39-caef85fa82a5">
-        <dmn:literalExpression id="_BF400674-DB9E-4800-8470-8A9BAECE500D">
+        <dmn:literalExpression id="_871AF2B6-2CA4-468C-B6EF-D2AD793A657C">
           <dmn:text>"widget"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_61D4884C-0682-4C98-AEAC-4F0F0B090813">
+        <dmn:literalExpression id="_A71CBD35-7163-4EAA-A808-BA8701809B29">
           <dmn:text>25</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_4f90e9d4-2244-4d63-bbb9-d47b3e1d62ee">
-        <dmn:literalExpression id="_59BC1CA7-A51B-41B1-871B-B0EC1D1396E1">
+        <dmn:literalExpression id="_FC8F6B2F-0CF1-4C6E-B399-2A154DC1A0DC">
           <dmn:text>"sprocket"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_70AB4C32-033A-4BE2-B61D-027FF0AA396F">
+        <dmn:literalExpression id="_CD7B7647-EBB2-4B54-9F88-DECF100A474C">
           <dmn:text>15</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
       <dmn:row id="_cf9445b7-4f8e-4618-a39a-acca4ae5a48e">
-        <dmn:literalExpression id="_FB4BF78C-73C5-472A-BCFF-A214499EB1F5">
+        <dmn:literalExpression id="_EA8B1CE2-590A-44C0-8FE3-5B491A75FA27">
           <dmn:text>"trinket"</dmn:text>
         </dmn:literalExpression>
-        <dmn:literalExpression id="_7362D47F-047F-420C-AB3B-665005B1A5C3">
+        <dmn:literalExpression id="_F086D79F-92E9-4DE1-A23C-47AD8C06824E">
           <dmn:text>1.5</dmn:text>
         </dmn:literalExpression>
       </dmn:row>
@@ -50,88 +57,88 @@
   </dmn:decision>
   <dmn:decision id="_a747d388-e0c0-41e1-b3ef-2904ba1a5d63" name="everyGtTen1">
     <dmn:extensionElements/>
-    <dmn:variable id="_C36C6805-1DB0-4549-A9CA-643936A8CED3" name="everyGtTen1" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_a471e76a-64b1-44af-9ede-623f6c15b72e">
+    <dmn:variable id="_2E421F38-7571-4742-9D62-7097EEE380A9" name="everyGtTen1" typeRef="boolean"/>
+    <dmn:informationRequirement id="_2695B89D-6ED6-4229-8743-6D09014CFAC5">
       <dmn:requiredDecision href="#_a471e76a-64b1-44af-9ede-623f6c15b72e"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_75C07927-7591-47E8-8FFD-B6A46AB81978">
+    <dmn:literalExpression id="_A9F5F04D-5F8E-4B4C-A43E-E2B6C7C1A6B5">
       <dmn:text>every i in priceTable1 satisfies i.price &gt; 10</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_e5194b4c-2191-45c3-a78c-723d04197dc6" name="everyGtTen2">
     <dmn:extensionElements/>
-    <dmn:variable id="_CCB96397-89B6-4E77-8F9B-16F2BB9EAA31" name="everyGtTen2" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_87bb4ba6-43bb-4fc5-a120-0c15c3901278">
+    <dmn:variable id="_7E89D4D1-8D44-4CA1-927E-108294DCA7D5" name="everyGtTen2" typeRef="boolean"/>
+    <dmn:informationRequirement id="_5E32CF6B-C2DA-4170-8FFD-338E0226C6D3">
       <dmn:requiredInput href="#_87bb4ba6-43bb-4fc5-a120-0c15c3901278"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_DD002E3E-D4EC-466F-8798-E766D5EE054F">
+    <dmn:literalExpression id="_80705438-516D-4E31-B94D-08D9BBE3CA69">
       <dmn:text>every i in priceTable2 satisfies i.price &gt; 10</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_655236ba-669a-4a80-a07c-ec051f57a529" name="someGtTen1">
     <dmn:extensionElements/>
-    <dmn:variable id="_A882546D-EFC5-4715-BEE2-1D69DF532BF6" name="someGtTen1" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_a471e76a-64b1-44af-9ede-623f6c15b72e">
+    <dmn:variable id="_60B9E7CA-03E7-4B7B-A7D8-F566BC5C9FDF" name="someGtTen1" typeRef="boolean"/>
+    <dmn:informationRequirement id="_6C8B308E-EDC1-47DE-9E9A-A4AC5BF71681">
       <dmn:requiredDecision href="#_a471e76a-64b1-44af-9ede-623f6c15b72e"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_5F5464DA-F8BE-4382-A396-59412342D8F9">
+    <dmn:literalExpression id="_13E4112A-7BBA-4FE1-95B3-74CB50B774D9">
       <dmn:text>some i in priceTable1 satisfies i.price &gt; 10</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_41ed4571-ad86-4c9d-9d3b-7b813ae5cd28" name="someGtTen2">
     <dmn:extensionElements/>
-    <dmn:variable id="_83865B05-7033-4522-99C8-05D009A0B276" name="someGtTen2" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_87bb4ba6-43bb-4fc5-a120-0c15c3901278">
+    <dmn:variable id="_DE514B63-E3DC-4451-8827-33F2F5913C11" name="someGtTen2" typeRef="boolean"/>
+    <dmn:informationRequirement id="_11056A87-5E24-437A-B51A-851FD5A6546E">
       <dmn:requiredInput href="#_87bb4ba6-43bb-4fc5-a120-0c15c3901278"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_CE51EE48-AE90-49ED-8FC9-96BB9B265FFF">
+    <dmn:literalExpression id="_BE8F0DFE-AB4B-4B17-931A-48C64EF9CCF0">
       <dmn:text>some i in priceTable2 satisfies i.price &gt; 10</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_72422ed3-5088-4ed0-9ab6-dbcfe3a6cf48" name="everyGtTen3">
     <dmn:extensionElements/>
-    <dmn:variable id="_B852C054-DE69-45EC-AF8B-9B3FDE4872ED" name="everyGtTen3" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_a471e76a-64b1-44af-9ede-623f6c15b72e">
+    <dmn:variable id="_3AEF6B84-1D4C-443D-BFDB-D26C8991A029" name="everyGtTen3" typeRef="boolean"/>
+    <dmn:informationRequirement id="_D15C6FAD-E5B4-46E8-A68B-04FDC183C30C">
       <dmn:requiredDecision href="#_a471e76a-64b1-44af-9ede-623f6c15b72e"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_d59cc17d-7f21-4706-8d10-47f7ee297b15">
+    <dmn:knowledgeRequirement id="_73B41F49-2C7C-4001-A3F7-1A6C3F94D665">
       <dmn:requiredKnowledge href="#_d59cc17d-7f21-4706-8d10-47f7ee297b15"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_44C1FC20-5807-4732-AE7A-D2E2A34226CC">
+    <dmn:literalExpression id="_565D4512-0570-4EE3-81EE-B0E47CF6FC2E">
       <dmn:text>every i in priceTable1 satisfies gtTen(i.price)=true</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="_d59cc17d-7f21-4706-8d10-47f7ee297b15" name="gtTen">
     <dmn:extensionElements/>
-    <dmn:variable id="_EE7D7E0C-9150-489F-85BA-CAEFA770387F" name="gtTen" typeRef="feel:boolean"/>
-    <dmn:encapsulatedLogic id="_120A9396-17DB-4203-B055-2CDCCB57A58E" kind="FEEL">
-      <dmn:formalParameter id="_776A5BEF-ECDD-4FD4-A19B-66B6F4C898DC" name="theNumber" typeRef="feel:number"/>
-      <dmn:literalExpression id="_05878170-F324-4761-BF37-F38130FAB3B9" expressionLanguage="FEEL">
+    <dmn:variable id="_6D008CDB-0C21-4BEA-B55C-58592BA5166E" name="gtTen" typeRef="boolean"/>
+    <dmn:encapsulatedLogic id="_F45C435F-7D0D-47B1-99D2-A12AE10FE2CB" kind="FEEL">
+      <dmn:formalParameter id="_807DC45D-E02E-456D-ACB8-E3368B2F4CEA" name="theNumber" typeRef="number"/>
+      <dmn:literalExpression id="_A4CD6556-1232-4ACE-9BDB-55FB9503B9FB" expressionLanguage="FEEL">
         <dmn:text>theNumber &gt; 10</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_7C8A9CD4-D764-4E4C-A699-0B334E76E3E7" name="DRG">
+    <dmndi:DMNDiagram id="_4C155A45-3B32-4F00-97D6-C37F4B5848EA" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_7A09A1D4-666F-49AF-BBC1-C0C6BF8BD4A4"/>
-          <kie:ComponentWidths dmnElementRef="_BF400674-DB9E-4800-8470-8A9BAECE500D"/>
-          <kie:ComponentWidths dmnElementRef="_61D4884C-0682-4C98-AEAC-4F0F0B090813"/>
-          <kie:ComponentWidths dmnElementRef="_59BC1CA7-A51B-41B1-871B-B0EC1D1396E1"/>
-          <kie:ComponentWidths dmnElementRef="_70AB4C32-033A-4BE2-B61D-027FF0AA396F"/>
-          <kie:ComponentWidths dmnElementRef="_FB4BF78C-73C5-472A-BCFF-A214499EB1F5"/>
-          <kie:ComponentWidths dmnElementRef="_7362D47F-047F-420C-AB3B-665005B1A5C3"/>
-          <kie:ComponentWidths dmnElementRef="_75C07927-7591-47E8-8FFD-B6A46AB81978"/>
-          <kie:ComponentWidths dmnElementRef="_DD002E3E-D4EC-466F-8798-E766D5EE054F"/>
-          <kie:ComponentWidths dmnElementRef="_5F5464DA-F8BE-4382-A396-59412342D8F9"/>
-          <kie:ComponentWidths dmnElementRef="_CE51EE48-AE90-49ED-8FC9-96BB9B265FFF"/>
-          <kie:ComponentWidths dmnElementRef="_44C1FC20-5807-4732-AE7A-D2E2A34226CC"/>
-          <kie:ComponentWidths dmnElementRef="_05878170-F324-4761-BF37-F38130FAB3B9"/>
-          <kie:ComponentWidths dmnElementRef="_120A9396-17DB-4203-B055-2CDCCB57A58E"/>
+          <kie:ComponentWidths dmnElementRef="_2DBA3010-56A4-4B39-9B6E-5D0D08AA0042"/>
+          <kie:ComponentWidths dmnElementRef="_871AF2B6-2CA4-468C-B6EF-D2AD793A657C"/>
+          <kie:ComponentWidths dmnElementRef="_A71CBD35-7163-4EAA-A808-BA8701809B29"/>
+          <kie:ComponentWidths dmnElementRef="_FC8F6B2F-0CF1-4C6E-B399-2A154DC1A0DC"/>
+          <kie:ComponentWidths dmnElementRef="_CD7B7647-EBB2-4B54-9F88-DECF100A474C"/>
+          <kie:ComponentWidths dmnElementRef="_EA8B1CE2-590A-44C0-8FE3-5B491A75FA27"/>
+          <kie:ComponentWidths dmnElementRef="_F086D79F-92E9-4DE1-A23C-47AD8C06824E"/>
+          <kie:ComponentWidths dmnElementRef="_A9F5F04D-5F8E-4B4C-A43E-E2B6C7C1A6B5"/>
+          <kie:ComponentWidths dmnElementRef="_80705438-516D-4E31-B94D-08D9BBE3CA69"/>
+          <kie:ComponentWidths dmnElementRef="_13E4112A-7BBA-4FE1-95B3-74CB50B774D9"/>
+          <kie:ComponentWidths dmnElementRef="_BE8F0DFE-AB4B-4B17-931A-48C64EF9CCF0"/>
+          <kie:ComponentWidths dmnElementRef="_565D4512-0570-4EE3-81EE-B0E47CF6FC2E"/>
+          <kie:ComponentWidths dmnElementRef="_A4CD6556-1232-4ACE-9BDB-55FB9503B9FB"/>
+          <kie:ComponentWidths dmnElementRef="_F45C435F-7D0D-47B1-99D2-A12AE10FE2CB"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_87bb4ba6-43bb-4fc5-a120-0c15c3901278" dmnElementRef="tns:_87bb4ba6-43bb-4fc5-a120-0c15c3901278" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_87bb4ba6-43bb-4fc5-a120-0c15c3901278" dmnElementRef="_87bb4ba6-43bb-4fc5-a120-0c15c3901278" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -140,7 +147,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_a471e76a-64b1-44af-9ede-623f6c15b72e" dmnElementRef="tns:_a471e76a-64b1-44af-9ede-623f6c15b72e" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_a471e76a-64b1-44af-9ede-623f6c15b72e" dmnElementRef="_a471e76a-64b1-44af-9ede-623f6c15b72e" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -149,7 +156,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_a747d388-e0c0-41e1-b3ef-2904ba1a5d63" dmnElementRef="tns:_a747d388-e0c0-41e1-b3ef-2904ba1a5d63" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_a747d388-e0c0-41e1-b3ef-2904ba1a5d63" dmnElementRef="_a747d388-e0c0-41e1-b3ef-2904ba1a5d63" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -158,7 +165,7 @@
         <dc:Bounds x="225" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_e5194b4c-2191-45c3-a78c-723d04197dc6" dmnElementRef="tns:_e5194b4c-2191-45c3-a78c-723d04197dc6" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_e5194b4c-2191-45c3-a78c-723d04197dc6" dmnElementRef="_e5194b4c-2191-45c3-a78c-723d04197dc6" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -167,7 +174,7 @@
         <dc:Bounds x="50" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_655236ba-669a-4a80-a07c-ec051f57a529" dmnElementRef="tns:_655236ba-669a-4a80-a07c-ec051f57a529" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_655236ba-669a-4a80-a07c-ec051f57a529" dmnElementRef="_655236ba-669a-4a80-a07c-ec051f57a529" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -176,7 +183,7 @@
         <dc:Bounds x="750" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_41ed4571-ad86-4c9d-9d3b-7b813ae5cd28" dmnElementRef="tns:_41ed4571-ad86-4c9d-9d3b-7b813ae5cd28" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_41ed4571-ad86-4c9d-9d3b-7b813ae5cd28" dmnElementRef="_41ed4571-ad86-4c9d-9d3b-7b813ae5cd28" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -185,7 +192,7 @@
         <dc:Bounds x="575" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_72422ed3-5088-4ed0-9ab6-dbcfe3a6cf48" dmnElementRef="tns:_72422ed3-5088-4ed0-9ab6-dbcfe3a6cf48" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_72422ed3-5088-4ed0-9ab6-dbcfe3a6cf48" dmnElementRef="_72422ed3-5088-4ed0-9ab6-dbcfe3a6cf48" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -194,7 +201,7 @@
         <dc:Bounds x="400" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_d59cc17d-7f21-4706-8d10-47f7ee297b15" dmnElementRef="tns:_d59cc17d-7f21-4706-8d10-47f7ee297b15" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_d59cc17d-7f21-4706-8d10-47f7ee297b15" dmnElementRef="_d59cc17d-7f21-4706-8d10-47f7ee297b15" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -203,15 +210,27 @@
         <dc:Bounds x="575" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_a471e76a-64b1-44af-9ede-623f6c15b72e" dmnElementRef="tns:_a471e76a-64b1-44af-9ede-623f6c15b72e">
+      <dmndi:DMNEdge id="dmnedge-drg-_2695B89D-6ED6-4229-8743-6D09014CFAC5" dmnElementRef="_2695B89D-6ED6-4229-8743-6D09014CFAC5">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_87bb4ba6-43bb-4fc5-a120-0c15c3901278" dmnElementRef="tns:_87bb4ba6-43bb-4fc5-a120-0c15c3901278">
+      <dmndi:DMNEdge id="dmnedge-drg-_5E32CF6B-C2DA-4170-8FFD-338E0226C6D3" dmnElementRef="_5E32CF6B-C2DA-4170-8FFD-338E0226C6D3">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="50" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_d59cc17d-7f21-4706-8d10-47f7ee297b15" dmnElementRef="tns:_d59cc17d-7f21-4706-8d10-47f7ee297b15">
+      <dmndi:DMNEdge id="dmnedge-drg-_6C8B308E-EDC1-47DE-9E9A-A4AC5BF71681" dmnElementRef="_6C8B308E-EDC1-47DE-9E9A-A4AC5BF71681">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_11056A87-5E24-437A-B51A-851FD5A6546E" dmnElementRef="_11056A87-5E24-437A-B51A-851FD5A6546E">
+        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_D15C6FAD-E5B4-46E8-A68B-04FDC183C30C" dmnElementRef="_D15C6FAD-E5B4-46E8-A68B-04FDC183C30C">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_73B41F49-2C7C-4001-A3F7-1A6C3F94D665" dmnElementRef="_73B41F49-2C7C-4001-A3F7-1A6C3F94D665">
         <di:waypoint x="575" y="225"/>
         <di:waypoint x="400" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0017-tableTests.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0017-tableTests.dmn
@@ -1,49 +1,56 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:tns="http://www.trisotech.com/definitions/_92a0c25f-707e-4fc8-ae2d-2ab51ebe6bb6" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_92a0c25f-707e-4fc8-ae2d-2ab51ebe6bb6" name="tableTest" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_92a0c25f-707e-4fc8-ae2d-2ab51ebe6bb6">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="http://www.trisotech.com/definitions/_92a0c25f-707e-4fc8-ae2d-2ab51ebe6bb6"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_92a0c25f-707e-4fc8-ae2d-2ab51ebe6bb6" name="tableTest" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.trisotech.com/definitions/_92a0c25f-707e-4fc8-ae2d-2ab51ebe6bb6">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="tNumList" name="tNumList" isCollection="true">
-    <dmn:typeRef>feel:number</dmn:typeRef>
+    <dmn:typeRef>number</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tA" name="tA" isCollection="false">
     <dmn:itemComponent id="_adf6f96a-c574-4ba7-a305-ea14ad9852b1" name="name" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_d297adac-f086-42a0-989e-04c431270f77" name="price" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="tStringList" name="tStringList" isCollection="true">
-    <dmn:typeRef>feel:string</dmn:typeRef>
+    <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="_18b9d486-1ec0-436d-af4b-3e4567e8bca9" name="structA">
     <dmn:extensionElements/>
-    <dmn:variable id="_BE60EEF5-12F5-4935-8182-CC56DDFCD1CF" name="structA" typeRef="tns:tA"/>
+    <dmn:variable id="_1C29D1AB-1FBC-459F-B35C-1AC50CED734B" name="structA" typeRef="tA"/>
   </dmn:inputData>
   <dmn:inputData id="_3b175722-5f96-49e4-a50d-0bf9588c901c" name="numB">
     <dmn:extensionElements/>
-    <dmn:variable id="_AEF87A0C-9B41-4EE4-9687-9C70CAE800FA" name="numB" typeRef="feel:number"/>
+    <dmn:variable id="_B9F1C003-6F47-43D0-A4D8-0165C62B91AD" name="numB" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d" name="numC">
     <dmn:extensionElements/>
-    <dmn:variable id="_1FB95BDF-B64C-4C04-A988-30F7E5DE2557" name="numC" typeRef="feel:number"/>
+    <dmn:variable id="_1D876ACF-784A-44F6-AD3D-1D02948CAB44" name="numC" typeRef="number"/>
   </dmn:inputData>
   <dmn:inputData id="_fabdbafc-f28a-466d-ae08-86c5b928dad5" name="dateD">
     <dmn:extensionElements/>
-    <dmn:variable id="_25DC519E-59E8-4EB1-A6D5-509D3558C38F" name="dateD" typeRef="feel:date"/>
+    <dmn:variable id="_039690FE-17EE-4635-B38F-E803ECE47F7C" name="dateD" typeRef="date"/>
   </dmn:inputData>
   <dmn:inputData id="_4926f78e-5df0-4d88-8ee7-1a418b08562f" name="dateE">
     <dmn:extensionElements/>
-    <dmn:variable id="_9ACBE1FD-2A1D-4C0D-BA4C-6F7C55B5DD6C" name="dateE" typeRef="feel:date"/>
+    <dmn:variable id="_DBF41BFA-1400-44B6-B216-42C8C7A3E538" name="dateE" typeRef="date"/>
   </dmn:inputData>
   <dmn:decision id="_2683ec7f-fa17-4a1e-9151-8077a10c561f" name="priceGt10">
     <dmn:extensionElements/>
-    <dmn:variable id="_D55AB2E4-BB19-4B77-A0D3-ADE6DFC2C58A" name="priceGt10" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_18b9d486-1ec0-436d-af4b-3e4567e8bca9">
+    <dmn:variable id="_2D598B06-4AE9-429B-9BF2-53BA3D28F45E" name="priceGt10" typeRef="boolean"/>
+    <dmn:informationRequirement id="_4E115516-5903-4555-B62D-8CE03B90C1C5">
       <dmn:requiredInput href="#_18b9d486-1ec0-436d-af4b-3e4567e8bca9"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_3BB954B9-BCF1-412D-8B24-DA0668675DF4" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="priceGt10">
+    <dmn:decisionTable id="_88B3CDFA-3CBB-419E-B60F-D523E173B592" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="priceGt10">
       <dmn:input id="_bfb04e56-12dc-461f-a341-f5522efc7388">
-        <dmn:inputExpression id="_5BE9F43B-6D9A-4167-B12C-840A47C8517C" typeRef="feel:number">
+        <dmn:inputExpression id="_D1D6407B-3264-48C6-82AC-FCE7E315BB69" typeRef="number">
           <dmn:text>structA.price</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
@@ -75,24 +82,24 @@
   </dmn:decision>
   <dmn:decision id="_98e08c9d-66de-4f67-8bd9-cc667be27eb3" name="priceInRange">
     <dmn:extensionElements/>
-    <dmn:variable id="_AAB27655-1D20-4E2D-9474-575A5C0B8337" name="priceInRange" typeRef="feel:string"/>
-    <dmn:informationRequirement id="_3b175722-5f96-49e4-a50d-0bf9588c901c">
+    <dmn:variable id="_FBDE95B5-55A0-489D-B6A3-456E07092393" name="priceInRange" typeRef="string"/>
+    <dmn:informationRequirement id="_AA2E31C1-82F9-496F-BA37-FEA3EA421CA6">
       <dmn:requiredInput href="#_3b175722-5f96-49e4-a50d-0bf9588c901c"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d">
+    <dmn:informationRequirement id="_11B7F784-A6EE-4756-9369-F434FA50948A">
       <dmn:requiredInput href="#_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_18b9d486-1ec0-436d-af4b-3e4567e8bca9">
+    <dmn:informationRequirement id="_AEDADB70-6D75-4170-893B-CCC62481F956">
       <dmn:requiredInput href="#_18b9d486-1ec0-436d-af4b-3e4567e8bca9"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_06AF65D2-9930-470C-A6A9-16A44FB7520D" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="priceInRange">
+    <dmn:decisionTable id="_349543E9-F8E2-4213-8D11-A5912C642461" hitPolicy="PRIORITY" preferredOrientation="Rule-as-Row" outputLabel="priceInRange">
       <dmn:input id="_ea1c33b5-593b-416a-b507-75e419506451">
-        <dmn:inputExpression id="_BBBB1F21-F059-48B3-B789-06B400EC8A79" typeRef="feel:number">
+        <dmn:inputExpression id="_239E9614-0672-4633-80F8-8119F177A01A" typeRef="number">
           <dmn:text>structA.price</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
       <dmn:output id="_2d6d203c-7f53-4d4c-bfe1-1ce30c374fad">
-        <dmn:outputValues id="_8F5948E6-4477-42D2-9536-5D4929E64AF1">
+        <dmn:outputValues id="_945C1274-9857-4B43-B492-E2E625250AEE">
           <dmn:text>"In range", "Not in range"</dmn:text>
         </dmn:outputValues>
       </dmn:output>
@@ -123,13 +130,13 @@
   </dmn:decision>
   <dmn:decision id="_ca5e0efd-3fff-4bf8-8939-85fc3b9c20b8" name="dateCompare1">
     <dmn:extensionElements/>
-    <dmn:variable id="_601760FA-419D-4BD7-B436-CAC939A4C621" name="dateCompare1" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_fabdbafc-f28a-466d-ae08-86c5b928dad5">
+    <dmn:variable id="_1807790D-C7A1-4A73-9546-37ED9198A65C" name="dateCompare1" typeRef="boolean"/>
+    <dmn:informationRequirement id="_0B68BC6B-7D82-43D5-8AF0-292080197316">
       <dmn:requiredInput href="#_fabdbafc-f28a-466d-ae08-86c5b928dad5"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_2D027101-A382-4079-A151-7516FFF2A6E3" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="dateCompare1">
+    <dmn:decisionTable id="_C5DC1376-010E-4C68-9364-AF72BCA4928A" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="dateCompare1">
       <dmn:input id="_cccfb596-2349-4ff2-bed6-51373e84a7c6">
-        <dmn:inputExpression id="_838F221F-DC15-422A-BE8E-9CDB8A053E5E" typeRef="feel:date">
+        <dmn:inputExpression id="_FCA3B3C8-869D-4FF8-9277-175F2888269D" typeRef="date">
           <dmn:text>dateD</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
@@ -161,16 +168,16 @@
   </dmn:decision>
   <dmn:decision id="_bf3c3a79-9fa2-491f-8065-a990c70b50de" name="dateCompare2">
     <dmn:extensionElements/>
-    <dmn:variable id="_8897F578-6737-468E-8EE7-759E05222A26" name="dateCompare2" typeRef="feel:boolean"/>
-    <dmn:informationRequirement id="_fabdbafc-f28a-466d-ae08-86c5b928dad5">
+    <dmn:variable id="_4F5F7E27-30AC-4905-8B23-515C196D65C6" name="dateCompare2" typeRef="boolean"/>
+    <dmn:informationRequirement id="_DFA8D6EB-8E5D-4D6C-8168-EAB25B825006">
       <dmn:requiredInput href="#_fabdbafc-f28a-466d-ae08-86c5b928dad5"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="_4926f78e-5df0-4d88-8ee7-1a418b08562f">
+    <dmn:informationRequirement id="_C9363E39-465B-48CE-A105-7B8DE005136D">
       <dmn:requiredInput href="#_4926f78e-5df0-4d88-8ee7-1a418b08562f"/>
     </dmn:informationRequirement>
-    <dmn:decisionTable id="_FCAB9CDA-80BE-4D67-A8F4-2476B8B5128F" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="dateCompare2">
+    <dmn:decisionTable id="_9DF26032-7DA3-45E1-AD47-D5A7E4D3DAE0" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row" outputLabel="dateCompare2">
       <dmn:input id="_510a77ec-f587-41eb-a3c0-139cb0fd1cb4">
-        <dmn:inputExpression id="_94FF19D3-5DB6-4E47-B04E-6D97391DC918" typeRef="feel:date">
+        <dmn:inputExpression id="_DE884848-22B1-46BF-AA0A-9712AFAB076C" typeRef="date">
           <dmn:text>dateD</dmn:text>
         </dmn:inputExpression>
       </dmn:input>
@@ -201,16 +208,16 @@
     </dmn:decisionTable>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_FF5A0824-9D29-4224-B0A2-D3E91293A443" name="DRG">
+    <dmndi:DMNDiagram id="_6B575074-3DDA-4CA3-AFD8-26B647204C9B" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_3BB954B9-BCF1-412D-8B24-DA0668675DF4"/>
-          <kie:ComponentWidths dmnElementRef="_06AF65D2-9930-470C-A6A9-16A44FB7520D"/>
-          <kie:ComponentWidths dmnElementRef="_2D027101-A382-4079-A151-7516FFF2A6E3"/>
-          <kie:ComponentWidths dmnElementRef="_FCAB9CDA-80BE-4D67-A8F4-2476B8B5128F"/>
+          <kie:ComponentWidths dmnElementRef="_88B3CDFA-3CBB-419E-B60F-D523E173B592"/>
+          <kie:ComponentWidths dmnElementRef="_349543E9-F8E2-4213-8D11-A5912C642461"/>
+          <kie:ComponentWidths dmnElementRef="_C5DC1376-010E-4C68-9364-AF72BCA4928A"/>
+          <kie:ComponentWidths dmnElementRef="_9DF26032-7DA3-45E1-AD47-D5A7E4D3DAE0"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_18b9d486-1ec0-436d-af4b-3e4567e8bca9" dmnElementRef="tns:_18b9d486-1ec0-436d-af4b-3e4567e8bca9" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_18b9d486-1ec0-436d-af4b-3e4567e8bca9" dmnElementRef="_18b9d486-1ec0-436d-af4b-3e4567e8bca9" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -219,7 +226,7 @@
         <dc:Bounds x="400" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_3b175722-5f96-49e4-a50d-0bf9588c901c" dmnElementRef="tns:_3b175722-5f96-49e4-a50d-0bf9588c901c" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_3b175722-5f96-49e4-a50d-0bf9588c901c" dmnElementRef="_3b175722-5f96-49e4-a50d-0bf9588c901c" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -228,7 +235,7 @@
         <dc:Bounds x="50" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d" dmnElementRef="tns:_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d" dmnElementRef="_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -237,7 +244,7 @@
         <dc:Bounds x="225" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_fabdbafc-f28a-466d-ae08-86c5b928dad5" dmnElementRef="tns:_fabdbafc-f28a-466d-ae08-86c5b928dad5" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_fabdbafc-f28a-466d-ae08-86c5b928dad5" dmnElementRef="_fabdbafc-f28a-466d-ae08-86c5b928dad5" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -246,7 +253,7 @@
         <dc:Bounds x="750" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_4926f78e-5df0-4d88-8ee7-1a418b08562f" dmnElementRef="tns:_4926f78e-5df0-4d88-8ee7-1a418b08562f" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_4926f78e-5df0-4d88-8ee7-1a418b08562f" dmnElementRef="_4926f78e-5df0-4d88-8ee7-1a418b08562f" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -255,7 +262,7 @@
         <dc:Bounds x="575" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2683ec7f-fa17-4a1e-9151-8077a10c561f" dmnElementRef="tns:_2683ec7f-fa17-4a1e-9151-8077a10c561f" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_2683ec7f-fa17-4a1e-9151-8077a10c561f" dmnElementRef="_2683ec7f-fa17-4a1e-9151-8077a10c561f" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -264,7 +271,7 @@
         <dc:Bounds x="313" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_98e08c9d-66de-4f67-8bd9-cc667be27eb3" dmnElementRef="tns:_98e08c9d-66de-4f67-8bd9-cc667be27eb3" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_98e08c9d-66de-4f67-8bd9-cc667be27eb3" dmnElementRef="_98e08c9d-66de-4f67-8bd9-cc667be27eb3" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -273,7 +280,7 @@
         <dc:Bounds x="138" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ca5e0efd-3fff-4bf8-8939-85fc3b9c20b8" dmnElementRef="tns:_ca5e0efd-3fff-4bf8-8939-85fc3b9c20b8" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_ca5e0efd-3fff-4bf8-8939-85fc3b9c20b8" dmnElementRef="_ca5e0efd-3fff-4bf8-8939-85fc3b9c20b8" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -282,7 +289,7 @@
         <dc:Bounds x="663" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bf3c3a79-9fa2-491f-8065-a990c70b50de" dmnElementRef="tns:_bf3c3a79-9fa2-491f-8065-a990c70b50de" isCollapsed="false">
+      <dmndi:DMNShape id="dmnshape-drg-_bf3c3a79-9fa2-491f-8065-a990c70b50de" dmnElementRef="_bf3c3a79-9fa2-491f-8065-a990c70b50de" isCollapsed="false">
         <dmndi:DMNStyle>
           <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
@@ -291,23 +298,31 @@
         <dc:Bounds x="488" y="50" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_18b9d486-1ec0-436d-af4b-3e4567e8bca9" dmnElementRef="tns:_18b9d486-1ec0-436d-af4b-3e4567e8bca9">
+      <dmndi:DMNEdge id="dmnedge-drg-_4E115516-5903-4555-B62D-8CE03B90C1C5" dmnElementRef="_4E115516-5903-4555-B62D-8CE03B90C1C5">
         <di:waypoint x="400" y="225"/>
         <di:waypoint x="313" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_3b175722-5f96-49e4-a50d-0bf9588c901c" dmnElementRef="tns:_3b175722-5f96-49e4-a50d-0bf9588c901c">
+      <dmndi:DMNEdge id="dmnedge-drg-_AA2E31C1-82F9-496F-BA37-FEA3EA421CA6" dmnElementRef="_AA2E31C1-82F9-496F-BA37-FEA3EA421CA6">
         <di:waypoint x="50" y="225"/>
         <di:waypoint x="138" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d" dmnElementRef="tns:_25cdd674-9b3f-47b1-bace-1d4e3ce50d5d">
+      <dmndi:DMNEdge id="dmnedge-drg-_11B7F784-A6EE-4756-9369-F434FA50948A" dmnElementRef="_11B7F784-A6EE-4756-9369-F434FA50948A">
         <di:waypoint x="225" y="225"/>
         <di:waypoint x="138" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_fabdbafc-f28a-466d-ae08-86c5b928dad5" dmnElementRef="tns:_fabdbafc-f28a-466d-ae08-86c5b928dad5">
+      <dmndi:DMNEdge id="dmnedge-drg-_AEDADB70-6D75-4170-893B-CCC62481F956" dmnElementRef="_AEDADB70-6D75-4170-893B-CCC62481F956">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="138" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_0B68BC6B-7D82-43D5-8AF0-292080197316" dmnElementRef="_0B68BC6B-7D82-43D5-8AF0-292080197316">
         <di:waypoint x="750" y="225"/>
         <di:waypoint x="663" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_4926f78e-5df0-4d88-8ee7-1a418b08562f" dmnElementRef="tns:_4926f78e-5df0-4d88-8ee7-1a418b08562f">
+      <dmndi:DMNEdge id="dmnedge-drg-_DFA8D6EB-8E5D-4D6C-8168-EAB25B825006" dmnElementRef="_DFA8D6EB-8E5D-4D6C-8168-EAB25B825006">
+        <di:waypoint x="750" y="225"/>
+        <di:waypoint x="488" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C9363E39-465B-48CE-A105-7B8DE005136D" dmnElementRef="_C9363E39-465B-48CE-A105-7B8DE005136D">
         <di:waypoint x="575" y="225"/>
         <di:waypoint x="488" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0019-flight-rebooking.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0019-flight-rebooking.dmn
@@ -1,94 +1,100 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://www.drools.org/kie-dmn" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0019_flight_rebooking" name="0019-flight-rebooking" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://www.drools.org/kie-dmn">
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
+  xmlns="https://www.drools.org/kie-dmn"
+  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
+  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0019_flight_rebooking" name="0019-flight-rebooking" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://www.drools.org/kie-dmn">
   <dmn:extensionElements/>
   <dmn:itemDefinition id="_tFlight" name="tFlight" isCollection="false">
     <dmn:itemComponent id="_tFlight_Flight" name="Flight Number" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tFlight_From" name="From" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tFlight_To" name="To" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tFlight_Dep" name="Departure" isCollection="false">
-      <dmn:typeRef>feel:dateTime</dmn:typeRef>
+      <dmn:typeRef>dateTime</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tFlight_Arr" name="Arrival" isCollection="false">
-      <dmn:typeRef>feel:dateTime</dmn:typeRef>
+      <dmn:typeRef>dateTime</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tFlight_Capacity" name="Capacity" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tFlight_Status" name="Status" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="_tFlightTable" name="tFlightTable" isCollection="true">
-    <dmn:typeRef>kie:tFlight</dmn:typeRef>
+    <dmn:typeRef>tFlight</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="_tPassenger" name="tPassenger" isCollection="false">
     <dmn:itemComponent id="_tPassenger_Name" name="Name" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tPassenger_Status" name="Status" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tPassenger_Miles" name="Miles" isCollection="false">
-      <dmn:typeRef>feel:number</dmn:typeRef>
+      <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
     <dmn:itemComponent id="_tPassenger_Flight" name="Flight Number" isCollection="false">
-      <dmn:typeRef>feel:string</dmn:typeRef>
+      <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:itemDefinition id="_tPassengerTable" name="tPassengerTable" isCollection="true">
-    <dmn:typeRef>kie:tPassenger</dmn:typeRef>
+    <dmn:typeRef>tPassenger</dmn:typeRef>
   </dmn:itemDefinition>
   <dmn:inputData id="i_Flight_List" name="Flight List">
     <dmn:extensionElements/>
-    <dmn:variable id="_9DAFCCE2-631F-4BC3-9D3D-BE9779204424" name="Flight List" typeRef="kie:tFlightTable"/>
+    <dmn:variable id="_EFFC4300-C44F-4120-8EEB-6A95D28A74D3" name="Flight List" typeRef="tFlightTable"/>
   </dmn:inputData>
   <dmn:inputData id="i_Passenger_List" name="Passenger List">
     <dmn:extensionElements/>
-    <dmn:variable id="_1A89507E-CDC6-4F39-AAC2-50414E88B480" name="Passenger List" typeRef="kie:tPassengerTable"/>
+    <dmn:variable id="_1402E3D4-CCFE-4075-B7DC-2AB693898331" name="Passenger List" typeRef="tPassengerTable"/>
   </dmn:inputData>
   <dmn:decision id="d_PrioritizedWaitingList" name="Prioritized Waiting List">
     <dmn:extensionElements/>
-    <dmn:variable id="_7D8D6950-99E8-46A2-8CEB-0F30F6637665" name="Prioritized Waiting List" typeRef="kie:tPassengerTable"/>
-    <dmn:informationRequirement id="i_Passenger_List">
+    <dmn:variable id="_34C1817C-EF04-4D6A-AE61-8EBE3FF1495D" name="Prioritized Waiting List" typeRef="tPassengerTable"/>
+    <dmn:informationRequirement id="_D23FCE0A-25F3-4FCE-9A32-D23F6C4C57C1">
       <dmn:requiredInput href="#i_Passenger_List"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_Flight_List">
+    <dmn:informationRequirement id="_26A0DF82-39CD-4617-A998-712743F003B3">
       <dmn:requiredInput href="#i_Flight_List"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_StatusPriority">
+    <dmn:knowledgeRequirement id="_B15EF6FC-5689-4D60-9C6C-6E5A6DCE0C07">
       <dmn:requiredKnowledge href="#b_StatusPriority"/>
     </dmn:knowledgeRequirement>
-    <dmn:context id="_424AB64B-8A8B-47EE-9CDC-B2531FF361C1">
+    <dmn:context id="_694D50A6-66A5-4AE6-82B5-D624586AA224">
       <dmn:contextEntry>
-        <dmn:variable id="_EF608D77-8D77-48E3-BB8F-CAD816AE11BB" name="Cancelled Flights" typeRef="feel:string"/>
-        <dmn:literalExpression id="_DADE28CB-D884-40C9-8298-7FEB9558FFB5">
+        <dmn:variable id="_6CAFD111-8488-48C6-84CF-C3ED3DCCA58B" name="Cancelled Flights" typeRef="string"/>
+        <dmn:literalExpression id="_830A5904-2528-4411-886F-CD26BD5DA4F3">
           <dmn:text>Flight List[ Status = "cancelled" ].Flight Number</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_B2A7E1AB-6EF9-4CD3-B646-DF1C1EA472D0" name="Waiting List" typeRef="kie:tPassengerTable"/>
-        <dmn:literalExpression id="_D1C5951F-AB89-479F-B861-ECDBD6E19AAB">
+        <dmn:variable id="_DE4E4C9A-E5B5-4D1F-A583-F37C4FB35275" name="Waiting List" typeRef="tPassengerTable"/>
+        <dmn:literalExpression id="_9D3BED31-273F-4306-99F6-88AAF5C4D73B">
           <dmn:text>Passenger List[ list contains( Cancelled Flights, Flight Number ) ]</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:variable id="_78929F8F-ECC2-4F41-83C8-6119A12DBBD4" name="passenger priority" typeRef="feel:boolean"/>
-        <dmn:functionDefinition id="_121902DB-4B42-442F-9D6E-3FDEA85EA36E" kind="FEEL">
-          <dmn:formalParameter id="_26EA3FDB-E47C-4B39-971E-575288CE7883" name="Passenger1" typeRef="kie:tPassenger"/>
-          <dmn:formalParameter id="_17B92DA2-7E05-47B2-AFD1-8AF24A2B21D0" name="Passenger2" typeRef="kie:tPassenger"/>
-          <dmn:literalExpression id="_DB6F564A-0470-4A5C-8FBA-B150BCDDC081">
-            <dmn:text>status priority( Passenger1.Status ) &lt; status priority( Passenger2.Status ) or							   ( status priority( Passenger1.Status ) = status priority( Passenger2.Status ) and 							     Passenger1.Miles &gt; Passenger2.Miles ) 							   )</dmn:text>
+        <dmn:variable id="_9C454B18-AB8C-4B38-B2DE-684FD9CB9111" name="passenger priority" typeRef="boolean"/>
+        <dmn:functionDefinition id="_93D9E7BA-1508-47AA-83E9-2B64DF1F6741" kind="FEEL">
+          <dmn:formalParameter id="_2E726E98-1E5A-4E7C-BAED-EA49E63D24D1" name="Passenger1" typeRef="tPassenger"/>
+          <dmn:formalParameter id="_B3463711-45BE-46E4-9AAA-B3D0F8307EAC" name="Passenger2" typeRef="tPassenger"/>
+          <dmn:literalExpression id="_4365CE39-19AF-49B2-81ED-F8E57DAE07CA">
+            <dmn:text> status priority( Passenger1.Status ) &lt; status priority( Passenger2.Status ) or							   ( status priority( Passenger1.Status ) = status priority( Passenger2.Status ) and 							     Passenger1.Miles &gt; Passenger2.Miles ) 							   )</dmn:text>
           </dmn:literalExpression>
         </dmn:functionDefinition>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:literalExpression id="_97164D8D-EDC2-4802-890F-5C1544E9C648">
+        <dmn:literalExpression id="_778C956B-3167-4C95-9098-1BDE3F511CB3">
           <dmn:text>sort( Waiting List, passenger priority )</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
@@ -96,31 +102,31 @@
   </dmn:decision>
   <dmn:decision id="d_RebookedPassengers" name="Rebooked Passengers">
     <dmn:extensionElements/>
-    <dmn:variable id="_982B50C1-581F-4A86-8F85-BAD72F7B4FEC" name="Rebooked Passengers" typeRef="kie:tPassengerTable"/>
-    <dmn:informationRequirement id="d_PrioritizedWaitingList">
+    <dmn:variable id="_CC6031BF-B67D-4466-9C48-08504B91B331" name="Rebooked Passengers" typeRef="tPassengerTable"/>
+    <dmn:informationRequirement id="_D552FBC5-D9B0-40CD-B054-7E7EA5662C48">
       <dmn:requiredDecision href="#d_PrioritizedWaitingList"/>
     </dmn:informationRequirement>
-    <dmn:informationRequirement id="i_Flight_List">
+    <dmn:informationRequirement id="_425E881A-1B5A-4102-BE16-00A64306130B">
       <dmn:requiredInput href="#i_Flight_List"/>
     </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="b_RebookedFlights">
+    <dmn:knowledgeRequirement id="_E74FE5AC-B920-415A-BFF5-2BE646C54881">
       <dmn:requiredKnowledge href="#b_RebookedFlights"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_B21566B4-1392-4481-8936-ED0D3BB0018B">
-      <dmn:text>rebooked flights( Prioritized Waiting List, [], Flight List )</dmn:text>
+    <dmn:literalExpression id="_0BB1A436-3D60-42EC-9F1D-9FB573869A11">
+      <dmn:text>				rebooked flights( Prioritized Waiting List, [], Flight List )			</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="b_StatusPriority" name="status priority">
     <dmn:extensionElements/>
-    <dmn:variable id="_A8717B8B-AC99-47AE-850C-7732C2AB7F72" name="status priority" typeRef="feel:number"/>
-    <dmn:encapsulatedLogic id="_0F180650-92EC-4970-9A48-8520E56EFDC1" kind="FEEL">
-      <dmn:formalParameter id="_73E8445F-1674-408E-A29B-5C5E7F978C54" name="Status" typeRef="feel:string"/>
-      <dmn:decisionTable id="_08491153-9B5C-4BDD-8272-891A49398DDE" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+    <dmn:variable id="_728B9790-E4E1-4C2C-ABBF-B338B4468E0A" name="status priority" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_74812A88-DEB5-49B9-98C8-79C9B6641394" kind="FEEL">
+      <dmn:formalParameter id="_859EDDDE-D700-42A4-B380-6A15D91247FF" name="Status" typeRef="string"/>
+      <dmn:decisionTable id="_5CCC6093-1FE2-4477-8EE4-DC3E722118AE" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
         <dmn:input id="b_Status_Priority_dt_i_Status">
-          <dmn:inputExpression id="_CA89C027-1EC0-4883-870C-8A096F71B3D4" typeRef="feel:string">
+          <dmn:inputExpression id="_DC343345-4BA6-4AC6-9359-ED80BACD13B5" typeRef="string">
             <dmn:text>Status</dmn:text>
           </dmn:inputExpression>
-          <dmn:inputValues id="_66085483-C468-4023-943D-C8F77DAF7475">
+          <dmn:inputValues id="_0D285157-08C2-49E0-8F4C-70AE41E512CE">
             <dmn:text>"gold", "silver", "bronze"</dmn:text>
           </dmn:inputValues>
         </dmn:input>
@@ -164,103 +170,103 @@
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="b_RebookedFlights" name="rebooked flights">
     <dmn:extensionElements/>
-    <dmn:variable id="_289D42B1-5C59-474D-BFC3-C3DD5A09C52A" name="rebooked flights" typeRef="kie:tPassengerTable"/>
-    <dmn:encapsulatedLogic id="_F9F7FE3E-F250-4AB8-B7E1-8BE164392FA5" kind="FEEL">
-      <dmn:formalParameter id="_18BEFABC-4727-4B4D-B42E-21C850B72180" name="Waiting" typeRef="kie:tPassengerTable"/>
-      <dmn:formalParameter id="_C0EA0B44-7C79-4BC0-AAC5-65D909B8A130" name="Rebooked" typeRef="kie:tPassengerTable"/>
-      <dmn:formalParameter id="_31C6F208-667D-475E-B483-AD4479F7C196" name="Flights" typeRef="kie:tFlightTable"/>
-      <dmn:context id="_691E8732-6083-43BE-8733-C7A1EB8B2C0B">
+    <dmn:variable id="_0AC63706-D766-4993-8C33-1E556D682E0E" name="rebooked flights" typeRef="tPassengerTable"/>
+    <dmn:encapsulatedLogic id="_14511F2A-5DAE-40DD-AE8F-8FC0E9800A2F" kind="FEEL">
+      <dmn:formalParameter id="_373FAFAE-F333-488B-8654-1FB2EA33A75D" name="Waiting" typeRef="tPassengerTable"/>
+      <dmn:formalParameter id="_D77E2C65-D1E9-4D70-B2D4-7AAB1B4865B5" name="Rebooked" typeRef="tPassengerTable"/>
+      <dmn:formalParameter id="_78441F64-ACED-4ADD-AF23-2DAADAC905B1" name="Flights" typeRef="tFlightTable"/>
+      <dmn:context id="_C06C2015-86A3-4ECF-B198-22B7DEB2694E">
         <dmn:contextEntry>
-          <dmn:variable id="_56FDB16B-BDFD-4615-ACEC-3BFC93C6854D" name="Passenger" typeRef="kie:tPassenger"/>
-          <dmn:literalExpression id="_E2E3BA03-36E4-4DD6-AD78-BE04E31644EC">
+          <dmn:variable id="_CF4D1736-5A73-4FE1-BFC3-8A26670CEBC4" name="Passenger" typeRef="tPassenger"/>
+          <dmn:literalExpression id="_997EA10A-8FD4-479A-B992-7D298866F282">
             <dmn:text>Waiting[1]</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_0D390DBE-04DA-40FB-971E-5879B813EED9" name="Original Flight" typeRef="kie:tFlight"/>
-          <dmn:literalExpression id="_CAB1CFE8-56F8-4288-A9D6-41631D934125">
+          <dmn:variable id="_459CB737-B9BD-4DFE-B2F3-2DF6F9913C00" name="Original Flight" typeRef="tFlight"/>
+          <dmn:literalExpression id="_A2C7CC2A-68AC-40B3-9188-F16A97C8B521">
             <dmn:text>Flights[ Flight Number = Passenger.Flight Number ][1]</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_903FE38C-1536-4594-9C49-6FFBA47F6545" name="has capacity" typeRef="feel:boolean"/>
-          <dmn:functionDefinition id="_9593E685-FA69-486B-9244-7D362DD2678E" kind="FEEL">
-            <dmn:formalParameter id="_0302F2D1-0521-49CB-B427-66DE8F39F098" name="flight" typeRef="kie:tFlight"/>
-            <dmn:formalParameter id="_2FA2E751-505E-464F-BCA0-2F4D302149C4" name="rebooked list" typeRef="kie:tPassengerTable"/>
-            <dmn:literalExpression id="_B036F8F7-009B-4FDC-BD2C-ED9B6716B869">
-              <dmn:text>flight.Capacity &gt; count( rebooked list[ Flight Number = flight.Flight Number ] )</dmn:text>
+          <dmn:variable id="_0462E871-EEFF-4A14-97F9-81AD5CFE2A2C" name="has capacity" typeRef="boolean"/>
+          <dmn:functionDefinition id="_B8C1E92F-74C4-45B1-8841-ABC860B424DD" kind="FEEL">
+            <dmn:formalParameter id="_3E3F9FF0-06FC-4445-B78C-B6E7BA15208B" name="flight" typeRef="tFlight"/>
+            <dmn:formalParameter id="_D8FD144C-C50A-47C3-911F-0D26637A56C7" name="rebooked list" typeRef="tPassengerTable"/>
+            <dmn:literalExpression id="_BA1F19A6-6D0D-405C-843D-26C28CD3B39A">
+              <dmn:text> flight.Capacity &gt; count( rebooked list[ Flight Number = flight.Flight Number ] ) </dmn:text>
             </dmn:literalExpression>
           </dmn:functionDefinition>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_EEB71DAD-E0CE-4552-9E81-D9BB273E4036" name="Best Alternate Flight" typeRef="kie:tFlight"/>
-          <dmn:literalExpression id="_0A779ADF-A13A-4488-A2F0-D25323CF697F">
+          <dmn:variable id="_5106EC4E-58F9-4D02-9F39-748AFEDBCD9C" name="Best Alternate Flight" typeRef="tFlight"/>
+          <dmn:literalExpression id="_063F2D73-717E-45D4-8B88-068B59D1A074">
             <dmn:text>Flight List[ From = Original Flight.From and 							               To = Original Flight.To and							               Departure &gt; Original Flight.Departure and							               Status = "scheduled" and							               has capacity( item, Rebooked ) ][1]</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:variable id="_FBF8DC8B-EA96-4DD6-B941-DA1580E5FC61" name="New Flight" typeRef="kie:tPassenger"/>
-          <dmn:context id="_F3993D9C-7B3F-4C74-88D4-88CC32414784">
+          <dmn:variable id="_D80C8735-B16B-4776-A9A1-085E29DA8243" name="New Flight" typeRef="tPassenger"/>
+          <dmn:context id="_9FFFCC2F-2AC6-40B8-8705-09B9187F205B">
             <dmn:contextEntry>
-              <dmn:variable id="_35EC5E95-E232-4C9A-AA0F-BDE724CD4260" name="Name" typeRef="feel:string"/>
-              <dmn:literalExpression id="_005AAAC6-3FA2-47AC-9CC2-27F38A17812F">
+              <dmn:variable id="_A86D7C48-4F78-4550-AE9C-92F88C7C9918" name="Name" typeRef="string"/>
+              <dmn:literalExpression id="_23105A96-D0B1-4DAA-9A05-1FA183199052">
                 <dmn:text>Passenger.Name</dmn:text>
               </dmn:literalExpression>
             </dmn:contextEntry>
             <dmn:contextEntry>
-              <dmn:variable id="_DFF04719-CB16-46C0-94C5-AA9B551DC5E7" name="Status" typeRef="feel:string"/>
-              <dmn:literalExpression id="_78BAF6B7-58D3-4A15-895B-C494AF936287">
+              <dmn:variable id="_B0788F1D-7B1D-45DD-A970-DF639CCFC195" name="Status" typeRef="string"/>
+              <dmn:literalExpression id="_C84534C9-2B3A-4249-A15C-E54FA6931731">
                 <dmn:text>Passenger.Status</dmn:text>
               </dmn:literalExpression>
             </dmn:contextEntry>
             <dmn:contextEntry>
-              <dmn:variable id="_2DF95258-7574-427B-9316-468D83884DFC" name="Miles" typeRef="feel:number"/>
-              <dmn:literalExpression id="_4676C989-01FE-4E4C-BBD5-6CAB7E013508">
+              <dmn:variable id="_D390B5B4-22BA-4614-AC22-0536006219AA" name="Miles" typeRef="number"/>
+              <dmn:literalExpression id="_93886C23-3EB0-40A9-81EB-0D539A3C1339">
                 <dmn:text>Passenger.Miles</dmn:text>
               </dmn:literalExpression>
             </dmn:contextEntry>
             <dmn:contextEntry>
-              <dmn:variable id="_F3F8BE5E-F24E-4B3D-820C-A359463FA68A" name="Flight Number" typeRef="feel:string"/>
-              <dmn:literalExpression id="_E0DC87D6-FA0F-42A8-BBFE-0F99C2BA68EC">
+              <dmn:variable id="_F5C51149-560A-49A8-90C1-08D045BE9D64" name="Flight Number" typeRef="string"/>
+              <dmn:literalExpression id="_8CF837F6-2DEA-40FE-B737-E85E071FF5B8">
                 <dmn:text>Best Alternate Flight.Flight Number</dmn:text>
               </dmn:literalExpression>
             </dmn:contextEntry>
           </dmn:context>
         </dmn:contextEntry>
         <dmn:contextEntry>
-          <dmn:literalExpression id="_084D1E9D-AABA-41E2-9061-713FC1204FF0">
-            <dmn:text>if count( Waiting ) &gt; 1 							  then							       rebooked flights( remove( Waiting, 1 ),							                         append( Rebooked, New Flight ),							                         Flights )							  else 							       append( Rebooked, New Flight )</dmn:text>
+          <dmn:literalExpression id="_8F070D82-4A44-43C5-A7C3-7EDC5409252E">
+            <dmn:text>if count( Waiting ) &gt; 1 							  then							       rebooked flights( remove( Waiting, 1 ),							                         append( Rebooked, New Flight ),							                         Flights )							  else 							       append( Rebooked, New Flight )						</dmn:text>
           </dmn:literalExpression>
         </dmn:contextEntry>
       </dmn:context>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_42C1B81D-D06C-44F2-8D1C-A3F7FAE6A28D" name="DRG">
+    <dmndi:DMNDiagram id="_ABDC73D2-9743-43E4-87F5-6CF94C254C74" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_424AB64B-8A8B-47EE-9CDC-B2531FF361C1"/>
-          <kie:ComponentWidths dmnElementRef="_DADE28CB-D884-40C9-8298-7FEB9558FFB5"/>
-          <kie:ComponentWidths dmnElementRef="_D1C5951F-AB89-479F-B861-ECDBD6E19AAB"/>
-          <kie:ComponentWidths dmnElementRef="_121902DB-4B42-442F-9D6E-3FDEA85EA36E"/>
-          <kie:ComponentWidths dmnElementRef="_DB6F564A-0470-4A5C-8FBA-B150BCDDC081"/>
-          <kie:ComponentWidths dmnElementRef="_97164D8D-EDC2-4802-890F-5C1544E9C648"/>
-          <kie:ComponentWidths dmnElementRef="_B21566B4-1392-4481-8936-ED0D3BB0018B"/>
-          <kie:ComponentWidths dmnElementRef="_08491153-9B5C-4BDD-8272-891A49398DDE"/>
-          <kie:ComponentWidths dmnElementRef="_0F180650-92EC-4970-9A48-8520E56EFDC1"/>
-          <kie:ComponentWidths dmnElementRef="_691E8732-6083-43BE-8733-C7A1EB8B2C0B"/>
-          <kie:ComponentWidths dmnElementRef="_E2E3BA03-36E4-4DD6-AD78-BE04E31644EC"/>
-          <kie:ComponentWidths dmnElementRef="_CAB1CFE8-56F8-4288-A9D6-41631D934125"/>
-          <kie:ComponentWidths dmnElementRef="_9593E685-FA69-486B-9244-7D362DD2678E"/>
-          <kie:ComponentWidths dmnElementRef="_B036F8F7-009B-4FDC-BD2C-ED9B6716B869"/>
-          <kie:ComponentWidths dmnElementRef="_0A779ADF-A13A-4488-A2F0-D25323CF697F"/>
-          <kie:ComponentWidths dmnElementRef="_F3993D9C-7B3F-4C74-88D4-88CC32414784"/>
-          <kie:ComponentWidths dmnElementRef="_005AAAC6-3FA2-47AC-9CC2-27F38A17812F"/>
-          <kie:ComponentWidths dmnElementRef="_78BAF6B7-58D3-4A15-895B-C494AF936287"/>
-          <kie:ComponentWidths dmnElementRef="_4676C989-01FE-4E4C-BBD5-6CAB7E013508"/>
-          <kie:ComponentWidths dmnElementRef="_E0DC87D6-FA0F-42A8-BBFE-0F99C2BA68EC"/>
-          <kie:ComponentWidths dmnElementRef="_084D1E9D-AABA-41E2-9061-713FC1204FF0"/>
-          <kie:ComponentWidths dmnElementRef="_F9F7FE3E-F250-4AB8-B7E1-8BE164392FA5"/>
+          <kie:ComponentWidths dmnElementRef="_694D50A6-66A5-4AE6-82B5-D624586AA224"/>
+          <kie:ComponentWidths dmnElementRef="_830A5904-2528-4411-886F-CD26BD5DA4F3"/>
+          <kie:ComponentWidths dmnElementRef="_9D3BED31-273F-4306-99F6-88AAF5C4D73B"/>
+          <kie:ComponentWidths dmnElementRef="_93D9E7BA-1508-47AA-83E9-2B64DF1F6741"/>
+          <kie:ComponentWidths dmnElementRef="_4365CE39-19AF-49B2-81ED-F8E57DAE07CA"/>
+          <kie:ComponentWidths dmnElementRef="_778C956B-3167-4C95-9098-1BDE3F511CB3"/>
+          <kie:ComponentWidths dmnElementRef="_0BB1A436-3D60-42EC-9F1D-9FB573869A11"/>
+          <kie:ComponentWidths dmnElementRef="_5CCC6093-1FE2-4477-8EE4-DC3E722118AE"/>
+          <kie:ComponentWidths dmnElementRef="_74812A88-DEB5-49B9-98C8-79C9B6641394"/>
+          <kie:ComponentWidths dmnElementRef="_C06C2015-86A3-4ECF-B198-22B7DEB2694E"/>
+          <kie:ComponentWidths dmnElementRef="_997EA10A-8FD4-479A-B992-7D298866F282"/>
+          <kie:ComponentWidths dmnElementRef="_A2C7CC2A-68AC-40B3-9188-F16A97C8B521"/>
+          <kie:ComponentWidths dmnElementRef="_B8C1E92F-74C4-45B1-8841-ABC860B424DD"/>
+          <kie:ComponentWidths dmnElementRef="_BA1F19A6-6D0D-405C-843D-26C28CD3B39A"/>
+          <kie:ComponentWidths dmnElementRef="_063F2D73-717E-45D4-8B88-068B59D1A074"/>
+          <kie:ComponentWidths dmnElementRef="_9FFFCC2F-2AC6-40B8-8705-09B9187F205B"/>
+          <kie:ComponentWidths dmnElementRef="_23105A96-D0B1-4DAA-9A05-1FA183199052"/>
+          <kie:ComponentWidths dmnElementRef="_C84534C9-2B3A-4249-A15C-E54FA6931731"/>
+          <kie:ComponentWidths dmnElementRef="_93886C23-3EB0-40A9-81EB-0D539A3C1339"/>
+          <kie:ComponentWidths dmnElementRef="_8CF837F6-2DEA-40FE-B737-E85E071FF5B8"/>
+          <kie:ComponentWidths dmnElementRef="_8F070D82-4A44-43C5-A7C3-7EDC5409252E"/>
+          <kie:ComponentWidths dmnElementRef="_14511F2A-5DAE-40DD-AE8F-8FC0E9800A2F"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
       <dmndi:DMNShape id="dmnshape-drg-i_Flight_List" dmnElementRef="i_Flight_List" isCollapsed="false">
@@ -317,23 +323,27 @@
         <dc:Bounds x="313" y="225" width="100" height="50"/>
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-i_Passenger_List" dmnElementRef="i_Passenger_List">
+      <dmndi:DMNEdge id="dmnedge-drg-_D23FCE0A-25F3-4FCE-9A32-D23F6C4C57C1" dmnElementRef="_D23FCE0A-25F3-4FCE-9A32-D23F6C4C57C1">
         <di:waypoint x="225" y="400"/>
         <di:waypoint x="138" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-i_Flight_List" dmnElementRef="i_Flight_List">
+      <dmndi:DMNEdge id="dmnedge-drg-_26A0DF82-39CD-4617-A998-712743F003B3" dmnElementRef="_26A0DF82-39CD-4617-A998-712743F003B3">
         <di:waypoint x="50" y="400"/>
         <di:waypoint x="138" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_StatusPriority" dmnElementRef="b_StatusPriority">
+      <dmndi:DMNEdge id="dmnedge-drg-_B15EF6FC-5689-4D60-9C6C-6E5A6DCE0C07" dmnElementRef="_B15EF6FC-5689-4D60-9C6C-6E5A6DCE0C07">
         <di:waypoint x="400" y="400"/>
         <di:waypoint x="138" y="225"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-d_PrioritizedWaitingList" dmnElementRef="d_PrioritizedWaitingList">
+      <dmndi:DMNEdge id="dmnedge-drg-_D552FBC5-D9B0-40CD-B054-7E7EA5662C48" dmnElementRef="_D552FBC5-D9B0-40CD-B054-7E7EA5662C48">
         <di:waypoint x="138" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-b_RebookedFlights" dmnElementRef="b_RebookedFlights">
+      <dmndi:DMNEdge id="dmnedge-drg-_425E881A-1B5A-4102-BE16-00A64306130B" dmnElementRef="_425E881A-1B5A-4102-BE16-00A64306130B">
+        <di:waypoint x="50" y="400"/>
+        <di:waypoint x="225" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E74FE5AC-B920-415A-BFF5-2BE646C54881" dmnElementRef="_E74FE5AC-B920-415A-BFF5-2BE646C54881">
         <di:waypoint x="313" y="225"/>
         <di:waypoint x="225" y="50"/>
       </dmndi:DMNEdge>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
@@ -2,233 +2,233 @@
 <dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0082-feel-coercion" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_i9fboPUUEeesLuP4RHs4vA" name="0082-feel-coercion" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0082-feel-coercion">
   <dmn:description>FEEL type conformance of DT and BKM results</dmn:description>
   <dmn:extensionElements/>
-  <dmn:itemDefinition id="_0E933CE3-4C53-4BC8-91E7-D47BCC97B7FD" name="tNumberList" isCollection="true">
+  <dmn:itemDefinition id="_9A05F869-BDDD-49C2-B30D-DDBF72D755C6" name="tNumberList" isCollection="true">
     <dmn:typeRef>number</dmn:typeRef>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_FF4EFBF3-F86F-4C6B-B10C-68F0EE08753F" name="tStringList" isCollection="true">
+  <dmn:itemDefinition id="_64EF4AF0-FFB7-4A88-88B4-01216CF63680" name="tStringList" isCollection="true">
     <dmn:typeRef>string</dmn:typeRef>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_A2CB79BE-FA5E-4C0F-A538-DAB1BE34CB7C" name="tDS_001" isCollection="false">
-    <dmn:itemComponent id="_B2B94BF3-91EA-4ADB-A70D-77D831DB57F7" name="decision_ds_001" isCollection="false">
+  <dmn:itemDefinition id="_40F06DA8-5B16-4F71-8103-F3570DAA96EA" name="tDS_001" isCollection="false">
+    <dmn:itemComponent id="_6E3CA6D6-2B73-4C61-90FE-D84D9C423D70" name="decision_ds_001" isCollection="false">
       <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
-  <dmn:itemDefinition id="_27D9E40F-CE37-459B-BBBA-A109CF56F98D" name="tNameAndAge" isCollection="false">
-    <dmn:itemComponent id="_C8929114-02FC-481B-BF62-C7271E419A56" name="name" isCollection="false">
+  <dmn:itemDefinition id="_6386BE4D-F8F7-4C68-88BA-626D43EB6AFE" name="tNameAndAge" isCollection="false">
+    <dmn:itemComponent id="_FC917A0C-1FAD-41FE-AD49-614CD044BC8F" name="name" isCollection="false">
       <dmn:typeRef>string</dmn:typeRef>
     </dmn:itemComponent>
-    <dmn:itemComponent id="_15DFD8F0-D473-49AF-B3A0-69079A07EE2B" name="age" isCollection="false">
+    <dmn:itemComponent id="_A87E5274-E598-4D76-B0CD-7866AF2F7046" name="age" isCollection="false">
       <dmn:typeRef>number</dmn:typeRef>
     </dmn:itemComponent>
   </dmn:itemDefinition>
   <dmn:decisionService id="_decisionService_001" name="decisionService_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_3C2B65CF-F807-40ED-8952-D89CD769D8F0" name="decisionService_001" typeRef="tDS_001"/>
+    <dmn:variable id="_E746D611-FFC1-4DC4-977E-C6A531A4EB90" name="decisionService_001" typeRef="tDS_001"/>
   </dmn:decisionService>
   <dmn:decisionService id="_decisionService_002" name="decisionService_002">
     <dmn:extensionElements/>
-    <dmn:variable id="_6EAF53F3-A539-477E-BB50-C6456C65E6E4" name="decisionService_002"/>
+    <dmn:variable id="_9E7E8AE3-B156-4219-9F2A-4B4D28234787" name="decisionService_002"/>
   </dmn:decisionService>
   <dmn:decisionService id="_decisionService_003" name="decisionService_003">
     <dmn:extensionElements/>
-    <dmn:variable id="_EFC64899-F221-44FA-AD9B-003418F7CFBE" name="decisionService_003"/>
+    <dmn:variable id="_566FD956-AD78-411E-B9EA-54DD1DEF0295" name="decisionService_003"/>
   </dmn:decisionService>
   <dmn:decision id="_decision_001" name="decision_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_172E661A-12E4-41AF-97A4-8F1415B92A19" name="decision_001" typeRef="string"/>
-    <dmn:literalExpression id="_D1D607A8-7D27-413A-A85F-2ED29FF4979B">
+    <dmn:variable id="_DC539B91-2FB5-4BF9-ABE9-E44D73C49DBA" name="decision_001" typeRef="string"/>
+    <dmn:literalExpression id="_4D52EE06-25BB-474B-B030-1DDE122A8424">
       <dmn:text>1+1</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_003" name="decision_003">
     <dmn:extensionElements/>
-    <dmn:variable id="_26E09CDF-092A-4970-8063-331F724F91CF" name="decision_003" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_5377061D-8200-4314-86E4-3132A84082CC">
+    <dmn:variable id="_1464F046-5BC4-4858-A3C0-9C1579B43C4E" name="decision_003" typeRef="tNumberList"/>
+    <dmn:literalExpression id="_EAE3D59E-734D-49E2-BD45-F57D9737DFB6">
       <dmn:text>[1,2,"foo"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_004" name="decision_004">
     <dmn:extensionElements/>
-    <dmn:variable id="_8DDEAC4B-2DD6-4144-BA00-C5674F173E1F" name="decision_004" typeRef="tNameAndAge"/>
-    <dmn:literalExpression id="_1B10BE79-6862-4FCB-A1DB-C2F0ABD1607F">
+    <dmn:variable id="_C6400D70-47CE-4900-9AC8-142E7E7FC9B9" name="decision_004" typeRef="tNameAndAge"/>
+    <dmn:literalExpression id="_83883E5A-E19E-469A-985D-4DC31AE1EB90">
       <dmn:text>{name: "foo", surname: "bar", age: 10}</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_005" name="decision_005">
     <dmn:extensionElements/>
-    <dmn:variable id="_82E44F6E-B8A9-4C87-9C3E-1CE952450E8F" name="decision_005" typeRef="tNameAndAge"/>
-    <dmn:literalExpression id="_A6B049B5-A928-4667-ACE0-0ACB57E08C6A">
+    <dmn:variable id="_32A67EB0-9FC3-4F1D-A3F9-E4AF4F6B3E9B" name="decision_005" typeRef="tNameAndAge"/>
+    <dmn:literalExpression id="_717B58E6-90C0-4AC9-91C1-65BBFC6C412F">
       <dmn:text>{name: "foo"}</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_006" name="decision_006">
     <dmn:extensionElements/>
-    <dmn:variable id="_514A26B3-D413-4CF5-9431-ECB849E03828" name="decision_006" typeRef="tStringList"/>
-    <dmn:literalExpression id="_3F77D9FD-8062-4B20-B834-E3F9CC793E6F">
+    <dmn:variable id="_954ADCC2-CE01-4D65-AABC-AE28CE374790" name="decision_006" typeRef="tStringList"/>
+    <dmn:literalExpression id="_AFA2D2DA-C8DF-4816-BE44-45F149707D20">
       <dmn:text>"foo"</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_006_a" name="decision_006_a">
     <dmn:extensionElements/>
-    <dmn:variable id="_AB80C754-CE74-43B0-887F-3F6F01775316" name="decision_006_a" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_0434B701-4E04-4B18-8770-799FA1B89B06">
+    <dmn:variable id="_2E04A2C9-5DBE-4B88-9090-20C61D0D9F49" name="decision_006_a" typeRef="tNumberList"/>
+    <dmn:literalExpression id="_3A7A53EB-38A3-488F-9246-2C7CABB9B33C">
       <dmn:text>"foo"</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_007" name="decision_007">
     <dmn:extensionElements/>
-    <dmn:variable id="_48CE096D-ACFD-4062-BA43-40448B20F958" name="decision_007" typeRef="string"/>
-    <dmn:literalExpression id="_A3A1ECC6-0F0D-4737-935C-A9F5019E2B9E">
+    <dmn:variable id="_B34C2A69-E356-4756-B6DD-A8FD5604BDAB" name="decision_007" typeRef="string"/>
+    <dmn:literalExpression id="_696F7BC3-9512-4A96-9BEF-C74B734A3F38">
       <dmn:text>["foo"]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_007_a" name="decision_007_a">
     <dmn:extensionElements/>
-    <dmn:variable id="_90444C74-8C62-4CF6-8D75-3AA30FB9EBC4" name="decision_007_a" typeRef="string"/>
-    <dmn:literalExpression id="_6EB006B6-2126-4E57-9DA1-0EF00421161E">
+    <dmn:variable id="_8F5E8E1A-9C75-453C-9D91-621573F98B68" name="decision_007_a" typeRef="string"/>
+    <dmn:literalExpression id="_8F2F4ECA-125B-4F60-8D9A-0A3E24A126B4">
       <dmn:text>[1]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_008" name="decision_008">
     <dmn:extensionElements/>
-    <dmn:variable id="_49BFE136-2E46-4A93-9144-44633812EEF6" name="decision_008" typeRef="list"/>
-    <dmn:literalExpression id="_3DE611A4-D167-44D4-99A9-283E1DB46F5A">
+    <dmn:variable id="_5FA836E4-EA83-4057-8A55-A868230F4CF0" name="decision_008" typeRef="list"/>
+    <dmn:literalExpression id="_2C30E334-4F12-4C94-8A9A-F9356EC5E3AE">
       <dmn:text>null</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="_bkm_001" name="bkm_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_A0930F5C-F027-4EBA-B6DC-8469B7FC87F3" name="bkm_001"/>
-    <dmn:encapsulatedLogic id="_C29396F3-9F48-48F7-B500-F6B792471D61" kind="FEEL">
-      <dmn:formalParameter id="_3D34C891-045D-4BA1-AD47-1EE395AAD270" name="nameAndAge" typeRef="tNameAndAge"/>
-      <dmn:literalExpression id="_22796919-E0A5-43E0-8610-0926509BCA8F">
+    <dmn:variable id="_113E95AA-5A7A-4117-9B28-523AF453743D" name="bkm_001"/>
+    <dmn:encapsulatedLogic id="_7D8AAE90-5B7A-42FF-AAA7-F4BC07B5F823" kind="FEEL">
+      <dmn:formalParameter id="_3934FFC1-EF50-44DA-8202-306CFFF1E240" name="nameAndAge" typeRef="tNameAndAge"/>
+      <dmn:literalExpression id="_4727B860-2E96-4002-9FA3-A18D3717DABA">
         <dmn:text>nameAndAge != null</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:decision id="_decision_bkm_001" name="decision_bkm_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_B411F2D7-0ADD-49A5-9957-0E0C4E042F78" name="decision_bkm_001"/>
-    <dmn:knowledgeRequirement id="_bkm_001">
+    <dmn:variable id="_A6EFF4EA-5DF1-4075-A3DB-A8FD8B5D91F3" name="decision_bkm_001"/>
+    <dmn:knowledgeRequirement id="_7B3BE5CF-8218-47D2-B2CC-970E1FD58468">
       <dmn:requiredKnowledge href="#_bkm_001"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_3B90E76D-29F6-433B-BBAB-FFF1638B051C">
+    <dmn:literalExpression id="_8613DB9D-217D-4AD6-9A00-A616688B5216">
       <dmn:text>bkm_001({name: "foo", surname: "bar", age: 10})</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_bkm_002" name="decision_bkm_002">
     <dmn:extensionElements/>
-    <dmn:variable id="_688FD421-A9F5-46BA-AC23-EEDB43A10B48" name="decision_bkm_002"/>
-    <dmn:knowledgeRequirement id="_bkm_001">
+    <dmn:variable id="_82089E0F-C919-4400-BDBE-228841C17547" name="decision_bkm_002"/>
+    <dmn:knowledgeRequirement id="_8063F8D3-6062-4478-92B1-CEDFEFC9575A">
       <dmn:requiredKnowledge href="#_bkm_001"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_35F40F73-61BB-4480-97CF-AD10D75599FC">
+    <dmn:literalExpression id="_879392DB-597B-4F0E-9BBD-3DAE0A7A7AAF">
       <dmn:text>bkm_001({name: "foo"})</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="_bkm_002" name="bkm_002">
     <dmn:extensionElements/>
-    <dmn:variable id="_4E51C1AD-4BBB-428D-BF63-00492339D68B" name="bkm_002" typeRef="tNameAndAge"/>
-    <dmn:encapsulatedLogic id="_76FEDAE5-98F0-4712-B2A5-BEFAF8E77FCE" kind="FEEL">
-      <dmn:formalParameter id="_D6A313E7-79F7-4A2F-894E-D19F96E2BB92" name="nameAndAge" typeRef="tNameAndAge"/>
-      <dmn:literalExpression id="_DF107F97-07B3-451D-B7AA-BFEA8246AFE2">
+    <dmn:variable id="_8ECF4F3B-7A2E-4352-9108-2E59B70D0CBB" name="bkm_002" typeRef="tNameAndAge"/>
+    <dmn:encapsulatedLogic id="_94CDAB0B-54DE-4C39-95FE-A9A3CF5B1966" kind="FEEL">
+      <dmn:formalParameter id="_901F02AA-7356-4A82-B3D9-0378CAF09176" name="nameAndAge" typeRef="tNameAndAge"/>
+      <dmn:literalExpression id="_2E8FBA80-3C4F-412B-9C37-B7EA5BAE3DF8">
         <dmn:text>nameAndAge != null</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:decision id="_decision_bkm_003" name="decision_bkm_003">
     <dmn:extensionElements/>
-    <dmn:variable id="_5822D69C-F00C-4132-910F-8EC0521FAE40" name="decision_bkm_003"/>
-    <dmn:knowledgeRequirement id="_bkm_002">
+    <dmn:variable id="_D8EEF06A-35AF-4179-ABE9-EBA3FDF59F0A" name="decision_bkm_003"/>
+    <dmn:knowledgeRequirement id="_5ACB2078-518E-4743-9575-4BD03EDDA126">
       <dmn:requiredKnowledge href="#_bkm_002"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_AF814687-4F94-4E56-9F12-125F3F3C5DBD">
+    <dmn:literalExpression id="_F2AD0936-C3A0-47D5-9730-67D609F97606">
       <dmn:text>bkm_002({name: "foo"})</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:businessKnowledgeModel id="_bkm_004" name="bkm_004">
     <dmn:extensionElements/>
-    <dmn:variable id="_195626C9-FB37-4CD9-86CD-1CE438BF77D0" name="bkm_004" typeRef="tNumberList"/>
-    <dmn:encapsulatedLogic id="_0C1BB27B-D182-4312-81A2-2660DDB73282" kind="FEEL">
-      <dmn:formalParameter id="_147379C2-5B76-4C53-B7DB-019F85A36875" name="arg"/>
-      <dmn:literalExpression id="_CB44AA6B-2BD1-43EE-B129-A493B8A73D92">
+    <dmn:variable id="_03A3846D-BD69-4B83-B97B-D2BCE9A31437" name="bkm_004" typeRef="tNumberList"/>
+    <dmn:encapsulatedLogic id="_56DFE8A9-5C73-48C3-BD04-6FE89702D91F" kind="FEEL">
+      <dmn:formalParameter id="_760ED606-3975-4B4D-8165-6E8FC9804871" name="arg"/>
+      <dmn:literalExpression id="_8D1633B7-76C4-479F-8CA2-4E19F6BFD163">
         <dmn:text>arg</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:businessKnowledgeModel id="_bkm_005" name="bkm_005">
     <dmn:extensionElements/>
-    <dmn:variable id="_963D34B5-F999-48DA-B202-67037D55CC3C" name="bkm_005" typeRef="number"/>
-    <dmn:encapsulatedLogic id="_A3319E1D-5ADC-4205-BD36-05A0F769F0F8" kind="FEEL">
-      <dmn:formalParameter id="_FAEC64C2-1CCA-49C5-8B01-306CFB39AE37" name="arg"/>
-      <dmn:literalExpression id="_95FEAA05-2361-4440-B0F7-7FA34706F41A">
+    <dmn:variable id="_6BDB1ABD-981E-4B87-9D5F-6F2192D67D0C" name="bkm_005" typeRef="number"/>
+    <dmn:encapsulatedLogic id="_CCC20C6C-5EB5-4289-BDF2-887DAC80C3AD" kind="FEEL">
+      <dmn:formalParameter id="_A836A9D2-D829-4590-A9E2-8F5CFF31FF8B" name="arg"/>
+      <dmn:literalExpression id="_99C422DC-9A90-4572-8FFB-25FA604C41FB">
         <dmn:text>[arg]</dmn:text>
       </dmn:literalExpression>
     </dmn:encapsulatedLogic>
   </dmn:businessKnowledgeModel>
   <dmn:decision id="_decision_bkm_004" name="decision_bkm_004">
     <dmn:extensionElements/>
-    <dmn:variable id="_71D99471-2F53-4FD9-9CFF-B00440179851" name="decision_bkm_004"/>
-    <dmn:knowledgeRequirement id="_bkm_004">
+    <dmn:variable id="_46EE1842-0C85-4EB9-9FEC-5230B6662AA7" name="decision_bkm_004"/>
+    <dmn:knowledgeRequirement id="_A0CCB912-9FA0-446A-9CBD-6706BA653DD2">
       <dmn:requiredKnowledge href="#_bkm_004"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_18F6963D-1D60-412F-8B8B-A352C7FFB94B">
+    <dmn:literalExpression id="_CDF7850B-7D2A-4E56-A0E5-CE5F64F8764F">
       <dmn:text>bkm_004(10)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_bkm_004_a" name="decision_bkm_004_a">
     <dmn:extensionElements/>
-    <dmn:variable id="_AF7B3645-AF1E-4C63-AA38-4B7DE834274D" name="decision_bkm_004_a"/>
-    <dmn:knowledgeRequirement id="_bkm_004">
+    <dmn:variable id="_8AB8B8C7-C055-41FC-B508-0E263A0E6EE9" name="decision_bkm_004_a"/>
+    <dmn:knowledgeRequirement id="_32CEA84D-85B5-48A6-8BA3-D241F7A261FE">
       <dmn:requiredKnowledge href="#_bkm_004"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_12FAAFEC-3647-41F8-8D1A-0F94C1996093">
+    <dmn:literalExpression id="_2AF29277-430E-4F4D-A5E5-9DCA00BD805A">
       <dmn:text>bkm_004("foo")</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_bkm_004_b" name="decision_bkm_004_b">
     <dmn:extensionElements/>
-    <dmn:variable id="_BE3C5626-C17C-49B1-BD55-F69C3CCFFD68" name="decision_bkm_004_b"/>
-    <dmn:knowledgeRequirement id="_bkm_004">
+    <dmn:variable id="_20565219-71E1-418B-950B-BF515D083647" name="decision_bkm_004_b"/>
+    <dmn:knowledgeRequirement id="_AB09AF7F-53DA-433F-93CA-78E46482703F">
       <dmn:requiredKnowledge href="#_bkm_004"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_2AE86FFD-85F6-46F3-8B16-3AF7A260F0BC">
+    <dmn:literalExpression id="_4547B8C0-EC6B-4122-BE6F-27A6AC2F90AB">
       <dmn:text>bkm_004(null)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_bkm_005" name="decision_bkm_005">
     <dmn:extensionElements/>
-    <dmn:variable id="_596FA7C8-421E-4DB5-A768-B17AC7508355" name="decision_bkm_005"/>
-    <dmn:knowledgeRequirement id="_bkm_005">
+    <dmn:variable id="_354ED0C1-1336-44BE-A65E-048E3A18769E" name="decision_bkm_005"/>
+    <dmn:knowledgeRequirement id="_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2">
       <dmn:requiredKnowledge href="#_bkm_005"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_A8616933-CE11-441C-8F7C-5AEFE6231E3A">
+    <dmn:literalExpression id="_4985DB9C-1EAB-40FB-8F57-4FAFB8B339E7">
       <dmn:text>bkm_005(10)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_bkm_005_a" name="decision_bkm_005_a">
     <dmn:extensionElements/>
-    <dmn:variable id="_2C1BA504-7E86-4E71-A08C-98EB24BEB81F" name="decision_bkm_005_a"/>
-    <dmn:knowledgeRequirement id="_bkm_005">
+    <dmn:variable id="_E37780CE-6042-46A7-8A64-D838F7248BC5" name="decision_bkm_005_a"/>
+    <dmn:knowledgeRequirement id="_32616BE5-7354-455A-B94F-1E5F494BBD61">
       <dmn:requiredKnowledge href="#_bkm_005"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_BD77B888-248E-4BF9-9E11-E61F14A6A6B8">
+    <dmn:literalExpression id="_927F22D4-EBC0-4C83-B809-C4E57854AC94">
       <dmn:text>bkm_005("foo")</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_invoke_001" name="invoke_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_BB598098-A303-4256-B472-F75E56F375D7" name="invoke_001"/>
-    <dmn:knowledgeRequirement id="_bkm_001">
+    <dmn:variable id="_20D68AE5-9E60-4616-BDC8-60C903AD5346" name="invoke_001"/>
+    <dmn:knowledgeRequirement id="_844CC3F6-599F-4499-A803-C1886139969A">
       <dmn:requiredKnowledge href="#_bkm_001"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_1225D9D6-A5F6-4414-8953-74BAFEDC2CDE">
-      <dmn:literalExpression id="_C93D64F3-0379-45F1-8223-14315E604E6B">
+    <dmn:invocation id="_3FF9B459-238C-4F5B-9940-120899A2A557">
+      <dmn:literalExpression id="_400E2660-F788-4B34-8ECA-9EFA6320F0FA">
         <dmn:text>bkm_001</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
-        <dmn:parameter id="_63D6072F-5FDD-4F61-9EC4-39C386BD6D09" name="nameAndAge"/>
-        <dmn:literalExpression id="_36F6A377-BD2C-44DE-A04D-84E7A316457B">
+        <dmn:parameter id="_80DD4332-DBDA-43B9-8DBB-D20EF9E577F8" name="nameAndAge"/>
+        <dmn:literalExpression id="_D7A09AF7-F630-45CC-9D6F-8A9B22B32339">
           <dmn:text>{name: "foo"}</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -236,17 +236,17 @@
   </dmn:decision>
   <dmn:decision id="_invoke_002" name="invoke_002">
     <dmn:extensionElements/>
-    <dmn:variable id="_493DC800-BA94-4DBA-9548-0F4F9D7437DC" name="invoke_002" typeRef="string"/>
-    <dmn:knowledgeRequirement id="_bkm_001">
+    <dmn:variable id="_0F4B072E-9790-4F11-8C05-1442C6A9C123" name="invoke_002" typeRef="string"/>
+    <dmn:knowledgeRequirement id="_743FD00A-040C-4EF3-A16F-51F8E36EFE49">
       <dmn:requiredKnowledge href="#_bkm_001"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_EBE1694F-0088-4FF6-8E45-250534F8C40A" typeRef="string">
-      <dmn:literalExpression id="_79BFDCB5-13F7-4DE1-88B6-53EB20E57733">
+    <dmn:invocation id="_E11E9A94-D7CA-4F56-A551-20368C9A5E71" typeRef="string">
+      <dmn:literalExpression id="_E968333D-479F-4584-B273-F26560021DC0">
         <dmn:text>bkm_001</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
-        <dmn:parameter id="_4741D334-0A15-416C-A80A-F77D8D685421" name="nameAndAge"/>
-        <dmn:literalExpression id="_FD92F234-E904-43E1-8C54-508A59B50435">
+        <dmn:parameter id="_B2C745EC-78E6-4404-A86A-4FE9CDE1B2BB" name="nameAndAge"/>
+        <dmn:literalExpression id="_5811B4F0-9BA3-4083-93C0-C2C14441B585">
           <dmn:text>{name: "foo", age: 10}</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -254,17 +254,17 @@
   </dmn:decision>
   <dmn:decision id="_invoke_003" name="invoke_003">
     <dmn:extensionElements/>
-    <dmn:variable id="_D99F5D31-9125-4547-B056-BF9DB64DDC7F" name="invoke_003" typeRef="tNumberList"/>
-    <dmn:knowledgeRequirement id="_bkm_005">
+    <dmn:variable id="_D977DFF6-8C37-459D-A784-FFBB4781F66C" name="invoke_003" typeRef="tNumberList"/>
+    <dmn:knowledgeRequirement id="_004EB93A-E37A-4C38-BF48-CA4FED683432">
       <dmn:requiredKnowledge href="#_bkm_005"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_6D18EC45-D3E8-407F-B058-E99DBEF3B2D0" typeRef="tNumberList">
-      <dmn:literalExpression id="_FB69ACF3-A4AA-4CE3-A2E2-4075D488A65B">
+    <dmn:invocation id="_2E781A59-36A3-49F7-8B0F-F1D0ADADE60E" typeRef="tNumberList">
+      <dmn:literalExpression id="_7FD82BC4-67FC-4033-B58F-98A19ED8B890">
         <dmn:text>bkm_005</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
-        <dmn:parameter id="_C8E40DAA-8955-4293-8510-CA76E4B57BE6" name="arg"/>
-        <dmn:literalExpression id="_BB36B18B-F45D-4216-9142-F3554098CC69">
+        <dmn:parameter id="_24CA7AC9-F47B-4051-9EC3-BB22E48B17E7" name="arg"/>
+        <dmn:literalExpression id="_FA66787D-DB73-46A6-A12F-4CCA1E27C1A5">
           <dmn:text>10</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -272,17 +272,17 @@
   </dmn:decision>
   <dmn:decision id="_invoke_004" name="invoke_004">
     <dmn:extensionElements/>
-    <dmn:variable id="_1E970E50-9623-459B-965C-F98BFAC6AB24" name="invoke_004" typeRef="tNumberList"/>
-    <dmn:knowledgeRequirement id="_bkm_005">
+    <dmn:variable id="_A79302B7-C7A2-4005-AB89-277E3D013819" name="invoke_004" typeRef="tNumberList"/>
+    <dmn:knowledgeRequirement id="_EBD496F0-9E21-47AD-A630-8C5E032B6749">
       <dmn:requiredKnowledge href="#_bkm_005"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_078D3EF0-E3F1-4B6F-A03A-C1AED2F2D03A" typeRef="tNumberList">
-      <dmn:literalExpression id="_3538F6C7-A660-48C1-A9E0-A9FF4B21D7E5">
+    <dmn:invocation id="_9A884F00-26B9-4ADA-BB53-802C218DB96A" typeRef="tNumberList">
+      <dmn:literalExpression id="_EEE0851D-107F-444F-B0E0-98E1EA0C98CB">
         <dmn:text>bkm_005</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
-        <dmn:parameter id="_15E52B29-F9A1-43F3-9460-8645683F7416" name="arg"/>
-        <dmn:literalExpression id="_AE9320B6-25D0-462C-9DFE-90593F1CBA4E">
+        <dmn:parameter id="_C82D0D6B-1628-46AB-A93D-44FE1901DCFC" name="arg"/>
+        <dmn:literalExpression id="_9C1A5BA9-5B9B-4EA6-B970-6CB106CBDC49">
           <dmn:text>"foo"</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -290,17 +290,17 @@
   </dmn:decision>
   <dmn:decision id="_invoke_005" name="invoke_005">
     <dmn:extensionElements/>
-    <dmn:variable id="_CC18F6DC-CDF7-4CC5-B747-28CAAC3E3CD2" name="invoke_005" typeRef="number"/>
-    <dmn:knowledgeRequirement id="_bkm_005">
+    <dmn:variable id="_1B435357-01B7-41BC-8C67-DE15A60A6266" name="invoke_005" typeRef="number"/>
+    <dmn:knowledgeRequirement id="_ED2359BA-F57A-495B-8E75-C0913CD2BA05">
       <dmn:requiredKnowledge href="#_bkm_005"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_81CBE18D-7C0A-4BD5-A4A2-C1A04621FA8A" typeRef="number">
-      <dmn:literalExpression id="_0D8C9A48-90C6-4F85-B9C7-D5457627C1D4">
+    <dmn:invocation id="_6042D108-15EE-4041-AFBA-9A73892B0F36" typeRef="number">
+      <dmn:literalExpression id="_E66FBA75-5B4D-4D11-A00C-8DA09C36E687">
         <dmn:text>bkm_005</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
-        <dmn:parameter id="_DB9E059C-B0DB-4BC5-AF6B-2664BA25B432" name="arg"/>
-        <dmn:literalExpression id="_56653F99-99F1-483C-A7FC-C0DCCC055FA6">
+        <dmn:parameter id="_E5E80ACD-538E-47D4-9B63-A66618EF7E13" name="arg"/>
+        <dmn:literalExpression id="_754C9313-F07B-4EF6-8B51-F7E662374559">
           <dmn:text>[10]</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -308,17 +308,17 @@
   </dmn:decision>
   <dmn:decision id="_invoke_006" name="invoke_006">
     <dmn:extensionElements/>
-    <dmn:variable id="_702C36D6-F1D5-4E72-8009-F5319CDBDCAF" name="invoke_006" typeRef="number"/>
-    <dmn:knowledgeRequirement id="_bkm_005">
+    <dmn:variable id="_BE9E1631-9BBB-413A-A8BC-0EE7EC1C66FE" name="invoke_006" typeRef="number"/>
+    <dmn:knowledgeRequirement id="_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB">
       <dmn:requiredKnowledge href="#_bkm_005"/>
     </dmn:knowledgeRequirement>
-    <dmn:invocation id="_972DCB95-098B-4BDF-B02D-F736ADD84038" typeRef="number">
-      <dmn:literalExpression id="_04A00600-C146-4322-BF20-7DFD8F5AEF10">
+    <dmn:invocation id="_8CCB9AA5-2551-4CBE-A6D0-5258EA7D7B2A" typeRef="number">
+      <dmn:literalExpression id="_9F3CE04E-B813-4A4D-B795-00EF110CDB41">
         <dmn:text>bkm_005</dmn:text>
       </dmn:literalExpression>
       <dmn:binding>
-        <dmn:parameter id="_7037F340-7332-4D59-99BF-DB1B4156AEB8" name="arg"/>
-        <dmn:literalExpression id="_16914DE1-7019-4312-BD96-9B69CB59517C">
+        <dmn:parameter id="_F0C43900-9AE8-4A01-9F3A-772D7535DD61" name="arg"/>
+        <dmn:literalExpression id="_AD152E30-FFBE-446F-93FA-ADB08AFE3C1D">
           <dmn:text>["foo"]</dmn:text>
         </dmn:literalExpression>
       </dmn:binding>
@@ -326,16 +326,16 @@
   </dmn:decision>
   <dmn:decision id="_fd_001" name="fd_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_9CC50617-0E64-49C0-9A17-C8098EE06DB2" name="fd_001"/>
-    <dmn:context id="_B59F2F95-BBEA-40DF-B04C-94C8441BC2B8">
+    <dmn:variable id="_D9D6E81C-7FEC-4DB5-BE18-13C8E3A570D6" name="fd_001"/>
+    <dmn:context id="_BFA99D23-4ED5-443E-A404-EB8E39ABC0B8">
       <dmn:contextEntry>
-        <dmn:variable id="_5FDE645C-7D9A-48EF-8257-03E3B7CDD57F" name="fn"/>
-        <dmn:literalExpression id="_E041423C-65B6-44DF-ACE8-AB9515DA4579">
+        <dmn:variable id="_2B21258E-3EE9-45C5-9C80-E4FD963E9ED2" name="fn"/>
+        <dmn:literalExpression id="_B16C4F7F-73AB-44B6-BC3A-18A2187567A0">
           <dmn:text>function(arg: number) arg</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:literalExpression id="_DEFAC661-6676-48AA-BB1E-BFABEC10BD44">
+        <dmn:literalExpression id="_11E452BA-7C70-4BDA-B33A-B69329828153">
           <dmn:text>fn(10)</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
@@ -343,16 +343,16 @@
   </dmn:decision>
   <dmn:decision id="_fd_002" name="fd_002">
     <dmn:extensionElements/>
-    <dmn:variable id="_CB6D06B8-D80F-4047-A445-A7B9EF02CADF" name="fd_002"/>
-    <dmn:context id="_3843D408-A970-48EE-A6F3-7A1168516800">
+    <dmn:variable id="_6FD58395-581E-4759-8078-E578E4587E17" name="fd_002"/>
+    <dmn:context id="_9F3B05D9-D013-4E9A-9007-89F24E2987A3">
       <dmn:contextEntry>
-        <dmn:variable id="_3AD2CBEA-FBBD-4DA7-A9AF-6AE764143DC2" name="fn"/>
-        <dmn:literalExpression id="_FE8622B6-BE48-42AF-9648-736FDBA71FFB">
+        <dmn:variable id="_F11FF135-35E0-4C3C-BFE5-5EE530EF5606" name="fn"/>
+        <dmn:literalExpression id="_9ECECABF-C811-4A7E-B161-7EFAE322E35E">
           <dmn:text>function(arg: number) arg</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>
-        <dmn:literalExpression id="_5CB72104-FE38-415C-A8D3-99C84385CB83">
+        <dmn:literalExpression id="_05157905-263E-4A93-99B8-5C4010C0013E">
           <dmn:text>fn("foo")</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
@@ -360,636 +360,680 @@
   </dmn:decision>
   <dmn:decision id="_literal_001" name="literal_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_9E748A12-8E98-445F-8DA3-26CB685B1F02" name="literal_001" typeRef="number"/>
-    <dmn:literalExpression id="_E0871C1B-AB63-4439-98E6-3B6A817D3422" typeRef="number">
+    <dmn:variable id="_3A0C56EB-3F2F-4371-A093-C5E96F51D39A" name="literal_001" typeRef="number"/>
+    <dmn:literalExpression id="_AE433AB6-13C6-4842-91FC-433456F6E9E2" typeRef="number">
       <dmn:text>5+5</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_literal_002" name="literal_002">
     <dmn:extensionElements/>
-    <dmn:variable id="_027F00ED-0E3A-44C1-A9EC-F5C26A8DE2F4" name="literal_002" typeRef="number"/>
-    <dmn:literalExpression id="_E9B642AB-896F-4510-8FDA-311540A47A2E" typeRef="number">
+    <dmn:variable id="_7C1280C8-F133-4912-B4D5-663CC9B667B5" name="literal_002" typeRef="number"/>
+    <dmn:literalExpression id="_405E4248-0F47-40E1-8C0D-C664D43DE004" typeRef="number">
       <dmn:text>"foo"</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_literal_003" name="literal_003">
     <dmn:extensionElements/>
-    <dmn:variable id="_B2F620F7-E638-4D99-B58B-5004F9D88C2F" name="literal_003" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_13AEA31B-6888-4C41-918B-D5AB7ED33B8C" typeRef="tNumberList">
+    <dmn:variable id="_5199C8EB-0115-4D5B-9BB7-E71F46C3F9EB" name="literal_003" typeRef="tNumberList"/>
+    <dmn:literalExpression id="_00B05E56-2C80-4E18-BE2D-4FDDAA6C0462" typeRef="tNumberList">
       <dmn:text>10</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_literal_004" name="literal_004">
     <dmn:extensionElements/>
-    <dmn:variable id="_9B62341F-C08F-4116-B36A-761A4B6251CA" name="literal_004" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_64FAAC59-97A6-4304-B5B5-6AC27F6F4E8B" typeRef="tNumberList">
+    <dmn:variable id="_2A866D70-8078-4659-9935-7D7AC06701E9" name="literal_004" typeRef="tNumberList"/>
+    <dmn:literalExpression id="_707987A6-7B84-4869-B510-283EC111D92F" typeRef="tNumberList">
       <dmn:text>"foo"</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_literal_005" name="literal_005">
     <dmn:extensionElements/>
-    <dmn:variable id="_C2910DBC-957E-4DDB-A3EE-DF76B3AD8FE1" name="literal_005" typeRef="number"/>
-    <dmn:literalExpression id="_C51B16D2-2A1C-4A45-AAC6-CF4E2C0E2F7F" typeRef="number">
+    <dmn:variable id="_A4ADEDAC-4DA4-4360-B182-FDC27031291F" name="literal_005" typeRef="number"/>
+    <dmn:literalExpression id="_F74B86CA-18B9-4121-B60C-33BC976AADAE" typeRef="number">
       <dmn:text>[10]</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_literal_006" name="literal_006">
     <dmn:extensionElements/>
-    <dmn:variable id="_209B6DE8-284B-480B-BBEB-B505B07098A1" name="literal_006" typeRef="number"/>
-    <dmn:literalExpression id="_D1D422F5-F236-4FD2-A1C0-047DED9643FE" typeRef="number">
+    <dmn:variable id="_B5998FF9-FBD9-435B-B7F5-E4A5E0F1D94D" name="literal_006" typeRef="number"/>
+    <dmn:literalExpression id="_3D653879-9215-4EDE-BB8E-7384A9920FDC" typeRef="number">
       <dmn:text>["foo"]</dmn:text>
     </dmn:literalExpression>
-  </dmn:decision>  
+  </dmn:decision>
   <dmn:decision id="_decision_ds_001" name="decision_ds_001">
     <dmn:extensionElements/>
-    <dmn:variable id="_1ED16D17-7733-4ADC-AEBD-53BDF9826681" name="decision_ds_001"/>
-    <dmn:literalExpression id="_733B8260-CAE7-4339-BC22-78B25DB97DA3">
+    <dmn:variable id="_9BC85929-813B-4DEC-AD59-0F9B6BCC7F51" name="decision_ds_001"/>
+    <dmn:literalExpression id="_703534DA-03C6-45F6-9076-DCD70F05BC13">
       <dmn:text>1000</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_decision_ds_002" name="decision_ds_002">
     <dmn:extensionElements/>
-    <dmn:variable id="_A6D19DB9-2A96-47C1-8236-923E1C6D750A" name="decision_ds_002"/>
-    <dmn:informationRequirement id="_decisionService_002_input_1">
+    <dmn:variable id="_714A73AE-938B-4BA2-A5AB-E61F186A1457" name="decision_ds_002"/>
+    <dmn:informationRequirement id="_590A1A56-B5B1-435D-827C-03671BB0C575">
       <dmn:requiredInput href="#_decisionService_002_input_1"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_105D5B78-63E7-4C69-A83E-AD74A28A1CDA">
+    <dmn:literalExpression id="_67C2B891-A256-41CE-B8F4-7FE909555A20">
       <dmn:text>decisionService_002_input_1</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_decisionService_002_input_1" name="decisionService_002_input_1">
     <dmn:extensionElements/>
-    <dmn:variable id="_562A96F2-FF06-463F-A43F-7AF2848297A7" name="decisionService_002_input_1" typeRef="string"/>
+    <dmn:variable id="_B5CD8000-F3BE-4944-A993-9A8BA5398FF3" name="decisionService_002_input_1" typeRef="string"/>
   </dmn:inputData>
   <dmn:decision id="_ds_invoke_002_with_number" name="ds_invoke_002_with_number">
     <dmn:extensionElements/>
-    <dmn:variable id="_489DB04D-539B-48DA-BA60-7082F23718BF" name="ds_invoke_002_with_number"/>
-    <dmn:knowledgeRequirement id="_decisionService_002">
+    <dmn:variable id="_2F31B0E0-9B99-4F1C-938A-DA9FF9A081A0" name="ds_invoke_002_with_number"/>
+    <dmn:knowledgeRequirement id="_1E490D2C-A941-4F7B-BEB1-8409E4C63880">
       <dmn:requiredKnowledge href="#_decisionService_002"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_49E74171-B81B-4ECE-B7FB-C4CA9BA00987">
+    <dmn:literalExpression id="_3B9EBB55-5949-4838-A45C-2B652839265B">
       <dmn:text>decisionService_002(10)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_ds_invoke_002_with_singleton_list" name="ds_invoke_002_with_singleton_list">
     <dmn:extensionElements/>
-    <dmn:variable id="_BFFC9EA9-DA3E-4A58-983F-D05B02FD6FEB" name="ds_invoke_002_with_singleton_list"/>
-    <dmn:knowledgeRequirement id="_decisionService_002">
+    <dmn:variable id="_46966129-92E3-4C82-80E5-AE962BA55EFD" name="ds_invoke_002_with_singleton_list"/>
+    <dmn:knowledgeRequirement id="_1A757F6C-CC80-45E0-B19A-A78E2E0D8382">
       <dmn:requiredKnowledge href="#_decisionService_002"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_F99FC66D-8732-47D8-B935-DD97E5D7D373">
+    <dmn:literalExpression id="_685C2316-FC3E-49F2-8E96-81D9FFA923A3">
       <dmn:text>decisionService_002(["foo"])</dmn:text>
     </dmn:literalExpression>
-  </dmn:decision>  
+  </dmn:decision>
   <dmn:decision id="_decision_ds_003" name="decision_ds_003">
     <dmn:extensionElements/>
-    <dmn:variable id="_E9DCBB86-FFD6-4B31-8348-FCD868077BB4" name="decision_ds_003"/>
-    <dmn:informationRequirement id="_decisionService_003_input_1">
+    <dmn:variable id="_F1DE46B2-60F5-4A79-A033-EBB80266648E" name="decision_ds_003"/>
+    <dmn:informationRequirement id="_7BD5372D-20EE-4D47-8AA9-B8E651010343">
       <dmn:requiredInput href="#_decisionService_003_input_1"/>
     </dmn:informationRequirement>
-    <dmn:literalExpression id="_08225521-BA34-4085-AB4C-A48A383BBDB4">
+    <dmn:literalExpression id="_B27AE1EE-AD5E-4C5E-9070-D098018A557E">
       <dmn:text>decisionService_003_input_1</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:inputData id="_decisionService_003_input_1" name="decisionService_003_input_1">
     <dmn:extensionElements/>
-    <dmn:variable id="_118D329D-69B4-43C9-A1EA-7F99C9637D59" name="decisionService_003_input_1" typeRef="tStringList"/>
+    <dmn:variable id="_6BC2A6B5-C668-49F5-910D-6FAAA99F434C" name="decisionService_003_input_1" typeRef="tStringList"/>
   </dmn:inputData>
   <dmn:decision id="_ds_invoke_003_with_string" name="ds_invoke_003_with_string">
     <dmn:extensionElements/>
-    <dmn:variable id="_99BA51C5-F33E-4EF2-9CFD-A6FD6673D1FC" name="ds_invoke_003_with_string"/>
-    <dmn:knowledgeRequirement id="_decisionService_003">
+    <dmn:variable id="_5DFF8550-1321-4688-A375-FEA369016EFE" name="ds_invoke_003_with_string"/>
+    <dmn:knowledgeRequirement id="_3E92ADC3-4BAD-4D40-93F9-4591994078FB">
       <dmn:requiredKnowledge href="#_decisionService_003"/>
     </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_4F8CF5E0-9664-48AA-B136-5FA70D8D7C4C">
+    <dmn:literalExpression id="_3EADD38C-A59B-4F10-BC98-EC980E1CA342">
       <dmn:text>decisionService_003("foo")</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_94322F88-42D2-451F-A2BD-8DB8F4C0B02B" name="DRG">
+    <dmndi:DMNDiagram id="_D8DB7496-FF51-43D8-B089-4F8A0E4BFDF7" name="DRG">
       <di:extension>
         <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_D1D607A8-7D27-413A-A85F-2ED29FF4979B"/>
-          <kie:ComponentWidths dmnElementRef="_5377061D-8200-4314-86E4-3132A84082CC"/>
-          <kie:ComponentWidths dmnElementRef="_1B10BE79-6862-4FCB-A1DB-C2F0ABD1607F"/>
-          <kie:ComponentWidths dmnElementRef="_A6B049B5-A928-4667-ACE0-0ACB57E08C6A"/>
-          <kie:ComponentWidths dmnElementRef="_3F77D9FD-8062-4B20-B834-E3F9CC793E6F"/>
-          <kie:ComponentWidths dmnElementRef="_0434B701-4E04-4B18-8770-799FA1B89B06"/>
-          <kie:ComponentWidths dmnElementRef="_A3A1ECC6-0F0D-4737-935C-A9F5019E2B9E"/>
-          <kie:ComponentWidths dmnElementRef="_6EB006B6-2126-4E57-9DA1-0EF00421161E"/>
-          <kie:ComponentWidths dmnElementRef="_3DE611A4-D167-44D4-99A9-283E1DB46F5A"/>
-          <kie:ComponentWidths dmnElementRef="_22796919-E0A5-43E0-8610-0926509BCA8F"/>
-          <kie:ComponentWidths dmnElementRef="_C29396F3-9F48-48F7-B500-F6B792471D61"/>
-          <kie:ComponentWidths dmnElementRef="_3B90E76D-29F6-433B-BBAB-FFF1638B051C"/>
-          <kie:ComponentWidths dmnElementRef="_35F40F73-61BB-4480-97CF-AD10D75599FC"/>
-          <kie:ComponentWidths dmnElementRef="_DF107F97-07B3-451D-B7AA-BFEA8246AFE2"/>
-          <kie:ComponentWidths dmnElementRef="_76FEDAE5-98F0-4712-B2A5-BEFAF8E77FCE"/>
-          <kie:ComponentWidths dmnElementRef="_AF814687-4F94-4E56-9F12-125F3F3C5DBD"/>
-          <kie:ComponentWidths dmnElementRef="_CB44AA6B-2BD1-43EE-B129-A493B8A73D92"/>
-          <kie:ComponentWidths dmnElementRef="_0C1BB27B-D182-4312-81A2-2660DDB73282"/>
-          <kie:ComponentWidths dmnElementRef="_95FEAA05-2361-4440-B0F7-7FA34706F41A"/>
-          <kie:ComponentWidths dmnElementRef="_A3319E1D-5ADC-4205-BD36-05A0F769F0F8"/>
-          <kie:ComponentWidths dmnElementRef="_18F6963D-1D60-412F-8B8B-A352C7FFB94B"/>
-          <kie:ComponentWidths dmnElementRef="_12FAAFEC-3647-41F8-8D1A-0F94C1996093"/>
-          <kie:ComponentWidths dmnElementRef="_2AE86FFD-85F6-46F3-8B16-3AF7A260F0BC"/>
-          <kie:ComponentWidths dmnElementRef="_A8616933-CE11-441C-8F7C-5AEFE6231E3A"/>
-          <kie:ComponentWidths dmnElementRef="_BD77B888-248E-4BF9-9E11-E61F14A6A6B8"/>
-          <kie:ComponentWidths dmnElementRef="_1225D9D6-A5F6-4414-8953-74BAFEDC2CDE"/>
-          <kie:ComponentWidths dmnElementRef="_C93D64F3-0379-45F1-8223-14315E604E6B"/>
-          <kie:ComponentWidths dmnElementRef="_36F6A377-BD2C-44DE-A04D-84E7A316457B"/>
-          <kie:ComponentWidths dmnElementRef="_EBE1694F-0088-4FF6-8E45-250534F8C40A"/>
-          <kie:ComponentWidths dmnElementRef="_79BFDCB5-13F7-4DE1-88B6-53EB20E57733"/>
-          <kie:ComponentWidths dmnElementRef="_FD92F234-E904-43E1-8C54-508A59B50435"/>
-          <kie:ComponentWidths dmnElementRef="_6D18EC45-D3E8-407F-B058-E99DBEF3B2D0"/>
-          <kie:ComponentWidths dmnElementRef="_FB69ACF3-A4AA-4CE3-A2E2-4075D488A65B"/>
-          <kie:ComponentWidths dmnElementRef="_BB36B18B-F45D-4216-9142-F3554098CC69"/>
-          <kie:ComponentWidths dmnElementRef="_078D3EF0-E3F1-4B6F-A03A-C1AED2F2D03A"/>
-          <kie:ComponentWidths dmnElementRef="_3538F6C7-A660-48C1-A9E0-A9FF4B21D7E5"/>
-          <kie:ComponentWidths dmnElementRef="_AE9320B6-25D0-462C-9DFE-90593F1CBA4E"/>
-          <kie:ComponentWidths dmnElementRef="_81CBE18D-7C0A-4BD5-A4A2-C1A04621FA8A"/>
-          <kie:ComponentWidths dmnElementRef="_0D8C9A48-90C6-4F85-B9C7-D5457627C1D4"/>
-          <kie:ComponentWidths dmnElementRef="_56653F99-99F1-483C-A7FC-C0DCCC055FA6"/>
-          <kie:ComponentWidths dmnElementRef="_972DCB95-098B-4BDF-B02D-F736ADD84038"/>
-          <kie:ComponentWidths dmnElementRef="_04A00600-C146-4322-BF20-7DFD8F5AEF10"/>
-          <kie:ComponentWidths dmnElementRef="_16914DE1-7019-4312-BD96-9B69CB59517C"/>
-          <kie:ComponentWidths dmnElementRef="_B59F2F95-BBEA-40DF-B04C-94C8441BC2B8"/>
-          <kie:ComponentWidths dmnElementRef="_E041423C-65B6-44DF-ACE8-AB9515DA4579"/>
-          <kie:ComponentWidths dmnElementRef="_DEFAC661-6676-48AA-BB1E-BFABEC10BD44"/>
-          <kie:ComponentWidths dmnElementRef="_3843D408-A970-48EE-A6F3-7A1168516800"/>
-          <kie:ComponentWidths dmnElementRef="_FE8622B6-BE48-42AF-9648-736FDBA71FFB"/>
-          <kie:ComponentWidths dmnElementRef="_5CB72104-FE38-415C-A8D3-99C84385CB83"/>
-          <kie:ComponentWidths dmnElementRef="_E0871C1B-AB63-4439-98E6-3B6A817D3422"/>
-          <kie:ComponentWidths dmnElementRef="_E9B642AB-896F-4510-8FDA-311540A47A2E"/>
-          <kie:ComponentWidths dmnElementRef="_13AEA31B-6888-4C41-918B-D5AB7ED33B8C"/>
-          <kie:ComponentWidths dmnElementRef="_64FAAC59-97A6-4304-B5B5-6AC27F6F4E8B"/>
-          <kie:ComponentWidths dmnElementRef="_C51B16D2-2A1C-4A45-AAC6-CF4E2C0E2F7F"/>
-          <kie:ComponentWidths dmnElementRef="_D1D422F5-F236-4FD2-A1C0-047DED9643FE"/>
-          <kie:ComponentWidths dmnElementRef="_733B8260-CAE7-4339-BC22-78B25DB97DA3"/>
-          <kie:ComponentWidths dmnElementRef="_105D5B78-63E7-4C69-A83E-AD74A28A1CDA"/>
-          <kie:ComponentWidths dmnElementRef="_49E74171-B81B-4ECE-B7FB-C4CA9BA00987"/>
-          <kie:ComponentWidths dmnElementRef="_F99FC66D-8732-47D8-B935-DD97E5D7D373"/>
-          <kie:ComponentWidths dmnElementRef="_08225521-BA34-4085-AB4C-A48A383BBDB4"/>
-          <kie:ComponentWidths dmnElementRef="_4F8CF5E0-9664-48AA-B136-5FA70D8D7C4C"/>
+          <kie:ComponentWidths dmnElementRef="_4D52EE06-25BB-474B-B030-1DDE122A8424"/>
+          <kie:ComponentWidths dmnElementRef="_EAE3D59E-734D-49E2-BD45-F57D9737DFB6"/>
+          <kie:ComponentWidths dmnElementRef="_83883E5A-E19E-469A-985D-4DC31AE1EB90"/>
+          <kie:ComponentWidths dmnElementRef="_717B58E6-90C0-4AC9-91C1-65BBFC6C412F"/>
+          <kie:ComponentWidths dmnElementRef="_AFA2D2DA-C8DF-4816-BE44-45F149707D20"/>
+          <kie:ComponentWidths dmnElementRef="_3A7A53EB-38A3-488F-9246-2C7CABB9B33C"/>
+          <kie:ComponentWidths dmnElementRef="_696F7BC3-9512-4A96-9BEF-C74B734A3F38"/>
+          <kie:ComponentWidths dmnElementRef="_8F2F4ECA-125B-4F60-8D9A-0A3E24A126B4"/>
+          <kie:ComponentWidths dmnElementRef="_2C30E334-4F12-4C94-8A9A-F9356EC5E3AE"/>
+          <kie:ComponentWidths dmnElementRef="_4727B860-2E96-4002-9FA3-A18D3717DABA"/>
+          <kie:ComponentWidths dmnElementRef="_7D8AAE90-5B7A-42FF-AAA7-F4BC07B5F823"/>
+          <kie:ComponentWidths dmnElementRef="_8613DB9D-217D-4AD6-9A00-A616688B5216"/>
+          <kie:ComponentWidths dmnElementRef="_879392DB-597B-4F0E-9BBD-3DAE0A7A7AAF"/>
+          <kie:ComponentWidths dmnElementRef="_2E8FBA80-3C4F-412B-9C37-B7EA5BAE3DF8"/>
+          <kie:ComponentWidths dmnElementRef="_94CDAB0B-54DE-4C39-95FE-A9A3CF5B1966"/>
+          <kie:ComponentWidths dmnElementRef="_F2AD0936-C3A0-47D5-9730-67D609F97606"/>
+          <kie:ComponentWidths dmnElementRef="_8D1633B7-76C4-479F-8CA2-4E19F6BFD163"/>
+          <kie:ComponentWidths dmnElementRef="_56DFE8A9-5C73-48C3-BD04-6FE89702D91F"/>
+          <kie:ComponentWidths dmnElementRef="_99C422DC-9A90-4572-8FFB-25FA604C41FB"/>
+          <kie:ComponentWidths dmnElementRef="_CCC20C6C-5EB5-4289-BDF2-887DAC80C3AD"/>
+          <kie:ComponentWidths dmnElementRef="_CDF7850B-7D2A-4E56-A0E5-CE5F64F8764F"/>
+          <kie:ComponentWidths dmnElementRef="_2AF29277-430E-4F4D-A5E5-9DCA00BD805A"/>
+          <kie:ComponentWidths dmnElementRef="_4547B8C0-EC6B-4122-BE6F-27A6AC2F90AB"/>
+          <kie:ComponentWidths dmnElementRef="_4985DB9C-1EAB-40FB-8F57-4FAFB8B339E7"/>
+          <kie:ComponentWidths dmnElementRef="_927F22D4-EBC0-4C83-B809-C4E57854AC94"/>
+          <kie:ComponentWidths dmnElementRef="_3FF9B459-238C-4F5B-9940-120899A2A557"/>
+          <kie:ComponentWidths dmnElementRef="_400E2660-F788-4B34-8ECA-9EFA6320F0FA"/>
+          <kie:ComponentWidths dmnElementRef="_D7A09AF7-F630-45CC-9D6F-8A9B22B32339"/>
+          <kie:ComponentWidths dmnElementRef="_E11E9A94-D7CA-4F56-A551-20368C9A5E71"/>
+          <kie:ComponentWidths dmnElementRef="_E968333D-479F-4584-B273-F26560021DC0"/>
+          <kie:ComponentWidths dmnElementRef="_5811B4F0-9BA3-4083-93C0-C2C14441B585"/>
+          <kie:ComponentWidths dmnElementRef="_2E781A59-36A3-49F7-8B0F-F1D0ADADE60E"/>
+          <kie:ComponentWidths dmnElementRef="_7FD82BC4-67FC-4033-B58F-98A19ED8B890"/>
+          <kie:ComponentWidths dmnElementRef="_FA66787D-DB73-46A6-A12F-4CCA1E27C1A5"/>
+          <kie:ComponentWidths dmnElementRef="_9A884F00-26B9-4ADA-BB53-802C218DB96A"/>
+          <kie:ComponentWidths dmnElementRef="_EEE0851D-107F-444F-B0E0-98E1EA0C98CB"/>
+          <kie:ComponentWidths dmnElementRef="_9C1A5BA9-5B9B-4EA6-B970-6CB106CBDC49"/>
+          <kie:ComponentWidths dmnElementRef="_6042D108-15EE-4041-AFBA-9A73892B0F36"/>
+          <kie:ComponentWidths dmnElementRef="_E66FBA75-5B4D-4D11-A00C-8DA09C36E687"/>
+          <kie:ComponentWidths dmnElementRef="_754C9313-F07B-4EF6-8B51-F7E662374559"/>
+          <kie:ComponentWidths dmnElementRef="_8CCB9AA5-2551-4CBE-A6D0-5258EA7D7B2A"/>
+          <kie:ComponentWidths dmnElementRef="_9F3CE04E-B813-4A4D-B795-00EF110CDB41"/>
+          <kie:ComponentWidths dmnElementRef="_AD152E30-FFBE-446F-93FA-ADB08AFE3C1D"/>
+          <kie:ComponentWidths dmnElementRef="_BFA99D23-4ED5-443E-A404-EB8E39ABC0B8"/>
+          <kie:ComponentWidths dmnElementRef="_B16C4F7F-73AB-44B6-BC3A-18A2187567A0"/>
+          <kie:ComponentWidths dmnElementRef="_11E452BA-7C70-4BDA-B33A-B69329828153"/>
+          <kie:ComponentWidths dmnElementRef="_9F3B05D9-D013-4E9A-9007-89F24E2987A3"/>
+          <kie:ComponentWidths dmnElementRef="_9ECECABF-C811-4A7E-B161-7EFAE322E35E"/>
+          <kie:ComponentWidths dmnElementRef="_05157905-263E-4A93-99B8-5C4010C0013E"/>
+          <kie:ComponentWidths dmnElementRef="_AE433AB6-13C6-4842-91FC-433456F6E9E2"/>
+          <kie:ComponentWidths dmnElementRef="_405E4248-0F47-40E1-8C0D-C664D43DE004"/>
+          <kie:ComponentWidths dmnElementRef="_00B05E56-2C80-4E18-BE2D-4FDDAA6C0462"/>
+          <kie:ComponentWidths dmnElementRef="_707987A6-7B84-4869-B510-283EC111D92F"/>
+          <kie:ComponentWidths dmnElementRef="_F74B86CA-18B9-4121-B60C-33BC976AADAE"/>
+          <kie:ComponentWidths dmnElementRef="_3D653879-9215-4EDE-BB8E-7384A9920FDC"/>
+          <kie:ComponentWidths dmnElementRef="_703534DA-03C6-45F6-9076-DCD70F05BC13"/>
+          <kie:ComponentWidths dmnElementRef="_67C2B891-A256-41CE-B8F4-7FE909555A20"/>
+          <kie:ComponentWidths dmnElementRef="_3B9EBB55-5949-4838-A45C-2B652839265B"/>
+          <kie:ComponentWidths dmnElementRef="_685C2316-FC3E-49F2-8E96-81D9FFA923A3"/>
+          <kie:ComponentWidths dmnElementRef="_B27AE1EE-AD5E-4C5E-9070-D098018A557E"/>
+          <kie:ComponentWidths dmnElementRef="_3EADD38C-A59B-4F10-BC98-EC980E1CA342"/>
         </kie:ComponentsWidthsExtension>
       </di:extension>
-       <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="50" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="50" y="150" />
-               <di:waypoint x="150" y="150" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3375" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="3375" y="325" />
-               <di:waypoint x="3475" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3550" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="3550" y="325" />
-               <di:waypoint x="3650" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="225" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="400" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_004" dmnElementRef="_decision_004" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="575" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_005" dmnElementRef="_decision_005" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1100" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_006" dmnElementRef="_decision_006" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1625" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_006_a" dmnElementRef="_decision_006_a" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2500" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_007" dmnElementRef="_decision_007" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2675" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_007_a" dmnElementRef="_decision_007_a" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2850" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_008" dmnElementRef="_decision_008" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3550" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_bkm_001" dmnElementRef="_bkm_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2850" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_001" dmnElementRef="_decision_bkm_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="925" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_002" dmnElementRef="_decision_bkm_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1275" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_bkm_002" dmnElementRef="_bkm_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2675" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_003" dmnElementRef="_decision_bkm_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="750" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_bkm_004" dmnElementRef="_bkm_004" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3025" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_bkm_005" dmnElementRef="_bkm_005" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3200" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004" dmnElementRef="_decision_bkm_004" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1450" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_a" dmnElementRef="_decision_bkm_004_a" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1800" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_b" dmnElementRef="_decision_bkm_004_b" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2150" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005" dmnElementRef="_decision_bkm_005" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3025" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005_a" dmnElementRef="_decision_bkm_005_a" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3200" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_invoke_001" dmnElementRef="_invoke_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1975" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_invoke_002" dmnElementRef="_invoke_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2325" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_invoke_003" dmnElementRef="_invoke_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3375" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_invoke_004" dmnElementRef="_invoke_004" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3725" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_invoke_005" dmnElementRef="_invoke_005" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3900" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_invoke_006" dmnElementRef="_invoke_006" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4075" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_fd_001" dmnElementRef="_fd_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5125" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_fd_002" dmnElementRef="_fd_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5300" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_literal_001" dmnElementRef="_literal_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5475" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_literal_002" dmnElementRef="_literal_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5650" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_literal_003" dmnElementRef="_literal_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5825" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_literal_004" dmnElementRef="_literal_004" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="6000" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_literal_005" dmnElementRef="_literal_005" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="6175" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_literal_006" dmnElementRef="_literal_006" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="6350" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_001" dmnElementRef="_decision_ds_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="6525" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_002" dmnElementRef="_decision_ds_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4775" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3725" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_number" dmnElementRef="_ds_invoke_002_with_number" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4250" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_singleton_list" dmnElementRef="_ds_invoke_002_with_singleton_list" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4425" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_003" dmnElementRef="_decision_ds_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4950" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3900" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_003_with_string" dmnElementRef="_ds_invoke_003_with_string" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4600" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNEdge id="dmnedge-drg-_bkm_001" dmnElementRef="_bkm_001">
-            <di:waypoint x="2850" y="225" />
-            <di:waypoint x="925" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_bkm_002" dmnElementRef="_bkm_002">
-            <di:waypoint x="2675" y="225" />
-            <di:waypoint x="750" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_bkm_004" dmnElementRef="_bkm_004">
-            <di:waypoint x="3025" y="225" />
-            <di:waypoint x="1450" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_bkm_005" dmnElementRef="_bkm_005">
-            <di:waypoint x="3200" y="225" />
-            <di:waypoint x="3025" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1">
-            <di:waypoint x="3725" y="225" />
-            <di:waypoint x="4775" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_002" dmnElementRef="_decisionService_002">
-            <di:waypoint x="3375" y="225" />
-            <di:waypoint x="4250" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1">
-            <di:waypoint x="3900" y="225" />
-            <di:waypoint x="4950" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_003" dmnElementRef="_decisionService_003">
-            <di:waypoint x="3550" y="225" />
-            <di:waypoint x="4600" y="50" />
-         </dmndi:DMNEdge>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="50" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="50" y="150"/>
+          <di:waypoint x="150" y="150"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3375" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="3375" y="325"/>
+          <di:waypoint x="3475" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3550" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="3550" y="325"/>
+          <di:waypoint x="3650" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="225" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="400" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_004" dmnElementRef="_decision_004" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="575" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_005" dmnElementRef="_decision_005" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1100" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_006" dmnElementRef="_decision_006" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1625" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_006_a" dmnElementRef="_decision_006_a" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2500" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_007" dmnElementRef="_decision_007" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2675" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_007_a" dmnElementRef="_decision_007_a" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2850" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_008" dmnElementRef="_decision_008" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3550" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_bkm_001" dmnElementRef="_bkm_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2850" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_001" dmnElementRef="_decision_bkm_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="925" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_002" dmnElementRef="_decision_bkm_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1275" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_bkm_002" dmnElementRef="_bkm_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2675" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_003" dmnElementRef="_decision_bkm_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="750" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_bkm_004" dmnElementRef="_bkm_004" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3025" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_bkm_005" dmnElementRef="_bkm_005" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3200" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004" dmnElementRef="_decision_bkm_004" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1450" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_a" dmnElementRef="_decision_bkm_004_a" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1800" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_b" dmnElementRef="_decision_bkm_004_b" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2150" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005" dmnElementRef="_decision_bkm_005" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3025" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005_a" dmnElementRef="_decision_bkm_005_a" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3200" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_invoke_001" dmnElementRef="_invoke_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1975" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_invoke_002" dmnElementRef="_invoke_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2325" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_invoke_003" dmnElementRef="_invoke_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3375" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_invoke_004" dmnElementRef="_invoke_004" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3725" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_invoke_005" dmnElementRef="_invoke_005" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3900" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_invoke_006" dmnElementRef="_invoke_006" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4075" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_fd_001" dmnElementRef="_fd_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5125" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_fd_002" dmnElementRef="_fd_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5300" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_literal_001" dmnElementRef="_literal_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5475" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_literal_002" dmnElementRef="_literal_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5650" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_literal_003" dmnElementRef="_literal_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5825" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_literal_004" dmnElementRef="_literal_004" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="6000" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_literal_005" dmnElementRef="_literal_005" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="6175" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_literal_006" dmnElementRef="_literal_006" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="6350" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_001" dmnElementRef="_decision_ds_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="6525" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_002" dmnElementRef="_decision_ds_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4775" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3725" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_number" dmnElementRef="_ds_invoke_002_with_number" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4250" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_singleton_list" dmnElementRef="_ds_invoke_002_with_singleton_list" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4425" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_003" dmnElementRef="_decision_ds_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4950" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3900" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_003_with_string" dmnElementRef="_ds_invoke_003_with_string" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4600" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_7B3BE5CF-8218-47D2-B2CC-970E1FD58468" dmnElementRef="_7B3BE5CF-8218-47D2-B2CC-970E1FD58468">
+        <di:waypoint x="2850" y="225"/>
+        <di:waypoint x="925" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8063F8D3-6062-4478-92B1-CEDFEFC9575A" dmnElementRef="_8063F8D3-6062-4478-92B1-CEDFEFC9575A">
+        <di:waypoint x="2850" y="225"/>
+        <di:waypoint x="1275" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_5ACB2078-518E-4743-9575-4BD03EDDA126" dmnElementRef="_5ACB2078-518E-4743-9575-4BD03EDDA126">
+        <di:waypoint x="2675" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_A0CCB912-9FA0-446A-9CBD-6706BA653DD2" dmnElementRef="_A0CCB912-9FA0-446A-9CBD-6706BA653DD2">
+        <di:waypoint x="3025" y="225"/>
+        <di:waypoint x="1450" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_32CEA84D-85B5-48A6-8BA3-D241F7A261FE" dmnElementRef="_32CEA84D-85B5-48A6-8BA3-D241F7A261FE">
+        <di:waypoint x="3025" y="225"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_AB09AF7F-53DA-433F-93CA-78E46482703F" dmnElementRef="_AB09AF7F-53DA-433F-93CA-78E46482703F">
+        <di:waypoint x="3025" y="225"/>
+        <di:waypoint x="2150" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2" dmnElementRef="_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2">
+        <di:waypoint x="3200" y="225"/>
+        <di:waypoint x="3025" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_32616BE5-7354-455A-B94F-1E5F494BBD61" dmnElementRef="_32616BE5-7354-455A-B94F-1E5F494BBD61">
+        <di:waypoint x="3200" y="225"/>
+        <di:waypoint x="3200" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_844CC3F6-599F-4499-A803-C1886139969A" dmnElementRef="_844CC3F6-599F-4499-A803-C1886139969A">
+        <di:waypoint x="2850" y="225"/>
+        <di:waypoint x="1975" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_743FD00A-040C-4EF3-A16F-51F8E36EFE49" dmnElementRef="_743FD00A-040C-4EF3-A16F-51F8E36EFE49">
+        <di:waypoint x="2850" y="225"/>
+        <di:waypoint x="2325" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_004EB93A-E37A-4C38-BF48-CA4FED683432" dmnElementRef="_004EB93A-E37A-4C38-BF48-CA4FED683432">
+        <di:waypoint x="3200" y="225"/>
+        <di:waypoint x="3375" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_EBD496F0-9E21-47AD-A630-8C5E032B6749" dmnElementRef="_EBD496F0-9E21-47AD-A630-8C5E032B6749">
+        <di:waypoint x="3200" y="225"/>
+        <di:waypoint x="3725" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_ED2359BA-F57A-495B-8E75-C0913CD2BA05" dmnElementRef="_ED2359BA-F57A-495B-8E75-C0913CD2BA05">
+        <di:waypoint x="3200" y="225"/>
+        <di:waypoint x="3900" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB" dmnElementRef="_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB">
+        <di:waypoint x="3200" y="225"/>
+        <di:waypoint x="4075" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_590A1A56-B5B1-435D-827C-03671BB0C575" dmnElementRef="_590A1A56-B5B1-435D-827C-03671BB0C575">
+        <di:waypoint x="3725" y="225"/>
+        <di:waypoint x="4775" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_1E490D2C-A941-4F7B-BEB1-8409E4C63880" dmnElementRef="_1E490D2C-A941-4F7B-BEB1-8409E4C63880">
+        <di:waypoint x="3375" y="225"/>
+        <di:waypoint x="4250" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_1A757F6C-CC80-45E0-B19A-A78E2E0D8382" dmnElementRef="_1A757F6C-CC80-45E0-B19A-A78E2E0D8382">
+        <di:waypoint x="3375" y="225"/>
+        <di:waypoint x="4425" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_7BD5372D-20EE-4D47-8AA9-B8E651010343" dmnElementRef="_7BD5372D-20EE-4D47-8AA9-B8E651010343">
+        <di:waypoint x="3900" y="225"/>
+        <di:waypoint x="4950" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_3E92ADC3-4BAD-4D40-93F9-4591994078FB" dmnElementRef="_3E92ADC3-4BAD-4D40-93F9-4591994078FB">
+        <di:waypoint x="3550" y="225"/>
+        <di:waypoint x="4600" y="50"/>
+      </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>
 </dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
@@ -1,1281 +1,1297 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0085-decision-services" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="_i9fboPUUEeesLuP4RHs4vA" name="0085-decision-services" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0085-decision-services">
-   <dmn:description>Decision Services</dmn:description>
-   <dmn:extensionElements />
-   <dmn:decisionService id="_decisionService_001" name="decisionService_001">
-      <dmn:extensionElements />
-      <dmn:variable id="_37D1E458-DDF9-44CD-BCBD-ED8B13304C1A" name="decisionService_001" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_002" name="decisionService_002">
-      <dmn:extensionElements />
-      <dmn:variable id="_A0260B5C-17AB-4C4D-A71D-6EA328467930" name="decisionService_002" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_003" name="decisionService_003">
-      <dmn:extensionElements />
-      <dmn:variable id="_2DCD4D7F-B586-4395-939D-EF2244334ED9" name="decisionService_003" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_004" name="decisionService_004">
-      <dmn:extensionElements />
-      <dmn:variable id="_AA1DEEB1-7B27-41D9-9693-94AC3BB5EDA4" name="decisionService_004" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_005" name="decisionService_005">
-      <dmn:extensionElements />
-      <dmn:variable id="_4726BCB9-D5FA-41E4-9D5D-94BD103A8833" name="decisionService_005" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_006" name="decisionService_006">
-      <dmn:extensionElements />
-      <dmn:variable id="_8F46F5DC-EEAC-40A5-80EA-546CBB1C92BD" name="decisionService_006" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_007" name="decisionService_007">
-      <dmn:extensionElements />
-      <dmn:variable id="_A3D65BF0-B33B-4B63-8A5D-83567E16CA58" name="decisionService_007" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_008" name="decisionService_008">
-      <dmn:extensionElements />
-      <dmn:variable id="_5D01D2BF-E27C-40AF-A0B0-2AE477002725" name="decisionService_008" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_009" name="decisionService_009">
-      <dmn:extensionElements />
-      <dmn:variable id="_006C5EF0-64B8-491B-8729-2D23965EDA7E" name="decisionService_009" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_010" name="decisionService_010">
-      <dmn:extensionElements />
-      <dmn:variable id="_0A1CD4C1-B473-4D31-8071-9574C324FD2E" name="decisionService_010" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_011" name="decisionService_011">
-      <dmn:extensionElements />
-      <dmn:variable id="_00E8074F-47ED-4AB0-AF97-B7859A62FD3D" name="decisionService_011" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_012" name="decisionService_012">
-      <dmn:extensionElements />
-      <dmn:variable id="_B6F58FA3-3127-4530-9610-1E7E01140B92" name="decisionService_012" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_013" name="decisionService_013">
-      <dmn:extensionElements />
-      <dmn:variable id="_C4B21ACD-47F9-427E-8C33-4D7F8A04015C" name="decisionService_013" />
-   </dmn:decisionService>
-   <dmn:decisionService id="_decisionService_014" name="decisionService_014">
-      <dmn:extensionElements />
-      <dmn:variable id="_8A85BDE6-3C7B-47AF-8B0C-6AF0979FC18C" name="decisionService_014" />
-   </dmn:decisionService>
-   <dmn:decision id="_decision_001" name="decision_001">
-      <dmn:extensionElements />
-      <dmn:variable id="_E3A91D22-55B6-41F5-9EE9-BE8209AD1303" name="decision_001" />
-      <dmn:literalExpression id="_4C64C5CF-7525-4E43-A132-FA7B76EFCAD8">
-         <dmn:text>"foo"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_002" name="decision_002">
-      <dmn:extensionElements />
-      <dmn:variable id="_14568229-02C6-4191-844D-E26F9908B6FA" name="decision_002" />
-      <dmn:informationRequirement id="_decision_002_input">
-         <dmn:requiredDecision href="#_decision_002_input" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_4BA5093C-2B64-49FE-A477-9CF1C2B7247C">
-         <dmn:text>"foo " + decision_002_input</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_002_input" name="decision_002_input">
-      <dmn:extensionElements />
-      <dmn:variable id="_86F1A231-A2BB-4711-A1B0-D9CE423A94A9" name="decision_002_input" />
-      <dmn:literalExpression id="_4E10E982-553C-471E-9A2E-B03BB923D463">
-         <dmn:text>"bar"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_003" name="decision_003">
-      <dmn:extensionElements />
-      <dmn:variable id="_E6A5553F-81D2-413F-9422-C98BD5B77CA7" name="decision_003" />
-      <dmn:informationRequirement id="_decision_003_input_1">
-         <dmn:requiredDecision href="#_decision_003_input_1" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_decision_003_input_2">
-         <dmn:requiredDecision href="#_decision_003_input_2" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_003">
-         <dmn:requiredInput href="#_inputData_003" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_F0116906-55F7-4951-9ECA-1C9B4CE02A15">
-         <dmn:text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_003_input_1" name="decision_003_input_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_158BF5E8-2526-46C2-8767-A48B21FA6F7A" name="decision_003_input_1" />
-      <dmn:literalExpression id="_645ADA90-064F-4D70-B9BA-15ED1CF6F467">
-         <dmn:text>"d3_1"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_003_input_2" name="decision_003_input_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_1BD5A74A-DC1A-4C17-B927-5AB1786EF4BA" name="decision_003_input_2" />
-      <dmn:literalExpression id="_EC4E18CE-97B7-4678-99D5-FDB2CFE04E8C">
-         <dmn:text>"d3_2"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:inputData id="_inputData_003" name="inputData_003">
-      <dmn:extensionElements />
-      <dmn:variable id="_20E65205-393B-4FFE-9495-750BEE19ED4F" name="inputData_003" typeRef="string" />
-   </dmn:inputData>
-   <dmn:decision id="_decision_004_1" name="decision_004_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_44A3550D-9803-43B1-B8AF-BB62DF2AD262" name="decision_004_1" />
-      <dmn:knowledgeRequirement id="_decisionService_004">
-         <dmn:requiredKnowledge href="#_decisionService_004" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_5A734BE4-9B19-4B4C-9F43-2ED83B4FBBDA">
-         <dmn:text>decisionService_004()</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_004_2" name="decision_004_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_E4EE1F6C-C837-4755-8B94-F91775B7EE08" name="decision_004_2" />
-      <dmn:literalExpression id="_BA114448-8390-4314-8357-965F0591FD03">
-         <dmn:text>"foo"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_005_1" name="decision_005_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_066CF9A4-7D28-42D0-B775-1B2C8A996422" name="decision_005_1" />
-      <dmn:knowledgeRequirement id="_decisionService_005">
-         <dmn:requiredKnowledge href="#_decisionService_005" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_A33AFF2E-5947-4AA6-AB45-E5A1B455C57C">
-         <dmn:text>decisionService_005("bar")</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_005_2" name="decision_005_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_7F271875-6E67-4472-8A5E-D2855F8F7C5E" name="decision_005_2" typeRef="string" />
-      <dmn:literalExpression id="_080CD506-ABE5-4583-B894-0B910EAAEF9D">
-         <dmn:text>"foo"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_006_1" name="decision_006_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_9D4CB4B2-D255-424F-BB0A-BB83319A9526" name="decision_006_1" />
-      <dmn:knowledgeRequirement id="_decisionService_006">
-         <dmn:requiredKnowledge href="#_decisionService_006" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_43A61867-1919-40C7-9287-2E2C1FCE4096">
-         <dmn:text>decisionService_006("bar")</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_006_2" name="decision_006_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_3C10DF8D-9D9E-48C5-8ADA-09C7E976A581" name="decision_006_2" />
-      <dmn:informationRequirement id="_decision_006_3">
-         <dmn:requiredDecision href="#_decision_006_3" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_5CC73F4D-142C-458E-BC33-52562E6F0E2C">
-         <dmn:text>"foo " + decision_006_3</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_006_3" name="decision_006_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_E05B0430-C4FF-46D8-8F7E-AD9F5B44FECD" name="decision_006_3" typeRef="string" />
-      <dmn:literalExpression id="_32ECDAD7-3F41-44C8-84FE-D3347C4E77E5">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_007_1" name="decision_007_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_E35C6143-1D6E-4DD1-9A39-38036512ABFB" name="decision_007_1" />
-      <dmn:knowledgeRequirement id="_decisionService_007">
-         <dmn:requiredKnowledge href="#_decisionService_007" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_C69A9B78-4145-4CDB-B302-DC3BE7A805DC">
-         <dmn:text>decisionService_007(123)</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_007_2" name="decision_007_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_AF0F7448-93C6-4E07-9AEC-7ED07C00C0C5" name="decision_007_2" />
-      <dmn:informationRequirement id="_decision_007_3">
-         <dmn:requiredDecision href="#_decision_007_3" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_3E60D199-FC8D-4509-B9CA-71C38613694C">
-         <dmn:text>decision_007_3 = null</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_007_3" name="decision_007_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_279CC7D0-093B-4F2D-A1BD-60DE358F053C" name="decision_007_3" typeRef="string" />
-      <dmn:literalExpression id="_D2AC2879-D2C7-4F43-9AD9-FA92BA639186">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_008_1" name="decision_008_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_F56B5263-3D20-4793-A09D-C60E09D0A8FF" name="decision_008_1" />
-      <dmn:knowledgeRequirement id="_decisionService_008">
-         <dmn:requiredKnowledge href="#_decisionService_008" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_2E8C7D0A-9B10-4D13-9984-CE2F9E78B997">
-         <dmn:text>decisionService_008()</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_008_2" name="decision_008_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_EBB83CC3-514B-4286-8DF5-339207E54557" name="decision_008_2" />
-      <dmn:informationRequirement id="_decision_008_3">
-         <dmn:requiredDecision href="#_decision_008_3" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_0EE98A61-EE5E-4093-BBB5-583E27390C15">
-         <dmn:text>decision_008_3 = null</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_008_3" name="decision_008_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_FC686AC6-C08C-49FB-9B63-5A1CE742185D" name="decision_008_3" typeRef="string" />
-      <dmn:literalExpression id="_A799255D-9A34-47FB-BB55-F13DADFAB97D">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_009_1" name="decision_009_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_5F1F695A-A216-460E-8C82-174B38450EC0" name="decision_009_1" />
-      <dmn:knowledgeRequirement id="_decisionService_009">
-         <dmn:requiredKnowledge href="#_decisionService_009" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_AC69F8D1-4AE6-4E6F-95E3-ABF3F27A43A0">
-         <dmn:text>decisionService_009(decision_009_3: "bar")</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_009_2" name="decision_009_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_1BEF2202-37D0-4A45-A4DA-AA95376FAAB2" name="decision_009_2" />
-      <dmn:informationRequirement id="_decision_009_3">
-         <dmn:requiredDecision href="#_decision_009_3" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_06C178EB-E33B-446C-8760-489EA71CC75A">
-         <dmn:text>"foo " + decision_009_3</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_009_3" name="decision_009_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_1A33E292-DE05-4F30-A68E-5C2DDEB35AFF" name="decision_009_3" typeRef="string" />
-      <dmn:literalExpression id="_005FEEC9-9BE8-460C-8597-AF43CF6F8692">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_010_1" name="decision_010_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_9E6C63F6-4985-4CF6-ACC5-2B38DC3FA6DE" name="decision_010_1" />
-      <dmn:knowledgeRequirement id="_decisionService_010">
-         <dmn:requiredKnowledge href="#_decisionService_010" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_A3D81420-B588-42C9-8F19-A5C18F8E535C">
-         <dmn:text>decisionService_010(foo: "bar")</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_010_2" name="decision_010_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_DD091DE3-CBE7-4682-9342-68FCA9205993" name="decision_010_2" />
-      <dmn:informationRequirement id="_decision_010_3">
-         <dmn:requiredDecision href="#_decision_010_3" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_CFD9E35A-B575-4C65-9464-BB197467C5FA">
-         <dmn:text>"foo " + decision_010_3</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_010_3" name="decision_010_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_1123721A-4A3C-4FC0-8240-D4902F6C766E" name="decision_010_3" typeRef="string" />
-      <dmn:literalExpression id="_5F171256-04F0-472E-8DA0-6B3A21E64459">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_011_1" name="decision_011_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_92CF1219-D83B-4685-8C2B-CE2D97D6C41B" name="decision_011_1" />
-      <dmn:knowledgeRequirement id="_decisionService_011">
-         <dmn:requiredKnowledge href="#_decisionService_011" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_C9EEF6D4-7DCF-4A4F-92B7-CCC0D6E989F0">
-         <dmn:text>decisionService_011("A", "B", "C", "D")</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_011_2" name="decision_011_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_E91E74F2-7B0C-42FD-8EAD-82B7D86F3703" name="decision_011_2" typeRef="string" />
-      <dmn:informationRequirement id="_decision_011_3">
-         <dmn:requiredDecision href="#_decision_011_3" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_decision_011_4">
-         <dmn:requiredDecision href="#_decision_011_4" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_011_1">
-         <dmn:requiredInput href="#_inputData_011_1" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_011_2">
-         <dmn:requiredInput href="#_inputData_011_2" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_6C1B3316-5C3E-4583-9536-A4587579302D">
-         <dmn:text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_011_3" name="decision_011_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_E8DC8E10-2F45-4B55-8A1E-375E8B1A9A3D" name="decision_011_3" typeRef="string" />
-      <dmn:literalExpression id="_0BAACA8A-4B84-44CD-8F38-E817CE68236C">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_011_4" name="decision_011_4">
-      <dmn:extensionElements />
-      <dmn:variable id="_85D0B537-D930-4A6A-9DDE-801E59895C81" name="decision_011_4" typeRef="string" />
-      <dmn:literalExpression id="_95B0A67D-EDC7-4D9C-908F-5378617F1FBE">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:inputData id="_inputData_011_1" name="inputData_011_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_1C471FCC-4EF4-4373-A1DA-6CE306B99C40" name="inputData_011_1" typeRef="string" />
-   </dmn:inputData>
-   <dmn:inputData id="_inputData_011_2" name="inputData_011_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_349C8D9A-33A1-4BBF-89F0-B3089D2F2EDC" name="inputData_011_2" typeRef="string" />
-   </dmn:inputData>
-   <dmn:decision id="_decision_012_1" name="decision_012_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_4433133C-880F-45D1-B52C-DE56ECC3AEA6" name="decision_012_1" />
-      <dmn:knowledgeRequirement id="_decisionService_012">
-         <dmn:requiredKnowledge href="#_decisionService_012" />
-      </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_58C823E6-7CA9-4408-8272-DA9CA0B5902C">
-         <dmn:text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_012_2" name="decision_012_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_8CB2AD6F-6C8D-4657-847B-084559C59B95" name="decision_012_2" typeRef="string" />
-      <dmn:informationRequirement id="_decision_012_3">
-         <dmn:requiredDecision href="#_decision_012_3" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_decision_012_4">
-         <dmn:requiredDecision href="#_decision_012_4" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_012_1">
-         <dmn:requiredInput href="#_inputData_012_1" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_012_2">
-         <dmn:requiredInput href="#_inputData_012_2" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_CE0F18D6-3BCB-4E74-9F97-9CF593274BA5">
-         <dmn:text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_012_3" name="decision_012_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_EACD4136-005C-40BE-A6E7-D29C8A60ED4B" name="decision_012_3" typeRef="string" />
-      <dmn:literalExpression id="_E204D9D8-ED94-476B-9BF3-EF4D63E3D7FE">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_012_4" name="decision_012_4">
-      <dmn:extensionElements />
-      <dmn:variable id="_7D5A1731-115C-44B5-91BE-23B92173BE68" name="decision_012_4" typeRef="string" />
-      <dmn:literalExpression id="_B85C73C3-F4BE-45A5-BEED-106F3CD32C98">
-         <dmn:text>"I never get invoked"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:inputData id="_inputData_012_1" name="inputData_012_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_7535E52D-0467-423B-BF1E-F70B884FE3A9" name="inputData_012_1" typeRef="string" />
-   </dmn:inputData>
-   <dmn:inputData id="_inputData_012_2" name="inputData_012_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_778589B5-7475-4468-9396-B184DD924FF8" name="inputData_012_2" typeRef="string" />
-   </dmn:inputData>
-   <dmn:decision id="_decision_013_1" name="decision_013_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_012265DF-5BE8-42C9-9FD9-33FEFB992EDB" name="decision_013_1" />
-      <dmn:informationRequirement id="_decision_013_3">
-         <dmn:requiredDecision href="#_decision_013_3" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_013_1">
-         <dmn:requiredInput href="#_inputData_013_1" />
-      </dmn:informationRequirement>
-      <dmn:knowledgeRequirement id="_decisionService_013">
-         <dmn:requiredKnowledge href="#_decisionService_013" />
-      </dmn:knowledgeRequirement>
-      <dmn:context id="_C299F514-F842-46A8-AC95-EEE56D78EE5C">
-         <dmn:contextEntry>
-            <dmn:variable id="_E7B49B05-DFCB-43C1-9429-2AE1BB84E1AB" name="decisionService_013" />
-            <dmn:literalExpression id="_3D1DEFD5-39E1-481C-96A1-2567DB3D540C">
-               <dmn:text>decisionService_013("A", "B")</dmn:text>
-            </dmn:literalExpression>
-         </dmn:contextEntry>
-         <dmn:contextEntry>
-            <dmn:variable id="_3DD87DE7-212C-4107-AE6E-039EE6B0EB84" name="inputData_013_1" />
-            <dmn:literalExpression id="_04AA4DB6-E120-455B-A3CF-B99F53FDD1C5">
-               <dmn:text>inputData_013_1</dmn:text>
-            </dmn:literalExpression>
-         </dmn:contextEntry>
-         <dmn:contextEntry>
-            <dmn:variable id="_EB49163C-7C3F-49F5-B2D0-A534C2FF6C03" name="decision_013_3" />
-            <dmn:literalExpression id="_093645FE-A80F-4928-9973-8788FA9F0998">
-               <dmn:text>decision_013_3</dmn:text>
-            </dmn:literalExpression>
-         </dmn:contextEntry>
-      </dmn:context>
-   </dmn:decision>
-   <dmn:decision id="_decision_013_2" name="decision_013_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_F355FE27-AD35-4A70-B912-A24B5913525D" name="decision_013_2" typeRef="string" />
-      <dmn:informationRequirement id="_decision_013_3">
-         <dmn:requiredDecision href="#_decision_013_3" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_013_1">
-         <dmn:requiredInput href="#_inputData_013_1" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_71525EE7-5EBE-4B0B-9C8F-4E0E44413DD9">
-         <dmn:text>inputData_013_1 + " " + decision_013_3</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_013_3" name="decision_013_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_65DE7173-C9B2-4D89-B240-1335D3BEC608" name="decision_013_3" typeRef="string" />
-      <dmn:literalExpression id="_7F86472E-ECF0-4CA9-805C-BB3105615AB7">
-         <dmn:text>"D"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:inputData id="_inputData_013_1" name="inputData_013_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_48D32FC8-4F14-4E48-AEA0-5C660D16876C" name="inputData_013_1" typeRef="string" />
-   </dmn:inputData>
-   <dmn:decision id="_decision_014_1" name="decision_014_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_0A2164C2-8CF1-4DF5-80B4-47D2C7A79E87" name="decision_014_1" />
-      <dmn:informationRequirement id="_decision_014_3">
-         <dmn:requiredDecision href="#_decision_014_3" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_014_1">
-         <dmn:requiredInput href="#_inputData_014_1" />
-      </dmn:informationRequirement>
-      <dmn:knowledgeRequirement id="_decisionService_014">
-         <dmn:requiredKnowledge href="#_decisionService_014" />
-      </dmn:knowledgeRequirement>
-      <dmn:context id="_3C4183DE-09A3-4E32-A0B6-19365F34CDA9">
-         <dmn:contextEntry>
-            <dmn:variable id="_E28104E0-6685-4606-9C5B-9CEA26C45DDD" name="inputData_014_1" />
-            <dmn:literalExpression id="_484C4D14-853F-417D-BCB0-6A59FCA5BFAC">
-               <dmn:text>inputData_014_1</dmn:text>
-            </dmn:literalExpression>
-         </dmn:contextEntry>
-         <dmn:contextEntry>
-            <dmn:variable id="_F331A2E8-31C5-4DCB-8A95-F8C1E9CE2EFD" name="decision_014_3" />
-            <dmn:literalExpression id="_A2FD7673-8979-46C3-AF97-78BE02650AE7">
-               <dmn:text>decision_014_3</dmn:text>
-            </dmn:literalExpression>
-         </dmn:contextEntry>
-         <dmn:contextEntry>
-            <dmn:variable id="_7EE204B6-7232-48A3-8B8B-3301B4738829" name="decisionService_014" />
-            <dmn:literalExpression id="_6484D194-5F35-43DE-ADAB-F6FB0D9854D1">
-               <dmn:text>decisionService_014("A", "B")</dmn:text>
-            </dmn:literalExpression>
-         </dmn:contextEntry>
-      </dmn:context>
-   </dmn:decision>
-   <dmn:decision id="_decision_014_2" name="decision_014_2">
-      <dmn:extensionElements />
-      <dmn:variable id="_6AF7C5F2-0807-4D5A-B050-53ADD13A42E4" name="decision_014_2" typeRef="string" />
-      <dmn:informationRequirement id="_decision_014_3">
-         <dmn:requiredDecision href="#_decision_014_3" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_inputData_014_1">
-         <dmn:requiredInput href="#_inputData_014_1" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_D1CD27CA-434B-422F-AC70-EF584A95CA8C">
-         <dmn:text>inputData_014_1 + " " + decision_014_3</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_decision_014_3" name="decision_014_3">
-      <dmn:extensionElements />
-      <dmn:variable id="_C81A9867-133A-4537-A4EE-CBACC07AB3E7" name="decision_014_3" typeRef="string" />
-      <dmn:literalExpression id="_06FF986F-F53F-42CB-8A84-F6CDC44F3E82">
-         <dmn:text>"D"</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:inputData id="_inputData_014_1" name="inputData_014_1">
-      <dmn:extensionElements />
-      <dmn:variable id="_982610C0-9A5C-4C6C-A5E0-48D31949A7EC" name="inputData_014_1" typeRef="string" />
-   </dmn:inputData>
-   <dmndi:DMNDI>
-      <dmndi:DMNDiagram id="_CCA27F4C-29FD-49E2-AE82-4C837250B1BA" name="DRG">
-         <di:extension>
-            <kie:ComponentsWidthsExtension>
-               <kie:ComponentWidths dmnElementRef="_4C64C5CF-7525-4E43-A132-FA7B76EFCAD8" />
-               <kie:ComponentWidths dmnElementRef="_4BA5093C-2B64-49FE-A477-9CF1C2B7247C" />
-               <kie:ComponentWidths dmnElementRef="_4E10E982-553C-471E-9A2E-B03BB923D463" />
-               <kie:ComponentWidths dmnElementRef="_F0116906-55F7-4951-9ECA-1C9B4CE02A15" />
-               <kie:ComponentWidths dmnElementRef="_645ADA90-064F-4D70-B9BA-15ED1CF6F467" />
-               <kie:ComponentWidths dmnElementRef="_EC4E18CE-97B7-4678-99D5-FDB2CFE04E8C" />
-               <kie:ComponentWidths dmnElementRef="_5A734BE4-9B19-4B4C-9F43-2ED83B4FBBDA" />
-               <kie:ComponentWidths dmnElementRef="_BA114448-8390-4314-8357-965F0591FD03" />
-               <kie:ComponentWidths dmnElementRef="_A33AFF2E-5947-4AA6-AB45-E5A1B455C57C" />
-               <kie:ComponentWidths dmnElementRef="_080CD506-ABE5-4583-B894-0B910EAAEF9D" />
-               <kie:ComponentWidths dmnElementRef="_43A61867-1919-40C7-9287-2E2C1FCE4096" />
-               <kie:ComponentWidths dmnElementRef="_5CC73F4D-142C-458E-BC33-52562E6F0E2C" />
-               <kie:ComponentWidths dmnElementRef="_32ECDAD7-3F41-44C8-84FE-D3347C4E77E5" />
-               <kie:ComponentWidths dmnElementRef="_C69A9B78-4145-4CDB-B302-DC3BE7A805DC" />
-               <kie:ComponentWidths dmnElementRef="_3E60D199-FC8D-4509-B9CA-71C38613694C" />
-               <kie:ComponentWidths dmnElementRef="_D2AC2879-D2C7-4F43-9AD9-FA92BA639186" />
-               <kie:ComponentWidths dmnElementRef="_2E8C7D0A-9B10-4D13-9984-CE2F9E78B997" />
-               <kie:ComponentWidths dmnElementRef="_0EE98A61-EE5E-4093-BBB5-583E27390C15" />
-               <kie:ComponentWidths dmnElementRef="_A799255D-9A34-47FB-BB55-F13DADFAB97D" />
-               <kie:ComponentWidths dmnElementRef="_AC69F8D1-4AE6-4E6F-95E3-ABF3F27A43A0" />
-               <kie:ComponentWidths dmnElementRef="_06C178EB-E33B-446C-8760-489EA71CC75A" />
-               <kie:ComponentWidths dmnElementRef="_005FEEC9-9BE8-460C-8597-AF43CF6F8692" />
-               <kie:ComponentWidths dmnElementRef="_A3D81420-B588-42C9-8F19-A5C18F8E535C" />
-               <kie:ComponentWidths dmnElementRef="_CFD9E35A-B575-4C65-9464-BB197467C5FA" />
-               <kie:ComponentWidths dmnElementRef="_5F171256-04F0-472E-8DA0-6B3A21E64459" />
-               <kie:ComponentWidths dmnElementRef="_C9EEF6D4-7DCF-4A4F-92B7-CCC0D6E989F0" />
-               <kie:ComponentWidths dmnElementRef="_6C1B3316-5C3E-4583-9536-A4587579302D" />
-               <kie:ComponentWidths dmnElementRef="_0BAACA8A-4B84-44CD-8F38-E817CE68236C" />
-               <kie:ComponentWidths dmnElementRef="_95B0A67D-EDC7-4D9C-908F-5378617F1FBE" />
-               <kie:ComponentWidths dmnElementRef="_58C823E6-7CA9-4408-8272-DA9CA0B5902C" />
-               <kie:ComponentWidths dmnElementRef="_CE0F18D6-3BCB-4E74-9F97-9CF593274BA5" />
-               <kie:ComponentWidths dmnElementRef="_E204D9D8-ED94-476B-9BF3-EF4D63E3D7FE" />
-               <kie:ComponentWidths dmnElementRef="_B85C73C3-F4BE-45A5-BEED-106F3CD32C98" />
-               <kie:ComponentWidths dmnElementRef="_C299F514-F842-46A8-AC95-EEE56D78EE5C" />
-               <kie:ComponentWidths dmnElementRef="_3D1DEFD5-39E1-481C-96A1-2567DB3D540C" />
-               <kie:ComponentWidths dmnElementRef="_04AA4DB6-E120-455B-A3CF-B99F53FDD1C5" />
-               <kie:ComponentWidths dmnElementRef="_093645FE-A80F-4928-9973-8788FA9F0998" />
-               <kie:ComponentWidths dmnElementRef="_71525EE7-5EBE-4B0B-9C8F-4E0E44413DD9" />
-               <kie:ComponentWidths dmnElementRef="_7F86472E-ECF0-4CA9-805C-BB3105615AB7" />
-               <kie:ComponentWidths dmnElementRef="_3C4183DE-09A3-4E32-A0B6-19365F34CDA9" />
-               <kie:ComponentWidths dmnElementRef="_484C4D14-853F-417D-BCB0-6A59FCA5BFAC" />
-               <kie:ComponentWidths dmnElementRef="_A2FD7673-8979-46C3-AF97-78BE02650AE7" />
-               <kie:ComponentWidths dmnElementRef="_6484D194-5F35-43DE-ADAB-F6FB0D9854D1" />
-               <kie:ComponentWidths dmnElementRef="_D1CD27CA-434B-422F-AC70-EF584A95CA8C" />
-               <kie:ComponentWidths dmnElementRef="_06FF986F-F53F-42CB-8A84-F6CDC44F3E82" />
-            </kie:ComponentsWidthsExtension>
-         </di:extension>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3725" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="3725" y="150" />
-               <di:waypoint x="3825" y="150" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4075" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="4075" y="150" />
-               <di:waypoint x="4175" y="150" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4425" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="4425" y="150" />
-               <di:waypoint x="4525" y="150" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_004" dmnElementRef="_decisionService_004" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="575" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="575" y="325" />
-               <di:waypoint x="675" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_005" dmnElementRef="_decisionService_005" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="750" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="750" y="325" />
-               <di:waypoint x="850" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_006" dmnElementRef="_decisionService_006" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="925" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="925" y="325" />
-               <di:waypoint x="1025" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_007" dmnElementRef="_decisionService_007" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1800" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="1800" y="325" />
-               <di:waypoint x="1900" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_008" dmnElementRef="_decisionService_008" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2150" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="2150" y="325" />
-               <di:waypoint x="2250" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_009" dmnElementRef="_decisionService_009" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3025" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="3025" y="325" />
-               <di:waypoint x="3125" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_010" dmnElementRef="_decisionService_010" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3200" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="3200" y="325" />
-               <di:waypoint x="3300" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_011" dmnElementRef="_decisionService_011" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4075" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="4075" y="325" />
-               <di:waypoint x="4175" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_012" dmnElementRef="_decisionService_012" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4950" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="4950" y="325" />
-               <di:waypoint x="5050" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_013" dmnElementRef="_decisionService_013" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3375" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="3375" y="325" />
-               <di:waypoint x="3475" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decisionService_014" dmnElementRef="_decisionService_014" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4250" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="4250" y="325" />
-               <di:waypoint x="4350" y="325" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4600" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_002" dmnElementRef="_decision_002" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1450" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_002_input" dmnElementRef="_decision_002_input" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1975" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="400" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="50" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="225" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_inputData_003" dmnElementRef="_inputData_003" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="400" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_004_1" dmnElementRef="_decision_004_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="575" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_004_2" dmnElementRef="_decision_004_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4950" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_005_1" dmnElementRef="_decision_005_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="750" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_005_2" dmnElementRef="_decision_005_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5125" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_006_1" dmnElementRef="_decision_006_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="925" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_006_2" dmnElementRef="_decision_006_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2500" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_006_3" dmnElementRef="_decision_006_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3550" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_007_1" dmnElementRef="_decision_007_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1275" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_007_2" dmnElementRef="_decision_007_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3200" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_007_3" dmnElementRef="_decision_007_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4425" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_008_1" dmnElementRef="_decision_008_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1625" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_008_2" dmnElementRef="_decision_008_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3900" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_008_3" dmnElementRef="_decision_008_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5125" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_009_1" dmnElementRef="_decision_009_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1975" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_009_2" dmnElementRef="_decision_009_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4250" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_009_3" dmnElementRef="_decision_009_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5300" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_010_1" dmnElementRef="_decision_010_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2150" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_010_2" dmnElementRef="_decision_010_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4775" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_010_3" dmnElementRef="_decision_010_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="5475" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_011_1" dmnElementRef="_decision_011_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2850" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_011_2" dmnElementRef="_decision_011_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1100" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_011_3" dmnElementRef="_decision_011_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1100" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_011_4" dmnElementRef="_decision_011_4" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1275" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_inputData_011_1" dmnElementRef="_inputData_011_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1450" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_inputData_011_2" dmnElementRef="_inputData_011_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1625" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_012_1" dmnElementRef="_decision_012_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3550" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_012_2" dmnElementRef="_decision_012_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="1800" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_012_3" dmnElementRef="_decision_012_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2325" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_012_4" dmnElementRef="_decision_012_4" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2500" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_inputData_012_1" dmnElementRef="_inputData_012_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2675" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_inputData_012_2" dmnElementRef="_inputData_012_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2850" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_013_1" dmnElementRef="_decision_013_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2325" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_013_2" dmnElementRef="_decision_013_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="2675" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_013_3" dmnElementRef="_decision_013_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3725" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_inputData_013_1" dmnElementRef="_inputData_013_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3900" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_014_1" dmnElementRef="_decision_014_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3025" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_014_2" dmnElementRef="_decision_014_2" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="3375" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_decision_014_3" dmnElementRef="_decision_014_3" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4600" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_inputData_014_1" dmnElementRef="_inputData_014_1" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="4775" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_002_input" dmnElementRef="_decision_002_input">
-            <di:waypoint x="1975" y="225" />
-            <di:waypoint x="1450" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1">
-            <di:waypoint x="50" y="225" />
-            <di:waypoint x="400" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2">
-            <di:waypoint x="225" y="225" />
-            <di:waypoint x="400" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_inputData_003" dmnElementRef="_inputData_003">
-            <di:waypoint x="400" y="225" />
-            <di:waypoint x="400" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_004" dmnElementRef="_decisionService_004">
-            <di:waypoint x="575" y="225" />
-            <di:waypoint x="575" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_005" dmnElementRef="_decisionService_005">
-            <di:waypoint x="750" y="225" />
-            <di:waypoint x="750" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_006" dmnElementRef="_decisionService_006">
-            <di:waypoint x="925" y="225" />
-            <di:waypoint x="925" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_006_3" dmnElementRef="_decision_006_3">
-            <di:waypoint x="3550" y="225" />
-            <di:waypoint x="2500" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_007" dmnElementRef="_decisionService_007">
-            <di:waypoint x="1800" y="225" />
-            <di:waypoint x="1275" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_007_3" dmnElementRef="_decision_007_3">
-            <di:waypoint x="4425" y="225" />
-            <di:waypoint x="3200" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_008" dmnElementRef="_decisionService_008">
-            <di:waypoint x="2150" y="225" />
-            <di:waypoint x="1625" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_008_3" dmnElementRef="_decision_008_3">
-            <di:waypoint x="5125" y="225" />
-            <di:waypoint x="3900" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_009" dmnElementRef="_decisionService_009">
-            <di:waypoint x="3025" y="225" />
-            <di:waypoint x="1975" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_009_3" dmnElementRef="_decision_009_3">
-            <di:waypoint x="5300" y="225" />
-            <di:waypoint x="4250" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_010" dmnElementRef="_decisionService_010">
-            <di:waypoint x="3200" y="225" />
-            <di:waypoint x="2150" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_010_3" dmnElementRef="_decision_010_3">
-            <di:waypoint x="5475" y="225" />
-            <di:waypoint x="4775" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_011" dmnElementRef="_decisionService_011">
-            <di:waypoint x="4075" y="225" />
-            <di:waypoint x="2850" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_011_3" dmnElementRef="_decision_011_3">
-            <di:waypoint x="1100" y="225" />
-            <di:waypoint x="1100" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_011_4" dmnElementRef="_decision_011_4">
-            <di:waypoint x="1275" y="225" />
-            <di:waypoint x="1100" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_inputData_011_1" dmnElementRef="_inputData_011_1">
-            <di:waypoint x="1450" y="225" />
-            <di:waypoint x="1100" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_inputData_011_2" dmnElementRef="_inputData_011_2">
-            <di:waypoint x="1625" y="225" />
-            <di:waypoint x="1100" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_012" dmnElementRef="_decisionService_012">
-            <di:waypoint x="4950" y="225" />
-            <di:waypoint x="3550" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_012_3" dmnElementRef="_decision_012_3">
-            <di:waypoint x="2325" y="225" />
-            <di:waypoint x="1800" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_012_4" dmnElementRef="_decision_012_4">
-            <di:waypoint x="2500" y="225" />
-            <di:waypoint x="1800" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_inputData_012_1" dmnElementRef="_inputData_012_1">
-            <di:waypoint x="2675" y="225" />
-            <di:waypoint x="1800" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_inputData_012_2" dmnElementRef="_inputData_012_2">
-            <di:waypoint x="2850" y="225" />
-            <di:waypoint x="1800" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_013_3" dmnElementRef="_decision_013_3">
-            <di:waypoint x="3725" y="225" />
-            <di:waypoint x="2325" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_inputData_013_1" dmnElementRef="_inputData_013_1">
-            <di:waypoint x="3900" y="225" />
-            <di:waypoint x="2325" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_013" dmnElementRef="_decisionService_013">
-            <di:waypoint x="3375" y="225" />
-            <di:waypoint x="2325" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decision_014_3" dmnElementRef="_decision_014_3">
-            <di:waypoint x="4600" y="225" />
-            <di:waypoint x="3025" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_inputData_014_1" dmnElementRef="_inputData_014_1">
-            <di:waypoint x="4775" y="225" />
-            <di:waypoint x="3025" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_decisionService_014" dmnElementRef="_decisionService_014">
-            <di:waypoint x="4250" y="225" />
-            <di:waypoint x="3025" y="50" />
-         </dmndi:DMNEdge>
-      </dmndi:DMNDiagram>
-   </dmndi:DMNDI>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0085-decision-services" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_i9fboPUUEeesLuP4RHs4vA" name="0085-decision-services" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0085-decision-services">
+  <dmn:description>Decision Services</dmn:description>
+  <dmn:extensionElements/>
+  <dmn:decisionService id="_decisionService_001" name="decisionService_001">
+    <dmn:extensionElements/>
+    <dmn:variable id="_EC7DF9E4-FAB6-4AB9-8908-B481F22F2A25" name="decisionService_001"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_002" name="decisionService_002">
+    <dmn:extensionElements/>
+    <dmn:variable id="_45D50755-F64C-4954-8F89-BAC223CD21AE" name="decisionService_002"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_003" name="decisionService_003">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D76FBC5A-689D-4DE9-A588-EED2961E07D7" name="decisionService_003"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_004" name="decisionService_004">
+    <dmn:extensionElements/>
+    <dmn:variable id="_26675CA3-B2FB-4792-8C63-D4629EFCC9BD" name="decisionService_004"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_005" name="decisionService_005">
+    <dmn:extensionElements/>
+    <dmn:variable id="_EEDEA4B5-2AF4-4CAD-BCD6-DC92EAA0B217" name="decisionService_005"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_006" name="decisionService_006">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D1260077-9C4D-490D-9BF6-AD6A96E30F5E" name="decisionService_006"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_007" name="decisionService_007">
+    <dmn:extensionElements/>
+    <dmn:variable id="_AAB776B9-E2E8-49A9-9B5C-90E0A988AC50" name="decisionService_007"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_008" name="decisionService_008">
+    <dmn:extensionElements/>
+    <dmn:variable id="_1BF5587E-CA76-4C9C-9D5B-5BF34A11BA75" name="decisionService_008"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_009" name="decisionService_009">
+    <dmn:extensionElements/>
+    <dmn:variable id="_4E417097-1FDC-41D5-8137-1F9B49053F01" name="decisionService_009"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_010" name="decisionService_010">
+    <dmn:extensionElements/>
+    <dmn:variable id="_28F892E8-DB27-4822-9A56-41C1AF2755B0" name="decisionService_010"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_011" name="decisionService_011">
+    <dmn:extensionElements/>
+    <dmn:variable id="_008A6C56-36DD-4326-9920-3744ED20E368" name="decisionService_011"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_012" name="decisionService_012">
+    <dmn:extensionElements/>
+    <dmn:variable id="_8049FFF3-FAB0-4A4D-8E7C-66F64F0B76A5" name="decisionService_012"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_013" name="decisionService_013">
+    <dmn:extensionElements/>
+    <dmn:variable id="_9F79D1EB-7DD4-49E6-93A8-2B24236243D5" name="decisionService_013"/>
+  </dmn:decisionService>
+  <dmn:decisionService id="_decisionService_014" name="decisionService_014">
+    <dmn:extensionElements/>
+    <dmn:variable id="_7394ED1B-F341-438D-B53A-FBFA706A284A" name="decisionService_014"/>
+  </dmn:decisionService>
+  <dmn:decision id="_decision_001" name="decision_001">
+    <dmn:extensionElements/>
+    <dmn:variable id="_34B6642F-E948-449D-8B16-90CEFD6FB336" name="decision_001"/>
+    <dmn:literalExpression id="_7FDBBB36-ED6D-4F0A-BF43-E3FDDA44A21B">
+      <dmn:text>"foo"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_002" name="decision_002">
+    <dmn:extensionElements/>
+    <dmn:variable id="_7ED51E29-0507-492E-8077-74173AADD2F7" name="decision_002"/>
+    <dmn:informationRequirement id="_48327838-A3B3-4A1C-9018-C16961353832">
+      <dmn:requiredDecision href="#_decision_002_input"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_52594767-C42D-46EA-890A-61A738508E67">
+      <dmn:text>"foo " + decision_002_input</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_002_input" name="decision_002_input">
+    <dmn:extensionElements/>
+    <dmn:variable id="_4FE88921-82D7-42A7-BDC7-00A6AC02073B" name="decision_002_input"/>
+    <dmn:literalExpression id="_415FC122-078D-47F2-880B-0155697E9662">
+      <dmn:text>"bar"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_003" name="decision_003">
+    <dmn:extensionElements/>
+    <dmn:variable id="_B2B0F8D7-E607-4981-87E2-9722C56C7EA7" name="decision_003"/>
+    <dmn:informationRequirement id="_E2B96527-3A45-4FC3-A433-9F445073D21E">
+      <dmn:requiredDecision href="#_decision_003_input_1"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_C88D4810-6090-4C42-9B8B-765318419D94">
+      <dmn:requiredDecision href="#_decision_003_input_2"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_3BBF348F-7D76-43C5-9C3C-AB3954D2A001">
+      <dmn:requiredInput href="#_inputData_003"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_EE66BAA2-F15A-4FA9-890D-F2DB1FF31420">
+      <dmn:text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_003_input_1" name="decision_003_input_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_71129976-4968-4E86-B8CE-06EB52249428" name="decision_003_input_1"/>
+    <dmn:literalExpression id="_B877AFC4-2D88-4FEE-8C14-661585A02AF1">
+      <dmn:text>"d3_1"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_003_input_2" name="decision_003_input_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_5172A883-61AD-4819-959A-FDD742B7F6A3" name="decision_003_input_2"/>
+    <dmn:literalExpression id="_62CD8FBD-56E0-474C-8B1F-92AB5DCC2DD0">
+      <dmn:text>"d3_2"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_inputData_003" name="inputData_003">
+    <dmn:extensionElements/>
+    <dmn:variable id="_351D0B2E-25A3-4897-822D-4E2A2A1E7238" name="inputData_003" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:decision id="_decision_004_1" name="decision_004_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_9778E0D6-1B39-4A59-A0C8-A4B45E3F9E82" name="decision_004_1"/>
+    <dmn:knowledgeRequirement id="_2EB3293E-2DE4-419E-AFC7-E83C107EF972">
+      <dmn:requiredKnowledge href="#_decisionService_004"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_7E3F51E4-8251-4968-867B-81ACF16390EA">
+      <dmn:text>decisionService_004()</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_004_2" name="decision_004_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_F532D145-45A0-410F-986E-DF0B1E1E715E" name="decision_004_2"/>
+    <dmn:literalExpression id="_34705EDE-A378-4850-9A60-3E6335EE87B4">
+      <dmn:text>"foo"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_005_1" name="decision_005_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_87B1F551-2627-4831-BA0D-7E3E452EF096" name="decision_005_1"/>
+    <dmn:knowledgeRequirement id="_7C238A40-CE07-47A4-BD73-392645E9A07F">
+      <dmn:requiredKnowledge href="#_decisionService_005"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_17CB5BBE-A597-44A4-B937-F89D66C6C4E7">
+      <dmn:text>decisionService_005("bar")</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_005_2" name="decision_005_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_BE78BE6F-22DC-451F-813E-36AD69DE6BAE" name="decision_005_2" typeRef="string"/>
+    <dmn:literalExpression id="_CE8547A9-8F64-4C28-8C05-62CFB6447ADC">
+      <dmn:text>"foo"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_006_1" name="decision_006_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_2C1ABCE7-1BE8-4C7E-AA76-FB2AF0847C83" name="decision_006_1"/>
+    <dmn:knowledgeRequirement id="_FCE2091B-D88C-4EEA-9EB2-AECB8D644296">
+      <dmn:requiredKnowledge href="#_decisionService_006"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_2022C849-014F-4C56-A6D1-13E24115F3F4">
+      <dmn:text>decisionService_006("bar")</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_006_2" name="decision_006_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_E4D5F821-5E35-495B-AAD7-CF978290B1F8" name="decision_006_2"/>
+    <dmn:informationRequirement id="_3C60FB2C-767A-45E2-9630-367077116AAD">
+      <dmn:requiredDecision href="#_decision_006_3"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_49024C4A-881C-4055-A38C-BB0B42C488E4">
+      <dmn:text>"foo " + decision_006_3</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_006_3" name="decision_006_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_AB2C2537-C61C-4F87-BEF3-7105EC61463F" name="decision_006_3" typeRef="string"/>
+    <dmn:literalExpression id="_E37B2275-C9EE-4D59-8E54-360F59267175">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_007_1" name="decision_007_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_2DB62567-35CF-4729-AF61-2A77F331C021" name="decision_007_1"/>
+    <dmn:knowledgeRequirement id="_E2CCF4CC-61F7-4625-A47C-C02433674CB0">
+      <dmn:requiredKnowledge href="#_decisionService_007"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_DCDE434B-052F-4677-BB14-99F67EE8E6ED">
+      <dmn:text>decisionService_007(123)</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_007_2" name="decision_007_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_DA133DA9-BDF4-4A6D-A570-8FF5C237E2B3" name="decision_007_2"/>
+    <dmn:informationRequirement id="_8B06E8E0-C65D-4F2D-A31E-853E4DD86583">
+      <dmn:requiredDecision href="#_decision_007_3"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_0E3B6F2D-07BA-40F0-A49A-264F48EEA552">
+      <dmn:text>decision_007_3 = null</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_007_3" name="decision_007_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_4D172687-E4BB-47E2-8A8C-BCF1713E43E1" name="decision_007_3" typeRef="string"/>
+    <dmn:literalExpression id="_47C41417-D43F-4310-BEC6-55B6EA938319">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_008_1" name="decision_008_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_63DB3FDC-EF4B-483E-9DBB-2995E6997B3B" name="decision_008_1"/>
+    <dmn:knowledgeRequirement id="_59730883-C5AD-4838-A828-E36ED83F0A28">
+      <dmn:requiredKnowledge href="#_decisionService_008"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_5B598507-528B-42F8-9BA1-238D3B478D69">
+      <dmn:text>decisionService_008()</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_008_2" name="decision_008_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D83C9F6B-3418-4567-8943-80674601F2B6" name="decision_008_2"/>
+    <dmn:informationRequirement id="_8EA2F696-D099-4DD5-A67C-164D148824EB">
+      <dmn:requiredDecision href="#_decision_008_3"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_EEE16197-1AC0-4F91-A8F5-A933FC3A1F97">
+      <dmn:text>decision_008_3 = null</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_008_3" name="decision_008_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_62C75E8A-76DE-4C47-87BE-D9D546B81628" name="decision_008_3" typeRef="string"/>
+    <dmn:literalExpression id="_A1BFE2B0-89B0-480C-B016-767CF7597B58">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_009_1" name="decision_009_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_2BEDD4D7-351D-49B3-B536-C075D84FBF0C" name="decision_009_1"/>
+    <dmn:knowledgeRequirement id="_E212024F-4A31-4516-A465-85A3181542B3">
+      <dmn:requiredKnowledge href="#_decisionService_009"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_C25163F7-1ADA-443B-B2AD-DE2C14FEE0DE">
+      <dmn:text>decisionService_009(decision_009_3: "bar")</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_009_2" name="decision_009_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_B3BD7DB9-A6B3-4D55-B373-6EBDA9960D1A" name="decision_009_2"/>
+    <dmn:informationRequirement id="_298E4FA3-A9DB-4B02-B878-C53CFE708DF1">
+      <dmn:requiredDecision href="#_decision_009_3"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_656354B5-471C-416B-ABFE-FDFBF3BC0302">
+      <dmn:text>"foo " + decision_009_3</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_009_3" name="decision_009_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A851A690-975A-4653-B74A-67977F4E2AC7" name="decision_009_3" typeRef="string"/>
+    <dmn:literalExpression id="_092AF037-3183-41A0-8398-1A0B3B9CE80F">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_010_1" name="decision_010_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_7BC2E34C-C6F6-43D5-B778-70058F0D2D03" name="decision_010_1"/>
+    <dmn:knowledgeRequirement id="_1F343A9F-34AA-41DD-8134-8E23D7AB804E">
+      <dmn:requiredKnowledge href="#_decisionService_010"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_5F2ED633-51F5-4391-9480-3684F7C972EA">
+      <dmn:text>decisionService_010(foo: "bar")</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_010_2" name="decision_010_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_9C9E53A7-F01F-460A-9759-E7F49800C5B6" name="decision_010_2"/>
+    <dmn:informationRequirement id="_24FDD129-04BF-499F-8233-231FA35AF051">
+      <dmn:requiredDecision href="#_decision_010_3"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_8E17B04B-FEB5-45B4-9F51-9B51F6E7BF32">
+      <dmn:text>"foo " + decision_010_3</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_010_3" name="decision_010_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_B04E68D6-C173-4758-BBDA-67BBD020B831" name="decision_010_3" typeRef="string"/>
+    <dmn:literalExpression id="_FBF9E0B8-D74B-4742-BEEE-8C5E558B4907">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_011_1" name="decision_011_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_C2D8C7AC-B7BF-4A87-9729-354083F8C1F3" name="decision_011_1"/>
+    <dmn:knowledgeRequirement id="_C16DA847-D4B4-4736-8E1C-6DD808688E92">
+      <dmn:requiredKnowledge href="#_decisionService_011"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_9BB7616E-A222-4E16-A2E4-52F6EC320CCE">
+      <dmn:text>decisionService_011("A", "B", "C", "D")</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_011_2" name="decision_011_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_C98E507E-3D43-43D0-B8A2-0F6B905DDAFF" name="decision_011_2" typeRef="string"/>
+    <dmn:informationRequirement id="_E5B24964-1B33-4DE5-9C63-82A62E974DEC">
+      <dmn:requiredDecision href="#_decision_011_3"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07">
+      <dmn:requiredDecision href="#_decision_011_4"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3">
+      <dmn:requiredInput href="#_inputData_011_1"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_8B485F45-A12F-44FB-A72A-8F090678BDDD">
+      <dmn:requiredInput href="#_inputData_011_2"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_C6227EEB-10CA-4B69-A07E-079F4C530E24">
+      <dmn:text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_011_3" name="decision_011_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_765E446F-B923-4E13-901D-C5709A8FDE33" name="decision_011_3" typeRef="string"/>
+    <dmn:literalExpression id="_B7F329B9-482A-4E16-9C9A-1C1F939258D0">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_011_4" name="decision_011_4">
+    <dmn:extensionElements/>
+    <dmn:variable id="_E74E506F-B3FF-4421-871F-AEDF4A1B0D06" name="decision_011_4" typeRef="string"/>
+    <dmn:literalExpression id="_5AE4C508-A1EE-4C28-AF41-3B68DF65FCCF">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_inputData_011_1" name="inputData_011_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_82576A5C-B7FA-4383-9DFA-1EA499812378" name="inputData_011_1" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:inputData id="_inputData_011_2" name="inputData_011_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_29C656F0-5768-4D4E-8364-BAAFA4D6899A" name="inputData_011_2" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:decision id="_decision_012_1" name="decision_012_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_F1556702-0C14-4044-B035-7AE7FC8F0EC1" name="decision_012_1"/>
+    <dmn:knowledgeRequirement id="_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA">
+      <dmn:requiredKnowledge href="#_decisionService_012"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_621750B7-8033-45E0-90BF-7D00248CC251">
+      <dmn:text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_012_2" name="decision_012_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_17B1F637-B472-4291-944A-3C4DAA4D46A4" name="decision_012_2" typeRef="string"/>
+    <dmn:informationRequirement id="_F8800C29-3B28-4AE5-B2A2-0457F994F839">
+      <dmn:requiredDecision href="#_decision_012_3"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_386E4803-5F5F-4194-A8B5-F3534DFC7AD9">
+      <dmn:requiredDecision href="#_decision_012_4"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_D07DA03D-C33A-4807-8711-968E4853E0F1">
+      <dmn:requiredInput href="#_inputData_012_1"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_32E47634-89BF-4AF3-A6B7-61AE25AB151B">
+      <dmn:requiredInput href="#_inputData_012_2"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_68420CC3-DDF8-45C2-B850-B431E9F03DB9">
+      <dmn:text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_012_3" name="decision_012_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_3E7745CA-4B3F-4A27-A886-D8957D27C097" name="decision_012_3" typeRef="string"/>
+    <dmn:literalExpression id="_9753439E-01DE-4951-BB5A-3F2130C17B25">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_012_4" name="decision_012_4">
+    <dmn:extensionElements/>
+    <dmn:variable id="_1E8F5F3D-B562-4308-B3D8-5C1F148DA008" name="decision_012_4" typeRef="string"/>
+    <dmn:literalExpression id="_ACC927D0-6731-497E-94EB-001EE1031DCB">
+      <dmn:text>"I never get invoked"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_inputData_012_1" name="inputData_012_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_0AF9125C-D653-48F6-B8DF-618894CEF61D" name="inputData_012_1" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:inputData id="_inputData_012_2" name="inputData_012_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D188E9FA-3675-4A4F-98E8-051066D1B665" name="inputData_012_2" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:decision id="_decision_013_1" name="decision_013_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_48F74264-DBA9-45C5-A185-920B2C70D2EB" name="decision_013_1"/>
+    <dmn:informationRequirement id="_C66633F4-6718-491C-9D40-8AFF21CE4CD5">
+      <dmn:requiredDecision href="#_decision_013_3"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_1893C895-D655-4607-81A5-363DE8DBD597">
+      <dmn:requiredInput href="#_inputData_013_1"/>
+    </dmn:informationRequirement>
+    <dmn:knowledgeRequirement id="_D73018C3-F4DF-4B8A-946B-70692A2464DD">
+      <dmn:requiredKnowledge href="#_decisionService_013"/>
+    </dmn:knowledgeRequirement>
+    <dmn:context id="_BA9A5C7B-A043-4488-8087-1E0FD818394F">
+      <dmn:contextEntry>
+        <dmn:variable id="_8CFAD888-C64A-4386-B8A2-91DE5D79F1A9" name="decisionService_013"/>
+        <dmn:literalExpression id="_E35A33F0-5648-4150-AAA5-A65BBF324B47">
+          <dmn:text>decisionService_013("A", "B")</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_C0D9D68A-56A7-436A-BAFE-609FA7781DEF" name="inputData_013_1"/>
+        <dmn:literalExpression id="_55B320EF-7562-4608-A06D-11A550BF1F96">
+          <dmn:text>inputData_013_1</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_F2E4A4DA-4A5F-4F2E-9A99-0DC190416B26" name="decision_013_3"/>
+        <dmn:literalExpression id="_8834D5F9-21FC-4106-B292-1BCEDD58220F">
+          <dmn:text>decision_013_3</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmn:decision id="_decision_013_2" name="decision_013_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A83F6FDD-1FE9-4BA4-A51F-2B8859A4A2F7" name="decision_013_2" typeRef="string"/>
+    <dmn:informationRequirement id="_A9B18C1C-2D92-4A64-A936-3051A852D66F">
+      <dmn:requiredDecision href="#_decision_013_3"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_A975CC18-C9EC-48A1-8691-26DDC2A81F45">
+      <dmn:requiredInput href="#_inputData_013_1"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_8D028CA6-9754-492E-822B-F159B5E2F438">
+      <dmn:text>inputData_013_1 + " " + decision_013_3</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_013_3" name="decision_013_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_BA181F99-EFD7-4458-BB1C-DC37A05FE91B" name="decision_013_3" typeRef="string"/>
+    <dmn:literalExpression id="_0C1B1B54-3234-4D8E-A5D5-F3EC937414BC">
+      <dmn:text>"D"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_inputData_013_1" name="inputData_013_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D612C6F8-F9F7-4A17-A321-F61E929220C5" name="inputData_013_1" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:decision id="_decision_014_1" name="decision_014_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_B6FD71AF-516F-4D19-BFB1-668F076D9E62" name="decision_014_1"/>
+    <dmn:informationRequirement id="_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F">
+      <dmn:requiredDecision href="#_decision_014_3"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550">
+      <dmn:requiredInput href="#_inputData_014_1"/>
+    </dmn:informationRequirement>
+    <dmn:knowledgeRequirement id="_00254681-64B2-4809-95A3-1B7AFAC4D1ED">
+      <dmn:requiredKnowledge href="#_decisionService_014"/>
+    </dmn:knowledgeRequirement>
+    <dmn:context id="_92D2CB90-6C26-46BE-AA2A-21B95DCAB74E">
+      <dmn:contextEntry>
+        <dmn:variable id="_DEC673FD-913A-4232-8795-D4A795EBF4C3" name="inputData_014_1"/>
+        <dmn:literalExpression id="_79A9451C-7E30-4562-AADE-023010A48E47">
+          <dmn:text>inputData_014_1</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_0E14B7C6-1110-4DE4-8034-F62EACFA0E8E" name="decision_014_3"/>
+        <dmn:literalExpression id="_67C34FE6-31AC-4810-9577-EA694ADE2127">
+          <dmn:text>decision_014_3</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:variable id="_89FED9AF-5258-4F8A-943C-20966F9C881D" name="decisionService_014"/>
+        <dmn:literalExpression id="_A8E8FE1E-EBB4-473E-A5E0-408565FD28BF">
+          <dmn:text>decisionService_014("A", "B")</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmn:decision id="_decision_014_2" name="decision_014_2">
+    <dmn:extensionElements/>
+    <dmn:variable id="_10DA8AB0-E1B9-44A8-9473-8979F6D66624" name="decision_014_2" typeRef="string"/>
+    <dmn:informationRequirement id="_80959823-0175-4165-8060-DFAAB74A1123">
+      <dmn:requiredDecision href="#_decision_014_3"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_40616155-0E1B-4A83-A65A-2DB14DD7B65D">
+      <dmn:requiredInput href="#_inputData_014_1"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_87F856EE-0726-4DB7-92CC-D16F5B1A5A29">
+      <dmn:text>inputData_014_1 + " " + decision_014_3</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_decision_014_3" name="decision_014_3">
+    <dmn:extensionElements/>
+    <dmn:variable id="_D4EFBAF0-72B8-466A-B39A-E25CB0A04135" name="decision_014_3" typeRef="string"/>
+    <dmn:literalExpression id="_DD6BD7E1-A422-42EF-B2F2-942DC0B1A92F">
+      <dmn:text>"D"</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_inputData_014_1" name="inputData_014_1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_13B39E4F-DFE1-4516-A007-8C64985881A2" name="inputData_014_1" typeRef="string"/>
+  </dmn:inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_3681B41E-85D2-4111-9061-E4F7A725F207" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_7FDBBB36-ED6D-4F0A-BF43-E3FDDA44A21B"/>
+          <kie:ComponentWidths dmnElementRef="_52594767-C42D-46EA-890A-61A738508E67"/>
+          <kie:ComponentWidths dmnElementRef="_415FC122-078D-47F2-880B-0155697E9662"/>
+          <kie:ComponentWidths dmnElementRef="_EE66BAA2-F15A-4FA9-890D-F2DB1FF31420"/>
+          <kie:ComponentWidths dmnElementRef="_B877AFC4-2D88-4FEE-8C14-661585A02AF1"/>
+          <kie:ComponentWidths dmnElementRef="_62CD8FBD-56E0-474C-8B1F-92AB5DCC2DD0"/>
+          <kie:ComponentWidths dmnElementRef="_7E3F51E4-8251-4968-867B-81ACF16390EA"/>
+          <kie:ComponentWidths dmnElementRef="_34705EDE-A378-4850-9A60-3E6335EE87B4"/>
+          <kie:ComponentWidths dmnElementRef="_17CB5BBE-A597-44A4-B937-F89D66C6C4E7"/>
+          <kie:ComponentWidths dmnElementRef="_CE8547A9-8F64-4C28-8C05-62CFB6447ADC"/>
+          <kie:ComponentWidths dmnElementRef="_2022C849-014F-4C56-A6D1-13E24115F3F4"/>
+          <kie:ComponentWidths dmnElementRef="_49024C4A-881C-4055-A38C-BB0B42C488E4"/>
+          <kie:ComponentWidths dmnElementRef="_E37B2275-C9EE-4D59-8E54-360F59267175"/>
+          <kie:ComponentWidths dmnElementRef="_DCDE434B-052F-4677-BB14-99F67EE8E6ED"/>
+          <kie:ComponentWidths dmnElementRef="_0E3B6F2D-07BA-40F0-A49A-264F48EEA552"/>
+          <kie:ComponentWidths dmnElementRef="_47C41417-D43F-4310-BEC6-55B6EA938319"/>
+          <kie:ComponentWidths dmnElementRef="_5B598507-528B-42F8-9BA1-238D3B478D69"/>
+          <kie:ComponentWidths dmnElementRef="_EEE16197-1AC0-4F91-A8F5-A933FC3A1F97"/>
+          <kie:ComponentWidths dmnElementRef="_A1BFE2B0-89B0-480C-B016-767CF7597B58"/>
+          <kie:ComponentWidths dmnElementRef="_C25163F7-1ADA-443B-B2AD-DE2C14FEE0DE"/>
+          <kie:ComponentWidths dmnElementRef="_656354B5-471C-416B-ABFE-FDFBF3BC0302"/>
+          <kie:ComponentWidths dmnElementRef="_092AF037-3183-41A0-8398-1A0B3B9CE80F"/>
+          <kie:ComponentWidths dmnElementRef="_5F2ED633-51F5-4391-9480-3684F7C972EA"/>
+          <kie:ComponentWidths dmnElementRef="_8E17B04B-FEB5-45B4-9F51-9B51F6E7BF32"/>
+          <kie:ComponentWidths dmnElementRef="_FBF9E0B8-D74B-4742-BEEE-8C5E558B4907"/>
+          <kie:ComponentWidths dmnElementRef="_9BB7616E-A222-4E16-A2E4-52F6EC320CCE"/>
+          <kie:ComponentWidths dmnElementRef="_C6227EEB-10CA-4B69-A07E-079F4C530E24"/>
+          <kie:ComponentWidths dmnElementRef="_B7F329B9-482A-4E16-9C9A-1C1F939258D0"/>
+          <kie:ComponentWidths dmnElementRef="_5AE4C508-A1EE-4C28-AF41-3B68DF65FCCF"/>
+          <kie:ComponentWidths dmnElementRef="_621750B7-8033-45E0-90BF-7D00248CC251"/>
+          <kie:ComponentWidths dmnElementRef="_68420CC3-DDF8-45C2-B850-B431E9F03DB9"/>
+          <kie:ComponentWidths dmnElementRef="_9753439E-01DE-4951-BB5A-3F2130C17B25"/>
+          <kie:ComponentWidths dmnElementRef="_ACC927D0-6731-497E-94EB-001EE1031DCB"/>
+          <kie:ComponentWidths dmnElementRef="_BA9A5C7B-A043-4488-8087-1E0FD818394F"/>
+          <kie:ComponentWidths dmnElementRef="_E35A33F0-5648-4150-AAA5-A65BBF324B47"/>
+          <kie:ComponentWidths dmnElementRef="_55B320EF-7562-4608-A06D-11A550BF1F96"/>
+          <kie:ComponentWidths dmnElementRef="_8834D5F9-21FC-4106-B292-1BCEDD58220F"/>
+          <kie:ComponentWidths dmnElementRef="_8D028CA6-9754-492E-822B-F159B5E2F438"/>
+          <kie:ComponentWidths dmnElementRef="_0C1B1B54-3234-4D8E-A5D5-F3EC937414BC"/>
+          <kie:ComponentWidths dmnElementRef="_92D2CB90-6C26-46BE-AA2A-21B95DCAB74E"/>
+          <kie:ComponentWidths dmnElementRef="_79A9451C-7E30-4562-AADE-023010A48E47"/>
+          <kie:ComponentWidths dmnElementRef="_67C34FE6-31AC-4810-9577-EA694ADE2127"/>
+          <kie:ComponentWidths dmnElementRef="_A8E8FE1E-EBB4-473E-A5E0-408565FD28BF"/>
+          <kie:ComponentWidths dmnElementRef="_87F856EE-0726-4DB7-92CC-D16F5B1A5A29"/>
+          <kie:ComponentWidths dmnElementRef="_DD6BD7E1-A422-42EF-B2F2-942DC0B1A92F"/>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3725" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="3725" y="150"/>
+          <di:waypoint x="3825" y="150"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4075" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="4075" y="150"/>
+          <di:waypoint x="4175" y="150"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4425" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="4425" y="150"/>
+          <di:waypoint x="4525" y="150"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_004" dmnElementRef="_decisionService_004" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="575" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="575" y="325"/>
+          <di:waypoint x="675" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_005" dmnElementRef="_decisionService_005" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="750" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="750" y="325"/>
+          <di:waypoint x="850" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_006" dmnElementRef="_decisionService_006" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="925" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="925" y="325"/>
+          <di:waypoint x="1025" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_007" dmnElementRef="_decisionService_007" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1800" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="1800" y="325"/>
+          <di:waypoint x="1900" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_008" dmnElementRef="_decisionService_008" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2150" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="2150" y="325"/>
+          <di:waypoint x="2250" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_009" dmnElementRef="_decisionService_009" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3025" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="3025" y="325"/>
+          <di:waypoint x="3125" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_010" dmnElementRef="_decisionService_010" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3200" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="3200" y="325"/>
+          <di:waypoint x="3300" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_011" dmnElementRef="_decisionService_011" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4075" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="4075" y="325"/>
+          <di:waypoint x="4175" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_012" dmnElementRef="_decisionService_012" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4950" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="4950" y="325"/>
+          <di:waypoint x="5050" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_013" dmnElementRef="_decisionService_013" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3375" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="3375" y="325"/>
+          <di:waypoint x="3475" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decisionService_014" dmnElementRef="_decisionService_014" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4250" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="4250" y="325"/>
+          <di:waypoint x="4350" y="325"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4600" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_002" dmnElementRef="_decision_002" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1450" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_002_input" dmnElementRef="_decision_002_input" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1975" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="400" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="50" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="225" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_inputData_003" dmnElementRef="_inputData_003" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="400" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_004_1" dmnElementRef="_decision_004_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="575" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_004_2" dmnElementRef="_decision_004_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4950" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_005_1" dmnElementRef="_decision_005_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="750" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_005_2" dmnElementRef="_decision_005_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5125" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_006_1" dmnElementRef="_decision_006_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="925" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_006_2" dmnElementRef="_decision_006_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2500" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_006_3" dmnElementRef="_decision_006_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3550" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_007_1" dmnElementRef="_decision_007_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1275" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_007_2" dmnElementRef="_decision_007_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3200" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_007_3" dmnElementRef="_decision_007_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4425" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_008_1" dmnElementRef="_decision_008_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1625" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_008_2" dmnElementRef="_decision_008_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3900" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_008_3" dmnElementRef="_decision_008_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5125" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_009_1" dmnElementRef="_decision_009_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1975" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_009_2" dmnElementRef="_decision_009_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4250" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_009_3" dmnElementRef="_decision_009_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5300" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_010_1" dmnElementRef="_decision_010_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2150" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_010_2" dmnElementRef="_decision_010_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4775" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_010_3" dmnElementRef="_decision_010_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="5475" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_011_1" dmnElementRef="_decision_011_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2850" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_011_2" dmnElementRef="_decision_011_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1100" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_011_3" dmnElementRef="_decision_011_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1100" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_011_4" dmnElementRef="_decision_011_4" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1275" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_inputData_011_1" dmnElementRef="_inputData_011_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1450" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_inputData_011_2" dmnElementRef="_inputData_011_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1625" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_012_1" dmnElementRef="_decision_012_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3550" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_012_2" dmnElementRef="_decision_012_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="1800" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_012_3" dmnElementRef="_decision_012_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2325" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_012_4" dmnElementRef="_decision_012_4" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2500" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_inputData_012_1" dmnElementRef="_inputData_012_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2675" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_inputData_012_2" dmnElementRef="_inputData_012_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2850" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_013_1" dmnElementRef="_decision_013_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2325" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_013_2" dmnElementRef="_decision_013_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="2675" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_013_3" dmnElementRef="_decision_013_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3725" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_inputData_013_1" dmnElementRef="_inputData_013_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3900" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_014_1" dmnElementRef="_decision_014_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3025" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_014_2" dmnElementRef="_decision_014_2" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="3375" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_decision_014_3" dmnElementRef="_decision_014_3" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4600" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_inputData_014_1" dmnElementRef="_inputData_014_1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="4775" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_48327838-A3B3-4A1C-9018-C16961353832" dmnElementRef="_48327838-A3B3-4A1C-9018-C16961353832">
+        <di:waypoint x="1975" y="225"/>
+        <di:waypoint x="1450" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E2B96527-3A45-4FC3-A433-9F445073D21E" dmnElementRef="_E2B96527-3A45-4FC3-A433-9F445073D21E">
+        <di:waypoint x="50" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C88D4810-6090-4C42-9B8B-765318419D94" dmnElementRef="_C88D4810-6090-4C42-9B8B-765318419D94">
+        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_3BBF348F-7D76-43C5-9C3C-AB3954D2A001" dmnElementRef="_3BBF348F-7D76-43C5-9C3C-AB3954D2A001">
+        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="400" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_2EB3293E-2DE4-419E-AFC7-E83C107EF972" dmnElementRef="_2EB3293E-2DE4-419E-AFC7-E83C107EF972">
+        <di:waypoint x="575" y="225"/>
+        <di:waypoint x="575" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_7C238A40-CE07-47A4-BD73-392645E9A07F" dmnElementRef="_7C238A40-CE07-47A4-BD73-392645E9A07F">
+        <di:waypoint x="750" y="225"/>
+        <di:waypoint x="750" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_FCE2091B-D88C-4EEA-9EB2-AECB8D644296" dmnElementRef="_FCE2091B-D88C-4EEA-9EB2-AECB8D644296">
+        <di:waypoint x="925" y="225"/>
+        <di:waypoint x="925" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_3C60FB2C-767A-45E2-9630-367077116AAD" dmnElementRef="_3C60FB2C-767A-45E2-9630-367077116AAD">
+        <di:waypoint x="3550" y="225"/>
+        <di:waypoint x="2500" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E2CCF4CC-61F7-4625-A47C-C02433674CB0" dmnElementRef="_E2CCF4CC-61F7-4625-A47C-C02433674CB0">
+        <di:waypoint x="1800" y="225"/>
+        <di:waypoint x="1275" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8B06E8E0-C65D-4F2D-A31E-853E4DD86583" dmnElementRef="_8B06E8E0-C65D-4F2D-A31E-853E4DD86583">
+        <di:waypoint x="4425" y="225"/>
+        <di:waypoint x="3200" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_59730883-C5AD-4838-A828-E36ED83F0A28" dmnElementRef="_59730883-C5AD-4838-A828-E36ED83F0A28">
+        <di:waypoint x="2150" y="225"/>
+        <di:waypoint x="1625" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8EA2F696-D099-4DD5-A67C-164D148824EB" dmnElementRef="_8EA2F696-D099-4DD5-A67C-164D148824EB">
+        <di:waypoint x="5125" y="225"/>
+        <di:waypoint x="3900" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E212024F-4A31-4516-A465-85A3181542B3" dmnElementRef="_E212024F-4A31-4516-A465-85A3181542B3">
+        <di:waypoint x="3025" y="225"/>
+        <di:waypoint x="1975" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_298E4FA3-A9DB-4B02-B878-C53CFE708DF1" dmnElementRef="_298E4FA3-A9DB-4B02-B878-C53CFE708DF1">
+        <di:waypoint x="5300" y="225"/>
+        <di:waypoint x="4250" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_1F343A9F-34AA-41DD-8134-8E23D7AB804E" dmnElementRef="_1F343A9F-34AA-41DD-8134-8E23D7AB804E">
+        <di:waypoint x="3200" y="225"/>
+        <di:waypoint x="2150" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_24FDD129-04BF-499F-8233-231FA35AF051" dmnElementRef="_24FDD129-04BF-499F-8233-231FA35AF051">
+        <di:waypoint x="5475" y="225"/>
+        <di:waypoint x="4775" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C16DA847-D4B4-4736-8E1C-6DD808688E92" dmnElementRef="_C16DA847-D4B4-4736-8E1C-6DD808688E92">
+        <di:waypoint x="4075" y="225"/>
+        <di:waypoint x="2850" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E5B24964-1B33-4DE5-9C63-82A62E974DEC" dmnElementRef="_E5B24964-1B33-4DE5-9C63-82A62E974DEC">
+        <di:waypoint x="1100" y="225"/>
+        <di:waypoint x="1100" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07" dmnElementRef="_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07">
+        <di:waypoint x="1275" y="225"/>
+        <di:waypoint x="1100" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3" dmnElementRef="_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3">
+        <di:waypoint x="1450" y="225"/>
+        <di:waypoint x="1100" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8B485F45-A12F-44FB-A72A-8F090678BDDD" dmnElementRef="_8B485F45-A12F-44FB-A72A-8F090678BDDD">
+        <di:waypoint x="1625" y="225"/>
+        <di:waypoint x="1100" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA" dmnElementRef="_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA">
+        <di:waypoint x="4950" y="225"/>
+        <di:waypoint x="3550" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F8800C29-3B28-4AE5-B2A2-0457F994F839" dmnElementRef="_F8800C29-3B28-4AE5-B2A2-0457F994F839">
+        <di:waypoint x="2325" y="225"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_386E4803-5F5F-4194-A8B5-F3534DFC7AD9" dmnElementRef="_386E4803-5F5F-4194-A8B5-F3534DFC7AD9">
+        <di:waypoint x="2500" y="225"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_D07DA03D-C33A-4807-8711-968E4853E0F1" dmnElementRef="_D07DA03D-C33A-4807-8711-968E4853E0F1">
+        <di:waypoint x="2675" y="225"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_32E47634-89BF-4AF3-A6B7-61AE25AB151B" dmnElementRef="_32E47634-89BF-4AF3-A6B7-61AE25AB151B">
+        <di:waypoint x="2850" y="225"/>
+        <di:waypoint x="1800" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C66633F4-6718-491C-9D40-8AFF21CE4CD5" dmnElementRef="_C66633F4-6718-491C-9D40-8AFF21CE4CD5">
+        <di:waypoint x="3725" y="225"/>
+        <di:waypoint x="2325" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_1893C895-D655-4607-81A5-363DE8DBD597" dmnElementRef="_1893C895-D655-4607-81A5-363DE8DBD597">
+        <di:waypoint x="3900" y="225"/>
+        <di:waypoint x="2325" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_D73018C3-F4DF-4B8A-946B-70692A2464DD" dmnElementRef="_D73018C3-F4DF-4B8A-946B-70692A2464DD">
+        <di:waypoint x="3375" y="225"/>
+        <di:waypoint x="2325" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_A9B18C1C-2D92-4A64-A936-3051A852D66F" dmnElementRef="_A9B18C1C-2D92-4A64-A936-3051A852D66F">
+        <di:waypoint x="3725" y="225"/>
+        <di:waypoint x="2675" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_A975CC18-C9EC-48A1-8691-26DDC2A81F45" dmnElementRef="_A975CC18-C9EC-48A1-8691-26DDC2A81F45">
+        <di:waypoint x="3900" y="225"/>
+        <di:waypoint x="2675" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F" dmnElementRef="_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F">
+        <di:waypoint x="4600" y="225"/>
+        <di:waypoint x="3025" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550" dmnElementRef="_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550">
+        <di:waypoint x="4775" y="225"/>
+        <di:waypoint x="3025" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_00254681-64B2-4809-95A3-1B7AFAC4D1ED" dmnElementRef="_00254681-64B2-4809-95A3-1B7AFAC4D1ED">
+        <di:waypoint x="4250" y="225"/>
+        <di:waypoint x="3025" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_80959823-0175-4165-8060-DFAAB74A1123" dmnElementRef="_80959823-0175-4165-8060-DFAAB74A1123">
+        <di:waypoint x="4600" y="225"/>
+        <di:waypoint x="3375" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_40616155-0E1B-4A83-A65A-2DB14DD7B65D" dmnElementRef="_40616155-0E1B-4A83-A65A-2DB14DD7B65D">
+        <di:waypoint x="4775" y="225"/>
+        <di:waypoint x="3375" y="50"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
 </dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
@@ -1,234 +1,242 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_BA898F11-9F63-4A74-AF32-235D82663253" name="x1" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820">
-   <dmn:extensionElements />
-   <dmn:itemDefinition id="_1A35CDE5-592B-4C7D-A302-15043E11830C" name="tGrade" isCollection="false">
-      <dmn:typeRef>string</dmn:typeRef>
-      <dmn:allowedValues kie:constraintType="enumeration" id="_E9560012-0F49-44D2-96D8-BA655980F315">
-         <dmn:text>"A", "B", "C", "D", "E", "F"</dmn:text>
-      </dmn:allowedValues>
-   </dmn:itemDefinition>
-   <dmn:decisionService id="_7A9C80F8-4A44-4080-9031-F28EA411A35C" name="Evaluation DS">
-      <dmn:extensionElements />
-      <dmn:variable id="_7D7F3394-69B4-46A6-BFED-4F71AFF6ABB3" name="Evaluation DS" />
-   </dmn:decisionService>
-   <dmn:decision id="_2770588B-EF63-490A-BA13-B21D4EB1926D" name="Graduation DT">
-      <dmn:extensionElements />
-      <dmn:variable id="_A41CE5F4-5B2F-490B-90A3-9E5F53ED5B01" name="Graduation DT" typeRef="string" />
-      <dmn:informationRequirement id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
-         <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
-      </dmn:informationRequirement>
-      <dmn:decisionTable id="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
-         <dmn:input id="_AF31943B-2A05-4F02-839A-4F1B6C5DC073">
-            <dmn:inputExpression id="_BB692782-9108-449A-9D15-27D06007E04E">
-               <dmn:text>Grade</dmn:text>
-            </dmn:inputExpression>
-         </dmn:input>
-         <dmn:output id="_5F1FEDAD-C742-445A-B194-47B0112573B8" />
-         <dmn:annotation name="" />
-         <dmn:rule id="_967C2799-CC1E-45C5-9F6B-BF3C2F5BCF36">
-            <dmn:inputEntry id="_47B77F78-DE9F-4CF3-A78D-AD274A951078">
-               <dmn:text>"A"</dmn:text>
-            </dmn:inputEntry>
-            <dmn:outputEntry id="_BF4EB2E1-51E3-4087-A9B4-5FB39F646CCB">
-               <dmn:text>"Graduated with merit"</dmn:text>
-            </dmn:outputEntry>
-            <dmn:annotationEntry>
-               <dmn:text />
-            </dmn:annotationEntry>
-         </dmn:rule>
-         <dmn:rule id="_CC4BEE1B-2A3D-4EE7-8C97-4382E8213EA0">
-            <dmn:inputEntry id="_1DA3FD5D-E479-4153-881A-4A087C9B7F9F">
-               <dmn:text>"B"</dmn:text>
-            </dmn:inputEntry>
-            <dmn:outputEntry id="_2B336B1E-F6FC-4742-9C43-77D1A21746FC">
-               <dmn:text>"Graduated"</dmn:text>
-            </dmn:outputEntry>
-            <dmn:annotationEntry>
-               <dmn:text />
-            </dmn:annotationEntry>
-         </dmn:rule>
-         <dmn:rule id="_95BBC24F-F50C-4D0E-A5B5-D07E328680C9">
-            <dmn:inputEntry id="_459FB1AA-8588-4C7B-AD2E-70A670569BD2">
-               <dmn:text>"C"</dmn:text>
-            </dmn:inputEntry>
-            <dmn:outputEntry id="_92D429DE-3FD9-4E9F-864B-F9147B040121">
-               <dmn:text>"Graduated"</dmn:text>
-            </dmn:outputEntry>
-            <dmn:annotationEntry>
-               <dmn:text />
-            </dmn:annotationEntry>
-         </dmn:rule>
-         <dmn:rule id="_161963E2-94C8-4391-A8BF-DEC458BEB62C">
-            <dmn:inputEntry id="_076CA1F7-DC4A-4D33-BAF9-3E3D0A4A3462">
-               <dmn:text>"D"</dmn:text>
-            </dmn:inputEntry>
-            <dmn:outputEntry id="_E14D7E3E-DA88-409E-8506-10A7EE1AC18D">
-               <dmn:text>"Not graduated"</dmn:text>
-            </dmn:outputEntry>
-            <dmn:annotationEntry>
-               <dmn:text />
-            </dmn:annotationEntry>
-         </dmn:rule>
-         <dmn:rule id="_A3513F68-6132-4535-95E0-739ACE67F456">
-            <dmn:inputEntry id="_F0479B26-22F1-4983-81A9-B53F7D8BCF41">
-               <dmn:text>"E"</dmn:text>
-            </dmn:inputEntry>
-            <dmn:outputEntry id="_04CFBB41-21E0-456F-B9E5-AB8070DA84C8">
-               <dmn:text>"Not graduated"</dmn:text>
-            </dmn:outputEntry>
-            <dmn:annotationEntry>
-               <dmn:text />
-            </dmn:annotationEntry>
-         </dmn:rule>
-         <dmn:rule id="_D9577634-8F7B-462D-BBAB-210F5FD586DC">
-            <dmn:inputEntry id="_79112C49-AD12-42B1-B056-8210E5AABF9A">
-               <dmn:text>"F"</dmn:text>
-            </dmn:inputEntry>
-            <dmn:outputEntry id="_7C07ED74-5578-4906-B542-D294C426B2B9">
-               <dmn:text>"Not graduated"</dmn:text>
-            </dmn:outputEntry>
-            <dmn:annotationEntry>
-               <dmn:text />
-            </dmn:annotationEntry>
-         </dmn:rule>
-      </dmn:decisionTable>
-   </dmn:decision>
-   <dmn:decision id="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" name="Graduation result">
-      <dmn:extensionElements />
-      <dmn:variable id="_5F80DA91-A764-42C4-A526-3CADCD34E856" name="Graduation result" typeRef="string" />
-      <dmn:informationRequirement id="_2770588B-EF63-490A-BA13-B21D4EB1926D">
-         <dmn:requiredDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
-         <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
-         <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
-      </dmn:informationRequirement>
-      <dmn:informationRequirement id="_0C226138-201A-4073-8ED4-F28FA2A1BC64">
-         <dmn:requiredDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64" />
-      </dmn:informationRequirement>
-      <dmn:literalExpression id="_7C49F288-73F5-41AB-97D8-C569099B2CC7">
-         <dmn:text>Student's name + " is " + Graduation DT + " with grade: " + Grade + " and evaluation: " + Teacher's Evaluation</dmn:text>
-      </dmn:literalExpression>
-   </dmn:decision>
-   <dmn:decision id="_0C226138-201A-4073-8ED4-F28FA2A1BC64" name="Teacher's Evaluation">
-      <dmn:extensionElements />
-      <dmn:variable id="_A2732FC7-2D94-4EFE-9A70-5A5D5F0EDCA3" name="Teacher's Evaluation" />
-      <dmn:informationRequirement id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
-         <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
-      </dmn:informationRequirement>
-      <dmn:authorityRequirement id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32">
-         <dmn:requiredAuthority href="#_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" />
-      </dmn:authorityRequirement>
-   </dmn:decision>
-   <dmn:knowledgeSource id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" name="Teacher's knowledge" locationURI="">
-      <dmn:extensionElements />
-      <dmn:type />
-   </dmn:knowledgeSource>
-   <dmn:inputData id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" name="Student's name">
-      <dmn:extensionElements />
-      <dmn:variable id="_9114ABD1-CD57-4E59-B6C7-FE7CD5AB1EFD" name="Student's name" typeRef="string" />
-   </dmn:inputData>
-   <dmn:inputData id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" name="Grade">
-      <dmn:extensionElements />
-      <dmn:variable id="_22CC6AB7-BBB7-4F30-AFB3-FA67486F2DBA" name="Grade" typeRef="tGrade" />
-   </dmn:inputData>
-   <dmndi:DMNDI>
-      <dmndi:DMNDiagram id="_52995918-2649-4B81-866F-D0887B927DF5" name="DRG">
-         <di:extension>
-            <kie:ComponentsWidthsExtension>
-               <kie:ComponentWidths dmnElementRef="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" />
-               <kie:ComponentWidths dmnElementRef="_7C49F288-73F5-41AB-97D8-C569099B2CC7" />
-            </kie:ComponentsWidthsExtension>
-         </di:extension>
-         <dmndi:DMNShape id="dmnshape-drg-_7A9C80F8-4A44-4080-9031-F28EA411A35C" dmnElementRef="_7A9C80F8-4A44-4080-9031-F28EA411A35C" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="313" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-            <dmndi:DMNDecisionServiceDividerLine>
-               <di:waypoint x="313" y="150" />
-               <di:waypoint x="413" y="150" />
-            </dmndi:DMNDecisionServiceDividerLine>
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="313" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" dmnElementRef="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="138" y="50" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="138" y="225" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="50" y="400" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="225" y="400" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNShape id="dmnshape-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" isCollapsed="false">
-            <dmndi:DMNStyle>
-               <dmndi:FillColor red="255" green="255" blue="255" />
-               <dmndi:StrokeColor red="0" green="0" blue="0" />
-               <dmndi:FontColor red="0" green="0" blue="0" />
-            </dmndi:DMNStyle>
-            <dc:Bounds x="400" y="400" width="100" height="50" />
-            <dmndi:DMNLabel />
-         </dmndi:DMNShape>
-         <dmndi:DMNEdge id="dmnedge-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C">
-            <di:waypoint x="400" y="400" />
-            <di:waypoint x="313" y="225" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D">
-            <di:waypoint x="313" y="225" />
-            <di:waypoint x="138" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794">
-            <di:waypoint x="225" y="400" />
-            <di:waypoint x="138" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64">
-            <di:waypoint x="138" y="225" />
-            <di:waypoint x="138" y="50" />
-         </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32">
-            <di:waypoint x="50" y="400" />
-            <di:waypoint x="138" y="225" />
-         </dmndi:DMNEdge>
-      </dmndi:DMNDiagram>
-   </dmndi:DMNDI>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_BA898F11-9F63-4A74-AF32-235D82663253" name="x1" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_1A35CDE5-592B-4C7D-A302-15043E11830C" name="tGrade" isCollection="false">
+    <dmn:typeRef>string</dmn:typeRef>
+    <dmn:allowedValues kie:constraintType="enumeration" id="_E9560012-0F49-44D2-96D8-BA655980F315">
+      <dmn:text>"A", "B", "C", "D", "E", "F"</dmn:text>
+    </dmn:allowedValues>
+  </dmn:itemDefinition>
+  <dmn:decisionService id="_7A9C80F8-4A44-4080-9031-F28EA411A35C" name="Evaluation DS">
+    <dmn:extensionElements/>
+    <dmn:variable id="_7D7F3394-69B4-46A6-BFED-4F71AFF6ABB3" name="Evaluation DS"/>
+  </dmn:decisionService>
+  <dmn:decision id="_2770588B-EF63-490A-BA13-B21D4EB1926D" name="Graduation DT">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A41CE5F4-5B2F-490B-90A3-9E5F53ED5B01" name="Graduation DT" typeRef="string"/>
+    <dmn:informationRequirement id="_84729018-9BDD-4607-B235-1806B18C89BB">
+      <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_AF31943B-2A05-4F02-839A-4F1B6C5DC073">
+        <dmn:inputExpression id="_BB692782-9108-449A-9D15-27D06007E04E">
+          <dmn:text>Grade</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_5F1FEDAD-C742-445A-B194-47B0112573B8"/>
+      <dmn:annotation name=""/>
+      <dmn:rule id="_967C2799-CC1E-45C5-9F6B-BF3C2F5BCF36">
+        <dmn:inputEntry id="_47B77F78-DE9F-4CF3-A78D-AD274A951078">
+          <dmn:text>"A"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_BF4EB2E1-51E3-4087-A9B4-5FB39F646CCB">
+          <dmn:text>"Graduated with merit"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text></dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_CC4BEE1B-2A3D-4EE7-8C97-4382E8213EA0">
+        <dmn:inputEntry id="_1DA3FD5D-E479-4153-881A-4A087C9B7F9F">
+          <dmn:text>"B"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_2B336B1E-F6FC-4742-9C43-77D1A21746FC">
+          <dmn:text>"Graduated"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text></dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_95BBC24F-F50C-4D0E-A5B5-D07E328680C9">
+        <dmn:inputEntry id="_459FB1AA-8588-4C7B-AD2E-70A670569BD2">
+          <dmn:text>"C"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_92D429DE-3FD9-4E9F-864B-F9147B040121">
+          <dmn:text>"Graduated"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text></dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_161963E2-94C8-4391-A8BF-DEC458BEB62C">
+        <dmn:inputEntry id="_076CA1F7-DC4A-4D33-BAF9-3E3D0A4A3462">
+          <dmn:text>"D"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_E14D7E3E-DA88-409E-8506-10A7EE1AC18D">
+          <dmn:text>"Not graduated"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text></dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_A3513F68-6132-4535-95E0-739ACE67F456">
+        <dmn:inputEntry id="_F0479B26-22F1-4983-81A9-B53F7D8BCF41">
+          <dmn:text>"E"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_04CFBB41-21E0-456F-B9E5-AB8070DA84C8">
+          <dmn:text>"Not graduated"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text></dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_D9577634-8F7B-462D-BBAB-210F5FD586DC">
+        <dmn:inputEntry id="_79112C49-AD12-42B1-B056-8210E5AABF9A">
+          <dmn:text>"F"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_7C07ED74-5578-4906-B542-D294C426B2B9">
+          <dmn:text>"Not graduated"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text></dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:decision id="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" name="Graduation result">
+    <dmn:extensionElements/>
+    <dmn:variable id="_5F80DA91-A764-42C4-A526-3CADCD34E856" name="Graduation result" typeRef="string"/>
+    <dmn:informationRequirement id="_92B8883D-CEFA-4379-90F9-3C0F42E0569F">
+      <dmn:requiredDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76">
+      <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_E7DA2900-46F8-4DC1-BCF7-2E928619926A">
+      <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_92B4D37C-3DCB-4BD2-A4E8-28465566C79E">
+      <dmn:requiredDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_7C49F288-73F5-41AB-97D8-C569099B2CC7">
+      <dmn:text>Student's name + " is " + Graduation DT + " with grade: " + Grade + " and evaluation: " + Teacher's Evaluation</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_0C226138-201A-4073-8ED4-F28FA2A1BC64" name="Teacher's Evaluation">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A2732FC7-2D94-4EFE-9A70-5A5D5F0EDCA3" name="Teacher's Evaluation"/>
+    <dmn:informationRequirement id="_E7C0F865-D014-4005-B313-6FA55BD4203C">
+      <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794"/>
+    </dmn:informationRequirement>
+    <dmn:authorityRequirement id="_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249">
+      <dmn:requiredAuthority href="#_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32"/>
+    </dmn:authorityRequirement>
+  </dmn:decision>
+  <dmn:knowledgeSource id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" name="Teacher's knowledge" locationURI="">
+    <dmn:extensionElements/>
+    <dmn:type></dmn:type>
+  </dmn:knowledgeSource>
+  <dmn:inputData id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" name="Student's name">
+    <dmn:extensionElements/>
+    <dmn:variable id="_9114ABD1-CD57-4E59-B6C7-FE7CD5AB1EFD" name="Student's name" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:inputData id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" name="Grade">
+    <dmn:extensionElements/>
+    <dmn:variable id="_22CC6AB7-BBB7-4F30-AFB3-FA67486F2DBA" name="Grade" typeRef="tGrade"/>
+  </dmn:inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_329FD8A1-95D6-4199-AB25-F5FCFEB4E6C5" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02"/>
+          <kie:ComponentWidths dmnElementRef="_7C49F288-73F5-41AB-97D8-C569099B2CC7"/>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_7A9C80F8-4A44-4080-9031-F28EA411A35C" dmnElementRef="_7A9C80F8-4A44-4080-9031-F28EA411A35C" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="313" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="313" y="150"/>
+          <di:waypoint x="413" y="150"/>
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="313" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" dmnElementRef="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="138" y="50" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="138" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="50" y="400" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="225" y="400" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="400" y="400" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_84729018-9BDD-4607-B235-1806B18C89BB" dmnElementRef="_84729018-9BDD-4607-B235-1806B18C89BB">
+        <di:waypoint x="400" y="400"/>
+        <di:waypoint x="313" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_92B8883D-CEFA-4379-90F9-3C0F42E0569F" dmnElementRef="_92B8883D-CEFA-4379-90F9-3C0F42E0569F">
+        <di:waypoint x="313" y="225"/>
+        <di:waypoint x="138" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76" dmnElementRef="_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76">
+        <di:waypoint x="225" y="400"/>
+        <di:waypoint x="138" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E7DA2900-46F8-4DC1-BCF7-2E928619926A" dmnElementRef="_E7DA2900-46F8-4DC1-BCF7-2E928619926A">
+        <di:waypoint x="400" y="400"/>
+        <di:waypoint x="138" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_92B4D37C-3DCB-4BD2-A4E8-28465566C79E" dmnElementRef="_92B4D37C-3DCB-4BD2-A4E8-28465566C79E">
+        <di:waypoint x="138" y="225"/>
+        <di:waypoint x="138" y="50"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_E7C0F865-D014-4005-B313-6FA55BD4203C" dmnElementRef="_E7C0F865-D014-4005-B313-6FA55BD4203C">
+        <di:waypoint x="225" y="400"/>
+        <di:waypoint x="138" y="225"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249" dmnElementRef="_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249">
+        <di:waypoint x="50" y="400"/>
+        <di:waypoint x="138" y="225"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
 </dmn:definitions>


### PR DESCRIPTION
**JIRA**: [KOGITO-4197](https://issues.redhat.com/browse/KOGITO-4197) - [DMN Designer] DMN 1.1 model can not be fixed to proper DMN 1.2

**VS Code**: [plugin](https://www.dropbox.com/s/849xubznssst8zx/plugin-KOGITO-4197.vsix?dl=0)

The fix lives into https://github.com/kiegroup/kie-wb-common/pull/3543/commits/f9fcb0ed26a5dd00639d741587d5df54431d851e and https://github.com/kiegroup/kie-wb-common/pull/3543/commits/44f341fd059f3f254943f6ea26cee456de987f44 (the rest of this PR introduce updates in the test suite assets).

<img width="1710" alt="Screen Shot 2021-01-18 at 20 00 11" src="https://user-images.githubusercontent.com/1079279/104954017-d1505980-59c7-11eb-8c16-b993452749aa.png">

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
