### PR TITLE
KOGITO-4078 - Creating a new process with "-" in VSCode generates incorrect Process ID

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriter.java
@@ -81,7 +81,8 @@ public class ProcessPropertyWriter extends BasePropertyWriter implements Element
 
     public void setId(String value) {
         // ids should be properly sanitized at a higher level
-        String sanitized = Objects.nonNull(value) ? value.replaceAll("\\s", "") : value;
+        String sanitized = Objects.nonNull(value) ? value.replaceAll("\\s", "") : null;
+        sanitized = Objects.nonNull(sanitized) ? sanitized.replace("-", "_") : null;
         process.setId(sanitized);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/ProcessPropertyWriterTest.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories.bpmn2;
 import static org.kie.workbench.common.stunner.bpmn.client.marshall.converters.fromstunner.Factories.di;
@@ -66,9 +67,20 @@ public class ProcessPropertyWriterTest {
 
     @Test
     public void setIdWithWhitespace() {
+        p.setId(null);
+        Process process1 = p.getProcess();
+        assertNull(process1.getId());
+
         p.setId("some weird   id \t");
+        Process process2 = p.getProcess();
+        assertThat(process2.getId()).isEqualTo("someweirdid");
+    }
+
+    @Test
+    public void setIdWithDash() {
+        p.setId("some-weird-id \t");
         Process process = p.getProcess();
-        assertThat(process.getId()).isEqualTo("someweirdid");
+        assertThat(process.getId()).isEqualTo("some_weird_id");
     }
 
     @Test


### PR DESCRIPTION
Process IDs containing the character "-" will be serialized with the character "_" instead.
Process-test will be serialized as process_test, for example.

**JIRA**: [KOGITO-4078](https://issues.redhat.com/browse/KOGITO-4078)

**Business Central**: Does not apply.

**VS Code**: [plugin](https://drive.google.com/file/d/1PYWB9xxEJaNF_P6yOUxvHFwuncR3Tk6p/view?usp=sharing)
