### PR TITLE
DROOLS-5960: Sort lines of Validation&Verification report

### DIFF
--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/IssuePresenter.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/main/java/org/kie/workbench/common/services/verifier/reporting/client/panel/IssuePresenter.java
@@ -51,6 +51,7 @@ public class IssuePresenter
     private String makeRowNumbers(final Issue issue) {
         return issue.getRowNumbers()
                 .stream()
+                .sorted()
                 .map(Object::toString)
                 .collect(Collectors.joining(", "));
     }

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/IssuePresenterTest.java
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/src/test/java/org/kie/workbench/common/services/verifier/reporting/client/panel/IssuePresenterTest.java
@@ -53,9 +53,9 @@ public class IssuePresenterTest {
 
         Issue issue = new Issue(Severity.WARNING,
                                 CheckType.REDUNDANT_ROWS,
-                                new HashSet<>(Arrays.asList(1,
+                                new HashSet<>(Arrays.asList(3,
                                                             2,
-                                                            3))
+                                                            1))
         );
 
         screen.show(issue);


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [DROOLS-5960](https://issues.redhat.com/browse/DROOLS-5960)

This is a complementary PR to have report with sorted line numbers. Imagine there is missing range on lines 1, 2 and 3. Before this PR report contained item:
```
3, 2, 1 - Missing range
```

After this PR
```
1, 2, 3 - Missing range
```

**Referenced Pull Requests**:
* https://github.com/kiegroup/drools-wb/pull/1457/files
* https://github.com/kiegroup/drools/pull/3333/files
