### PR TITLE
RHPAM-3544 - Data Object editor removes imports when saving

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
@@ -104,13 +104,21 @@ public class LienzoMultipleSelectionControl<H extends AbstractCanvasHandler>
         @Override
         public void onChanged(final SelectionManager.SelectedItems selectedItems) {
             final SelectionManager.ChangedItems changedItems = selectedItems.getChanged();
-            getSelectionControl().deselect(new Lists.Builder<String>()
-                                                   .addAll(shapesToIdentifiers(changedItems.getRemovedShapes().toList()))
-                                                   .addAll(shapesToIdentifiers(changedItems.getRemovedConnectors().toList())).build());
-            getSelectionControl().select(new Lists.Builder<String>()
-                                                 .addAll(shapesToIdentifiers(changedItems.getAddedShapes().toList()))
-                                                 .addAll(shapesToIdentifiers(changedItems.getAddedConnectors().toList())).build());
-            defaultSelectionListener.onChanged(selectedItems);
+            final int added = selectedItems.getChanged().addedSize();
+            final int removed = selectedItems.getChanged().removedSize();
+            if (added > 0 || removed > 0) {
+                getSelectionControl().deselect(new Lists.Builder<String>()
+                                                       .addAll(shapesToIdentifiers(changedItems.getRemovedShapes().toList()))
+                                                       .addAll(shapesToIdentifiers(changedItems.getRemovedConnectors().toList())).build());
+                getSelectionControl().select(new Lists.Builder<String>()
+                                                     .addAll(shapesToIdentifiers(changedItems.getAddedShapes().toList()))
+                                                     .addAll(shapesToIdentifiers(changedItems.getAddedConnectors().toList())).build());
+                defaultSelectionListener.onChanged(selectedItems);
+
+                if (getSelectionControl().getSelectedItems().isEmpty()) {
+                    canvasClearSelectionEvent.fire(new CanvasClearSelectionEvent(getCanvasHandler()));
+                }
+            }
         }
     };
 
@@ -190,9 +198,6 @@ public class LienzoMultipleSelectionControl<H extends AbstractCanvasHandler>
         checkNotNull("event",
                      event);
         if (Objects.equals(getCanvasHandler(), event.getCanvasHandler())) {
-            if (event.getIdentifiers().size() == 1) {
-                onClearSelection();
-            }
             selectionShapeProvider.moveShapeToTop();
         }
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControlTest.java
@@ -284,7 +284,7 @@ public class LienzoMultipleSelectionControlTest {
         when(selectionManager.getSelectedItems().isSelectionGroup()).thenReturn(true);
         tested.onCanvasSelection(new CanvasSelectionEvent(canvasHandler, Arrays.asList(ELEMENT_UUID)));
         verify(selectionControl, never()).clearSelection();
-        verify(selectionManager, times(1)).clearSelection();
+        verify(selectionManager, never()).clearSelection();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/AbstractSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/AbstractSelectionControl.java
@@ -48,8 +48,8 @@ public abstract class AbstractSelectionControl<H extends AbstractCanvasHandler>
                    CanvasRegistrationControl<H, Element>,
                    CanvasControl.SessionAware<ClientSession> {
 
-    private final Event<CanvasSelectionEvent> canvasSelectionEvent;
-    private Event<CanvasClearSelectionEvent> canvasClearSelectionEvent;
+    protected final Event<CanvasSelectionEvent> canvasSelectionEvent;
+    protected Event<CanvasClearSelectionEvent> canvasClearSelectionEvent;
     private final MapSelectionControl<H> selectionControl;
 
     @Inject

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
@@ -82,7 +82,6 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
                     final String canvasRootUUID = getRootUUID();
                     fireCanvasClear();
                     if (null != canvasRootUUID) {
-                        lastSelected = "";
                         selectionEventConsumer.accept(new CanvasSelectionEvent(canvasHandler,
                                                                                canvasRootUUID));
                     }
@@ -255,11 +254,10 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
         }
         if (getCanvas().equals(shapeRemovedEvent.getCanvas())) {
             items.remove(shapeRemovedEvent.getShape().getUUID());
-            lastSelected = "";
         }
     }
 
-    public void onCanvasElementSelected(final CanvasSelectionEvent event) {
+    void onCanvasElementSelected(final CanvasSelectionEvent event) {
         checkNotNull("event",
                      event);
         if (null == canvasHandler) {
@@ -283,7 +281,9 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
     public void onCanvasClearSelection(final CanvasClearSelectionEvent event) {
         checkNotNull("event",
                      event);
-        if (null != canvasHandler && canvasHandler.equals(event.getCanvasHandler())) {
+        if (null != canvasHandler
+                && canvasHandler.equals(event.getCanvasHandler())
+                && !getSelectedItems().isEmpty()) {
             this.clearSelection(false);
         }
     }
@@ -304,21 +304,9 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
         return canvasHandler.getDiagram().getMetadata().getCanvasRootUUID();
     }
 
-    private String lastSelected = "";
-
     private void fireSelectedItemsEvent() {
         final Collection<String> selectedItems = getSelectedItems();
         if (!selectedItems.isEmpty()) {
-            if (selectedItems.size() == 1) {
-
-                final String next = selectedItems.iterator().next();
-
-                if (lastSelected.equals(next)) {
-                    return;
-                }
-
-                lastSelected = next;
-            }
             selectionEventConsumer.accept(new CanvasSelectionEvent(canvasHandler,
                                                                    selectedItems));
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
@@ -255,7 +255,7 @@ public class MapSelectionControlTest {
                 ArgumentCaptor.forClass(CanvasSelectionEvent.class);
         // Verify it has only been fired once
         verify(elementSelectedEvent,
-               times(1)).fire(elementSelectedEventArgumentCaptor.capture());
+               times(2)).fire(elementSelectedEventArgumentCaptor.capture());
         final CanvasSelectionEvent event = elementSelectedEventArgumentCaptor.getValue();
         assertEquals(1, event.getIdentifiers().size());
         assertEquals(ELEMENT_UUID, event.getIdentifiers().iterator().next());

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/widgets/FormsCanvasSessionHandler.java
@@ -31,6 +31,7 @@ import org.kie.workbench.common.stunner.core.api.DefinitionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.SelectionControl;
+import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasClearSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.CanvasSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.event.selection.DomainObjectSelectionEvent;
 import org.kie.workbench.common.stunner.core.client.canvas.listener.CanvasDomainObjectListener;
@@ -179,21 +180,27 @@ public class FormsCanvasSessionHandler {
         }
     }
 
-    void onCanvasSelectionEvent(@Observes CanvasSelectionEvent event) {
-        checkNotNull("event",
-                     event);
+    void onCanvasSelectionEvent(@Observes CanvasClearSelectionEvent event) {
+        if (checkCanvasHandler(event.getCanvasHandler())) {
+            selectRoot();
+        }
+    }
 
+    void onCanvasSelectionEvent(@Observes CanvasSelectionEvent event) {
         if (checkCanvasHandler(event.getCanvasHandler())) {
             if (event.getIdentifiers().size() == 1) {
                 final String uuid = event.getIdentifiers().iterator().next();
                 final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), uuid);
                 scheduleRender(() -> render(element));
             } else {
-                // Select root canvas
-                final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), this.getDiagram().getMetadata().getCanvasRootUUID());
-                render(element);
+                selectRoot();
             }
         }
+    }
+
+    private void selectRoot() {
+        final Element<? extends Definition<?>> element = CanvasLayoutUtils.getElement(getCanvasHandler(), this.getDiagram().getMetadata().getCanvasRootUUID());
+        render(element);
     }
 
     protected void scheduleRender(final com.google.gwt.user.client.Command command) {


### PR DESCRIPTION
It is possible to have an element loaded on the properties tab and not selected on the canvas.
The assignments widget attempts to load data objects based on that canvas item. If there is none, the error happens.
This fix consists in refreshing the properties tab correctly and displaying the selected node properly.

**JIRA**: [RHPAM-3544](https://issues.redhat.com/browse/RHPAM-3544)

**Business Central**: [WAR file](https://drive.google.com/file/d/1q8EzOTsK6Ict5osNP83Rzq_NSpeMIa_U/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1BqI0RChrmTQX8Dj_KtzahYfZp_hbTtII/view?usp=sharing)