### PR TITLE
[7.52.x] RHPAM-3250: Stunner - Not all illegal characters are removed from Data Object name

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.java
@@ -83,10 +83,7 @@ public interface StunnerWidgetsConstants {
     @TranslationKey(defaultValue = "Data Object-Name")
     String MarshallingResponsePopup_dataObjectWithName = "MarshallingMessage.dataObjectWithName";
 
-    @TranslationKey(defaultValue = "contains Illegal Chars ([space], #, :, [quotes]), will be replaced with (-)")
-    String MarshallingResponsePopup_dataObjectWithIllegalCharacters = "MarshallingMessage.dataObjectWithIllegalCharacters";
-
-    @TranslationKey(defaultValue = "Data Object with Invalid Name Exists")
+    @TranslationKey(defaultValue = "Data Object with Invalid Name Exists. Illegal chars will be replaced by -")
     String MarshallingResponsePopup_dataObjectWithInvalidName = "MarshallingMessage.dataObjectWithInvalidName";
 
     @TranslationKey(defaultValue = "Info")

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
@@ -37,8 +37,7 @@ MarshallingMessage.convertedElement=Element {0} of type {1} was converted to {2}
 MarshallingMessage.elementFailure=Failure on element {0} of type {1}
 MarshallingMessage.dataObjectsSameNameDifferentType=Data Object Exists with Same Name and Different Type - Will be Changed to (Object)
 MarshallingMessage.dataObjectWithName=Data Object-Name
-MarshallingMessage.dataObjectWithIllegalCharacters=contains Illegal Chars ([space], #, :, [quotes]), will be replaced with (-)
-MarshallingMessage.dataObjectWithInvalidName=Data Object with Invalid Name Exists
+MarshallingMessage.dataObjectWithInvalidName=Data Object with Invalid Name Exists. Illegal chars will be replaced by -
 
 SessionCardinalityStateHandler.EmptyStateCaption=Click, drag or interact with a node
 SessionCardinalityStateHandler.EmptyStateMessage=To start, click or drag a node in the left-hand palette onto the canvas

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/util/StringUtils.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/util/StringUtils.java
@@ -124,6 +124,7 @@ public class StringUtils {
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < value.length(); i++) {
             final char c = value.charAt(i);
+
             switch (c) {
                 case '#':
                 case '"':
@@ -131,10 +132,83 @@ public class StringUtils {
                 case ' ':
                     sb.append("-");
                     break;
-                case '\n':
+                case '\n': // Leave as is
+                    break;
+
+                // Normal Characters
+                case 'a':
+                case 'b':
+                case 'c':
+                case 'd':
+                case 'e':
+                case 'f':
+                case 'g':
+                case 'h':
+                case 'i':
+                case 'j':
+                case 'k':
+                case 'l':
+                case 'm':
+                case 'n':
+                case 'o':
+                case 'p':
+                case 'q':
+                case 'r':
+                case 's':
+                case 't':
+                case 'u':
+                case 'v':
+                case 'w':
+                case 'x':
+                case 'y':
+                case 'z':
+                case 'A':
+                case 'B':
+                case 'C':
+                case 'D':
+                case 'E':
+                case 'F':
+                case 'G':
+                case 'H':
+                case 'I':
+                case 'J':
+                case 'K':
+                case 'L':
+                case 'M':
+                case 'N':
+                case 'O':
+                case 'P':
+                case 'Q':
+                case 'R':
+                case 'S':
+                case 'T':
+                case 'U':
+                case 'V':
+                case 'W':
+                case 'X':
+                case 'Y':
+                case 'Z':
+                case '\'':
+                case '?':
+                case '*':
+                case '/':
+                case '+':
+                case '_':
+                case '-':
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                    sb.append(c);
                     break;
                 default:
-                    sb.append(c);
+                    sb.append("-");
                     break;
             }
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/util/StringUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/test/java/org/kie/workbench/common/stunner/core/util/StringUtilsTest.java
@@ -31,6 +31,7 @@ public class StringUtilsTest {
     private final String ENCODED_VALUE = "&lt; Valid &quot;&amp;&quot; Symbols &gt;";
     private final String DECODED_VALUE = "< Valid \"&\" Symbols >";
     private final String DECODED_VALUE_DATA_OBJECT_NEWLINE = "DATA\nOBJECT";
+    private final String DECODED_VALUE_DATA_OBJECT_ILLEGAL_CHARS = "~!@#$%^&*()_+`10-={}[]:\"|;'\\<>?,./°ľščťžýáíéúä!ô§ň";
 
     private final String EMPTY_STRING = "";
 
@@ -174,4 +175,8 @@ public class StringUtilsTest {
         assertEquals("DATAOBJECT", replaceIllegalCharsForDataObjects(DECODED_VALUE_DATA_OBJECT_NEWLINE));
     }
 
+    @Test
+    public void testReplaceIllegalCharsDataObjectName() {
+        assertEquals("--------*--_+-10----------'---?--/----------------", replaceIllegalCharsForDataObjects(DECODED_VALUE_DATA_OBJECT_ILLEGAL_CHARS));
+    }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNDataObjectValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNDataObjectValidator.java
@@ -37,7 +37,6 @@ import org.kie.workbench.common.stunner.core.validation.Violation;
 public abstract class BPMNDataObjectValidator implements DomainValidator {
 
     private static final String ALLOWED_CHARS = "^[a-zA-Z0-9\\-\\_\\ \\+\\/\\*\\?\\'\\.]*$";
-    private static final String ILLEGAL_CHARS = ".*[#:\" ]+.*";
 
     @Override
     public String getDefinitionSetId() {
@@ -65,11 +64,6 @@ public abstract class BPMNDataObjectValidator implements DomainValidator {
                     dataObjectsMap.put(name, type);
                 }
 
-                if (name.matches(ILLEGAL_CHARS)) {
-                    BPMNViolation bpmnViolation = new BPMNViolation(getMessageDataObjectWithName() + ": " + name + " " + getMessageDataObjectWithIllegalCharacters(), Violation.Type.WARNING, element.getUUID());
-                    violations.add(bpmnViolation);
-                }
-
                 if (!name.matches(ALLOWED_CHARS)) {
                     BPMNViolation bpmnViolation = new BPMNViolation(getMessageDataObjectIllegalName() + " : " + name, Violation.Type.WARNING, element.getUUID());
                     violations.add(bpmnViolation);
@@ -82,8 +76,6 @@ public abstract class BPMNDataObjectValidator implements DomainValidator {
     public abstract String getMessageDataObjectWithTypeSameName();
 
     public abstract String getMessageDataObjectWithName();
-
-    public abstract String getMessageDataObjectWithIllegalCharacters();
 
     public abstract String getMessageDataObjectIllegalName();
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/validation/BPMNDataObjectClientValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/validation/BPMNDataObjectClientValidator.java
@@ -44,11 +44,6 @@ public class BPMNDataObjectClientValidator extends BPMNDataObjectValidator {
     }
 
     @Override
-    public String getMessageDataObjectWithIllegalCharacters() {
-        return translationService.getValue(StunnerWidgetsConstants.MarshallingResponsePopup_dataObjectWithIllegalCharacters);
-    }
-
-    @Override
     public String getMessageDataObjectIllegalName() {
         return translationService.getValue(StunnerWidgetsConstants.MarshallingResponsePopup_dataObjectWithInvalidName);
     }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [JBPM-9242](https://issues.redhat.com/browse/JBPM-0000)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
