### PR TITLE
AF-2811: Required Process Variable Tags shouldn't be accepted in forms when empty

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/main/java/org/kie/workbench/common/forms/jbpm/service/bpmn/util/BPMNVariableUtils.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/main/java/org/kie/workbench/common/forms/jbpm/service/bpmn/util/BPMNVariableUtils.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.lists.input
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.model.impl.meta.entries.FieldReadOnlyEntry;
+import org.kie.workbench.common.forms.model.impl.meta.entries.FieldRequiredEntry;
 import org.kie.workbench.common.forms.model.impl.meta.entries.FieldTypeEntry;
 import org.kie.workbench.common.forms.service.backend.util.ModelPropertiesGenerator;
 
@@ -94,10 +95,14 @@ public class BPMNVariableUtils {
     }
 
     public static ModelProperty generateVariableProperty(String name, String type, ClassLoader classLoader) {
-        return generateVariableProperty(name, type, false, classLoader);
+        return generateVariableProperty(name, type, false, false, classLoader);
     }
 
     public static ModelProperty generateVariableProperty(String name, String type, boolean readOnly, ClassLoader classLoader) {
+        return generateVariableProperty(name, type, false, readOnly, classLoader);
+    }
+
+    public static ModelProperty generateVariableProperty(String name, String type, boolean required, boolean readOnly, ClassLoader classLoader) {
 
         ModelProperty property = ModelPropertiesGenerator.createModelProperty(name,
                                                                               BPMNVariableUtils.getRealTypeForInput(type),
@@ -106,6 +111,9 @@ public class BPMNVariableUtils {
         if(property != null) {
             if(readOnly) {
                 property.getMetaData().addEntry(new FieldReadOnlyEntry(readOnly));
+            }
+            if(required) {
+                property.getMetaData().addEntry(new FieldRequiredEntry(required));
             }
 
             if (property.getTypeInfo().getClassName().equals(Object.class.getName())) {

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/test/java/org/kie/workbench/common/forms/jbpm/service/bpmn/util/BPMNVariableUnitsTest.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/src/test/java/org/kie/workbench/common/forms/jbpm/service/bpmn/util/BPMNVariableUnitsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.forms.jbpm.service.bpmn.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.model.ModelProperty;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BPMNVariableUnitsTest {
+
+    @Test
+    public void testGenerateVariableProperty() {
+        ModelProperty modelProperty = BPMNVariableUtils.generateVariableProperty("Object",
+                                                                                 "java.lang.Object",
+                                                                                 new ClassLoader() {
+                                                                                     @Override
+                                                                                     public Class<?> loadClass(String name) throws ClassNotFoundException {
+                                                                                         return Object.class;
+                                                                                     }
+                                                                                 });
+        Assert.assertNull(modelProperty.getMetaData().getEntry("field-required"));
+        Assert.assertNull(modelProperty.getMetaData().getEntry("field-readOnly"));
+
+        modelProperty = BPMNVariableUtils.generateVariableProperty("Object",
+                                                                   "java.lang.Object",
+                                                                   true,
+                                                                   new ClassLoader() {
+                                                                       @Override
+                                                                       public Class<?> loadClass(String name) throws ClassNotFoundException {
+                                                                           return Object.class;
+                                                                       }
+                                                                   });
+
+        Assert.assertTrue((Boolean)modelProperty.getMetaData().getEntry("field-readOnly").getValue());
+
+        modelProperty = BPMNVariableUtils.generateVariableProperty("Object",
+                                                                   "java.lang.Object",
+                                                                   true,
+                                                                   true,
+                                                                   new ClassLoader() {
+                                                                       @Override
+                                                                       public Class<?> loadClass(String name) throws ClassNotFoundException {
+                                                                           return Object.class;
+                                                                       }
+                                                                   });
+
+        Assert.assertTrue((Boolean)modelProperty.getMetaData().getEntry("field-required").getValue());
+        Assert.assertTrue((Boolean)modelProperty.getMetaData().getEntry("field-readOnly").getValue());
+    }
+}


### PR DESCRIPTION
* Added required and readonly properties to generate variable property

(cherry picked from commit 2199c2b0c102db24053661d3f34ca61a04dcae59)

**Thank you for submitting this pull request**

**JIRA**: 
[AF-2811](https://issues.redhat.com/browse/AF-2811)
[RHPAM-3047](https://issues.redhat.com/browse/RHPAM-3047)

**Referenced Pull Requests**:
Original PR: https://github.com/kiegroup/kie-wb-common/pull/3592

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
