### PR TITLE
[7.52.x] DROOLS-6268 : Guided Rule Editor: Add memberOf and not memberOf operators

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImplTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/AsyncPackageDataModelOracleImplTest.java
@@ -557,7 +557,7 @@ public class AsyncPackageDataModelOracleImplTest {
             @Override
             public void callback(String[] result) {
                 assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "contains", "not contains",
-                                          "matches", "not matches", "soundslike", "not soundslike",
+                                          "matches", "not matches", "soundslike", "not soundslike", "memberOf", "not memberOf",
                                           "== null", "!= null", "in", "not in"},
                                   result);
             }
@@ -577,7 +577,7 @@ public class AsyncPackageDataModelOracleImplTest {
         Callback<String[]> callback = spy(new Callback<String[]>() {
             @Override
             public void callback(String[] result) {
-                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "== null", "!= null", "in", "not in"},
+                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "== null", "!= null", "memberOf", "not memberOf", "in", "not in"},
                                   result);
             }
         });
@@ -596,7 +596,7 @@ public class AsyncPackageDataModelOracleImplTest {
         Callback<String[]> callback = spy(new Callback<String[]>() {
             @Override
             public void callback(String[] result) {
-                assertArrayEquals(new String[]{"==", "!=", "== null", "!= null"},
+                assertArrayEquals(new String[]{"==", "!=", "== null", "!= null", "memberOf", "not memberOf"},
                                   result);
             }
         });
@@ -636,7 +636,7 @@ public class AsyncPackageDataModelOracleImplTest {
         Callback<String[]> callback = spy(new Callback<String[]>() {
             @Override
             public void callback(String[] result) {
-                assertArrayEquals(new String[]{"==", "!=", "== null", "!= null"},
+                assertArrayEquals(new String[]{"==", "!=", "== null", "!= null", "memberOf", "not memberOf"},
                                   result);
             }
         });

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelOracleCEPCompletionsTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelOracleCEPCompletionsTest.java
@@ -105,7 +105,7 @@ public class PackageDataModelOracleCEPCompletionsTest {
                                       new Callback<String[]>() {
                                           @Override
                                           public void callback(final String[] notAnEventDateFieldOperators) {
-                                              assertEquals(13,
+                                              assertEquals(15,
                                                            notAnEventDateFieldOperators.length);
                                               assertEquals(notAnEventDateFieldOperators[0],
                                                            "==");
@@ -124,14 +124,18 @@ public class PackageDataModelOracleCEPCompletionsTest {
                                               assertEquals(notAnEventDateFieldOperators[7],
                                                            "!= null");
                                               assertEquals(notAnEventDateFieldOperators[8],
-                                                           "in");
+                                                           "memberOf");
                                               assertEquals(notAnEventDateFieldOperators[9],
-                                                           "not in");
+                                                           "not memberOf");
                                               assertEquals(notAnEventDateFieldOperators[10],
-                                                           "after");
+                                                           "in");
                                               assertEquals(notAnEventDateFieldOperators[11],
-                                                           "before");
+                                                           "not in");
                                               assertEquals(notAnEventDateFieldOperators[12],
+                                                           "after");
+                                              assertEquals(notAnEventDateFieldOperators[13],
+                                                           "before");
+                                              assertEquals(notAnEventDateFieldOperators[14],
                                                            "coincides");
                                           }
                                       });
@@ -141,7 +145,7 @@ public class PackageDataModelOracleCEPCompletionsTest {
                                       new Callback<String[]>() {
                                           @Override
                                           public void callback(final String[] anEventThisOperators) {
-                                              assertEquals(17,
+                                              assertEquals(19,
                                                            anEventThisOperators.length);
                                               assertEquals(anEventThisOperators[0],
                                                            "==");
@@ -152,30 +156,34 @@ public class PackageDataModelOracleCEPCompletionsTest {
                                               assertEquals(anEventThisOperators[3],
                                                            "!= null");
                                               assertEquals(anEventThisOperators[4],
-                                                           "after");
+                                                           "memberOf");
                                               assertEquals(anEventThisOperators[5],
-                                                           "before");
+                                                           "not memberOf");
                                               assertEquals(anEventThisOperators[6],
-                                                           "coincides");
+                                                           "after");
                                               assertEquals(anEventThisOperators[7],
-                                                           "during");
+                                                           "before");
                                               assertEquals(anEventThisOperators[8],
-                                                           "finishes");
+                                                           "coincides");
                                               assertEquals(anEventThisOperators[9],
-                                                           "finishedby");
+                                                           "during");
                                               assertEquals(anEventThisOperators[10],
-                                                           "includes");
+                                                           "finishes");
                                               assertEquals(anEventThisOperators[11],
-                                                           "meets");
+                                                           "finishedby");
                                               assertEquals(anEventThisOperators[12],
-                                                           "metby");
+                                                           "includes");
                                               assertEquals(anEventThisOperators[13],
-                                                           "overlaps");
+                                                           "meets");
                                               assertEquals(anEventThisOperators[14],
-                                                           "overlappedby");
+                                                           "metby");
                                               assertEquals(anEventThisOperators[15],
-                                                           "starts");
+                                                           "overlaps");
                                               assertEquals(anEventThisOperators[16],
+                                                           "overlappedby");
+                                              assertEquals(anEventThisOperators[17],
+                                                           "starts");
+                                              assertEquals(anEventThisOperators[18],
                                                            "startedby");
                                           }
                                       });

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelOracleCompletionsTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelOracleCompletionsTest.java
@@ -261,7 +261,7 @@ public class PackageDataModelOracleCompletionsTest {
             @Override
             public void callback(final String[] personThisOperators) {
 
-                assertArrayEquals(new String[]{"==", "!=", "== null", "!= null"},
+                assertArrayEquals(new String[]{"==", "!=", "== null", "!= null", "memberOf", "not memberOf"},
                                   personThisOperators);
             }
         });
@@ -274,7 +274,7 @@ public class PackageDataModelOracleCompletionsTest {
         Callback<String[]> personAgeCallback = spy(new Callback<String[]>() {
             @Override
             public void callback(final String[] personAgeOperators) {
-                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "== null", "!= null", "in", "not in"},
+                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "== null", "!= null", "memberOf", "not memberOf", "in", "not in"},
                                   personAgeOperators);
             }
         });
@@ -287,7 +287,7 @@ public class PackageDataModelOracleCompletionsTest {
         Callback<String[]> personRankCallback = spy(new Callback<String[]>() {
             @Override
             public void callback(final String[] personRankOperators) {
-                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "== null", "!= null"},
+                assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "== null", "!= null", "memberOf", "not memberOf"},
                                   personRankOperators);
             }
         });
@@ -301,7 +301,7 @@ public class PackageDataModelOracleCompletionsTest {
             @Override
             public void callback(final String[] personNameOperators) {
                 assertArrayEquals(new String[]{"==", "!=", "<", ">", "<=", ">=", "contains", "not contains",
-                                          "matches", "not matches", "soundslike", "not soundslike",
+                                          "matches", "not matches", "soundslike", "not soundslike", "memberOf", "not memberOf",
                                           "== null", "!= null", "in", "not in"},
                                   personNameOperators);
             }
@@ -356,7 +356,7 @@ public class PackageDataModelOracleCompletionsTest {
         Callback<String[]> personThisCallback = spy(new Callback<String[]>() {
             @Override
             public void callback(final String[] personThisConnectiveOperators) {
-                assertEquals(3,
+                assertEquals(5,
                              personThisConnectiveOperators.length);
                 assertEquals(personThisConnectiveOperators[0],
                              "|| ==");
@@ -364,6 +364,10 @@ public class PackageDataModelOracleCompletionsTest {
                              "|| !=");
                 assertEquals(personThisConnectiveOperators[2],
                              "&& !=");
+                assertEquals(personThisConnectiveOperators[3],
+                             "memberOf");
+                assertEquals(personThisConnectiveOperators[4],
+                             "not memberOf");
             }
         });
         oracle.getConnectiveOperatorCompletions("Person",
@@ -445,7 +449,7 @@ public class PackageDataModelOracleCompletionsTest {
         Callback<String[]> personNameCallback2 = spy(new Callback<String[]>() {
             @Override
             public void callback(final String[] personNameConnectiveOperators) {
-                assertEquals(13,
+                assertEquals(15,
                              personNameConnectiveOperators.length);
                 assertEquals(personNameConnectiveOperators[0],
                              "|| ==");
@@ -473,6 +477,10 @@ public class PackageDataModelOracleCompletionsTest {
                              "&& matches");
                 assertEquals(personNameConnectiveOperators[12],
                              "|| matches");
+                assertEquals(personNameConnectiveOperators[13],
+                             "memberOf");
+                assertEquals(personNameConnectiveOperators[14],
+                             "not memberOf");
             }
         });
         oracle.getConnectiveOperatorCompletions("Person",


### PR DESCRIPTION
(cherry picked from commit 5c4563d7533cc9eefcad61e9e7387f1c36ffc3f1)

**JIRA**: 

[DROOLS-6268](https://issues.redhat.com/browse/DROOLS-6268)

**referenced Pull Requests**:

* https://github.com/kiegroup/kie-soup/pull/194
* https://github.com/kiegroup/drools/pull/3689
* https://github.com/kiegroup/kie-wb-common/pull/3620
* https://github.com/kiegroup/drools-wb/pull/1483

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
