### PR TITLE
Temporary disabling stunner's project showcase, as it's causing build…

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-showcase/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-showcase/pom.xml
@@ -1270,6 +1270,8 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
+          <!-- Temporary disabling this gwt compilation as the CI environment complains about too many arguments when running the java process. -->
+          <skip>true</skip>
           <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
           <extraJvmArgs>-Xmx6G -Xms1G -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.marshalling.server.classOutput=${project.build.outputDirectory} -Derrai.dynamic_validation.enabled=true</extraJvmArgs>
           <module>org.kie.workbench.common.stunner.project.StunnerProjectShowcase</module>


### PR DESCRIPTION
Hey @mareknovotny @tiagobento 

As this showcase is producing build issues in our CI, I would suggest to disable the gwt compilation for it in a temporary way, until we find the rigth solution. At least this way we'll be not blocking others' work.

WDYT?