### PR TITLE
KOGITO-4155: BPMN Editor - Cannot properly edit Expressions in the Data Assignments

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorViewImpl.java
@@ -58,7 +58,7 @@ public class ActivityDataIOEditorViewImpl extends BaseModal implements ActivityD
 
     private Column column = new Column(ColumnSize.MD_12);
 
-    public static final int EXPRESSION_MAX_DISPLAY_LENGTH = 10;
+    public static final int EXPRESSION_MAX_DISPLAY_LENGTH = 65;
 
     public ActivityDataIOEditorViewImpl() {
         super();
@@ -93,6 +93,7 @@ public class ActivityDataIOEditorViewImpl extends BaseModal implements ActivityD
         btnCancel.addClickHandler(event -> presenter.handleCancelClick());
         btnColumn.add(btnCancel);
         container.add(btnRow);
+        setWidth("1200px");
         setBody(container);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/ActivityDataIOEditorWidget.html
@@ -51,24 +51,24 @@
                         </thead>
                         <tbody id="assignments">
                         <tr id="assignment">
-                            <td>
-                                <input type="text" class="form-control" style="width: 11em;" data-field="name"/>
+                            <td style="width:200px">
+                                <input type="text" class="form-control" style="width: 100%" data-field="name"/>
                             </td>
-                            <td>
-                                <select data-field="dataType" class="form-control" style="width: 11em;">
+                            <td style="width:380px">
+                                <select data-field="dataType" class="form-control" style="width: 100%;">
                                     <option value="Integer">Integer</option>
                                     <option value="String">String</option>
                                 </select>
-                                <input type="text" class="form-control" style="width: 11em;" data-field="customDataType"/>
+                                <input type="text" class="form-control" style="width: 100%;" data-field="customDataType"/>
                             </td>
                             <td>
-                                <select data-field="processVar" class="form-control" style="width: 11em;">
+                                <select data-field="processVar" class="form-control" style="width: 100%;">
                                     <option value="Var1">Var1</option>
                                     <option value="Var2">Var2</option>
                                 </select>
-                                <input type="text" class="form-control" style="width: 11em;" data-field="expression"/>
+                                <input type="text" class="form-control" style="width: 100%;" data-field="expression"/>
                             </td>
-                            <td>
+                            <td style="width:30px">
                                 <button type="button" class="center-block btn btn-danger" data-field="deleteButton"></button>
                             </td>
                         </tr>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValues.java
@@ -31,11 +31,11 @@ import static org.kie.workbench.common.stunner.core.util.StringUtils.isQuoted;
  */
 public class ListBoxValues {
 
-    protected List<String> acceptableValuesWithCustomValues = new ArrayList<String>();
-    protected List<String> acceptableValuesWithoutCustomValues = new ArrayList<String>();
-    protected List<String> customValues = new ArrayList<String>();
+    protected List<String> acceptableValuesWithCustomValues = new ArrayList<>();
+    protected List<String> acceptableValuesWithoutCustomValues = new ArrayList<>();
+    protected List<String> customValues = new ArrayList<>();
 
-    protected Map<String, String> mapDisplayValuesToValues = new HashMap<String, String>();
+    protected Map<String, String> mapDisplayValuesToValues = new HashMap<>();
 
     protected String customPrompt;
     protected String editPrefix;
@@ -144,14 +144,14 @@ public class ListBoxValues {
             String newDisplayValue = addDisplayValue(newValue);
             if (!acceptableValuesWithCustomValues.contains(newDisplayValue)) {
                 int index = 1;
-                if (acceptableValuesWithCustomValues.size() < 1) {
-                    index = acceptableValuesWithCustomValues.size();
+                if (acceptableValuesWithCustomValues.isEmpty()) {
+                    index = 0;
                 }
                 acceptableValuesWithCustomValues.add(index,
                                                      newDisplayValue);
             }
             if (!customValues.contains(newDisplayValue)) {
-                customValues.add(newDisplayValue);
+                customValues.add(newValue);
             }
             return newDisplayValue;
         } else {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/assignmentsEditor/AssignmentListItemWidgetTest.java
@@ -339,7 +339,7 @@ public class AssignmentListItemWidgetTest {
                                                                   ActivityDataIOEditorViewImpl.EXPRESSION_MAX_DISPLAY_LENGTH);
         processVarComboBox.setAddCustomValues(true);
         processVarComboBox.setListBoxValues(processVarListBoxValues);
-        String sConstant = "\"abcdeabcde12345\"";
+        String sConstant = "\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234567890\"";
         widget.setExpression(sConstant);
         widget.setProcessVariables(processVarListBoxValues);
         verify(processVarComboBox,
@@ -348,6 +348,6 @@ public class AssignmentListItemWidgetTest {
                times(2)).setListBoxValues(any(ListBoxValues.class));
         verify(processVarComboBox).addCustomValueToListBoxValues(sConstant,
                                                                  "");
-        verify(processVar).setValue("\"abcdeabcde...\"");
+        verify(processVar).setValue("\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde12345...\"");
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/ListBoxValuesTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 public class ListBoxValuesTest {
 
     final String EMPTY_STRING = "";
+    final String EDIT = "Edit ";
     final String CUSTOM_VALUE = "Custom Value";
     final String EDIT_CUSTOM_VALUE = "Edit Custom Value ...";
 
@@ -51,7 +52,7 @@ public class ListBoxValuesTest {
                 "performance"
         );
         ListBoxValues processVarValues = new ListBoxValues("Constant ...",
-                                                           "Edit ",
+                                                           EDIT,
                                                            null);
         processVarValues.addValues(processVarStartValues);
         processVarValues.addCustomValue("\"abc\"",
@@ -116,14 +117,12 @@ public class ListBoxValuesTest {
     @Test
     public void testDataTypeListBoxValues() {
         ListBoxValues dataTypeValues = new ListBoxValues("Custom ...",
-                                                         "Edit ",
-                                                         new ListBoxValues.ValueTester() {
-                                                             public String getNonCustomValueForUserString(String userValue) {
-                                                                 if (assignmentData1 != null) {
-                                                                     return assignmentData1.getDataTypeDisplayNameForUserString(userValue);
-                                                                 } else {
-                                                                     return null;
-                                                                 }
+                                                         EDIT,
+                                                         userValue -> {
+                                                             if (assignmentData1 != null) {
+                                                                 return assignmentData1.getDataTypeDisplayNameForUserString(userValue);
+                                                             } else {
+                                                                 return null;
                                                              }
                                                          });
         dataTypeValues.addValues(assignmentData1.getDataTypeDisplayNames());
@@ -191,15 +190,22 @@ public class ListBoxValuesTest {
     }
 
     @Test
+    public void testSetEditPromptForLongValues() {
+        ListBoxValues processVarValues = new ListBoxValues("Expression ...",
+                                                           EDIT,
+                                                           null,
+                                                           ActivityDataIOEditorViewImpl.EXPRESSION_MAX_DISPLAY_LENGTH);
+        String value = "\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234567890\"";
+        processVarValues.addCustomValue(value, "");
+        String displayValue = processVarValues.getDisplayNameForValue(value);
+        List<String> values = processVarValues.update(displayValue);
+        assertTrue("ListBox values doesn't contain Edit message for long value", values.contains(EDIT + displayValue + " ..."));
+    }
+
+    @Test
     public void testAddDisplayValue() {
-        List<String> processVarStartValues = Arrays.asList(
-                "** Variable Definitions **",
-                "employee",
-                "reason",
-                "performance"
-        );
-        ListBoxValues processVarValues = new ListBoxValues("Constant ...",
-                                                           "Edit ",
+        ListBoxValues processVarValues = new ListBoxValues("Expression ...",
+                                                           EDIT,
                                                            null,
                                                            ActivityDataIOEditorViewImpl.EXPRESSION_MAX_DISPLAY_LENGTH);
         // not double-quoted string - displayValue is the same
@@ -218,7 +224,7 @@ public class ListBoxValuesTest {
         Assert.assertEquals(value,
                             displayValue);
         // value less than MAX and a quoted string - displayValue is the same
-        value = "\"abcdeabcde\"";
+        value = "\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde12345\"";
         displayValue = processVarValues.addDisplayValue(value);
         Assert.assertEquals(value,
                             displayValue);
@@ -233,34 +239,34 @@ public class ListBoxValuesTest {
         Assert.assertEquals(value,
                             displayValue);
         // value longer than MAX and a quoted string - displayValue is truncated with "(01)"
-        value = "\"abcdeabcde1\"";
+        value = "\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234567890\"";
         displayValue = processVarValues.addDisplayValue(value);
-        Assert.assertEquals("\"abcdeabcde...(01)\"",
+        Assert.assertEquals("\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde12345...(01)\"",
                             displayValue);
         // value longer than MAX and a quoted string - displayValue is 1st truncated
-        value = "\"0123456789x\"";
+        value = "\"01234567890123456789012345678901234567890123456789012345678901234x\"";
         displayValue = processVarValues.addDisplayValue(value);
-        Assert.assertEquals("\"0123456789...\"",
+        Assert.assertEquals("\"01234567890123456789012345678901234567890123456789012345678901234...\"",
                             displayValue);
         // value longer than MAX and a quoted string - displayValue is 2nd truncated
-        value = "\"0123456789y\"";
+        value = "\"01234567890123456789012345678901234567890123456789012345678901234y\"";
         displayValue = processVarValues.addDisplayValue(value);
-        Assert.assertEquals("\"0123456789...(01)\"",
+        Assert.assertEquals("\"01234567890123456789012345678901234567890123456789012345678901234...(01)\"",
                             displayValue);
         // value longer than MAX and a quoted string - displayValue is 3rd truncated
-        value = "\"0123456789z\"";
+        value = "\"01234567890123456789012345678901234567890123456789012345678901234z\"";
         displayValue = processVarValues.addDisplayValue(value);
-        Assert.assertEquals("\"0123456789...(02)\"",
+        Assert.assertEquals("\"01234567890123456789012345678901234567890123456789012345678901234...(02)\"",
                             displayValue);
         // value longer than MAX and a quoted string - displayValue is 1st truncated
-        value = "\"hello then goodbye\"";
+        value = "\"hello then hello then hello then hello then hello then hello then goodbye\"";
         displayValue = processVarValues.addDisplayValue(value);
-        Assert.assertEquals("\"hello then...\"",
+        Assert.assertEquals("\"hello then hello then hello then hello then hello then hello then...\"",
                             displayValue);
         // value longer than MAX and a quoted string - displayValue is 2nd truncated
-        value = "\"hello then hello\"";
+        value = "\"hello then hello then hello then hello then hello then hello then hello\"";
         displayValue = processVarValues.addDisplayValue(value);
-        Assert.assertEquals("\"hello then...(01)\"",
+        Assert.assertEquals("\"hello then hello then hello then hello then hello then hello then...(01)\"",
                             displayValue);
         // value longer than MAX but not a quoted string - displayValue is the same
         value = "hello then hello";
@@ -299,34 +305,34 @@ public class ListBoxValuesTest {
         Assert.assertEquals(displayValue,
                             value);
         // value longer than MAX and a quoted string - displayValue is truncated with "(01)"
-        displayValue = "\"abcdeabcde...(01)\"";
+        displayValue = "\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde12345...(01)\"";
         value = processVarValues.getValueForDisplayValue(displayValue);
-        Assert.assertEquals("\"abcdeabcde1\"",
+        Assert.assertEquals("\"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde1234567890\"",
                             value);
         // value longer than MAX and a quoted string - displayValue is 1st truncated
-        displayValue = "\"0123456789...\"";
+        displayValue = "\"01234567890123456789012345678901234567890123456789012345678901234...\"";
         value = processVarValues.getValueForDisplayValue(displayValue);
-        Assert.assertEquals("\"0123456789x\"",
+        Assert.assertEquals("\"01234567890123456789012345678901234567890123456789012345678901234x\"",
                             value);
         // value longer than MAX and a quoted string - displayValue is 2nd truncated
-        displayValue = "\"0123456789...(01)\"";
+        displayValue = "\"01234567890123456789012345678901234567890123456789012345678901234...(01)\"";
         value = processVarValues.getValueForDisplayValue(displayValue);
-        Assert.assertEquals("\"0123456789y\"",
+        Assert.assertEquals("\"01234567890123456789012345678901234567890123456789012345678901234y\"",
                             value);
         // value longer than MAX and a quoted string - displayValue is 3rd truncated
-        displayValue = "\"0123456789...(02)\"";
+        displayValue = "\"01234567890123456789012345678901234567890123456789012345678901234...(02)\"";
         value = processVarValues.getValueForDisplayValue(displayValue);
-        Assert.assertEquals("\"0123456789z\"",
+        Assert.assertEquals("\"01234567890123456789012345678901234567890123456789012345678901234z\"",
                             value);
         // value longer than MAX and a quoted string - displayValue is 1st truncated
-        displayValue = "\"hello then...\"";
+        displayValue = "\"hello then hello then hello then hello then hello then hello then...\"";
         value = processVarValues.getValueForDisplayValue(displayValue);
-        Assert.assertEquals("\"hello then goodbye\"",
+        Assert.assertEquals("\"hello then hello then hello then hello then hello then hello then goodbye\"",
                             value);
         // value longer than MAX and a quoted string - displayValue is 2nd truncated
-        displayValue = "\"hello then...(01)\"";
+        displayValue = "\"hello then hello then hello then hello then hello then hello then...(01)\"";
         value = processVarValues.getValueForDisplayValue(displayValue);
-        Assert.assertEquals("\"hello then hello\"",
+        Assert.assertEquals("\"hello then hello then hello then hello then hello then hello then hello\"",
                             value);
         // value longer than MAX but not a quoted string - displayValue is the same
         displayValue = "hello then hello";


### PR DESCRIPTION
Hi @romartin, @domhanak,

I found a root cause. It wasn't the second edit or dot. The issue was in long names. When user added new value which was cut to allowed size, it never displayed "Edit" prefix. Now the issue is fixed and also I expanded combobox as well so to test the fix you need to put a very long expression (66+ symbols).

As already mentioned I updated size of the dialogue as well:

![image](https://user-images.githubusercontent.com/1477262/106892416-5471ef00-66ec-11eb-874c-7eb11b799a2a.png)
I took the size of the most wide existing property editor (Notifications property of User Task), so the size should be OK, since we never got any complains that editor was too wide. I think it should be enough for most of the cases now, please let me know if more size fixes are required.

**JIRA**: [KOGITO-4328](https://issues.redhat.com/browse/KOGITO-4328)

**Business Central**: [here](https://drive.google.com/file/d/12hbiAJmLCHk6XHu4yVOLAsAvg0VV3HX7/view?usp=sharing)

**Kogito**: [Embedded](https://drive.google.com/file/d/1WLinL38aFRzYOAEaNTO7jHzPkQmCpWaY/view?usp=sharing) Download, unzip and run index.html to test

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
