### PR TITLE
JBPM-9695 - DMN - Data Types shortcuts do not work anymore

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -363,17 +363,17 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         if (!getStunnerEditor().isClosed()) {
             getStunnerEditor().focus();
             onDiagramLoad();
-            dataTypesPage.onFocus();
-            dataTypesPage.enableShortcuts();
         }
+        dataTypesPage.onFocus();
+        dataTypesPage.enableShortcuts();
     }
 
     @OnLostFocus
     public void onLostFocus() {
         if (!getStunnerEditor().isClosed()) {
             getStunnerEditor().lostFocus();
-            dataTypesPage.onLostFocus();
         }
+        dataTypesPage.onLostFocus();
     }
 
     @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -351,10 +351,33 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
     }
 
     @Test
+    public void testOnFocusWithClosedEditor() {
+        when(stunnerEditor.isClosed()).thenReturn(true);
+        diagramEditor.onFocus();
+        verify(stunnerEditor, never()).focus();
+        verify(stunnerEditor, never()).lostFocus();
+        verify(diagramEditor, never()).onDiagramLoad();
+        verify(dataTypesPage).onFocus();
+        verify(dataTypesPage).enableShortcuts();
+        verify(dataTypesPage, never()).onLostFocus();
+        verify(dataTypesPage, never()).disableShortcuts();
+    }
+
+    @Test
     public void testOnLostFocus() {
         when(stunnerEditor.isClosed()).thenReturn(false);
         diagramEditor.onLostFocus();
         verify(stunnerEditor).lostFocus();
+        verify(stunnerEditor, never()).focus();
+        verify(dataTypesPage).onLostFocus();
+        verify(dataTypesPage, never()).onFocus();
+    }
+
+    @Test
+    public void testOnLostFocusWithClosedEditor() {
+        when(stunnerEditor.isClosed()).thenReturn(true);
+        diagramEditor.onLostFocus();
+        verify(stunnerEditor, never()).lostFocus();
         verify(stunnerEditor, never()).focus();
         verify(dataTypesPage).onLostFocus();
         verify(dataTypesPage, never()).onFocus();


### PR DESCRIPTION
**JIRA**: [JBPM-9695](https://issues.redhat.com/browse/JBPM-9695)

**Business Central**: [WAR file](https://drive.google.com/file/d/15U_1fxYGVGkSBKTTQnjT7pJJZDdtCUDx/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1fj9pKYvwAD74al4StaPH0suolOVtaYb4/view?usp=sharing)

<details>
<summary>
Hi @jomarko, @karreiro, @romartin, there is a fix for shortcuts.

Just to double check: I build VS Code extension in this way:
* `mvn clean install -DskipTests -Dgwt.compiler.skip` under `kie-wb-common/kie-wb-common-dmn`
* `mvn clean install` under `kie-wb-common/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime`
* `export EXTERNAL_RESOURCE_PATH__dmnEditor=$KIEGROUP/kie-wb-common/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/target/kie-wb-common-dmn-webapp-kogito-runtime/`
* `yarn run init && yarn run build:prod` under `kogito-tooling`

Is it correct steps?
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
