### PR TITLE
[7.52.x] RHDM-1647: DMN - Reopened diagram with DRDs can not be edited

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/main/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditor.java
@@ -62,6 +62,7 @@ import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelp
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 import org.kie.workbench.common.stunner.core.validation.Violation;
@@ -314,9 +315,11 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
         kieView.getMultiPage().selectPage(DATA_TYPES_PAGE_INDEX);
     }
 
+    @SuppressWarnings("all")
     @Override
     public void open(final ProjectDiagram diagram,
                      final SessionPresenter.SessionPresenterCallback callback) {
+        final AbstractSession currentSession = !getStunnerEditor().isClosed() ? (AbstractSession) getStunnerEditor().getSession() : null;
         this.layoutHelper.applyLayout(diagram, openDiagramLayoutExecutor);
 
         feelInitializer.initializeFEELEditor();
@@ -326,6 +329,9 @@ public class DMNDiagramEditor extends AbstractProjectDiagramEditor<DMNDiagramRes
             public void onSuccess() {
                 setupSessionHeaderContainer();
                 callback.onSuccess();
+                if (null != currentSession) {
+                    currentSession.close();
+                }
             }
 
             @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/src/test/java/org/kie/workbench/common/dmn/project/client/editor/DMNDiagramEditorTest.java
@@ -86,6 +86,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -442,6 +443,16 @@ public class DMNDiagramEditorTest extends AbstractProjectDiagramEditorTest {
         verify(searchBarComponent).disableSearch();
         verify(sessionCommandManager).execute(eq(canvasHandler),
                                               Mockito.<NavigateToExpressionEditorCommand>any());
+    }
+
+    @Test
+    public void testCloseExistingSessionIfAny() {
+        when(sessionManager.getCurrentSession()).thenReturn(dmnEditorSession);
+        when(dmnEditorSession.getCanvasHandler()).thenReturn(canvasHandler);
+        when(stunnerEditor.isClosed()).thenReturn(false);
+        when(stunnerEditor.getSession()).thenReturn(dmnEditorSession);
+        diagramEditor.open(diagram);
+        verify(dmnEditorSession, times(1)).close();
     }
 
     @Test

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -62,6 +62,7 @@ import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationServic
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
+import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationPage;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
@@ -251,8 +252,10 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
         getWidget().getMultiPage().selectPage(DATA_TYPES_PAGE_INDEX);
     }
 
+    @SuppressWarnings("all")
     public void open(final Diagram diagram,
                      final SessionPresenter.SessionPresenterCallback callback) {
+        final AbstractSession currentSession = !stunnerEditor.isClosed() ? (AbstractSession) stunnerEditor.getSession() : null;
         this.layoutHelper.applyLayout(diagram, openDiagramLayoutExecutor);
         feelInitializer.initializeFEELEditor();
         stunnerEditor.open(diagram, new SessionPresenter.SessionPresenterCallback() {
@@ -276,6 +279,9 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
                 initialiseKieEditorForSession(diagram);
                 setupSessionHeaderContainer();
                 callback.onSuccess();
+                if (null != currentSession) {
+                    currentSession.close();
+                }
             }
 
             @Override

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerVie
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionDiagramPresenter;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
+import org.kie.workbench.common.stunner.core.client.PromiseMock;
 import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -387,6 +388,17 @@ public abstract class AbstractDMNDiagramEditorTest {
         serviceCallback.onSuccess(diagram);
 
         assertOnDiagramLoad();
+    }
+
+    @Test
+    @SuppressWarnings("all")
+    public void testCloseExistingSessionIfAny() {
+        final PromiseMock promise = new PromiseMock();
+        doReturn(promise.asPromise()).when(editor).getContent();
+        promise.then(() -> CONTENT);
+        when(stunnerEditor.getSession()).thenReturn(session);
+        openDiagram();
+        verify(session, times(1)).close();
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/AbstractSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/AbstractSession.java
@@ -34,6 +34,8 @@ public abstract class AbstractSession<C extends AbstractCanvas, H extends Abstra
 
     public abstract void destroy();
 
+    public abstract void close();
+
     protected void onControlRegistered(final CanvasControl control) {
         onControlRegistered(control, this);
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
@@ -137,6 +137,12 @@ public class DefaultEditorSession
     }
 
     @Override
+    public void close() {
+        commandRegistry.clear();
+        session.close();
+    }
+
+    @Override
     public void destroy() {
         commandRegistry.clear();
         session.destroy();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSession.java
@@ -138,7 +138,6 @@ public class DefaultEditorSession
 
     @Override
     public void close() {
-        commandRegistry.clear();
         session.close();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSession.java
@@ -78,6 +78,11 @@ public class DefaultViewerSession
     }
 
     @Override
+    public void close() {
+        session.close();
+    }
+
+    @Override
     public void destroy() {
         session.destroy();
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ManagedSession.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ManagedSession.java
@@ -202,19 +202,7 @@ public class ManagedSession
 
     @Override
     public void destroy() {
-        sessionLoader.destroy();
-        // Destroy listeners.
-        removeListeners();
-        // Destroy controls.
-        canvasControls.forEach(this::destroyCanvasControl);
-        canvasControls.clear();
-        canvasControlTypes.clear();
-        canvasHandlerControls.forEach(this::destroyCanvasHandlerControl);
-        canvasHandlerControls.clear();
-        canvasHandlerControlTypes.clear();
-        canvasControlInstances.destroyAll();
-        canvasHandlerControlInstances.destroyAll();
-        // Destroy canvas.
+        close();
         canvasHandler.destroy();
         canvasInstances.destroyAll();
         canvasHandlerInstances.destroyAll();
@@ -226,6 +214,20 @@ public class ManagedSession
         canvasControlDestroyed = null;
         canvasHandlerControlRegistered = null;
         canvasHandlerControlDestroyed = null;
+    }
+
+    @Override
+    public void close() {
+        sessionLoader.destroy();
+        removeListeners();
+        canvasControls.forEach(this::destroyCanvasControl);
+        canvasControls.clear();
+        canvasControlTypes.clear();
+        canvasHandlerControls.forEach(this::destroyCanvasHandlerControl);
+        canvasHandlerControls.clear();
+        canvasHandlerControlTypes.clear();
+        canvasControlInstances.destroyAll();
+        canvasHandlerControlInstances.destroyAll();
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
@@ -148,6 +148,13 @@ public class DefaultEditorSessionTest {
     }
 
     @Test
+    public void testClose() {
+        tested.close();
+        verify(commandRegistry, times(1)).clear();
+        verify(managedSession, times(1)).close();
+    }
+
+    @Test
     public void testDestroy() {
         tested.destroy();
         verify(commandRegistry, times(1)).clear();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultEditorSessionTest.java
@@ -55,6 +55,7 @@ import org.uberfire.mvp.Command;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -150,7 +151,7 @@ public class DefaultEditorSessionTest {
     @Test
     public void testClose() {
         tested.close();
-        verify(commandRegistry, times(1)).clear();
+        verify(commandRegistry, never()).clear();
         verify(managedSession, times(1)).close();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSessionTest.java
@@ -74,7 +74,6 @@ public class DefaultViewerSessionTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testInit() {
         Metadata metadata = mock(Metadata.class);
         Command command = mock(Command.class);
@@ -88,14 +87,18 @@ public class DefaultViewerSessionTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testOpen() {
         tested.open();
         verify(managedSession, times(1)).open();
     }
 
     @Test
-    @SuppressWarnings("unchecked")
+    public void testClose() {
+        tested.close();
+        verify(managedSession, times(1)).close();
+    }
+
+    @Test
     public void testDestroy() {
         tested.destroy();
         verify(managedSession, times(1)).destroy();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/ManagedSessionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/session/impl/ManagedSessionTest.java
@@ -39,12 +39,14 @@ import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -160,6 +162,30 @@ public class ManagedSessionTest {
         verify(canvasHandler, times(1)).addRegistrationListener(any(CanvasElementListener.class));
         verify(canvasControl, times(1)).init(eq(canvas));
         verify(canvasHandlerControl, times(1)).init(eq(canvasHandler));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testClose() {
+        tested.registerCanvasControl(SomeTestControl.class)
+                .registerCanvasHandlerControl(SomeTestControl.class)
+                .init(metadata,
+                      mock(Command.class));
+        tested.open();
+        tested.close();
+        assertNotNull(tested.getCanvas());
+        assertNotNull(tested.getCanvasHandler());
+        assertTrue(tested.getCanvasControls().isEmpty());
+        assertTrue(tested.getCanvasHandlerControls().isEmpty());
+        verify(canvasHandler, never()).destroy();
+        verify(canvas, times(1)).removeRegistrationListener(any(CanvasShapeListener.class));
+        verify(canvasHandler, times(1)).removeRegistrationListener(any(CanvasElementListener.class));
+        verify(canvasControl, times(1)).destroy();
+        verify(canvasHandlerControl, times(1)).destroy();
+        verify(canvasControlInstances, times(1)).destroyAll();
+        verify(canvasHandlerControlInstances, times(1)).destroyAll();
+        verify(canvasControlInstances, times(1)).destroyAll();
+        verify(canvasHandlerControlInstances, times(1)).destroyAll();
     }
 
     @Test


### PR DESCRIPTION
Hey  @karreiro @jomarko 

Here is the fix for https://issues.redhat.com/browse/RHDM-1647

I've properly tested kogtio and BC, and both look good to me. In fact in kogtio the issue was not being exposed, user didn't notice about it, although it was some memory leak there anyway, but now everything ok!! :tada: 

Please the deadline for this PR is this Fri, would appreciate en **early review (targeting RHPAM 7.11)**.

Thanks in advance!