### PR TITLE
[7.48.x]JBPM-8153 Container is removed from UI even though it was not possible to stop it.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/src/main/java/org/kie/workbench/common/screens/server/management/service/ContainerService.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/src/main/java/org/kie/workbench/common/screens/server/management/service/ContainerService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.server.management.service;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+
+@Remote
+public interface ContainerService {
+
+    /**
+     * Return true, when the Container has Process Definition and Process instance.
+     * @param containerSpec
+     * @return
+     */
+    boolean isRunningContainer(ContainerSpec containerSpec);
+
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.server.management.backend.service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.QueryServicesClient;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.impl.KieServerInstanceManager;
+import org.kie.server.controller.api.service.SpecManagementService;
+import org.kie.workbench.common.screens.server.management.service.ContainerService;
+
+@Service
+@ApplicationScoped
+public class ContainerServiceImpl implements ContainerService {
+
+    private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
+
+    @Inject
+    @Any
+    private SpecManagementService specManagementService;
+
+    @Override
+    public boolean isRunningContainer(ContainerSpec containerSpec) {
+        ServerTemplate serverTemplate = specManagementService.getServerTemplate(containerSpec.getServerTemplateKey().getId());
+        AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+        for (ServerInstanceKey serverInstanceKey : serverTemplate.getServerInstanceKeys()) {
+            KieServicesClient client = kieServerInstanceManager.getClient(serverInstanceKey.getUrl());
+
+            QueryServicesClient queryServicesClient = client.getServicesClient(QueryServicesClient.class);
+            List<ProcessInstance> processInstances = queryServicesClient.findProcessInstancesByContainerId(containerSpec.getId(), Arrays.asList(0, 1, 4), 0, 100);
+
+            if (!processInstances.isEmpty()) {
+                atomicBoolean.set(true);
+                break;
+            }
+        }
+
+        return atomicBoolean.get();
+    }
+
+    protected void setKieServerInstanceManager(KieServerInstanceManager kieServerInstanceManager) {
+        this.kieServerInstanceManager = kieServerInstanceManager;
+    }
+
+    protected void setSpecManagementService(SpecManagementService specManagementService) {
+        this.specManagementService = specManagementService;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/service/ContainerServiceImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.server.management.backend.service;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.QueryServicesClient;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.kie.server.controller.api.service.SpecManagementService;
+import org.kie.server.controller.impl.KieServerInstanceManager;
+import org.kie.workbench.common.screens.server.management.service.ContainerService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContainerServiceImplTest {
+
+    @Mock
+    SpecManagementService specManagementService ;
+
+    @Mock
+    KieServerInstanceManager kieServerInstanceManager;
+
+    private ContainerService containerService;
+
+    @Before
+    public void init() {
+        containerService = spy(new ContainerServiceImpl());
+        ((ContainerServiceImpl) containerService).setSpecManagementService(specManagementService);
+        ((ContainerServiceImpl) containerService).setKieServerInstanceManager(kieServerInstanceManager);
+    }
+
+    @Test
+    public void testIsRunningContainer() {
+        ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        doReturn(serverTemplate).when(specManagementService).getServerTemplate(any());
+        when(serverTemplate.getServerInstanceKeys()).thenReturn(Arrays.asList(new ServerInstanceKey("test", "test", "test", "test")));
+
+        QueryServicesClient queryServicesClient = mock(QueryServicesClient.class);
+        KieServicesClient client = mock(KieServicesClient.class);
+        when(kieServerInstanceManager.getClient(any())).thenReturn(client);
+        when(client.getServicesClient(QueryServicesClient.class)).thenReturn(queryServicesClient);
+        when(queryServicesClient.findProcessInstancesByContainerId("test", Arrays.asList(0, 1, 4), 0, 100)).thenReturn(Arrays.asList(new ProcessInstance()));
+        boolean runningResult = containerService.isRunningContainer(new ContainerSpec("test", "", new ServerTemplateKey("1", "test"), null, null, null));
+
+        assertEquals(true, runningResult);
+
+        when(queryServicesClient.findProcessInstancesByContainerId("test", Arrays.asList(0, 1, 4), 0, 100)).thenReturn(Collections.emptyList());
+        boolean result = containerService.isRunningContainer(new ContainerSpec("test", "", new ServerTemplateKey("1", "test"), null, null, null));
+        assertEquals(false, result);
+
+        when(queryServicesClient.findProcessesByContainerId("test", 0, 10)).thenReturn(Collections.emptyList());
+        assertEquals(false, result);
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenter.java
@@ -49,6 +49,7 @@ import org.kie.workbench.common.screens.server.management.client.util.State;
 import org.kie.workbench.common.screens.server.management.model.ContainerRuntimeOperation;
 import org.kie.workbench.common.screens.server.management.model.ContainerSpecData;
 import org.kie.workbench.common.screens.server.management.model.ContainerUpdateEvent;
+import org.kie.workbench.common.screens.server.management.service.ContainerService;
 import org.kie.workbench.common.screens.server.management.service.RuntimeManagementService;
 import org.kie.workbench.common.screens.server.management.service.SpecManagementService;
 import org.slf4j.Logger;
@@ -73,6 +74,7 @@ public class ContainerPresenter {
     private final Event<ServerTemplateSelected> serverTemplateSelectedEvent;
     private final Event<NotificationEvent> notification;
     private ContainerSpec containerSpec;
+    private final Caller<ContainerService> containerService;
 
     @Inject
     public ContainerPresenter(final Logger logger,
@@ -84,7 +86,8 @@ public class ContainerPresenter {
                               final Caller<RuntimeManagementService> runtimeManagementService,
                               final Caller<SpecManagementService> specManagementService,
                               final Event<ServerTemplateSelected> serverTemplateSelectedEvent,
-                              final Event<NotificationEvent> notification) {
+                              final Event<NotificationEvent> notification,
+                              final Caller<ContainerService> containerService) {
         this.logger = logger;
         this.view = view;
         this.containerRemoteStatusPresenter = containerRemoteStatusPresenter;
@@ -95,6 +98,7 @@ public class ContainerPresenter {
         this.specManagementService = specManagementService;
         this.serverTemplateSelectedEvent = serverTemplateSelectedEvent;
         this.notification = notification;
+        this.containerService = containerService;
     }
 
     @PostConstruct
@@ -286,22 +290,28 @@ public class ContainerPresenter {
     }
 
     public void stopContainer() {
-        specManagementService.call(new RemoteCallback<Void>() {
-                                       @Override
-                                       public void callback(final Void response) {
-                                           updateStatus(KieContainerStatus.STOPPED);
-                                       }
-                                   },
-                                   new ErrorCallback<Object>() {
-                                       @Override
-                                       public boolean error(final Object o,
-                                                            final Throwable throwable) {
-                                           notification.fire(new NotificationEvent(view.getStopContainerErrorMessage(),
-                                                                                   NotificationEvent.NotificationType.ERROR));
-                                           updateStatus(KieContainerStatus.STARTED);
-                                           return false;
-                                       }
-                                   }).stopContainer(containerSpec);
+        containerService.call(response -> {
+            if (Boolean.FALSE.equals((Boolean) response)) {
+                specManagementService.call(new RemoteCallback<Void>() {
+                                               @Override
+                                               public void callback(final Void response) {
+                                                   updateStatus(KieContainerStatus.STOPPED);
+                                               }
+                                           },
+                                           new ErrorCallback<Object>() {
+                                               @Override
+                                               public boolean error(final Object o,
+                                                                    final Throwable throwable) {
+                                                   notification.fire(new NotificationEvent(view.getStopContainerErrorMessage(),
+                                                                                           NotificationEvent.NotificationType.ERROR));
+                                                   updateStatus(KieContainerStatus.STARTED);
+                                                   return false;
+                                               }
+                                           }).stopContainer(containerSpec);
+            } else {
+                notification.fire(new NotificationEvent(view.getCanNotStopContainerMessage(), NotificationEvent.NotificationType.WARNING));
+            }
+        }).isRunningContainer(containerSpec);
     }
 
     public void startContainer() {
@@ -401,5 +411,7 @@ public class ContainerPresenter {
         String getStopContainerErrorMessage();
 
         String getStartContainerErrorMessage();
+
+        String getCanNotStopContainerMessage();
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerView.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/ContainerView.java
@@ -269,10 +269,15 @@ public class ContainerView extends Composite
     public String getStopContainerErrorMessage() {
         return translationService.format(Constants.ContainerView_StopContainerErrorMessage);
     }
-
+    
     @Override
     public String getStartContainerErrorMessage() {
         return translationService.format(Constants.ContainerView_StartContainerErrorMessage);
+    }
+
+    @Override
+    public String getCanNotStopContainerMessage() {
+        return translationService.format(Constants.CanNot_Stop_Container);
     }
 
     private String getConfirmRemovePopupMessage() {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.java
@@ -250,4 +250,7 @@ public class Constants {
 
     @TranslationKey(defaultValue = "")
     public static final String NewContainer_Deploying = "NewContainer.Deploying";
+
+    @TranslationKey(defaultValue = "")
+    public static final String CanNot_Stop_Container = "CanNot_Stop_Container";
 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/resources/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.properties
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/resources/org/kie/workbench/common/screens/server/management/client/resources/i18n/Constants.properties
@@ -152,3 +152,4 @@ NewContainer.GAVNotExist.Save=GAV '{0}' not found in the Maven repository. Are y
 NewContainer.Save=Ok
 NewContainer.SaveContainerSpec=Save Container Spec
 NewContainer.Deploying={0} is deploying
+CanNot_Stop_Container=It is not possible to stop the container due to running process instance.

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/container/ContainerPresenterTest.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.screens.server.management.client.util.State;
 import org.kie.workbench.common.screens.server.management.model.ContainerRuntimeOperation;
 import org.kie.workbench.common.screens.server.management.model.ContainerSpecData;
 import org.kie.workbench.common.screens.server.management.model.ContainerUpdateEvent;
+import org.kie.workbench.common.screens.server.management.service.ContainerService;
 import org.kie.workbench.common.screens.server.management.service.RuntimeManagementService;
 import org.kie.workbench.common.screens.server.management.service.SpecManagementService;
 import org.mockito.ArgumentCaptor;
@@ -82,6 +83,8 @@ public class ContainerPresenterTest {
 
     Caller<SpecManagementService> specManagementServiceCaller;
 
+    Caller<ContainerService> containerServiceCaller;
+
     @Mock
     SpecManagementService specManagementService;
 
@@ -106,6 +109,9 @@ public class ContainerPresenterTest {
     @Mock
     ContainerProcessConfigPresenter containerProcessConfigPresenter;
 
+    @Mock
+    ContainerService containerService;
+
     ContainerPresenter presenter;
 
     ReleaseId releaseId;
@@ -122,6 +128,7 @@ public class ContainerPresenterTest {
     public void init() {
         runtimeManagementServiceCaller = new CallerMock<RuntimeManagementService>(runtimeManagementService);
         specManagementServiceCaller = new CallerMock<SpecManagementService>(specManagementService);
+        containerServiceCaller = new CallerMock<ContainerService>(containerService) ;
         doNothing().when(serverTemplateSelectedEvent).fire(any(ServerTemplateSelected.class));
         doNothing().when(notification).fire(any(NotificationEvent.class));
         when(containerStatusEmptyPresenter.getView()).thenReturn(containerStatusEmptyPresenterView);
@@ -136,7 +143,8 @@ public class ContainerPresenterTest {
                 runtimeManagementServiceCaller,
                 specManagementServiceCaller,
                 serverTemplateSelectedEvent,
-                notification));
+                notification,
+                containerServiceCaller));
 
         releaseId = new ReleaseId("org.kie",
                                   "container",
@@ -220,6 +228,7 @@ public class ContainerPresenterTest {
 
     @Test
     public void testStopContainer() {
+        when(containerService.isRunningContainer(any())).thenReturn(false);
         presenter.loadContainers(containerSpecData);
 
         presenter.stopContainer();
@@ -241,8 +250,15 @@ public class ContainerPresenterTest {
         verify(view).setContainerStartState(State.ENABLED);
         verify(view).setContainerStopState(State.DISABLED);
         verify(view).disableRemoveButton();
+
+        when(containerService.isRunningContainer(any())).thenReturn(true);
+        final String canNotStopMessage = "can not stop";
+        when(view.getCanNotStopContainerMessage()).thenReturn(canNotStopMessage);
+        presenter.stopContainer();
+        verify(notification).fire(new NotificationEvent(canNotStopMessage, NotificationEvent.NotificationType.WARNING));
+        verify(specManagementService, times(2)).stopContainer(any());
     }
-    
+
     @Test
     public void testDeactivateContainerFromStopedState() {
         presenter.loadContainers(containerSpecData);


### PR DESCRIPTION
…e to stop it.

**Thank you for submitting this pull request**

**JIRA**: [JBPM-8153](https://issues.redhat.com/browse/JBPM-8153)

**Referenced Pull Requests**:
* https://github.com/kiegroup/droolsjbpm-integration/pull/2386
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
