### PR TITLE
Kogito-4978 : Stunner - Make new nodes editable automatically

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
@@ -21,6 +21,8 @@ import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Event;
+import elemental2.dom.DomGlobal;
+import jsinterop.base.Js;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -142,9 +144,9 @@ public class InlineTextEditorBoxViewImpl
         });
     }
 
-    public native void selectText(Object node) /*-{
-        $wnd.getSelection().selectAllChildren(node);
-    }-*/;
+    public void selectText(Div node) {
+        DomGlobal.window.getSelection().selectAllChildren(Js.cast(node));
+    }
 
     String buildStyle(final double width, final double height) {
         StringBuilder style = new StringBuilder();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
@@ -145,7 +145,9 @@ public class InlineTextEditorBoxViewImpl
     }
 
     public void selectText(Div node) {
-        DomGlobal.window.getSelection().selectAllChildren(Js.cast(node));
+        if (DomGlobal.window != null) {
+            DomGlobal.window.getSelection().selectAllChildren(Js.cast(node));
+        }
     }
 
     String buildStyle(final double width, final double height) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
@@ -136,8 +136,15 @@ public class InlineTextEditorBoxViewImpl
         nameField.setAttribute("data-text", placeholder);
 
         setVisible();
-        scheduleDeferredCommand(() -> nameField.focus());
+        scheduleDeferredCommand(() -> {
+            nameField.focus();
+            selectText(nameField);
+        });
     }
+
+    public static native void selectText(Object node) /*-{
+        $wnd.getSelection().selectAllChildren(node);
+    }-*/;
 
     String buildStyle(final double width, final double height) {
         StringBuilder style = new StringBuilder();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImpl.java
@@ -142,7 +142,7 @@ public class InlineTextEditorBoxViewImpl
         });
     }
 
-    public static native void selectText(Object node) /*-{
+    public native void selectText(Object node) /*-{
         $wnd.getSelection().selectAllChildren(node);
     }-*/;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
@@ -286,6 +286,17 @@ public class InlineTextEditorBoxViewImplTest {
     }
 
     @Test
+    public void testSelectedTextOnEdit() {
+        tested.setTextBoxInternalAlignment(ALIGN_MIDDLE);
+        tested.show("Task", BOX_WIDTH, BOX_HEIGHT);
+
+        verify(nameField,
+               times(1)).setTextContent(eq("Task"));
+        verify(showCommand, times(1)).execute();
+        verify(tested, times(1)).selectText(any());
+    }
+
+    @Test
     public void testShowNullName() {
         tested.setTextBoxInternalAlignment(ALIGN_MIDDLE);
         tested.show(null, BOX_WIDTH, BOX_HEIGHT);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/inlineeditor/InlineTextEditorBoxViewImplTest.java
@@ -91,6 +91,7 @@ public class InlineTextEditorBoxViewImplTest {
         this.tested.init(presenter);
         when(editNameBox.getStyle()).thenReturn(editNameBoxStyle);
         when(nameField.getStyle()).thenReturn(nameFieldStyle);
+
         doAnswer(i -> {
             ((Scheduler.ScheduledCommand) i.getArguments()[0]).execute();
             return null;

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
@@ -45,12 +45,9 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.TextEnterHa
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
-import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
-import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
-import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 import static org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent.Key.ESC;
 
@@ -170,25 +167,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
                                     clickHandler);
         registerHandler(shape.getUUID(),
                         clickHandler);
-        Node<View<?>, Edge> sourceNode = (Node<View<?>, Edge>) element;
-
-        final Object sourceDefinition = null != sourceNode ? sourceNode.getContent().getDefinition() : null;
-        final boolean isSourceGateway = isGateway(sourceDefinition);
-        if (!isSourceGateway) {
-            scheduleDeferredCommand(() -> AbstractCanvasInlineTextEditorControl.this.show(element));
-        }
-    }
-
-    private static boolean isGateway(final Object bean) {
-        switch (bean.getClass() + "") {
-            case "class org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway":
-            case "class org.kie.workbench.common.stunner.bpmn.definition.ExclusiveGateway":
-            case "class org.kie.workbench.common.stunner.bpmn.definition.InclusiveGateway":
-            case "class org.kie.workbench.common.stunner.bpmn.definition.EventGateway":
-                return false;
-            default:
-        }
-        return false;
+        scheduleDeferredCommand(() -> AbstractCanvasInlineTextEditorControl.this.show(element));
     }
 
     private void changeMouseCursorOnTextEnter(final Shape<?> shape, final HasEventHandlers hasEventHandlers) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
@@ -167,6 +167,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
                                     clickHandler);
         registerHandler(shape.getUUID(),
                         clickHandler);
+
         scheduleDeferredCommand(() -> AbstractCanvasInlineTextEditorControl.this.show(element));
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
@@ -45,9 +45,12 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.TextEnterHa
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitEvent;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.TextExitHandler;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.ViewEventType;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
 
 import static org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent.Key.ESC;
 
@@ -167,6 +170,25 @@ public abstract class AbstractCanvasInlineTextEditorControl
                                     clickHandler);
         registerHandler(shape.getUUID(),
                         clickHandler);
+        Node<View<?>, Edge> sourceNode = (Node<View<?>, Edge>) element;
+
+        final Object sourceDefinition = null != sourceNode ? sourceNode.getContent().getDefinition() : null;
+        final boolean isSourceGateway = isGateway(sourceDefinition);
+        if (!isSourceGateway) {
+            scheduleDeferredCommand(() -> AbstractCanvasInlineTextEditorControl.this.show(element));
+        }
+    }
+
+    private static boolean isGateway(final Object bean) {
+        switch (bean.getClass() + "") {
+            case "class org.kie.workbench.common.stunner.bpmn.definition.ParallelGateway":
+            case "class org.kie.workbench.common.stunner.bpmn.definition.ExclusiveGateway":
+            case "class org.kie.workbench.common.stunner.bpmn.definition.InclusiveGateway":
+            case "class org.kie.workbench.common.stunner.bpmn.definition.EventGateway":
+                return false;
+            default:
+        }
+        return false;
     }
 
     private void changeMouseCursorOnTextEnter(final Shape<?> shape, final HasEventHandlers hasEventHandlers) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
@@ -323,7 +323,7 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
 
         final TextDoubleClickHandler textDoubleClickHandler = textDoubleClickHandlerCaptor.getValue();
         textDoubleClickHandler.handle(new TextDoubleClickEvent(0, 1, SHAPE_X, SHAPE_Y));
-        verify(control).show(eq(element));
+        verify(control, times(2)).show(eq(element));
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
@@ -327,6 +327,20 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
     }
 
     @Test
+    public void testEditOnRegister() {
+        initCanvas(CANVAS_X, CANVAS_Y, CANVAS_WIDTH, CANVAS_HEIGHT);
+        initShape(SHAPE_X, SHAPE_Y, SCROLL_X, SCROLL_Y, ZOOM);
+        initHasTitle(POSITION_INSIDE, ORIENTATION_HORIZONTAL, FONT_FAMILY, ALIGN_MIDDLE, FONT_SIZE, 0);
+        control.bind(session);
+        control.init(canvasHandler);
+
+        when(testShapeView.supports(ViewEventType.TEXT_DBL_CLICK)).thenReturn(true);
+
+        control.register(element);
+        verify(control).show(eq(element));
+    }
+
+    @Test
     public void testRegisterTextEnter() {
         control.init(canvasHandler);
         when(testShapeView.supports(ViewEventType.TEXT_ENTER)).thenReturn(true);

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/workitem/NoWIDCustomTaskResolutionTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/workitem/NoWIDCustomTaskResolutionTest.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
 import org.kie.workbench.common.stunner.bpmn.BPMNTestDefinitionFactory;
 import org.kie.workbench.common.stunner.bpmn.backend.BPMNDirectDiagramMarshaller;
+import org.kie.workbench.common.stunner.bpmn.backend.converters.tostunner.processes.DataTypeCacheServer;
 import org.kie.workbench.common.stunner.bpmn.backend.service.diagram.Unmarshalling;
 import org.kie.workbench.common.stunner.bpmn.workitem.CustomTask;
 import org.kie.workbench.common.stunner.bpmn.workitem.WorkItemDefinition;
@@ -38,6 +39,7 @@ import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
@@ -70,6 +72,9 @@ public class NoWIDCustomTaskResolutionTest {
     private static final String ON_ENTRY_SCRIPT = "java : System.out.Println(\"On entry!\");";
     private static final String ON_EXIT_SCRIPT = "java : System.out.Println(\"On exit!\");";
 
+    @Mock
+    private DataTypeCacheServer dataTypeCacheServer;
+
     @Before
     @SuppressWarnings("unchecked")
     public void setup() throws Exception {
@@ -98,7 +103,8 @@ public class NoWIDCustomTaskResolutionTest {
                                                  widService,
                                                  stunnerAPI.getFactoryManager(),
                                                  stunnerAPI.commandFactory,
-                                                 stunnerAPI.commandManager);
+                                                 stunnerAPI.commandManager,
+                                                 dataTypeCacheServer);
 
         diagram = Unmarshalling.unmarshall(tested, BPMN_CUSTOM_TASK);
     }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [KOGITO-4978](https://issues.redhat.com/browse/KOGITO-4978)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
