### PR TITLE
DROOLS-6033 : LocaldateTime guided rule presents it incorrectly.

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/JavaTypeSystemTranslator.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/JavaTypeSystemTranslator.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.services.datamodel.backend.server.builder.proje
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Date;
 
@@ -79,6 +80,8 @@ public class JavaTypeSystemTranslator implements ClassToGenericClassConverter {
                 fieldType = DataType.TYPE_DATE;
             } else if (LocalDate.class.isAssignableFrom(type)) {
                 fieldType = DataType.TYPE_LOCAL_DATE;
+            } else if (LocalDateTime.class.isAssignableFrom(type)) {
+                fieldType = DataType.TYPE_LOCAL_DATE_TIME;
             } else if (Comparable.class.isAssignableFrom(type)) {
                 fieldType = DataType.TYPE_COMPARABLE;
             } else {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/JavaTypeSystemTranslatorTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/builder/projects/JavaTypeSystemTranslatorTest.java
@@ -26,7 +26,7 @@ public class JavaTypeSystemTranslatorTest {
                 {BigDecimal.class, "BigDecimal"},
                 {Date.class, "Date"},
                 {LocalDate.class, "LocalDate"},
-                {LocalDateTime.class, "Comparable"}
+                {LocalDateTime.class, "LocalDateTime"}
         });
     }
 


### PR DESCRIPTION


**JIRA**: [DROOLS-6033](https://issues.redhat.com/browse/DROOLS-6033)

**Referenced Pull Requests**:
* https://github.com/kiegroup/kie-soup/pull/178
* https://github.com/kiegroup/kie-wb-common/pull/3566


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
