### PR TITLE
JBPM-9597 - [BPMN] Open subprocesses in a new editor (BC only)

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/resources/StunnerCommonIconsGlyphFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/resources/StunnerCommonIconsGlyphFactory.java
@@ -25,4 +25,6 @@ public interface StunnerCommonIconsGlyphFactory {
     ImageStripGlyph GEARS = ImageStripGlyph.create(StunnerCommonIconsStrip.class, 1);
 
     ImageStripGlyph FORM = ImageStripGlyph.create(StunnerCommonIconsStrip.class, 2);
+
+    ImageStripGlyph SUBPROCESS = ImageStripGlyph.create(StunnerCommonIconsStrip.class, 2);
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/resources/i18n/StunnerProjectClientConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/resources/i18n/StunnerProjectClientConstants.java
@@ -31,4 +31,6 @@ public class StunnerProjectClientConstants {
     public static final String DIAGRAM_PARSING_ERROR = "org.kie.workbench.common.stunner.project.client.editor.DiagramParsingError";
 
     public static final String DOCUMENTATION = "org.kie.workbench.common.stunner.project.client.editor.Documentation";
+
+    public static final String OPEN_SUBPROCESS = "org.kie.workbench.common.stunner.project.client.component.toolbox.OpenSubprocessToolboxAction";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/util/GraphUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/util/GraphUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.util;
+
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+public class GraphUtils {
+
+    @SuppressWarnings("unchecked")
+    public static boolean isReusableSubProcess(final Element<?> element) {
+        return null != element.asNode() &&
+                element.getContent() instanceof View &&
+                ((Element<View<?>>) element).getContent().getDefinition() instanceof ReusableSubprocess;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/util/GraphUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/util/GraphUtilsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
+import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.graph.content.view.ViewImpl;
+import org.kie.workbench.common.stunner.core.graph.impl.NodeImpl;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GraphUtilsTest {
+
+    @Test
+    public void testContentIsNotSet() {
+        Element<Object> element = new NodeImpl<>("UUID");
+        assertFalse(GraphUtils.isReusableSubProcess(element));
+    }
+
+    @Test
+    public void testNonView() {
+        Element<Object> element = new NodeImpl<>("UUID");
+        element.setContent(new Object());
+        assertFalse(GraphUtils.isReusableSubProcess(element));
+    }
+
+    @Test
+    public void testNonReusableSubprocess() {
+        Element<View<UserTask>> element = new NodeImpl<>("UUID");
+        View<UserTask> userTaskView = new ViewImpl<>(new UserTask(), Bounds.create());
+        element.setContent(userTaskView);
+        assertFalse(GraphUtils.isReusableSubProcess(element));
+    }
+
+    @Test
+    public void testReusableSubprocess() {
+        Element<View<ReusableSubprocess>> element = new NodeImpl<>("UUID");
+        View<ReusableSubprocess> reusableSubprocessView = new ViewImpl<>(new ReusableSubprocess(), Bounds.create());
+        element.setContent(reusableSubprocessView);
+        assertTrue(GraphUtils.isReusableSubProcess(element));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/util/GraphUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/util/GraphUtilsTest.java
@@ -29,13 +29,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GraphUtilsTest {
 
     @Test
     public void testContentIsNotSet() {
-        Element<Object> element = new NodeImpl<>("UUID");
+        Element<Object> element = mock(Element.class);
         assertFalse(GraphUtils.isReusableSubProcess(element));
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/java/org/kie/workbench/common/stunner/bpmn/project/service/ProjectOpenReusableSubprocessService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/src/main/java/org/kie/workbench/common/stunner/bpmn/project/service/ProjectOpenReusableSubprocessService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.service;
+
+import java.util.List;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+
+@Remote
+public interface ProjectOpenReusableSubprocessService {
+    List<String> openReusableSubprocess(String processId);
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProjectOpenReusableSubprocessServiceImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProjectOpenReusableSubprocessServiceImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.backend.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.soup.commons.util.Sets;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueResourceIndexTerm;
+import org.kie.workbench.common.services.refactoring.service.RefactoringQueryService;
+import org.kie.workbench.common.services.refactoring.service.ResourceType;
+import org.kie.workbench.common.stunner.bpmn.project.backend.query.FindBpmnProcessIdsQuery;
+import org.kie.workbench.common.stunner.bpmn.project.service.ProjectOpenReusableSubprocessService;
+import org.uberfire.backend.vfs.Path;
+
+@ApplicationScoped
+@Service
+public class ProjectOpenReusableSubprocessServiceImpl implements ProjectOpenReusableSubprocessService {
+
+    private final RefactoringQueryService queryService;
+    private final Supplier<ResourceType> resourceType;
+    private final Supplier<String> queryName;
+    private final Set<ValueIndexTerm> queryTerms;
+
+    // CDI proxy.
+    protected ProjectOpenReusableSubprocessServiceImpl() {
+        this(null);
+    }
+
+    @Inject
+    public ProjectOpenReusableSubprocessServiceImpl(final RefactoringQueryService queryService) {
+        this.queryService = queryService;
+        this.resourceType = () -> ResourceType.BPMN2;
+        this.queryName = () -> FindBpmnProcessIdsQuery.NAME;
+        this.queryTerms = new Sets.Builder<ValueIndexTerm>()
+                .add(new ValueResourceIndexTerm("*",
+                                                resourceType.get(),
+                                                ValueIndexTerm.TermSearchType.WILDCARD))
+                .build();
+    }
+
+    String getQueryName() {
+        return queryName.get();
+    }
+
+    Set<ValueIndexTerm> createQueryTerms() {
+        return queryTerms;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<String> openReusableSubprocess(String processId) {
+        List<String> answer = new ArrayList<>();
+        Map<String, Path> subprocesses = queryService
+                .query(getQueryName(), createQueryTerms())
+                .stream()
+                .map(row -> (Map<String, Path>) row.getValue())
+                .filter(row -> row.get(processId) != null)
+                .findFirst()
+                .orElse(null);
+
+        if (subprocesses == null) {
+            return answer;
+        }
+
+        answer.add(subprocesses.get(processId).getFileName());
+        answer.add(subprocesses.get(processId).toURI());
+        return answer;
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProjectOpenReusableSubprocessServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProjectOpenReusableSubprocessServiceImplTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.backend.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.refactoring.model.query.RefactoringPageRow;
+import org.kie.workbench.common.services.refactoring.service.RefactoringQueryService;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectOpenReusableSubprocessServiceImplTest {
+
+    private static String PROCESS_ID = "processId";
+    private static String PROCESS_FILE_NAME = "File Name";
+    private static String PROCESS_URI = "URI";
+
+    @Mock
+    private RefactoringQueryService serviceQuery;
+    @Mock
+    private Path path;
+
+    private ProjectOpenReusableSubprocessServiceImpl service;
+    private List<RefactoringPageRow> rows;
+
+    @Before
+    public void setUp() {
+        when(path.getFileName()).thenReturn(PROCESS_FILE_NAME);
+        when(path.toURI()).thenReturn(PROCESS_URI);
+
+        RefactoringPageRow<Map<String, Path>> row = new RefactoringPageRow<Map<String, Path>>() {
+            @Override
+            public void setValue(Map<String, Path> value) {
+                super.setValue(value);
+            }
+
+            @Override
+            public Map<String, Path> getValue() {
+                Map<String, Path> subprocess = new HashMap<>();
+                subprocess.put(PROCESS_ID, path);
+                return subprocess;
+            }
+        };
+
+        rows = new ArrayList<>();
+        rows.add(row);
+
+        service = new ProjectOpenReusableSubprocessServiceImpl(serviceQuery);
+    }
+
+    @Test
+    public void testNotFound() {
+        assertTrue(service.openReusableSubprocess(PROCESS_ID).isEmpty());
+    }
+
+    @Test
+    public void testReusableSubprocessFound() {
+        when(serviceQuery.query(service.getQueryName(), service.createQueryTerms())).thenReturn(rows);
+
+        List<String> answer = service.openReusableSubprocess(PROCESS_ID);
+        assertEquals(2, answer.size());
+        assertEquals(PROCESS_FILE_NAME, answer.get(0));
+        assertEquals(PROCESS_URI, answer.get(1));
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProjectOpenReusableSubprocessServiceImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/project/backend/service/ProjectOpenReusableSubprocessServiceImplTest.java
@@ -37,9 +37,10 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectOpenReusableSubprocessServiceImplTest {
 
-    private static String PROCESS_ID = "processId";
-    private static String PROCESS_FILE_NAME = "File Name";
-    private static String PROCESS_URI = "URI";
+    private final static String PROCESS_ID = "processId";
+    private final static String NOT_REGISTERED_PROCESS_ID = "not_registered_process_id";
+    private final static String PROCESS_FILE_NAME = "File Name";
+    private final static String PROCESS_URI = "URI";
 
     @Mock
     private RefactoringQueryService serviceQuery;
@@ -87,5 +88,13 @@ public class ProjectOpenReusableSubprocessServiceImplTest {
         assertEquals(2, answer.size());
         assertEquals(PROCESS_FILE_NAME, answer.get(0));
         assertEquals(PROCESS_URI, answer.get(1));
+    }
+
+    @Test
+    public void testProcessWithIdNotFound() {
+        when(serviceQuery.query(service.getQueryName(), service.createQueryTerms())).thenReturn(rows);
+
+        List<String> answer = service.openReusableSubprocess(NOT_REGISTERED_PROCESS_ID);
+        assertEquals(0, answer.size());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/canvas/controls/BPMNProjectActionsToolboxFactory.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/canvas/controls/BPMNProjectActionsToolboxFactory.java
@@ -27,6 +27,8 @@ import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.bpmn.client.forms.util.BPMNFormsContextUtils;
+import org.kie.workbench.common.stunner.bpmn.client.util.GraphUtils;
+import org.kie.workbench.common.stunner.bpmn.project.client.toolbox.OpenSubprocessToolboxAction;
 import org.kie.workbench.common.stunner.bpmn.qualifiers.BPMN;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.AbstractActionsToolboxFactory;
@@ -47,14 +49,17 @@ public class BPMNProjectActionsToolboxFactory extends AbstractActionsToolboxFact
 
     private final ActionsToolboxFactory commonActionToolbox;
     private final ManagedInstance<FormGenerationToolboxAction> generateFormsActions;
+    private final ManagedInstance<OpenSubprocessToolboxAction> openSubprocessActions;
     private final ManagedInstance<ActionsToolboxView> views;
 
     @Inject
     public BPMNProjectActionsToolboxFactory(final @CommonActionsToolbox ActionsToolboxFactory commonActionToolbox,
                                             final @Any ManagedInstance<FormGenerationToolboxAction> generateFormsActions,
+                                            final @Any ManagedInstance<OpenSubprocessToolboxAction> openSubprocessActions,
                                             final @Any @CommonActionsToolbox ManagedInstance<ActionsToolboxView> views) {
         this.commonActionToolbox = commonActionToolbox;
         this.generateFormsActions = generateFormsActions;
+        this.openSubprocessActions = openSubprocessActions;
         this.views = views;
     }
 
@@ -71,12 +76,16 @@ public class BPMNProjectActionsToolboxFactory extends AbstractActionsToolboxFact
         if (BPMNFormsContextUtils.isFormGenerationSupported(e)) {
             actions.add(generateFormsActions.get());
         }
+        if (GraphUtils.isReusableSubProcess(e)) {
+            actions.add(openSubprocessActions.get());
+        }
         return actions;
     }
 
     @PreDestroy
     public void destroy() {
         generateFormsActions.destroyAll();
+        openSubprocessActions.destroyAll();
         views.destroyAll();
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/resources/BPMNClientConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/resources/BPMNClientConstants.java
@@ -60,6 +60,15 @@ public interface BPMNClientConstants {
     @TranslationKey(defaultValue = "An error was produced during migration")
     String EditorMigrateErrorGeneric = "editor.actions.migrateErrorGeneric";
 
-    @TranslationKey(defaultValue =  "An error was produced during diagram svg file generation")
+    @TranslationKey(defaultValue = "An error was produced during diagram svg file generation")
     String EditorGenerateSvgFileError = "editor.error.generateSvgFileError";
+
+    @TranslationKey(defaultValue = "Subprocess {0} not found.")
+    String SubprocessNotFound = "editor.error.subprocessNotFound";
+
+    @TranslationKey(defaultValue = "Subprocess ID is not specified.")
+    String SubprocessIdNotSpecified = "editor.error.subprocessNotSpecified";
+
+    @TranslationKey(defaultValue = "Open Sub-process")
+    String OpenSubprocessToolBoxAction = "editor.toolbox.openSubprocessToolboxAction";
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/service/ClientProjectOpenReusableSubprocessService.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/service/ClientProjectOpenReusableSubprocessService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.client.service;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import elemental2.promise.Promise;
+import org.jboss.errai.common.client.api.Caller;
+import org.kie.workbench.common.stunner.bpmn.project.service.ProjectOpenReusableSubprocessService;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.promise.Promises;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.PathPlaceRequest;
+
+@ApplicationScoped
+public class ClientProjectOpenReusableSubprocessService {
+
+    @Inject
+    PlaceManager placeManager;
+
+    private final Promises promises;
+    private final Caller<ProjectOpenReusableSubprocessService> openReusableSubprocessService;
+
+    protected ClientProjectOpenReusableSubprocessService() {
+        this(null, null);
+    }
+
+    @Inject
+    public ClientProjectOpenReusableSubprocessService(final Promises promises,
+                                                      final Caller<ProjectOpenReusableSubprocessService> openReusableSubprocessService) {
+
+        this.promises = promises;
+        this.openReusableSubprocessService = openReusableSubprocessService;
+    }
+
+    public Promise<List<String>> call(String processId) {
+        return promises.promisify(openReusableSubprocessService,
+                                  s -> {
+                                      s.openReusableSubprocess(processId);
+                                  });
+    }
+
+    public void openReusableSubprocess(List<String> processData) {
+        PlaceRequest placeRequestImpl = new PathPlaceRequest(
+                PathFactory.newPathBasedOn(processData.get(0), // "test.bpmn"
+                                           processData.get(1), // "default://master@testSpace/ProjectTest/src/main/resources/com/test.bpmn"
+                                           new PathFactory.PathImpl()) // not really used
+        );
+
+        placeRequestImpl.addParameter("uuid",
+                                      processData.get(1));
+        placeRequestImpl.addParameter("profile",
+                                      "jbpm");
+        this.placeManager.goTo(placeRequestImpl);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxAction.java
@@ -70,9 +70,7 @@ public class OpenSubprocessToolboxAction implements ToolboxAction<AbstractCanvas
     public ToolboxAction<AbstractCanvasHandler> onMouseClick(final AbstractCanvasHandler canvasHandler,
                                                              final String uuid,
                                                              final MouseClickEvent event) {
-        Node<View<ReusableSubprocess>, ?> node = canvasHandler.getDiagram().getGraph().getNode(uuid);
-        ReusableSubprocess subprocess = node.getContent().getDefinition();
-        String processId = subprocess.getExecutionSet().getCalledElement().getValue();
+        String processId = getProcessId(canvasHandler, uuid);
         if (isEmpty(processId)) {
             showNotification(translationService.getValue(SubprocessIdNotSpecified));
             return this;
@@ -90,6 +88,14 @@ public class OpenSubprocessToolboxAction implements ToolboxAction<AbstractCanvas
                 });
 
         return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    String getProcessId(final AbstractCanvasHandler canvasHandler,
+                        final String uuid) {
+        Node<View<ReusableSubprocess>, ?> node = canvasHandler.getDiagram().getGraph().getNode(uuid);
+        ReusableSubprocess subprocess = node.getContent().getDefinition();
+        return subprocess.getExecutionSet().getCalledElement().getValue();
     }
 
     void openSubprocess(final List<String> serverData,

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxAction.java
@@ -91,14 +91,14 @@ public class OpenSubprocessToolboxAction implements ToolboxAction<AbstractCanvas
     }
 
     @SuppressWarnings("unchecked")
-    String getProcessId(final AbstractCanvasHandler canvasHandler,
+    public String getProcessId(final AbstractCanvasHandler canvasHandler,
                         final String uuid) {
         Node<View<ReusableSubprocess>, ?> node = canvasHandler.getDiagram().getGraph().getNode(uuid);
         ReusableSubprocess subprocess = node.getContent().getDefinition();
         return subprocess.getExecutionSet().getCalledElement().getValue();
     }
 
-    void openSubprocess(final List<String> serverData,
+    public void openSubprocess(final List<String> serverData,
                         final String processId) {
         if (serverData.size() == 2) {
             openSubprocessService.openReusableSubprocess(serverData);
@@ -107,7 +107,7 @@ public class OpenSubprocessToolboxAction implements ToolboxAction<AbstractCanvas
         }
     }
 
-    void showNotification(final String message) {
+    public void showNotification(final String message) {
         Notify.notify("",
                       buildHtmlEscapedText(message),
                       IconType.EXCLAMATION);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxAction.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxAction.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.client.toolbox;
+
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.gwtbootstrap3.extras.notify.client.ui.Notify;
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
+import org.kie.workbench.common.stunner.bpmn.project.client.service.ClientProjectOpenReusableSubprocessService;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ToolboxAction;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.resources.StunnerCommonIconsGlyphFactory;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseClickEvent;
+import org.kie.workbench.common.stunner.core.definition.shape.Glyph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+
+import static org.kie.workbench.common.stunner.bpmn.client.forms.util.StringUtils.isEmpty;
+import static org.kie.workbench.common.stunner.bpmn.project.client.resources.BPMNClientConstants.OpenSubprocessToolBoxAction;
+import static org.kie.workbench.common.stunner.bpmn.project.client.resources.BPMNClientConstants.SubprocessIdNotSpecified;
+import static org.kie.workbench.common.stunner.bpmn.project.client.resources.BPMNClientConstants.SubprocessNotFound;
+
+@Dependent
+public class OpenSubprocessToolboxAction implements ToolboxAction<AbstractCanvasHandler> {
+
+    private final ClientTranslationService translationService;
+    private final ClientProjectOpenReusableSubprocessService openSubprocessService;
+
+    @Inject
+    public OpenSubprocessToolboxAction(final ClientTranslationService translationService,
+                                       final ClientProjectOpenReusableSubprocessService openSubprocessService) {
+        this.translationService = translationService;
+        this.openSubprocessService = openSubprocessService;
+    }
+
+    @Override
+    public Glyph getGlyph(final AbstractCanvasHandler canvasHandler,
+                          final String uuid) {
+        return StunnerCommonIconsGlyphFactory.SUBPROCESS;
+    }
+
+    @Override
+    public String getTitle(final AbstractCanvasHandler canvasHandler,
+                           final String uuid) {
+        return translationService.getValue(OpenSubprocessToolBoxAction);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ToolboxAction<AbstractCanvasHandler> onMouseClick(final AbstractCanvasHandler canvasHandler,
+                                                             final String uuid,
+                                                             final MouseClickEvent event) {
+        Node<View<ReusableSubprocess>, ?> node = canvasHandler.getDiagram().getGraph().getNode(uuid);
+        ReusableSubprocess subprocess = node.getContent().getDefinition();
+        String processId = subprocess.getExecutionSet().getCalledElement().getValue();
+        if (isEmpty(processId)) {
+            showNotification(translationService.getValue(SubprocessIdNotSpecified));
+            return this;
+        }
+
+        openSubprocessService
+                .call(processId)
+                .then(serverData -> {
+                    openSubprocess(serverData, processId);
+                    return null;
+                })
+                .catch_(exception -> {
+                    showNotification(translationService.getValue(SubprocessNotFound, processId));
+                    return null;
+                });
+
+        return this;
+    }
+
+    void openSubprocess(final List<String> serverData,
+                        final String processId) {
+        if (serverData.size() == 2) {
+            openSubprocessService.openReusableSubprocess(serverData);
+        } else {
+            showNotification(translationService.getValue(SubprocessNotFound, processId));
+        }
+    }
+
+    void showNotification(final String message) {
+        Notify.notify("",
+                      buildHtmlEscapedText(message),
+                      IconType.EXCLAMATION);
+    }
+
+    private static String buildHtmlEscapedText(final String message) {
+        return new SafeHtmlBuilder().appendEscapedLines(message).toSafeHtml().asString();
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/project/client/resources/i18n/BPMNClientConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/project/client/resources/i18n/BPMNClientConstants.properties
@@ -16,3 +16,6 @@ editor.actions.migrateErrorProcessAlreadyExists=A jBPM designer process already 
 editor.actions.migrateErrorGeneric=An error was produced during migration
 
 editor.error.generateSvgFileError=An error was produced during diagram svg file generation
+editor.error.subprocessNotFound=Subprocess {0} not found.
+editor.error.subprocessNotSpecified=Subprocess ID is not specified.
+editor.toolbox.openSubprocessToolboxAction=Open Sub-process

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/canvas/controls/BPMNProjectActionsToolboxFactoryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/canvas/controls/BPMNProjectActionsToolboxFactoryTest.java
@@ -24,8 +24,10 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.ScriptTask;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
+import org.kie.workbench.common.stunner.bpmn.project.client.toolbox.OpenSubprocessToolboxAction;
 import org.kie.workbench.common.stunner.core.client.ManagedInstanceStub;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.components.toolbox.actions.ActionsToolboxFactory;
@@ -60,9 +62,13 @@ public class BPMNProjectActionsToolboxFactoryTest {
     private ToolboxAction<AbstractCanvasHandler> action1;
 
     private ManagedInstance<FormGenerationToolboxAction> generateFormsActions;
+    private ManagedInstance<OpenSubprocessToolboxAction> openSubprocessActions;
 
     @Mock
     private FormGenerationToolboxAction formGenerationToolboxAction;
+
+    @Mock
+    private OpenSubprocessToolboxAction openSubprocessToolboxAction;
 
     private ManagedInstance<ActionsToolboxView> views;
 
@@ -78,9 +84,11 @@ public class BPMNProjectActionsToolboxFactoryTest {
         when(commonActionToolbox.getActions(eq(canvasHandler),
                                             eq(element))).thenReturn(Collections.singletonList(action1));
         generateFormsActions = spy(new ManagedInstanceStub<>(formGenerationToolboxAction));
+        openSubprocessActions = spy(new ManagedInstanceStub<>(openSubprocessToolboxAction));
         views = spy(new ManagedInstanceStub<>(view));
         tested = new BPMNProjectActionsToolboxFactory(commonActionToolbox,
                                                       generateFormsActions,
+                                                      openSubprocessActions,
                                                       views);
     }
 
@@ -91,7 +99,7 @@ public class BPMNProjectActionsToolboxFactoryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testGetActionsForSupportedNode() {
+    public void testGetActionsForSupportedUserTaskNode() {
         element.setContent(new ViewImpl<>(new UserTask(),
                                           Bounds.create()));
         final Collection<ToolboxAction<AbstractCanvasHandler>> actions = tested.getActions(canvasHandler,
@@ -99,6 +107,18 @@ public class BPMNProjectActionsToolboxFactoryTest {
         assertEquals(2, actions.size());
         assertTrue(actions.contains(action1));
         assertTrue(actions.contains(formGenerationToolboxAction));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetActionsForSupportedSubprocessNode() {
+        element.setContent(new ViewImpl<>(new ReusableSubprocess(),
+                                          Bounds.create()));
+        final Collection<ToolboxAction<AbstractCanvasHandler>> actions = tested.getActions(canvasHandler,
+                                                                                           element);
+        assertEquals(2, actions.size());
+        assertTrue(actions.contains(action1));
+        assertTrue(actions.contains(openSubprocessToolboxAction));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxActionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/src/test/java/org/kie/workbench/common/stunner/bpmn/project/client/toolbox/OpenSubprocessToolboxActionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.project.client.toolbox;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import elemental2.promise.Promise;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.project.client.service.ClientProjectOpenReusableSubprocessService;
+import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.shape.view.event.MouseClickEvent;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.kie.workbench.common.stunner.bpmn.project.client.resources.BPMNClientConstants.SubprocessIdNotSpecified;
+import static org.kie.workbench.common.stunner.bpmn.project.client.resources.BPMNClientConstants.SubprocessNotFound;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpenSubprocessToolboxActionTest {
+
+    private static String UUID = "SOME_NODE_ID";
+    private static String PROCESS_ID = "SomeProcess";
+    private static String SUBPROCESS_ID_NOT_FOUND = "Subprocess ID is not specified.";
+    private static String SUBPROCESS_NOT_FOUND = "Subprocess not found.";
+    private static String PATH = "default://path";
+
+    @Mock
+    private ClientTranslationService translationService;
+    @Mock
+    private ClientProjectOpenReusableSubprocessService openSubprocessService;
+    @Mock
+    private AbstractCanvasHandler canvasHandler;
+    @Mock
+    private Promise<List<String>> promise;
+    @Mock
+    private Promise<Object> promiseResult;
+
+    private OpenSubprocessToolboxAction action;
+
+    private MouseClickEvent event = new MouseClickEvent(0, 0, 0, 0);
+
+    @Before
+    public void setUp() {
+        action = mock(OpenSubprocessToolboxAction.class,
+                      withSettings().useConstructor(translationService, openSubprocessService));
+        doCallRealMethod().when(action).openSubprocess(any(), any());
+        when(action.onMouseClick(any(), any(), any())).thenCallRealMethod();
+
+        when(openSubprocessService.call(any())).thenReturn(promise);
+        when(promise.then(any())).thenReturn(promiseResult);
+        when(promiseResult.catch_(any())).thenReturn(promiseResult);
+    }
+
+    @Test
+    public void testNoProcessIdSpecified() {
+        when(translationService.getValue(SubprocessIdNotSpecified)).thenReturn(SUBPROCESS_ID_NOT_FOUND);
+
+        when(action.getProcessId(any(), any())).thenReturn("");
+
+        action.onMouseClick(canvasHandler, UUID, event);
+        verify(action).showNotification(SUBPROCESS_ID_NOT_FOUND);
+    }
+
+    @Test
+    public void testProcessIdSpecified() {
+        when(action.getProcessId(any(), any())).thenReturn(PROCESS_ID);
+
+        action.onMouseClick(canvasHandler, UUID, event);
+        verify(action, never()).showNotification(any());
+        verify(openSubprocessService).call(PROCESS_ID);
+    }
+
+    @Test
+    public void testOpenSubprocessNotFound() {
+        when(translationService.getValue(SubprocessNotFound, UUID)).thenReturn(SUBPROCESS_NOT_FOUND);
+
+        List<String> emptyList = new ArrayList<>();
+        action.openSubprocess(emptyList, UUID);
+
+        verify(action).showNotification(SUBPROCESS_NOT_FOUND);
+        verify(openSubprocessService, never()).openReusableSubprocess(any());
+    }
+
+    @Test
+    public void testOpenSubprocessInvoked() {
+        List<String> parameters = new ArrayList<>();
+        parameters.add(UUID);
+        parameters.add(PATH);
+        action.openSubprocess(parameters, UUID);
+
+        verify(action, never()).showNotification(any());
+        verify(openSubprocessService).openReusableSubprocess(parameters);
+    }
+}


### PR DESCRIPTION
**JIRA**: [[BPMN] Open subprocesses in a new editor (BC only)](https://issues.redhat.com/browse/JBPM-9597)

**Business Central**: [WAR](https://drive.google.com/file/d/1MvUFmtmZWH0Mkq-zHPFYyWxKTCbX3jAm/view?usp=sharing)

**VS Code**: [VSIX](https://drive.google.com/file/d/1W2uR_P-wqx3UxLq4lTQmwRTfK_bpAcOq/view?usp=sharing)

<details>
<summary>
Hi @romartin, @LuboTerifaj, what is done:

* Toolbox button for Reusable sub-process with tool-tip to open Sub-process in Business Central only
* Error notifications
    * Sub-process ID is empty
    * Sub-process not found
* Open processes by click on the toolbox button, tested for different projects and space as well
    * Found a bug that Business Central doesn't update breadcrumbs for spaces/projects, only for process name. I think it is not related to my changes and should be fixed in Business Central itself.

Possible future change: new icon for the toolbox button.

Thank you!
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
