### PR TITLE
[7.48.x] KOGITO-4539: [DMN Designer] DMN takes too long to open models with too many nodes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
@@ -23,6 +23,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import elemental2.dom.DomGlobal;
+import elemental2.dom.DomGlobal.SetTimeoutCallbackFn;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.client.docks.navigator.drds.DMNDiagramsSession;
@@ -30,12 +32,12 @@ import org.kie.workbench.common.dmn.client.docks.navigator.events.RefreshDecisio
 import org.kie.workbench.common.dmn.client.docks.navigator.included.components.DecisionComponents;
 import org.kie.workbench.common.dmn.client.docks.navigator.tree.DecisionNavigatorTreePresenter;
 import org.kie.workbench.common.dmn.client.editors.included.common.IncludedModelsContext;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementAddedEvent;
 import org.uberfire.client.annotations.DefaultPosition;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.mvp.UberElemental;
+import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.Position;
 
@@ -46,6 +48,8 @@ import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConsta
 public class DecisionNavigatorPresenter {
 
     public static final String IDENTIFIER = "org.kie.dmn.decision.navigator";
+
+    static final int DEFER_DELAY = 250;
 
     private View view;
 
@@ -63,7 +67,7 @@ public class DecisionNavigatorPresenter {
 
     private DMNDiagramsSession dmnDiagramsSession;
 
-    private boolean isRefreshHandlersEnabled = false;
+    double latestDeferred = 0;
 
     @Inject
     public DecisionNavigatorPresenter(final View view,
@@ -103,15 +107,10 @@ public class DecisionNavigatorPresenter {
     void setup() {
         initialize();
         setupView();
-        enableRefreshHandlers();
         refreshComponentsView();
     }
 
     public void onRefreshDecisionComponents(final @Observes RefreshDecisionComponents events) {
-        refreshComponentsView();
-    }
-
-    public void onElementAdded(final @Observes CanvasElementAddedEvent event) {
         refreshComponentsView();
     }
 
@@ -140,34 +139,15 @@ public class DecisionNavigatorPresenter {
     }
 
     public void refresh() {
-        if (dmnDiagramsSession.isSessionStatePresent()) {
-            refreshTreeView();
-            refreshComponentsView();
-        }
+        deferredRefresh();
     }
 
     public void refreshTreeView() {
-        if (isRefreshHandlersEnabled()) {
-            treePresenter.setupItems(getItems());
-        }
+        treePresenter.setupItems(getItems());
     }
 
     void refreshComponentsView() {
-        if (isRefreshHandlersEnabled()) {
-            decisionComponents.refresh();
-        }
-    }
-
-    public void enableRefreshHandlers() {
-        isRefreshHandlersEnabled = true;
-    }
-
-    public void disableRefreshHandlers() {
-        isRefreshHandlersEnabled = false;
-    }
-
-    private boolean isRefreshHandlersEnabled() {
-        return isRefreshHandlersEnabled;
+        decisionComponents.refresh();
     }
 
     List<DecisionNavigatorItem> getItems() {
@@ -176,6 +156,29 @@ public class DecisionNavigatorPresenter {
 
     public void clearSelections() {
         getTreePresenter().deselectItem();
+    }
+
+    void deferredRefresh() {
+        if (dmnDiagramsSession.isSessionStatePresent()) {
+            defer(() -> {
+                refreshTreeView();
+                refreshComponentsView();
+            });
+        }
+    }
+
+    void defer(final Command cmd) {
+        clearTimeout(latestDeferred);
+        latestDeferred = setTimeout((e) -> cmd.execute(), DEFER_DELAY);
+    }
+
+    double setTimeout(final SetTimeoutCallbackFn callbackFn,
+                      final int delay) {
+        return DomGlobal.setTimeout(callbackFn, delay);
+    }
+
+    void clearTimeout(final double latestDeferred) {
+        DomGlobal.clearTimeout(latestDeferred);
     }
 
     public interface View extends UberElemental<DecisionNavigatorPresenter>,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.client.docks.navigator;
 import java.util.ArrayList;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.DomGlobal.SetTimeoutCallbackFn;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,14 +29,20 @@ import org.kie.workbench.common.dmn.client.docks.navigator.events.RefreshDecisio
 import org.kie.workbench.common.dmn.client.docks.navigator.included.components.DecisionComponents;
 import org.kie.workbench.common.dmn.client.docks.navigator.tree.DecisionNavigatorTreePresenter;
 import org.kie.workbench.common.dmn.client.editors.included.common.IncludedModelsContext;
-import org.kie.workbench.common.stunner.core.client.canvas.event.registration.CanvasElementAddedEvent;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.Position;
 
 import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorPresenter.DEFER_DELAY;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DecisionNavigatorPresenter_DecisionNavigator;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -171,10 +178,6 @@ public class DecisionNavigatorPresenterTest {
         final ArrayList<DecisionNavigatorItem> items = new ArrayList<>();
         doReturn(items).when(presenter).getItems();
 
-        presenter.disableRefreshHandlers();
-        presenter.refreshTreeView();
-
-        presenter.enableRefreshHandlers();
         presenter.refreshTreeView();
 
         verify(treePresenter).setupItems(items);
@@ -182,9 +185,17 @@ public class DecisionNavigatorPresenterTest {
 
     @Test
     public void testRefresh() {
+
+        final ArgumentCaptor<Command> cmdCaptor = ArgumentCaptor.forClass(Command.class);
+
         doReturn(true).when(dmnDiagramsSession).isSessionStatePresent();
+        doNothing().when(presenter).defer(any());
 
         presenter.refresh();
+
+        verify(presenter).defer(cmdCaptor.capture());
+
+        cmdCaptor.getValue().execute();
 
         verify(presenter).refreshTreeView();
         verify(presenter).refreshComponentsView();
@@ -192,10 +203,15 @@ public class DecisionNavigatorPresenterTest {
 
     @Test
     public void testRefreshWhenSessionStateIsNotPresent() {
+
+        final ArgumentCaptor<Command> cmdCaptor = ArgumentCaptor.forClass(Command.class);
+
         doReturn(false).when(dmnDiagramsSession).isSessionStatePresent();
+        doNothing().when(presenter).defer(any());
 
         presenter.refresh();
 
+        verify(presenter, never()).defer(any());
         verify(presenter, never()).refreshTreeView();
         verify(presenter, never()).refreshComponentsView();
     }
@@ -218,11 +234,6 @@ public class DecisionNavigatorPresenterTest {
     @Test
     public void testOnRefreshDecisionComponents() {
 
-        presenter.disableRefreshHandlers();
-        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
-        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
-
-        presenter.enableRefreshHandlers();
         presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
         presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
 
@@ -230,16 +241,20 @@ public class DecisionNavigatorPresenterTest {
     }
 
     @Test
-    public void testOnElementAdded() {
+    public void testDefer() {
 
-        presenter.disableRefreshHandlers();
-        presenter.onElementAdded(mock(CanvasElementAddedEvent.class));
-        presenter.onElementAdded(mock(CanvasElementAddedEvent.class));
+        final Command cmd = mock(Command.class);
+        final ArgumentCaptor<SetTimeoutCallbackFn> timeoutCaptor = ArgumentCaptor.forClass(SetTimeoutCallbackFn.class);
 
-        presenter.enableRefreshHandlers();
-        presenter.onElementAdded(mock(CanvasElementAddedEvent.class));
-        presenter.onElementAdded(mock(CanvasElementAddedEvent.class));
+        doNothing().when(presenter).clearTimeout(anyInt());
+        doReturn(0d).when(presenter).setTimeout(any(), anyInt());
 
-        verify(decisionComponents, times(2)).refresh();
+        presenter.defer(cmd);
+
+        verify(presenter).clearTimeout(0d);
+        verify(presenter).setTimeout(timeoutCaptor.capture(), eq(DEFER_DELAY));
+
+        timeoutCaptor.getValue().onInvoke();
+        verify(cmd).execute();
     }
 }


### PR DESCRIPTION
**JIRA**: [KOGITO-4539](https://issues.redhat.com/browse/KOGITO-4539): [DMN Designer] DMN takes too long to open models with too many nodes

Cherry-picked from https://github.com/kiegroup/kie-wb-common/pull/3578

--

**- Business Central war (7.48.x)**: [war file](https://www.dropbox.com/s/urwzxb1h2pdtmdr/KOGITO-4539-7.48.x-business-central.war?dl=0)

**- VS Code plugin (7.48.x)**: [plugin file](https://www.dropbox.com/s/4kjegh5fwp6qqrh/KOGITO-4539-7.48.x-vscode.vsix?dl=0)

--

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
