### PR TITLE
[backport-7.52.x] RHPAM-2647 : [GSS](7.z) Errors when building a project are shown to all users

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
@@ -1117,6 +1117,9 @@ public class DataModelerScreenPresenter
         unpublishMessage.setShowSystemConsole(false);
         unpublishMessage.setMessageType(currentMessageType);
         unpublishMessage.setUserId((sessionInfo != null && sessionInfo.getIdentity() != null) ? sessionInfo.getIdentity().getIdentifier() : null);
+        if (workbenchContext.getActiveModule().isPresent()) {
+            unpublishMessage.setRootPath(workbenchContext.getActiveModule().get().getRootPath().toURI());
+        }
         unpublishMessagesEvent.fire(unpublishMessage);
     }
 
@@ -1140,6 +1143,10 @@ public class DataModelerScreenPresenter
             systemMessage.setColumn(error.getColumn());
             publishMessage.getMessagesToPublish().add(systemMessage);
         }
+        if (workbenchContext.getActiveModule().isPresent()) {
+            publishMessage.setRootPath(workbenchContext.getActiveModule().get().getRootPath().toURI());
+        }
+
         publishBatchMessagesEvent.fire(publishMessage);
     }
 

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/service/BuildServiceHelper.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/service/BuildServiceHelper.java
@@ -67,6 +67,7 @@ public class BuildServiceHelper {
         invokeLocalBuildPipeLine(module,
                                  localBinaryConfig -> {
                                      result[0] = localBinaryConfig.getBuildResults();
+                                     result[0].setRootPathURI(module.getRootPath().toURI());
                                  });
         return result[0];
     }
@@ -100,6 +101,7 @@ public class BuildServiceHelper {
                                  resource,
                                  localBinaryConfig -> {
                                      result[0] = localBinaryConfig.getIncrementalBuildResults();
+                                     result[0].setRootPathURI(module.getRootPath().toURI());
                                  });
         return result[0];
     }
@@ -119,6 +121,7 @@ public class BuildServiceHelper {
                                  resourceChanges,
                                  localBinaryConfig -> {
                                      result[0] = localBinaryConfig.getIncrementalBuildResults();
+                                     result[0].setRootPathURI(module.getRootPath().toURI());
                                  });
         return result[0];
     }
@@ -142,6 +145,7 @@ public class BuildServiceHelper {
                                  mode,
                                  localBinaryConfig -> {
                                      result[0] = localBinaryConfig.getBuildResults();
+                                     result[0].setRootPathURI(module.getRootPath().toURI());
                                  });
         return result[0];
     }

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/service/BuildServiceHelperTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/service/BuildServiceHelperTest.java
@@ -39,6 +39,7 @@ import org.uberfire.backend.vfs.Path;
 import org.uberfire.workbench.events.ResourceChange;
 
 import static org.junit.Assert.*;
+import static org.kie.workbench.common.services.backend.builder.ala.BuildPipelineTestConstants.ROOT_PATH_URI;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -72,12 +73,17 @@ public class BuildServiceHelperTest {
     @Mock
     private Path resource;
 
+    @Mock
+    private Path rootPath;
+
     private BuildPipelineInvoker.LocalBuildRequest expectedRequest;
 
     @Before
     public void setUp() {
         serviceHelper = new BuildServiceHelper(pipelineInvoker,
                                                deploymentVerifier);
+        when(module.getRootPath()).thenReturn(rootPath);
+        when(rootPath.toURI()).thenReturn(ROOT_PATH_URI);
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/main/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListener.java
@@ -22,6 +22,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
 import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.messageconsole.events.PublishMessagesEvent;
 import org.guvnor.messageconsole.events.SystemMessage;
@@ -43,9 +44,11 @@ public class ProjectMessagesListener {
     private final Event<UnpublishMessagesEvent> unpublishMessagesEvent;
     private final NotificationsObserver notificationsObserver;
     private final SessionManager clientSessionManager;
+    private WorkspaceProjectContext workspaceProjectContext;
 
     protected ProjectMessagesListener() {
         this(null,
+             null,
              null,
              null,
              null);
@@ -55,10 +58,12 @@ public class ProjectMessagesListener {
     public ProjectMessagesListener(final NotificationsObserver notificationsObserver,
                                    final Event<PublishMessagesEvent> publishMessagesEvent,
                                    final Event<UnpublishMessagesEvent> unpublishMessagesEvent,
+                                   final WorkspaceProjectContext workspaceProjectContext,
                                    final SessionManager clientSessionManager) {
         this.notificationsObserver = notificationsObserver;
         this.publishMessagesEvent = publishMessagesEvent;
         this.unpublishMessagesEvent = unpublishMessagesEvent;
+        this.workspaceProjectContext = workspaceProjectContext;
         this.clientSessionManager = clientSessionManager;
     }
 
@@ -99,6 +104,7 @@ public class ProjectMessagesListener {
         PublishMessagesEvent messages = new PublishMessagesEvent();
         messages.setShowSystemConsole(false);
         messages.setMessagesToPublish(messagesList);
+        messages.setRootPath(workspaceProjectContext.getActiveModule().get().getRootPath().toURI());
         publishMessagesEvent.fire(messages);
     }
 
@@ -110,6 +116,7 @@ public class ProjectMessagesListener {
         final UnpublishMessagesEvent unpublishMessagesEvent = new UnpublishMessagesEvent();
         unpublishMessagesEvent.setMessageType(getMessageType(getDiagramPath()));
         unpublishMessagesEvent.setShowSystemConsole(false);
+        unpublishMessagesEvent.setRootPath(workspaceProjectContext.getActiveModule().get().getRootPath().toURI());
         this.unpublishMessagesEvent.fire(unpublishMessagesEvent);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListenerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/src/test/java/org/kie/workbench/common/stunner/project/client/screens/ProjectMessagesListenerTest.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 
 import javax.enterprise.event.Event;
 
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
+import org.guvnor.common.services.project.model.Module;
 import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.messageconsole.events.PublishMessagesEvent;
 import org.guvnor.messageconsole.events.SystemMessage;
@@ -78,6 +80,8 @@ public class ProjectMessagesListenerTest {
     @Mock
     private SessionManager clientSessionManager;
     @Mock
+    private WorkspaceProjectContext workspaceProjectContext;
+    @Mock
     private Path path;
     @Mock
     private ClientSession session;
@@ -87,13 +91,15 @@ public class ProjectMessagesListenerTest {
     private Diagram diagram;
     @Mock
     private Metadata metadata;
-
+    @Mock
+    private Module module;
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         this.projectMessagesListener = spy(new ProjectMessagesListener(notificationsObserver,
                                                                        publishMessagesEvent,
                                                                        unpublishMessagesEvent,
+                                                                       workspaceProjectContext,
                                                                        clientSessionManager));
         when(clientSessionManager.getCurrentSession()).thenReturn(session);
         when(session.getCanvasHandler()).thenReturn(canvasHandler);
@@ -101,6 +107,8 @@ public class ProjectMessagesListenerTest {
         when(diagram.getMetadata()).thenReturn(metadata);
         when(metadata.getPath()).thenReturn(path);
         when(path.toURI()).thenReturn(PATH);
+        when(module.getRootPath()).thenReturn(path);
+        when(workspaceProjectContext.getActiveModule()).thenReturn(Optional.of(module));
     }
 
     @Test


### PR DESCRIPTION
(cherry picked from commit 93be73cf5bd57f9ace5728635ec16b20641bebf0)

**Thank you for submitting this pull request**

**RHPAM-2647:**: https://issues.redhat.com/browse/RHPAM-2647

**Referenced Pull Requests**:
original PR: https://github.com/kiegroup/kie-wb-common/pull/3546

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
