### PR TITLE
AF-2797: Reenable kie-wb-common-dmn tests on jdk 11

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/expressions/types/dtable/AddOutputClauseCommandTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,14 +93,6 @@ public class AddOutputClauseCommandTest {
     private DecisionTableUIModelMapper uiModelMapper;
 
     private AddOutputClauseCommand command;
-
-    @Before
-    public void doNotRunTestsOnJdkEleven() {
-
-        final String javaVersion = "11";
-        final String javaVersionPropertyKey = "java.version";
-        Assume.assumeFalse(System.getProperty(javaVersionPropertyKey).contains(javaVersion));
-    }
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
Due to recent jdk11 support [1] introduced on master we should re-enable few tests [2] not working on jdk 11 previously.

[1] - https://issues.redhat.com/browse/AF-1799
[2] - https://issues.redhat.com/browse/AF-2797


**JIRA**: [AF-2797](https://issues.redhat.com/browse/AF-2797)

**Referenced Pull Requests**:
No referenced PR


<details>
* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
