### PR TITLE
JBPM-9683 BPMN editor [Business Central]: Work Items not available

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/workitem/WorkItemDefinitionCacheRegistry.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/workitem/WorkItemDefinitionCacheRegistry.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.bpmn.workitem;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
@@ -36,7 +37,9 @@ public class WorkItemDefinitionCacheRegistry implements WorkItemDefinitionRegist
 
     @Override
     public Collection<WorkItemDefinition> items() {
-        return definitions.values();
+        // It is done for GWT/Errai compatibility since HashMap$Values do not
+        // have empty constructor. Do not simplify!
+        return definitions.values().stream().collect(Collectors.toList());
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/workitem/WorkItemDefinitionCacheRegistryTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/workitem/WorkItemDefinitionCacheRegistryTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.workitem;
 
+import java.util.ArrayList;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,6 +60,14 @@ public class WorkItemDefinitionCacheRegistryTest {
         assertEquals(2, tested.items().size());
         assertEquals(DEF1.getName(), tested.get("def1").getName());
         assertEquals(DEF2.getName(), tested.get("def2").getName());
+    }
+
+    @Test
+    public void testIsErraiCompatibleType() {
+        tested.register(DEF1);
+        tested.register(DEF1);
+        assertEquals("Type of this collection should be ArrayList since Errai CDI support only classes with empty constructors.",
+                     ArrayList.class, tested.items().getClass());
     }
 
     @Test


### PR DESCRIPTION
**JIRA**: [JBPM-9683](https://issues.redhat.com/browse/JBPM-9683)

**Business Central**: [WAR file](https://drive.google.com/file/d/1E_ckj-NpGnp1WJzdvfchgFd-tEOPMwh1/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1svUr2l-gcPdceJaacJIKW8dLMJgSlGm7/view?usp=sharing)

<details>
<summary>
Hi @romartin, @LuboTerifaj,

issue was caused by [this](https://github.com/kiegroup/kie-wb-common/pull/3552/files#diff-f39797a981aba47d2779b5819ef65ab2767d6314f7c14828b645de0b73f74242R39) refactoring. There is the fix, issue is caused by HashMap$Values which doesn't have empty constructor and that's why it can't be initialized during CDI work by Errai. The fix replacing HashMap$Values by ArrayList and now it works as expected.

I think there are no sense to write unit tests to check type of the collection, and we already have coverage by Selenium tests. I think it should be fine to not have a unit test there. I put a comment to prevent this regression in the future.

WDYT can we write meaningful unit test and if yes, than how?
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
