### PR TITLE
[7.52.x] DROOLS-6306: JDK 11 build fails on Enforcer Error BanDuplicateClasses in kie-wb-common-dmn-webapp-kogito-runtime

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -451,8 +451,8 @@
       <artifactId>xmlunit-core</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
         </exclusion>
       </exclusions>
       <scope>test</scope>


### PR DESCRIPTION
Cherry-pick _only_ the BanDuplicateClasses fix from https://github.com/kiegroup/kie-wb-common/pull/3611 to `7.52.x`.

**JIRA**: [DROOLS-6306](https://issues.redhat.com/browse/DROOLS-6306): JDK 11 build fails on Enforcer Error BanDuplicateClasses in kie-wb-common-dmn-webapp-kogito-runtime

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
