### PR TITLE
AF-2795: use managed jackson-databind version

### DIFF
--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/projects/dummy_deps_complex/dummyB/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/projects/dummy_deps_complex/dummyB/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version>
+      <version>${version.com.fasterxml.jackson.databind}</version>
     </dependency>
   </dependencies>
   <build>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-maven-plugins-testing/src/test/projects/dummy_deps_complex/dummyB/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-maven-plugins-testing/src/test/projects/dummy_deps_complex/dummyB/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version>
+      <version>${version.com.fasterxml.jackson.databind}</version>
     </dependency>
   </dependencies>
   <build>

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/projects/dummy_deps_complex/dummyB/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/projects/dummy_deps_complex/dummyB/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version>
+      <version>${version.com.fasterxml.jackson.databind}</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Use 'version.com.fasterxml.jackson.databind' from https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/pom.xml to fix issue reproted by dependabot

For more details see: https://issues.redhat.com/browse/AF-2795

**Thank you for submitting this pull request**

**JIRA**: [JBPM-0000](https://issues.redhat.com/browse/JBPM-0000)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
