### PR TITLE
KOGITO-4500: [DMN Designer] DMN schema/model validation errors when model has AUTO-SOURCE or AUTO-TARGET connections

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandalone.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandalone.java
@@ -144,9 +144,9 @@ public class DMNMarshallerStandalone implements DiagramMarshaller<Graph, Metadat
 
     private static final double CENTRE_TOLERANCE = 1.0;
 
-    private static final String AUTO_SOURCE_CONNECTION = "#AUTO-SOURCE";
+    private static final String AUTO_SOURCE_CONNECTION = "-AUTO-SOURCE";
 
-    private static final String AUTO_TARGET_CONNECTION = "#AUTO-TARGET";
+    private static final String AUTO_TARGET_CONNECTION = "-AUTO-TARGET";
 
     private XMLEncoderDiagramMetadataMarshaller diagramMetadataMarshaller;
     private FactoryManager factoryManager;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerStandaloneTest.java
@@ -2311,7 +2311,7 @@ public class DMNMarshallerStandaloneTest {
     @Test
     public void testIsAutoConnection() {
         String id = "DMNEdge-ID";
-        String autoConnectionID = "#AUTO-CONNECTION";
+        String autoConnectionID = "-AUTO-CONNECTION";
 
         DMNEdge dmnEdge1 = mock(DMNEdge.class);
         when(dmnEdge1.getId()).thenReturn(id);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/common/IdUtils.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/common/IdUtils.java
@@ -31,9 +31,9 @@ public class IdUtils {
 
     private static String COMBINER_DELIMITER = "-";
 
-    public static final String AUTO_SOURCE_CONNECTION = "#AUTO-SOURCE";
+    public static final String AUTO_SOURCE_CONNECTION = "-AUTO-SOURCE";
 
-    public static final String AUTO_TARGET_CONNECTION = "#AUTO-TARGET";
+    public static final String AUTO_TARGET_CONNECTION = "-AUTO-TARGET";
 
     public static final String getPrefixedId(final String prefixId,
                                              final String rawId) {


### PR DESCRIPTION
**JIRA**: [KOGITO-4500](https://issues.redhat.com/browse/KOGITO-4500)

This PR fixes a small issue we introduced [here](https://github.com/kiegroup/kie-wb-common/pull/3540).

If we create a model with AUTO-SOURCE or AUTO-TARGET connections and we try to execute it (like this: [learn-dmn-in-15-minutes.com/learn/execution](https://learn-dmn-in-15-minutes.com/learn/execution)) the validation fails, and we can't execute the model.

With this change, users can successfully execute and use AUTO-SOURCE or AUTO-TARGET connections.

**VS Code**: [plugin before this PR](https://www.dropbox.com/s/2o8g1c2y3bm8wop/KOGITO-4500-before.vsix?dl=0) -- [plugin after this PR](https://www.dropbox.com/s/ze4wvpber34jusz/KOGITO-4500-after.vsix?dl=0)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
