### PR TITLE
JBPM-9598 - Reusable Subprocess / Call Activity borders does not follow spec

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/bpmn-shapes.css
@@ -662,6 +662,11 @@
     stroke-width: 1.5px; /*this affects the adhoc and embedded subprocesses but not the collapsed one*/
 }
 
+.subProcess_reusable_border {
+    stroke: #393f44;
+    stroke-width: 5px;
+}
+
 .subProcess_background {
     fill: #FFFFFF; /*this affects only the reusable subprocess*/
 }
@@ -676,12 +681,6 @@
 
 .subProcess_reusable_icon {
     fill: #393f44;
-}
-
-.subProcess_reusable_boundingbox {
-    fill:none;
-    stroke: #393f44;     /* this is the little box around the icon. */
-    stroke-width: 1.5px;
 }
 
 .subProcess_event_background {
@@ -713,7 +712,6 @@
     fill: #000000;
 }
 
-
 .subProcess_group_multipleInstanceSubProcess_group {
     opacity: 0;
 }
@@ -723,6 +721,12 @@
     fill: #000000;
 }
 
+/* this is the little box around the icon. */
+.subProcess_reusable_boundingbox {
+    fill:none;
+    stroke: #393f44;
+    stroke-width: 1.5px;
+}
 
 #reusableSubProcess .subProcess {
     stroke-width: 3px; /* this is the whole outline */

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/subprocess.svg
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/resources/images/shapes/subprocess.svg
@@ -25,7 +25,7 @@
      width="153px" height="101px"
      viewBox="-1.5 -1.5 153 101">
   <rect id="subProcess-background" class="subProcess_background" x="0" y="0" width="150px" height="98px" rx="2" ry="2"/>
-  <rect id="subProcess-border" class="subProcess_border" stunner:shape-state="stroke" x="0" y="0" width="150px" height="98px" rx="2" ry="2"/>
+  <rect id="subProcess-border" class="subProcess_reusable_border" stunner:shape-state="stroke" x="0" y="0" width="150px" height="98px" rx="2" ry="2"/>
 
   <g id="subProcessReusableNormal" class="subProcess_group_reusable" stunner:transform="non-scalable" stunner:layout="BOTTOM"  transform="translate(0,0) scale(1,1)">
     <rect id="subProcessReusableNormalBoundingBox" class="subProcess_reusable_boundingbox" x="63" y="66" width="25px" height="25px"/>


### PR DESCRIPTION
**JIRA**: [JBPM-9598](https://issues.redhat.com/browse/JBPM-9598)

**Business Central**: [tbd](https://donwnload.here/something)

**Standalone version**: [Standalone Editor](https://drive.google.com/file/d/1rt7tpDEfs4sAhLkXwzBmtFr_6_dvZvCZ/view?usp=sharing)

<img width="807" alt="Screenshot 2021-02-09 at 19 04 25" src="https://user-images.githubusercontent.com/1477262/107407210-b45fff80-6b09-11eb-8ffe-94f8c6fb3b94.png">

Hi @romartin, @LuboTerifaj, @lazarotti, @lclay2 I made the line bold to follow the spec. However spec doesn't declare how bold should it be. Anyway there is the change, I changed it from 1.5 to 5 pixels (other activities still has 1.5 so you can compare), please tell me if you want to try different sizes or 5 pixels is ok.

To try on your own please download standalone version unzip and open index.html in any browser.

Thank you!

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
