### PR TITLE
KOGITO-3274: [DMN Designer] Read-only mode - Connectors appear differently on read-only mode

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
@@ -371,12 +371,15 @@ public class NodeConnector {
             // Generate new a edge and connect it
             final NodeEntry nodeEntry = nodeEntries.get(0);
             final Node requiredNode = nodeEntry.getNode();
+            final View<?> view = (View<?>)requiredNode.getContent();
+            final double viewWidth = view.getBounds().getWidth();
+            final double viewHeight = view.getBounds().getHeight();
 
             connectWbEdge(connectorTypeId,
                           diagramId,
                           currentNode,
                           requiredNode,
-                          newEdge(),
+                          newEdge(viewWidth/2, viewHeight/2),
                           uuid());
         } else if (existingEdge.isPresent()) {
             // Connect existing edge
@@ -415,11 +418,11 @@ public class NodeConnector {
         setConnectionMagnets(wbEdge, connectionContent, dmnEdge);
     }
 
-    JSIDMNEdge newEdge() {
+    JSIDMNEdge newEdge(double x, double y) {
         final JSIDMNEdge dmnEdge = new JSIDMNEdge();
         final JSIPoint point = new JSIPoint();
-        point.setX(0);
-        point.setY(0);
+        point.setX(x);
+        point.setY(y);
         dmnEdge.addAllWaypoint(point, point);
         return dmnEdge;
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnectorTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnectorTest.java
@@ -104,8 +104,17 @@ public class NodeConnectorTest {
         when(jsiDMNElementReference.getHref()).thenReturn("#123");
         when(jsiDMNElement.getId()).thenReturn("789");
         when(nodeEntry.getNode()).thenReturn(requiredNode);
+
+        final View<?> view = mock(View.class);
+        final Bounds bounds = mock(Bounds.class);
+
+        when(bounds.getHeight()).thenReturn(50d);
+        when(bounds.getWidth()).thenReturn(100d);
+        when(view.getBounds()).thenReturn(bounds);
+
+        when(requiredNode.getContent()).thenReturn(view);
         doReturn("456").when(nodeConnector).uuid();
-        doReturn(newEdge).when(nodeConnector).newEdge();
+        doReturn(newEdge).when(nodeConnector).newEdge(50, 25);
         doNothing().when(nodeConnector).connectWbEdge(any(), any(), any(), any(), any(), any());
 
         entriesById.put("123", singletonList(nodeEntry));

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-filter.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-filter.dmn
@@ -60,8 +60,8 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_FEA0C425-B1E9-41AD-B0CF-050F22CAABC5" dmnElementRef="_FEA0C425-B1E9-41AD-B0CF-050F22CAABC5">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-input-data-string.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0001-input-data-string.dmn
@@ -1,55 +1,49 @@
 <?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/"
-  xmlns="https://github.com/agilepro/dmn-tck"
-  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
-  xmlns:kie="http://www.drools.org/kie/dmn/1.2"
-  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
-  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
-  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0001-input-data-string" name="0001-input-data-string" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
-  <dmn:extensionElements/>
-  <dmn:decision id="d_GreetingMessage" name="Greeting Message">
-    <dmn:extensionElements/>
-    <dmn:variable id="_215A03DB-39E7-4DDC-A3A2-27137DC09CA2" name="Greeting Message" typeRef="string"/>
-    <dmn:informationRequirement id="_62A5A325-DE2E-4DAB-81B0-261BFD455721">
-      <dmn:requiredInput href="#i_FullName"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_4EFA4D67-5CE7-4816-AFEF-E70D4A69500E">
-      <dmn:text>"Hello " + Full Name</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="i_FullName" name="Full Name">
-    <dmn:extensionElements/>
-    <dmn:variable id="_F1E2768D-AD95-4827-9C68-BD80C9691DB2" name="Full Name" typeRef="string"/>
-  </dmn:inputData>
-  <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_94F32805-FCC5-43E1-AD96-B384AEA7E2D0" name="DRG">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_4EFA4D67-5CE7-4816-AFEF-E70D4A69500E"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-d_GreetingMessage" dmnElementRef="d_GreetingMessage" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-i_FullName" dmnElementRef="i_FullName" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_62A5A325-DE2E-4DAB-81B0-261BFD455721" dmnElementRef="_62A5A325-DE2E-4DAB-81B0-261BFD455721">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-  </dmndi:DMNDI>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/agilepro/dmn-tck" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_0001-input-data-string" name="0001-input-data-string" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/agilepro/dmn-tck">
+	<dmn:extensionElements/>
+	<dmn:decision id="d_GreetingMessage" name="Greeting Message">
+		<dmn:extensionElements/>
+		<dmn:variable id="_215A03DB-39E7-4DDC-A3A2-27137DC09CA2" name="Greeting Message" typeRef="string"/>
+		<dmn:informationRequirement id="_62A5A325-DE2E-4DAB-81B0-261BFD455721">
+			<dmn:requiredInput href="#i_FullName"/>
+		</dmn:informationRequirement>
+		<dmn:literalExpression id="_4EFA4D67-5CE7-4816-AFEF-E70D4A69500E">
+			<dmn:text>"Hello " + Full Name</dmn:text>
+		</dmn:literalExpression>
+	</dmn:decision>
+	<dmn:inputData id="i_FullName" name="Full Name">
+		<dmn:extensionElements/>
+		<dmn:variable id="_F1E2768D-AD95-4827-9C68-BD80C9691DB2" name="Full Name" typeRef="string"/>
+	</dmn:inputData>
+	<dmndi:DMNDI>
+		<dmndi:DMNDiagram id="_94F32805-FCC5-43E1-AD96-B384AEA7E2D0" name="DRG">
+			<di:extension>
+				<kie:ComponentsWidthsExtension>
+					<kie:ComponentWidths dmnElementRef="_4EFA4D67-5CE7-4816-AFEF-E70D4A69500E"/>
+				</kie:ComponentsWidthsExtension>
+			</di:extension>
+			<dmndi:DMNShape id="dmnshape-drg-d_GreetingMessage" dmnElementRef="d_GreetingMessage" isCollapsed="false">
+				<dmndi:DMNStyle>
+					<dmndi:FillColor red="255" green="255" blue="255"/>
+					<dmndi:StrokeColor red="0" green="0" blue="0"/>
+					<dmndi:FontColor red="0" green="0" blue="0"/>
+				</dmndi:DMNStyle>
+				<dc:Bounds x="50" y="50" width="100" height="50"/>
+				<dmndi:DMNLabel/>
+			</dmndi:DMNShape>
+			<dmndi:DMNShape id="dmnshape-drg-i_FullName" dmnElementRef="i_FullName" isCollapsed="false">
+				<dmndi:DMNStyle>
+					<dmndi:FillColor red="255" green="255" blue="255"/>
+					<dmndi:StrokeColor red="0" green="0" blue="0"/>
+					<dmndi:FontColor red="0" green="0" blue="0"/>
+				</dmndi:DMNStyle>
+				<dc:Bounds x="50" y="225" width="100" height="50"/>
+				<dmndi:DMNLabel/>
+			</dmndi:DMNShape>
+			<dmndi:DMNEdge id="dmnedge-drg-_62A5A325-DE2E-4DAB-81B0-261BFD455721" dmnElementRef="_62A5A325-DE2E-4DAB-81B0-261BFD455721">
+				<di:waypoint x="100" y="250"/>
+				<di:waypoint x="100" y="75"/>
+			</dmndi:DMNEdge>
+		</dmndi:DMNDiagram>
+	</dmndi:DMNDI>
 </dmn:definitions>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-input-data-number.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-input-data-number.dmn
@@ -47,8 +47,8 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_E3AEED90-FCBF-41A3-95BD-2EFEF0DA557E" dmnElementRef="_E3AEED90-FCBF-41A3-95BD-2EFEF0DA557E">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+		<di:waypoint x="100" y="250"/>
+		<di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-string-functions.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0002-string-functions.dmn
@@ -299,36 +299,36 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_3FE203E6-7254-4AC6-948E-65BF2EDC7CC9" dmnElementRef="_3FE203E6-7254-4AC6-948E-65BF2EDC7CC9">
-        <di:waypoint x="137" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="187" y="250"/>
+		<di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_29220E9C-93C4-4DF5-9FD1-9A6438BE7955" dmnElementRef="_29220E9C-93C4-4DF5-9FD1-9A6438BE7955">
-        <di:waypoint x="312" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="362" y="250"/>
+		<di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_BD831028-C7E2-47F4-A285-8D9EA191713E" dmnElementRef="_BD831028-C7E2-47F4-A285-8D9EA191713E">
-        <di:waypoint x="487" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="537" y="250"/>
+		<di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5DDE4200-3D43-4590-88F2-D9B6EC1520E3" dmnElementRef="_5DDE4200-3D43-4590-88F2-D9B6EC1520E3">
-        <di:waypoint x="137" y="225"/>
-        <di:waypoint x="50" y="50"/>
+		<di:waypoint x="187" y="250"/>
+		<di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E268A502-7CBC-424A-BBE1-C84656BE3C92" dmnElementRef="_E268A502-7CBC-424A-BBE1-C84656BE3C92">
-        <di:waypoint x="312" y="225"/>
-        <di:waypoint x="50" y="50"/>
+		<di:waypoint x="362" y="250"/>
+		<di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_11112D2C-9BFE-4C3C-96BF-3423E8A468B4" dmnElementRef="_11112D2C-9BFE-4C3C-96BF-3423E8A468B4">
-        <di:waypoint x="137" y="225"/>
-        <di:waypoint x="225" y="50"/>
+		<di:waypoint x="187" y="250"/>
+		<di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_52089F54-865B-4594-975D-D05181186E5F" dmnElementRef="_52089F54-865B-4594-975D-D05181186E5F">
-        <di:waypoint x="312" y="225"/>
-        <di:waypoint x="225" y="50"/>
+		<di:waypoint x="362" y="250"/>
+		<di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C630793E-5B0A-4AB6-9324-3E24B303CEAF" dmnElementRef="_C630793E-5B0A-4AB6-9324-3E24B303CEAF">
-        <di:waypoint x="487" y="225"/>
-        <di:waypoint x="575" y="50"/>
+		<di:waypoint x="537" y="250"/>
+		<di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-input-data-string-allowed-values.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-input-data-string-allowed-values.dmn
@@ -53,8 +53,8 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_0232CB3B-18B3-4E4E-9EE6-59AC1963B44A" dmnElementRef="_0232CB3B-18B3-4E4E-9EE6-59AC1963B44A">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+		<di:waypoint x="100" y="250"/>
+		<di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-iteration.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0003-iteration.dmn
@@ -87,12 +87,12 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_F5229939-6759-47E1-BCC4-7D98D590CD8E" dmnElementRef="_F5229939-6759-47E1-BCC4-7D98D590CD8E">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="137" y="50"/>
+		<di:waypoint x="275" y="250"/>
+		<di:waypoint x="187" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_AB4D9418-D21C-4FA4-9C1C-82775846D6C0" dmnElementRef="_AB4D9418-D21C-4FA4-9C1C-82775846D6C0">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="137" y="50"/>
+		<di:waypoint x="100" y="250"/>
+		<di:waypoint x="187" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-lending.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-lending.dmn
@@ -1884,144 +1884,144 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_C91DE08F-DDC5-447E-A60F-665B4EF3938A" dmnElementRef="_C91DE08F-DDC5-447E-A60F-665B4EF3938A">
-        <di:waypoint x="50" y="575"/>
-        <di:waypoint x="50" y="225"/>
+        <di:waypoint x="100" y="600"/>
+        <di:waypoint x="100" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A0D7E8FB-0EAB-4344-A83B-B88634994369" dmnElementRef="_A0D7E8FB-0EAB-4344-A83B-B88634994369">
-        <di:waypoint x="663" y="400"/>
-        <di:waypoint x="50" y="225"/>
+        <di:waypoint x="713" y="425"/>
+        <di:waypoint x="100" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6F67A0F0-5F9B-448F-99E9-889D016D414E" dmnElementRef="_6F67A0F0-5F9B-448F-99E9-889D016D414E">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_2BC67540-4C1B-4017-B8A0-ACB450CB5436" dmnElementRef="_2BC67540-4C1B-4017-B8A0-ACB450CB5436">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_048C76D3-5EE4-47F2-8EB1-78568A7FC838" dmnElementRef="_048C76D3-5EE4-47F2-8EB1-78568A7FC838">
-        <di:waypoint x="138" y="400"/>
-        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="188" y="425"/>
+        <di:waypoint x="275" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D408CEF0-827C-4F0F-A109-CBD0A5F030A5" dmnElementRef="_D408CEF0-827C-4F0F-A109-CBD0A5F030A5">
-        <di:waypoint x="50" y="575"/>
-        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="100" y="600"/>
+        <di:waypoint x="275" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7E59857C-836F-48F7-9CB1-6AD918ABC4FE" dmnElementRef="_7E59857C-836F-48F7-9CB1-6AD918ABC4FE">
-        <di:waypoint x="488" y="925"/>
-        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="538" y="950"/>
+        <di:waypoint x="275" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_2D49FF9E-9462-4880-9005-887F8C42E6E4" dmnElementRef="_2D49FF9E-9462-4880-9005-887F8C42E6E4">
-        <di:waypoint x="313" y="400"/>
-        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="363" y="425"/>
+        <di:waypoint x="275" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_582AE809-39DF-4161-BD66-10F5F9401749" dmnElementRef="_582AE809-39DF-4161-BD66-10F5F9401749">
-        <di:waypoint x="50" y="750"/>
-        <di:waypoint x="50" y="575"/>
+        <di:waypoint x="100" y="775"/>
+        <di:waypoint x="100" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E9164594-078A-4F26-B97E-5EA99FF5A78C" dmnElementRef="_E9164594-078A-4F26-B97E-5EA99FF5A78C">
-        <di:waypoint x="488" y="925"/>
-        <di:waypoint x="50" y="575"/>
+        <di:waypoint x="538" y="950"/>
+        <di:waypoint x="100" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F9D65271-F2FE-4653-B565-57FB9922EE10" dmnElementRef="_F9D65271-F2FE-4653-B565-57FB9922EE10">
-        <di:waypoint x="225" y="750"/>
-        <di:waypoint x="50" y="575"/>
+        <di:waypoint x="275" y="775"/>
+        <di:waypoint x="100" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A60EE052-6E71-48DC-8DBA-CC32829DCA37" dmnElementRef="_A60EE052-6E71-48DC-8DBA-CC32829DCA37">
-        <di:waypoint x="50" y="750"/>
-        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="100" y="775"/>
+        <di:waypoint x="538" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8A12BCF4-3323-4A0D-AE01-31A1299F1F3A" dmnElementRef="_8A12BCF4-3323-4A0D-AE01-31A1299F1F3A">
-        <di:waypoint x="750" y="575"/>
-        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="800" y="600"/>
+        <di:waypoint x="538" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_EDC16398-4948-4D9A-9598-CB45D067CEE9" dmnElementRef="_EDC16398-4948-4D9A-9598-CB45D067CEE9">
-        <di:waypoint x="488" y="925"/>
-        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="538" y="950"/>
+        <di:waypoint x="538" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_72F904DC-09B2-4779-AF1E-178111F8C78F" dmnElementRef="_72F904DC-09B2-4779-AF1E-178111F8C78F">
-        <di:waypoint x="575" y="575"/>
-        <di:waypoint x="488" y="400"/>
+        <di:waypoint x="625" y="600"/>
+        <di:waypoint x="538" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DCF5FBCE-33C3-4626-82F9-86D89D52F289" dmnElementRef="_DCF5FBCE-33C3-4626-82F9-86D89D52F289">
-        <di:waypoint x="488" y="925"/>
-        <di:waypoint x="50" y="750"/>
+        <di:waypoint x="538" y="950"/>
+        <di:waypoint x="100" y="775"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_AF61BD10-21B4-4F77-BDF7-8299C53A763B" dmnElementRef="_AF61BD10-21B4-4F77-BDF7-8299C53A763B">
-        <di:waypoint x="313" y="925"/>
-        <di:waypoint x="50" y="750"/>
+        <di:waypoint x="363" y="950"/>
+        <di:waypoint x="100" y="775"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B4FE0787-174C-40C8-AE49-1DEEF5898C3B" dmnElementRef="_B4FE0787-174C-40C8-AE49-1DEEF5898C3B">
-        <di:waypoint x="225" y="575"/>
-        <di:waypoint x="138" y="400"/>
+        <di:waypoint x="275" y="600"/>
+        <di:waypoint x="188" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A826343F-8944-40ED-945F-4DE43BE78547" dmnElementRef="_A826343F-8944-40ED-945F-4DE43BE78547">
-        <di:waypoint x="50" y="575"/>
-        <di:waypoint x="138" y="400"/>
+        <di:waypoint x="100" y="600"/>
+        <di:waypoint x="188" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_9D6C69E2-4D34-4635-8B16-3AD296526182" dmnElementRef="_9D6C69E2-4D34-4635-8B16-3AD296526182">
-        <di:waypoint x="488" y="925"/>
-        <di:waypoint x="138" y="400"/>
+        <di:waypoint x="538" y="950"/>
+        <di:waypoint x="188" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_BE2A20AE-2EDB-4080-8576-F207FB4566FC" dmnElementRef="_BE2A20AE-2EDB-4080-8576-F207FB4566FC">
-        <di:waypoint x="400" y="575"/>
-        <di:waypoint x="138" y="400"/>
+        <di:waypoint x="450" y="600"/>
+        <di:waypoint x="188" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_685011D2-3EB8-492F-9EB1-AEF5E6531905" dmnElementRef="_685011D2-3EB8-492F-9EB1-AEF5E6531905">
-        <di:waypoint x="225" y="575"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="275" y="600"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_69874D88-9AE2-4751-8A60-C9CDEECB12E6" dmnElementRef="_69874D88-9AE2-4751-8A60-C9CDEECB12E6">
-        <di:waypoint x="488" y="400"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="538" y="425"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D208CDBF-FCC3-4088-81E5-5048790EC753" dmnElementRef="_D208CDBF-FCC3-4088-81E5-5048790EC753">
-        <di:waypoint x="488" y="925"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="538" y="950"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F9E534D8-C75D-4FCC-B98C-44C6E92C2290" dmnElementRef="_F9E534D8-C75D-4FCC-B98C-44C6E92C2290">
-        <di:waypoint x="400" y="575"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="450" y="600"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B80FC328-8828-40B9-9598-0F8D64A9FF3A" dmnElementRef="_B80FC328-8828-40B9-9598-0F8D64A9FF3A">
-        <di:waypoint x="750" y="750"/>
-        <di:waypoint x="225" y="575"/>
+        <di:waypoint x="800" y="775"/>
+        <di:waypoint x="275" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A108CD18-2CF0-42D0-A55F-81D36D6AD412" dmnElementRef="_A108CD18-2CF0-42D0-A55F-81D36D6AD412">
-        <di:waypoint x="400" y="750"/>
-        <di:waypoint x="225" y="575"/>
+        <di:waypoint x="450" y="775"/>
+        <di:waypoint x="275" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FAC175CE-5DAD-4054-A067-5799F13286B1" dmnElementRef="_FAC175CE-5DAD-4054-A067-5799F13286B1">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_96B0D7F9-C453-4139-8D8A-E4C230EF7CB6" dmnElementRef="_96B0D7F9-C453-4139-8D8A-E4C230EF7CB6">
-        <di:waypoint x="488" y="400"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="538" y="425"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8A07A4C2-075A-4A9B-952D-B84CAE1F697F" dmnElementRef="_8A07A4C2-075A-4A9B-952D-B84CAE1F697F">
-        <di:waypoint x="750" y="575"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="800" y="600"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5D98E4E0-1011-4D6E-832F-F0BAAF6C9D40" dmnElementRef="_5D98E4E0-1011-4D6E-832F-F0BAAF6C9D40">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="625" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C81A85DD-DED2-4BB0-A4F3-888002E70D84" dmnElementRef="_C81A85DD-DED2-4BB0-A4F3-888002E70D84">
-        <di:waypoint x="750" y="575"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="800" y="600"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_4CB0C6AE-28EE-4548-9446-9E625699F913" dmnElementRef="_4CB0C6AE-28EE-4548-9446-9E625699F913">
-        <di:waypoint x="750" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="800" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6756474E-7427-459D-B6BB-8F1346782B22" dmnElementRef="_6756474E-7427-459D-B6BB-8F1346782B22">
-        <di:waypoint x="488" y="925"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="538" y="950"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8EE3AF6F-F478-4FCC-BA0C-7D994D01914D" dmnElementRef="_8EE3AF6F-F478-4FCC-BA0C-7D994D01914D">
-        <di:waypoint x="575" y="750"/>
-        <di:waypoint x="400" y="575"/>
+        <di:waypoint x="625" y="775"/>
+        <di:waypoint x="450" y="600"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-simpletable-U.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0004-simpletable-U.dmn
@@ -172,16 +172,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_11F06FEE-B38B-4784-A208-8920DC68C44E" dmnElementRef="_11F06FEE-B38B-4784-A208-8920DC68C44E">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B2A0A5F3-A2C3-494E-BD2A-B4539D35F5F2" dmnElementRef="_B2A0A5F3-A2C3-494E-BD2A-B4539D35F5F2">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D1374317-C07B-4CE0-83B0-DBF9E2CD24EF" dmnElementRef="_D1374317-C07B-4CE0-83B0-DBF9E2CD24EF">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-literal-invocation.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-literal-invocation.dmn
@@ -101,16 +101,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_376E38BC-CBB2-41F7-BE25-F91093774325" dmnElementRef="_376E38BC-CBB2-41F7-BE25-F91093774325">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C18E6ABA-89E3-49F8-9851-E6792FFBA10B" dmnElementRef="_C18E6ABA-89E3-49F8-9851-E6792FFBA10B">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_90853A2C-BB99-4F41-B7AF-FFED0C9CF667" dmnElementRef="_90853A2C-BB99-4F41-B7AF-FFED0C9CF667">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-simpletable-A.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0005-simpletable-A.dmn
@@ -172,16 +172,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_0D92E037-76AF-4224-B01D-792F707BD782" dmnElementRef="_0D92E037-76AF-4224-B01D-792F707BD782">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5623E3A1-9F87-4F6F-9ED7-B7D807B75ADE" dmnElementRef="_5623E3A1-9F87-4F6F-9ED7-B7D807B75ADE">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DB80BA13-2097-47F8-BB99-B383D983F3B8" dmnElementRef="_DB80BA13-2097-47F8-BB99-B383D983F3B8">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-join.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-join.dmn
@@ -105,16 +105,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_E61EBDBF-6A03-4BE4-8564-4F9CCD658818" dmnElementRef="_E61EBDBF-6A03-4BE4-8564-4F9CCD658818">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FA11668E-868E-4F46-8F97-50B1D4C09BE8" dmnElementRef="_FA11668E-868E-4F46-8F97-50B1D4C09BE8">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A4A3386A-F250-4D4B-A7C8-CCEA0D6585B2" dmnElementRef="_A4A3386A-F250-4D4B-A7C8-CCEA0D6585B2">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-simpletable-P1.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0006-simpletable-P1.dmn
@@ -172,16 +172,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_B4EC322E-ABB3-4EE4-B5EC-BA7CE4CE9152" dmnElementRef="_B4EC322E-ABB3-4EE4-B5EC-BA7CE4CE9152">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C5BD4042-CB34-4BBB-B64E-A8246958DFD9" dmnElementRef="_C5BD4042-CB34-4BBB-B64E-A8246958DFD9">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FF3E58D7-BEE1-4AA4-AD14-D404647D46BD" dmnElementRef="_FF3E58D7-BEE1-4AA4-AD14-D404647D46BD">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-date-time.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-date-time.dmn
@@ -658,132 +658,132 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_2F32C1AB-DE32-4CCD-B9AA-6B4E04C7821A" dmnElementRef="_2F32C1AB-DE32-4CCD-B9AA-6B4E04C7821A">
-        <di:waypoint x="663" y="750"/>
-        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="713" y="775"/>
+        <di:waypoint x="1063" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6DADBF64-C403-4708-860B-1EF8133EA368" dmnElementRef="_6DADBF64-C403-4708-860B-1EF8133EA368">
-        <di:waypoint x="1188" y="750"/>
-        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="1238" y="775"/>
+        <di:waypoint x="1063" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_57CB86DC-FF64-45FA-A07A-99A717753730" dmnElementRef="_57CB86DC-FF64-45FA-A07A-99A717753730">
-        <di:waypoint x="1363" y="750"/>
-        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="1413" y="775"/>
+        <di:waypoint x="1063" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_4EAD7C78-93CC-448C-BB07-D4A83929B5E8" dmnElementRef="_4EAD7C78-93CC-448C-BB07-D4A83929B5E8">
-        <di:waypoint x="1538" y="750"/>
-        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="1588" y="775"/>
+        <di:waypoint x="1063" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_764D785F-89BC-4054-9C5D-D81B884D7582" dmnElementRef="_764D785F-89BC-4054-9C5D-D81B884D7582">
-        <di:waypoint x="838" y="750"/>
-        <di:waypoint x="1013" y="575"/>
+        <di:waypoint x="888" y="775"/>
+        <di:waypoint x="1063" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B9F18756-FA08-4F4D-873E-1F3904825503" dmnElementRef="_B9F18756-FA08-4F4D-873E-1F3904825503">
-        <di:waypoint x="1100" y="925"/>
-        <di:waypoint x="838" y="750"/>
+        <di:waypoint x="1150" y="950"/>
+        <di:waypoint x="888" y="775"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6A05094C-71B1-44DC-A3D6-DB4CBCF44354" dmnElementRef="_6A05094C-71B1-44DC-A3D6-DB4CBCF44354">
-        <di:waypoint x="1013" y="750"/>
-        <di:waypoint x="1188" y="575"/>
+        <di:waypoint x="1063" y="775"/>
+        <di:waypoint x="1238" y="600"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6E31E108-B3CB-4CA7-9B16-BDFC57A0A169" dmnElementRef="_6E31E108-B3CB-4CA7-9B16-BDFC57A0A169">
-        <di:waypoint x="1013" y="575"/>
-        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="1063" y="600"/>
+        <di:waypoint x="1063" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1209E44E-C0C7-476C-B19B-EBC83C7EE3A7" dmnElementRef="_1209E44E-C0C7-476C-B19B-EBC83C7EE3A7">
-        <di:waypoint x="1188" y="575"/>
-        <di:waypoint x="1013" y="400"/>
+        <di:waypoint x="1238" y="600"/>
+        <di:waypoint x="1063" y="425"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DA0BCAE3-C5E0-4ECB-BE52-D59408C90579" dmnElementRef="_DA0BCAE3-C5E0-4ECB-BE52-D59408C90579">
-        <di:waypoint x="1013" y="400"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="1063" y="425"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8FF88619-083D-456D-ABDC-B447A83D3A0B" dmnElementRef="_8FF88619-083D-456D-ABDC-B447A83D3A0B">
-        <di:waypoint x="1013" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="1063" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F0D243DA-BA7A-42F5-BD1C-81E4949F786A" dmnElementRef="_F0D243DA-BA7A-42F5-BD1C-81E4949F786A">
-        <di:waypoint x="1188" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="1238" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_EFF0B589-D5C9-456D-AAEB-BA30D81F23F2" dmnElementRef="_EFF0B589-D5C9-456D-AAEB-BA30D81F23F2">
-        <di:waypoint x="1363" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="1413" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D8364D7C-A568-439C-970C-4C827013C4BD" dmnElementRef="_D8364D7C-A568-439C-970C-4C827013C4BD">
-        <di:waypoint x="1538" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="1588" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F4FC7369-10DB-457A-82AF-3A42D9E55D63" dmnElementRef="_F4FC7369-10DB-457A-82AF-3A42D9E55D63">
-        <di:waypoint x="1188" y="400"/>
-        <di:waypoint x="838" y="225"/>
+        <di:waypoint x="1238" y="425"/>
+        <di:waypoint x="888" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_048023B4-1E6B-4C5D-8D25-624A5FA1B22A" dmnElementRef="_048023B4-1E6B-4C5D-8D25-624A5FA1B22A">
-        <di:waypoint x="1013" y="400"/>
-        <di:waypoint x="488" y="225"/>
+        <di:waypoint x="1063" y="425"/>
+        <di:waypoint x="538" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F8E68AB4-E621-468C-8619-63A72972F1F1" dmnElementRef="_F8E68AB4-E621-468C-8619-63A72972F1F1">
-        <di:waypoint x="838" y="750"/>
-        <di:waypoint x="488" y="225"/>
+        <di:waypoint x="888" y="775"/>
+        <di:waypoint x="538" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_96962293-59EB-49F5-B1DF-01C484A06BA4" dmnElementRef="_96962293-59EB-49F5-B1DF-01C484A06BA4">
-        <di:waypoint x="1713" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="1763" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1C4BB9F4-4569-46BD-AE8F-2E8A99127AF5" dmnElementRef="_1C4BB9F4-4569-46BD-AE8F-2E8A99127AF5">
-        <di:waypoint x="488" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="538" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_68B86AE9-272F-4654-85A5-09A6FDB93564" dmnElementRef="_68B86AE9-272F-4654-85A5-09A6FDB93564">
-        <di:waypoint x="488" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="538" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A1EAE063-BD35-4D7C-AD55-ECEF8413A798" dmnElementRef="_A1EAE063-BD35-4D7C-AD55-ECEF8413A798">
-        <di:waypoint x="838" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="888" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_70678B25-C5A4-4CEB-BFBD-74A0E624318B" dmnElementRef="_70678B25-C5A4-4CEB-BFBD-74A0E624318B">
-        <di:waypoint x="1013" y="400"/>
-        <di:waypoint x="663" y="225"/>
+        <di:waypoint x="1063" y="425"/>
+        <di:waypoint x="713" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_54EB4B5D-1D44-413A-8254-7C08A8D6D40A" dmnElementRef="_54EB4B5D-1D44-413A-8254-7C08A8D6D40A">
-        <di:waypoint x="838" y="750"/>
-        <di:waypoint x="663" y="225"/>
+        <di:waypoint x="888" y="775"/>
+        <di:waypoint x="713" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DEFC6019-7DC9-475E-8E2B-47C32790672F" dmnElementRef="_DEFC6019-7DC9-475E-8E2B-47C32790672F">
-        <di:waypoint x="1013" y="575"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="1063" y="600"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FBE0E4DA-8F54-45C8-926B-7F27AEB01A03" dmnElementRef="_FBE0E4DA-8F54-45C8-926B-7F27AEB01A03">
-        <di:waypoint x="1013" y="575"/>
-        <di:waypoint x="1625" y="50"/>
+        <di:waypoint x="1063" y="600"/>
+        <di:waypoint x="1675" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E08C050E-A63E-4A55-8D54-F7FC7FBBA502" dmnElementRef="_E08C050E-A63E-4A55-8D54-F7FC7FBBA502">
-        <di:waypoint x="1013" y="575"/>
-        <di:waypoint x="1975" y="50"/>
+        <di:waypoint x="1063" y="600"/>
+        <di:waypoint x="2025" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5C2F3B54-3BE0-46D2-9042-8F49AA65EF68" dmnElementRef="_5C2F3B54-3BE0-46D2-9042-8F49AA65EF68">
-        <di:waypoint x="1013" y="400"/>
-        <di:waypoint x="925" y="50"/>
+        <di:waypoint x="1063" y="425"/>
+        <di:waypoint x="975" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_BB8EDC72-B01A-4673-95C8-4DF51FCF7D67" dmnElementRef="_BB8EDC72-B01A-4673-95C8-4DF51FCF7D67">
-        <di:waypoint x="1013" y="400"/>
-        <di:waypoint x="1275" y="50"/>
+        <di:waypoint x="1063" y="425"/>
+        <di:waypoint x="1325" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_15692DF4-8248-4D5E-86F0-C3A84D65CF90" dmnElementRef="_15692DF4-8248-4D5E-86F0-C3A84D65CF90">
-        <di:waypoint x="1013" y="400"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="1063" y="425"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_22101F33-1394-41F7-8D62-9815F12E9CF6" dmnElementRef="_22101F33-1394-41F7-8D62-9815F12E9CF6">
-        <di:waypoint x="1013" y="400"/>
-        <di:waypoint x="2150" y="50"/>
+        <di:waypoint x="1063" y="425"/>
+        <di:waypoint x="2200" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7AE36E0E-098B-4AC4-9567-40BFB87445E5" dmnElementRef="_7AE36E0E-098B-4AC4-9567-40BFB87445E5">
-        <di:waypoint x="663" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="713" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_BC847ABC-AA07-467F-BC2B-F6E248A2170E" dmnElementRef="_BC847ABC-AA07-467F-BC2B-F6E248A2170E">
-        <di:waypoint x="838" y="225"/>
-        <di:waypoint x="1450" y="50"/>
+        <di:waypoint x="888" y="250"/>
+        <di:waypoint x="1500" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-simpletable-P2.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0007-simpletable-P2.dmn
@@ -138,16 +138,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_55E54DF9-9380-4382-B422-E2129E5FCCC3" dmnElementRef="_55E54DF9-9380-4382-B422-E2129E5FCCC3">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F2A78307-E242-416D-B94E-6D7C42B2B88D" dmnElementRef="_F2A78307-E242-416D-B94E-6D7C42B2B88D">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_9C92B4C7-AD66-405D-B1A6-C6F0344F148F" dmnElementRef="_9C92B4C7-AD66-405D-B1A6-C6F0344F148F">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-LX-arithmetic.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-LX-arithmetic.dmn
@@ -60,8 +60,8 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_20E384BE-C605-46FC-9A3E-5846770B92BE" dmnElementRef="_20E384BE-C605-46FC-9A3E-5846770B92BE">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-listGen.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0008-listGen.dmn
@@ -400,76 +400,76 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_90001B99-B640-4269-A5F7-D8FC7F461BCE" dmnElementRef="_90001B99-B640-4269-A5F7-D8FC7F461BCE">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B85B5184-D999-4A7C-B2F2-42618AAE08F3" dmnElementRef="_B85B5184-D999-4A7C-B2F2-42618AAE08F3">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B4D2DE48-59A0-4FF9-B4D9-DD336C9A3290" dmnElementRef="_B4D2DE48-59A0-4FF9-B4D9-DD336C9A3290">
-        <di:waypoint x="488" y="400"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="538" y="425"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C2850877-39A0-4452-9E47-99C14CF8F62B" dmnElementRef="_C2850877-39A0-4452-9E47-99C14CF8F62B">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="925" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="975" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_35AE3DF4-C0A2-4FD3-B851-188A63E7C280" dmnElementRef="_35AE3DF4-C0A2-4FD3-B851-188A63E7C280">
-        <di:waypoint x="488" y="400"/>
-        <di:waypoint x="925" y="50"/>
+        <di:waypoint x="538" y="425"/>
+        <di:waypoint x="975" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_9A278924-5DEE-4531-BCBE-C8D4B1C6BFDE" dmnElementRef="_9A278924-5DEE-4531-BCBE-C8D4B1C6BFDE">
-        <di:waypoint x="488" y="400"/>
-        <di:waypoint x="575" y="225"/>
+        <di:waypoint x="538" y="425"/>
+        <di:waypoint x="625" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8CC21103-A65A-4B29-85F9-B24156FFB465" dmnElementRef="_8CC21103-A65A-4B29-85F9-B24156FFB465">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_50B314AE-978F-4DA6-8D1B-94BBBA8C956B" dmnElementRef="_50B314AE-978F-4DA6-8D1B-94BBBA8C956B">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7E7242AF-9607-402C-98D3-6E9EA45BDFBB" dmnElementRef="_7E7242AF-9607-402C-98D3-6E9EA45BDFBB">
-        <di:waypoint x="488" y="400"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="538" y="425"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_72B80600-F881-47D3-A768-BEEA284C2D57" dmnElementRef="_72B80600-F881-47D3-A768-BEEA284C2D57">
-        <di:waypoint x="663" y="400"/>
-        <di:waypoint x="750" y="225"/>
+        <di:waypoint x="713" y="425"/>
+        <di:waypoint x="800" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E8A9271A-C81B-4E4F-8E9B-674A3D10A8EB" dmnElementRef="_E8A9271A-C81B-4E4F-8E9B-674A3D10A8EB">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_12EF5810-5150-4289-803C-67E1C922ED5B" dmnElementRef="_12EF5810-5150-4289-803C-67E1C922ED5B">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B6E70DC8-CE1F-4790-A7A7-5EE1E69788F7" dmnElementRef="_B6E70DC8-CE1F-4790-A7A7-5EE1E69788F7">
-        <di:waypoint x="925" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="975" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_34DB8E67-29F0-4A6A-8B25-C533E4313ECF" dmnElementRef="_34DB8E67-29F0-4A6A-8B25-C533E4313ECF">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F0938126-C5A9-44A7-A2B2-F52B485711D1" dmnElementRef="_F0938126-C5A9-44A7-A2B2-F52B485711D1">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8086369C-58DE-487A-BFAB-7C9E9ABED146" dmnElementRef="_8086369C-58DE-487A-BFAB-7C9E9ABED146">
-        <di:waypoint x="750" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="800" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_34B0C881-E125-4D93-95C5-646B38DB12EA" dmnElementRef="_34B0C881-E125-4D93-95C5-646B38DB12EA">
-        <di:waypoint x="750" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="800" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_0F38AE74-7574-4834-AF08-74FB580BFA8E" dmnElementRef="_0F38AE74-7574-4834-AF08-74FB580BFA8E">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="625" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-append-flatten.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-append-flatten.dmn
@@ -253,52 +253,52 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_DC8BB6F1-15E9-477F-949D-85789FEDE037" dmnElementRef="_DC8BB6F1-15E9-477F-949D-85789FEDE037">
-        <di:waypoint x="400" y="400"/>
-        <di:waypoint x="50" y="225"/>
+        <di:waypoint x="450" y="425"/>
+        <di:waypoint x="100" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1650A2A7-AAB0-4AC0-9AAA-C52F1AA529EE" dmnElementRef="_1650A2A7-AAB0-4AC0-9AAA-C52F1AA529EE">
-        <di:waypoint x="50" y="400"/>
-        <di:waypoint x="50" y="225"/>
+        <di:waypoint x="100" y="425"/>
+        <di:waypoint x="100" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_249291EE-1BA4-4BBB-94EA-459423745C1F" dmnElementRef="_249291EE-1BA4-4BBB-94EA-459423745C1F">
-        <di:waypoint x="50" y="400"/>
-        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="100" y="425"/>
+        <di:waypoint x="275" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6177772C-8AD9-4A51-AEB6-55CF1856B23D" dmnElementRef="_6177772C-8AD9-4A51-AEB6-55CF1856B23D">
-        <di:waypoint x="225" y="400"/>
-        <di:waypoint x="225" y="225"/>
+        <di:waypoint x="275" y="425"/>
+        <di:waypoint x="275" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E7E53982-BAF4-4BB5-B39E-FF7C19DBD82F" dmnElementRef="_E7E53982-BAF4-4BB5-B39E-FF7C19DBD82F">
-        <di:waypoint x="400" y="400"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="450" y="425"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5E7432DD-5A54-43D3-812F-6F2E489207DE" dmnElementRef="_5E7432DD-5A54-43D3-812F-6F2E489207DE">
-        <di:waypoint x="225" y="400"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="275" y="425"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C9C38B25-13E6-42D9-9535-9161D3EE2512" dmnElementRef="_C9C38B25-13E6-42D9-9535-9161D3EE2512">
-        <di:waypoint x="400" y="400"/>
-        <di:waypoint x="575" y="225"/>
+        <di:waypoint x="450" y="425"/>
+        <di:waypoint x="625" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_13720F79-7269-4427-B680-EA6686042CDA" dmnElementRef="_13720F79-7269-4427-B680-EA6686042CDA">
-        <di:waypoint x="575" y="400"/>
-        <di:waypoint x="575" y="225"/>
+        <di:waypoint x="625" y="425"/>
+        <di:waypoint x="625" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A2407C26-3494-4482-9A03-205705246BF0" dmnElementRef="_A2407C26-3494-4482-9A03-205705246BF0">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_50E496E4-933F-45DA-B024-9ED020D1352B" dmnElementRef="_50E496E4-933F-45DA-B024-9ED020D1352B">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5C5DCDA0-0DDD-4A9F-A7C7-76146A276559" dmnElementRef="_5C5DCDA0-0DDD-4A9F-A7C7-76146A276559">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_05F0CD22-DF7B-4684-941F-04392FEDBBCC" dmnElementRef="_05F0CD22-DF7B-4684-941F-04392FEDBBCC">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="625" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-invocation-arithmetic.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0009-invocation-arithmetic.dmn
@@ -101,16 +101,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_1586A9BA-0E4F-44FA-8D90-5A83736E9C42" dmnElementRef="_1586A9BA-0E4F-44FA-8D90-5A83736E9C42">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_43F559D8-AD98-4081-9637-096BA73C4D9B" dmnElementRef="_43F559D8-AD98-4081-9637-096BA73C4D9B">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_64BA75A4-AFEC-4589-B421-80A4A782C152" dmnElementRef="_64BA75A4-AFEC-4589-B421-80A4A782C152">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-concatenate.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-concatenate.dmn
@@ -173,36 +173,36 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_A8F03B01-78C4-4AB7-BC40-D1F14CA5C24F" dmnElementRef="_A8F03B01-78C4-4AB7-BC40-D1F14CA5C24F">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_9B20674C-2B73-4FA0-8DF6-864D05661025" dmnElementRef="_9B20674C-2B73-4FA0-8DF6-864D05661025">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7ADC3B69-1CCC-4C93-9AC5-3F095C82CD48" dmnElementRef="_7ADC3B69-1CCC-4C93-9AC5-3F095C82CD48">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_98D0D74A-9098-4B63-BC52-1AEE91CA347C" dmnElementRef="_98D0D74A-9098-4B63-BC52-1AEE91CA347C">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_74DE7B09-2B2F-4539-9119-4E742B2F2057" dmnElementRef="_74DE7B09-2B2F-4539-9119-4E742B2F2057">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E4BF5584-3304-4092-8232-73E2E736CE2F" dmnElementRef="_E4BF5584-3304-4092-8232-73E2E736CE2F">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D85AC2E1-60E8-469B-96C1-EFD2305A5FA2" dmnElementRef="_D85AC2E1-60E8-469B-96C1-EFD2305A5FA2">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_ABF45914-CD7A-424F-8421-1539737570E4" dmnElementRef="_ABF45914-CD7A-424F-8421-1539737570E4">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="625" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-multi-output-U.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0010-multi-output-U.dmn
@@ -222,16 +222,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_CD737D33-2E3A-4BF0-AB07-CF0D63524322" dmnElementRef="_CD737D33-2E3A-4BF0-AB07-CF0D63524322">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6CEE9A57-9C03-463A-BBA4-06016C929C1B" dmnElementRef="_6CEE9A57-9C03-463A-BBA4-06016C929C1B">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_4B41B69F-671B-404B-9C0E-1BE27DCCA197" dmnElementRef="_4B41B69F-671B-404B-9C0E-1BE27DCCA197">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0011-insert-remove.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0011-insert-remove.dmn
@@ -198,52 +198,52 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_CB7C0187-B762-4F37-9C1C-838FB99FE465" dmnElementRef="_CB7C0187-B762-4F37-9C1C-838FB99FE465">
-        <di:waypoint x="313" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="363" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_0E8DF44E-83DF-4A98-B953-FBABEC9D163C" dmnElementRef="_0E8DF44E-83DF-4A98-B953-FBABEC9D163C">
-        <di:waypoint x="488" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="538" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_BD02C8E3-F6E2-4C67-BC4D-EAF2CEAA45EF" dmnElementRef="_BD02C8E3-F6E2-4C67-BC4D-EAF2CEAA45EF">
-        <di:waypoint x="663" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="713" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_987ACA10-B886-44AE-8C2F-C92E4E2F6BB0" dmnElementRef="_987ACA10-B886-44AE-8C2F-C92E4E2F6BB0">
-        <di:waypoint x="488" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="538" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B48403D5-C9A1-4E90-9E53-D2917FB111D2" dmnElementRef="_B48403D5-C9A1-4E90-9E53-D2917FB111D2">
-        <di:waypoint x="313" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="363" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DD92436D-E9DE-4E5D-87C3-24F82EC515C3" dmnElementRef="_DD92436D-E9DE-4E5D-87C3-24F82EC515C3">
-        <di:waypoint x="488" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="538" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B933CCFE-EB52-4BFC-9E66-150C222600EE" dmnElementRef="_B933CCFE-EB52-4BFC-9E66-150C222600EE">
-        <di:waypoint x="663" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="713" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B5609C47-42C8-475C-97E4-1D063D154165" dmnElementRef="_B5609C47-42C8-475C-97E4-1D063D154165">
-        <di:waypoint x="313" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="363" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_420E0234-CF1C-4400-BF12-8EF06DBE3CF7" dmnElementRef="_420E0234-CF1C-4400-BF12-8EF06DBE3CF7">
-        <di:waypoint x="488" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="538" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A7D3476D-2D4E-461D-9ADC-1D5227235198" dmnElementRef="_A7D3476D-2D4E-461D-9ADC-1D5227235198">
-        <di:waypoint x="138" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="188" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_4C219646-1242-4C8B-9D9A-91BCF122AA12" dmnElementRef="_4C219646-1242-4C8B-9D9A-91BCF122AA12">
-        <di:waypoint x="488" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="538" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8FDA7786-5311-419C-8256-055218D18BE5" dmnElementRef="_8FDA7786-5311-419C-8256-055218D18BE5">
-        <di:waypoint x="313" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="363" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0012-list-functions.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0012-list-functions.dmn
@@ -528,124 +528,124 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_0B8E53C3-715E-4B91-AADD-B51145B9D200" dmnElementRef="_0B8E53C3-715E-4B91-AADD-B51145B9D200">
-        <di:waypoint x="1187" y="400"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="1237" y="425"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F8DD4F61-8B94-4C66-8E68-3D17A26A7F94" dmnElementRef="_F8DD4F61-8B94-4C66-8E68-3D17A26A7F94">
-        <di:waypoint x="1362" y="400"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="1412" y="425"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C8CAD9F5-2D9F-4D60-BD1F-0AFF13910F84" dmnElementRef="_C8CAD9F5-2D9F-4D60-BD1F-0AFF13910F84">
-        <di:waypoint x="1362" y="400"/>
-        <di:waypoint x="1625" y="50"/>
+        <di:waypoint x="1412" y="425"/>
+        <di:waypoint x="1675" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_63F410CF-F442-4E4F-89D2-246F13FEA6F3" dmnElementRef="_63F410CF-F442-4E4F-89D2-246F13FEA6F3">
-        <di:waypoint x="1537" y="400"/>
-        <di:waypoint x="1625" y="50"/>
+        <di:waypoint x="1587" y="425"/>
+        <di:waypoint x="1675" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7C9A0B31-D9FD-484E-9F04-E549C586182E" dmnElementRef="_7C9A0B31-D9FD-484E-9F04-E549C586182E">
-        <di:waypoint x="1187" y="400"/>
-        <di:waypoint x="1275" y="50"/>
+        <di:waypoint x="1237" y="425"/>
+        <di:waypoint x="1325" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FB1E8D41-8698-4B69-A00A-D4BEC9ADA278" dmnElementRef="_FB1E8D41-8698-4B69-A00A-D4BEC9ADA278">
-        <di:waypoint x="1362" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="1412" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B8984900-4BC1-4DB1-A5E5-CFD12B881E31" dmnElementRef="_B8984900-4BC1-4DB1-A5E5-CFD12B881E31">
-        <di:waypoint x="1362" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="1412" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_3C3B2C77-E3F8-449E-969D-83A918ABB839" dmnElementRef="_3C3B2C77-E3F8-449E-969D-83A918ABB839">
-        <di:waypoint x="1362" y="225"/>
-        <di:waypoint x="925" y="50"/>
+        <di:waypoint x="1412" y="250"/>
+        <di:waypoint x="975" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_023F682D-3B8B-4791-BB24-D5DCACD120D3" dmnElementRef="_023F682D-3B8B-4791-BB24-D5DCACD120D3">
-        <di:waypoint x="837" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="887" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_08ED6657-FD97-4B43-9000-CC8C8F774723" dmnElementRef="_08ED6657-FD97-4B43-9000-CC8C8F774723">
-        <di:waypoint x="1012" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="1062" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_4AA4FF0F-152C-422D-BB55-1D7F5B8A1028" dmnElementRef="_4AA4FF0F-152C-422D-BB55-1D7F5B8A1028">
-        <di:waypoint x="1712" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="1762" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6BB243D1-CD29-4E9B-A9EC-A2B8F4307389" dmnElementRef="_6BB243D1-CD29-4E9B-A9EC-A2B8F4307389">
-        <di:waypoint x="1187" y="400"/>
-        <di:waypoint x="1975" y="50"/>
+        <di:waypoint x="1237" y="425"/>
+        <di:waypoint x="2025" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_0189AC2D-32B6-4F53-989C-777CDE9C26FA" dmnElementRef="_0189AC2D-32B6-4F53-989C-777CDE9C26FA">
-        <di:waypoint x="1187" y="400"/>
-        <di:waypoint x="2325" y="50"/>
+        <di:waypoint x="1237" y="425"/>
+        <di:waypoint x="2375" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1DDECF3D-923D-4FD6-B986-5DF741A2AC27" dmnElementRef="_1DDECF3D-923D-4FD6-B986-5DF741A2AC27">
-        <di:waypoint x="1362" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="1412" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_2073B4D3-5194-4DFE-9B00-F49BEAA9BB1D" dmnElementRef="_2073B4D3-5194-4DFE-9B00-F49BEAA9BB1D">
-        <di:waypoint x="837" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="887" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_3EF05BAB-32DA-4ECA-89ED-F65F17D2F131" dmnElementRef="_3EF05BAB-32DA-4ECA-89ED-F65F17D2F131">
-        <di:waypoint x="1012" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="1062" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_337E6258-101B-43FF-A27A-C218BA4C648F" dmnElementRef="_337E6258-101B-43FF-A27A-C218BA4C648F">
-        <di:waypoint x="1187" y="400"/>
-        <di:waypoint x="1187" y="225"/>
+        <di:waypoint x="1237" y="425"/>
+        <di:waypoint x="1237" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_CE99705F-D615-4A78-AC5B-1B05B5FF54F9" dmnElementRef="_CE99705F-D615-4A78-AC5B-1B05B5FF54F9">
-        <di:waypoint x="1362" y="400"/>
-        <di:waypoint x="1187" y="225"/>
+        <di:waypoint x="1412" y="425"/>
+        <di:waypoint x="1237" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1637F3CE-D35E-42DB-9D41-35FCA3BF541A" dmnElementRef="_1637F3CE-D35E-42DB-9D41-35FCA3BF541A">
-        <di:waypoint x="1362" y="400"/>
-        <di:waypoint x="1537" y="225"/>
+        <di:waypoint x="1412" y="425"/>
+        <di:waypoint x="1587" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5DA1D048-7F04-4DDE-A228-DB7F2D742895" dmnElementRef="_5DA1D048-7F04-4DDE-A228-DB7F2D742895">
-        <di:waypoint x="1537" y="400"/>
-        <di:waypoint x="1537" y="225"/>
+        <di:waypoint x="1587" y="425"/>
+        <di:waypoint x="1587" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_0962F364-B2A7-4738-9DC1-ECEC77CA1ACC" dmnElementRef="_0962F364-B2A7-4738-9DC1-ECEC77CA1ACC">
-        <di:waypoint x="1362" y="400"/>
-        <di:waypoint x="2675" y="50"/>
+        <di:waypoint x="1412" y="425"/>
+        <di:waypoint x="2725" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_AD261C65-88B9-4C37-AE6F-2433FCEE5404" dmnElementRef="_AD261C65-88B9-4C37-AE6F-2433FCEE5404">
-        <di:waypoint x="1187" y="225"/>
-        <di:waypoint x="1450" y="50"/>
+        <di:waypoint x="1237" y="250"/>
+        <di:waypoint x="1500" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FFD5D0CF-3E1A-46F6-B8D4-25FCE3F93886" dmnElementRef="_FFD5D0CF-3E1A-46F6-B8D4-25FCE3F93886">
-        <di:waypoint x="1187" y="400"/>
-        <di:waypoint x="1887" y="225"/>
+        <di:waypoint x="1237" y="425"/>
+        <di:waypoint x="1937" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_08922177-D594-4891-ACEE-81BEBEAECD46" dmnElementRef="_08922177-D594-4891-ACEE-81BEBEAECD46">
-        <di:waypoint x="1362" y="400"/>
-        <di:waypoint x="1887" y="225"/>
+        <di:waypoint x="1412" y="425"/>
+        <di:waypoint x="1937" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6DB7FDEE-331B-4BEB-A3A0-33A10A5B07F4" dmnElementRef="_6DB7FDEE-331B-4BEB-A3A0-33A10A5B07F4">
-        <di:waypoint x="1362" y="400"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="1412" y="425"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6537A260-A595-4232-91AA-922FF10FEDAC" dmnElementRef="_6537A260-A595-4232-91AA-922FF10FEDAC">
-        <di:waypoint x="1537" y="400"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="1587" y="425"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DD1D4DC9-6E72-457B-B5C5-6D0D1994C6E1" dmnElementRef="_DD1D4DC9-6E72-457B-B5C5-6D0D1994C6E1">
-        <di:waypoint x="1187" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="1237" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F8DD31F2-C579-4A4D-9BED-116B5F893EE6" dmnElementRef="_F8DD31F2-C579-4A4D-9BED-116B5F893EE6">
-        <di:waypoint x="1537" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="1587" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_4F8AF385-4195-4F00-85B5-A9C7C7E0B998" dmnElementRef="_4F8AF385-4195-4F00-85B5-A9C7C7E0B998">
-        <di:waypoint x="1537" y="225"/>
-        <di:waypoint x="2150" y="50"/>
+        <di:waypoint x="1587" y="250"/>
+        <di:waypoint x="2200" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_9F8C5723-4AFB-4678-8510-99A1131674D7" dmnElementRef="_9F8C5723-4AFB-4678-8510-99A1131674D7">
-        <di:waypoint x="1887" y="225"/>
-        <di:waypoint x="2500" y="50"/>
+        <di:waypoint x="1937" y="250"/>
+        <di:waypoint x="2550" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0013-sort.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0013-sort.dmn
@@ -137,16 +137,16 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_B003E907-840B-4CFD-85AF-FD3525E3BABD" dmnElementRef="_B003E907-840B-4CFD-85AF-FD3525E3BABD">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_2C9BC426-23D2-4164-BFAE-EF0DF8B9FE5E" dmnElementRef="_2C9BC426-23D2-4164-BFAE-EF0DF8B9FE5E">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_EA6FCAE6-75D7-4A14-9CE6-10DEEBCD6B90" dmnElementRef="_EA6FCAE6-75D7-4A14-9CE6-10DEEBCD6B90">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0014-loan-comparison.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0014-loan-comparison.dmn
@@ -482,24 +482,24 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_608B07F5-FDE8-4AD2-8816-DC77F980FA2C" dmnElementRef="_608B07F5-FDE8-4AD2-8816-DC77F980FA2C">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7057F3DB-00F4-4613-BFD9-5CECB3119503" dmnElementRef="_7057F3DB-00F4-4613-BFD9-5CECB3119503">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E3757580-2571-47EB-B428-989DED1434F3" dmnElementRef="_E3757580-2571-47EB-B428-989DED1434F3">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FE9BECB0-836E-4D5D-9CC4-1CAFAE5F9340" dmnElementRef="_FE9BECB0-836E-4D5D-9CC4-1CAFAE5F9340">
-        <di:waypoint x="138" y="400"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="188" y="425"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_69F0F987-6AE9-45F4-91E6-D179D0BA49C4" dmnElementRef="_69F0F987-6AE9-45F4-91E6-D179D0BA49C4">
-        <di:waypoint x="313" y="400"/>
-        <di:waypoint x="400" y="225"/>
+        <di:waypoint x="363" y="425"/>
+        <di:waypoint x="450" y="250"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0015-all-any.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0015-all-any.dmn
@@ -175,48 +175,48 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_6486B965-86B8-4E00-8170-8FAC4E9B235D" dmnElementRef="_6486B965-86B8-4E00-8170-8FAC4E9B235D">
-        <di:waypoint x="137" y="400"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="187" y="425"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8B3EFA94-D611-4E3E-9A93-1FA67E02DFCB" dmnElementRef="_8B3EFA94-D611-4E3E-9A93-1FA67E02DFCB">
-        <di:waypoint x="312" y="400"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="362" y="425"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DB37385A-2322-4D50-8402-CC8B9162951F" dmnElementRef="_DB37385A-2322-4D50-8402-CC8B9162951F">
-        <di:waypoint x="487" y="400"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="537" y="425"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_221D6962-1175-4F00-9A7A-C799BB291AA9" dmnElementRef="_221D6962-1175-4F00-9A7A-C799BB291AA9">
-        <di:waypoint x="312" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="362" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C027248F-BB76-4D69-B677-F4341EE018F8" dmnElementRef="_C027248F-BB76-4D69-B677-F4341EE018F8">
-        <di:waypoint x="137" y="400"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="187" y="425"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_930A457B-8313-4553-BEBD-8CBFE69F0ADF" dmnElementRef="_930A457B-8313-4553-BEBD-8CBFE69F0ADF">
-        <di:waypoint x="312" y="400"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="362" y="425"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_CF568108-11D7-4CF0-BB25-2346ABC3CB48" dmnElementRef="_CF568108-11D7-4CF0-BB25-2346ABC3CB48">
-        <di:waypoint x="487" y="400"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="537" y="425"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F0ECBE06-AE77-4FFD-8F40-8827112B97D8" dmnElementRef="_F0ECBE06-AE77-4FFD-8F40-8827112B97D8">
-        <di:waypoint x="312" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="362" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_89449474-A844-423A-858E-EFDEC2CE300B" dmnElementRef="_89449474-A844-423A-858E-EFDEC2CE300B">
-        <di:waypoint x="137" y="400"/>
-        <di:waypoint x="312" y="225"/>
+        <di:waypoint x="187" y="425"/>
+        <di:waypoint x="362" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C97D00A0-79E0-4867-8A3E-D73E17205245" dmnElementRef="_C97D00A0-79E0-4867-8A3E-D73E17205245">
-        <di:waypoint x="312" y="400"/>
-        <di:waypoint x="312" y="225"/>
+        <di:waypoint x="362" y="425"/>
+        <di:waypoint x="362" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_2BBFDEB0-FC15-43A1-920A-43FD27DD770F" dmnElementRef="_2BBFDEB0-FC15-43A1-920A-43FD27DD770F">
-        <di:waypoint x="487" y="400"/>
-        <di:waypoint x="312" y="225"/>
+        <di:waypoint x="537" y="425"/>
+        <di:waypoint x="362" y="250"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0016-some-every.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0016-some-every.dmn
@@ -211,28 +211,28 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_2695B89D-6ED6-4229-8743-6D09014CFAC5" dmnElementRef="_2695B89D-6ED6-4229-8743-6D09014CFAC5">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5E32CF6B-C2DA-4170-8FFD-338E0226C6D3" dmnElementRef="_5E32CF6B-C2DA-4170-8FFD-338E0226C6D3">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_6C8B308E-EDC1-47DE-9E9A-A4AC5BF71681" dmnElementRef="_6C8B308E-EDC1-47DE-9E9A-A4AC5BF71681">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_11056A87-5E24-437A-B51A-851FD5A6546E" dmnElementRef="_11056A87-5E24-437A-B51A-851FD5A6546E">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D15C6FAD-E5B4-46E8-A68B-04FDC183C30C" dmnElementRef="_D15C6FAD-E5B4-46E8-A68B-04FDC183C30C">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_73B41F49-2C7C-4001-A3F7-1A6C3F94D665" dmnElementRef="_73B41F49-2C7C-4001-A3F7-1A6C3F94D665">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="625" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0017-tableTests.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0017-tableTests.dmn
@@ -299,32 +299,32 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_4E115516-5903-4555-B62D-8CE03B90C1C5" dmnElementRef="_4E115516-5903-4555-B62D-8CE03B90C1C5">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="313" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="363" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_AA2E31C1-82F9-496F-BA37-FEA3EA421CA6" dmnElementRef="_AA2E31C1-82F9-496F-BA37-FEA3EA421CA6">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="138" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="188" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_11B7F784-A6EE-4756-9369-F434FA50948A" dmnElementRef="_11B7F784-A6EE-4756-9369-F434FA50948A">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="138" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="188" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_AEDADB70-6D75-4170-893B-CCC62481F956" dmnElementRef="_AEDADB70-6D75-4170-893B-CCC62481F956">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="138" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="188" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_0B68BC6B-7D82-43D5-8AF0-292080197316" dmnElementRef="_0B68BC6B-7D82-43D5-8AF0-292080197316">
-        <di:waypoint x="750" y="225"/>
-        <di:waypoint x="663" y="50"/>
+        <di:waypoint x="800" y="250"/>
+        <di:waypoint x="713" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_DFA8D6EB-8E5D-4D6C-8168-EAB25B825006" dmnElementRef="_DFA8D6EB-8E5D-4D6C-8168-EAB25B825006">
-        <di:waypoint x="750" y="225"/>
-        <di:waypoint x="488" y="50"/>
+        <di:waypoint x="800" y="250"/>
+        <di:waypoint x="538" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C9363E39-465B-48CE-A105-7B8DE005136D" dmnElementRef="_C9363E39-465B-48CE-A105-7B8DE005136D">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="488" y="50"/>
+        <di:waypoint x="625" y="250"/>
+        <di:waypoint x="538" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0019-flight-rebooking.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn11-expected/0019-flight-rebooking.dmn
@@ -324,28 +324,28 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_D23FCE0A-25F3-4FCE-9A32-D23F6C4C57C1" dmnElementRef="_D23FCE0A-25F3-4FCE-9A32-D23F6C4C57C1">
-        <di:waypoint x="225" y="400"/>
-        <di:waypoint x="138" y="225"/>
+        <di:waypoint x="275" y="425"/>
+        <di:waypoint x="188" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_26A0DF82-39CD-4617-A998-712743F003B3" dmnElementRef="_26A0DF82-39CD-4617-A998-712743F003B3">
-        <di:waypoint x="50" y="400"/>
-        <di:waypoint x="138" y="225"/>
+        <di:waypoint x="100" y="425"/>
+        <di:waypoint x="188" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_B15EF6FC-5689-4D60-9C6C-6E5A6DCE0C07" dmnElementRef="_B15EF6FC-5689-4D60-9C6C-6E5A6DCE0C07">
-        <di:waypoint x="400" y="400"/>
-        <di:waypoint x="138" y="225"/>
+        <di:waypoint x="450" y="425"/>
+        <di:waypoint x="188" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D552FBC5-D9B0-40CD-B054-7E7EA5662C48" dmnElementRef="_D552FBC5-D9B0-40CD-B054-7E7EA5662C48">
-        <di:waypoint x="138" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="188" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_425E881A-1B5A-4102-BE16-00A64306130B" dmnElementRef="_425E881A-1B5A-4102-BE16-00A64306130B">
-        <di:waypoint x="50" y="400"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="100" y="425"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E74FE5AC-B920-415A-BFF5-2BE646C54881" dmnElementRef="_E74FE5AC-B920-415A-BFF5-2BE646C54881">
-        <di:waypoint x="313" y="225"/>
-        <di:waypoint x="225" y="50"/>
+        <di:waypoint x="363" y="250"/>
+        <di:waypoint x="275" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
@@ -959,80 +959,80 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_7B3BE5CF-8218-47D2-B2CC-970E1FD58468" dmnElementRef="_7B3BE5CF-8218-47D2-B2CC-970E1FD58468">
-        <di:waypoint x="2850" y="225"/>
-        <di:waypoint x="925" y="50"/>
+        <di:waypoint x="2900" y="250"/>
+        <di:waypoint x="975" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8063F8D3-6062-4478-92B1-CEDFEFC9575A" dmnElementRef="_8063F8D3-6062-4478-92B1-CEDFEFC9575A">
-        <di:waypoint x="2850" y="225"/>
-        <di:waypoint x="1275" y="50"/>
+        <di:waypoint x="2900" y="250"/>
+        <di:waypoint x="1325" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_5ACB2078-518E-4743-9575-4BD03EDDA126" dmnElementRef="_5ACB2078-518E-4743-9575-4BD03EDDA126">
-        <di:waypoint x="2675" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="2725" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A0CCB912-9FA0-446A-9CBD-6706BA653DD2" dmnElementRef="_A0CCB912-9FA0-446A-9CBD-6706BA653DD2">
-        <di:waypoint x="3025" y="225"/>
-        <di:waypoint x="1450" y="50"/>
+        <di:waypoint x="3075" y="250"/>
+        <di:waypoint x="1500" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_32CEA84D-85B5-48A6-8BA3-D241F7A261FE" dmnElementRef="_32CEA84D-85B5-48A6-8BA3-D241F7A261FE">
-        <di:waypoint x="3025" y="225"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="3075" y="250"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_AB09AF7F-53DA-433F-93CA-78E46482703F" dmnElementRef="_AB09AF7F-53DA-433F-93CA-78E46482703F">
-        <di:waypoint x="3025" y="225"/>
-        <di:waypoint x="2150" y="50"/>
+        <di:waypoint x="3075" y="250"/>
+        <di:waypoint x="2200" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2" dmnElementRef="_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="3025" y="50"/>
+        <di:waypoint x="3250" y="250"/>
+        <di:waypoint x="3075" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_32616BE5-7354-455A-B94F-1E5F494BBD61" dmnElementRef="_32616BE5-7354-455A-B94F-1E5F494BBD61">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="3200" y="50"/>
+        <di:waypoint x="3250" y="250"/>
+        <di:waypoint x="3250" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_844CC3F6-599F-4499-A803-C1886139969A" dmnElementRef="_844CC3F6-599F-4499-A803-C1886139969A">
-        <di:waypoint x="2850" y="225"/>
-        <di:waypoint x="1975" y="50"/>
+        <di:waypoint x="2900" y="250"/>
+        <di:waypoint x="2025" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_743FD00A-040C-4EF3-A16F-51F8E36EFE49" dmnElementRef="_743FD00A-040C-4EF3-A16F-51F8E36EFE49">
-        <di:waypoint x="2850" y="225"/>
-        <di:waypoint x="2325" y="50"/>
+        <di:waypoint x="2900" y="250"/>
+        <di:waypoint x="2375" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_004EB93A-E37A-4C38-BF48-CA4FED683432" dmnElementRef="_004EB93A-E37A-4C38-BF48-CA4FED683432">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="3375" y="50"/>
+        <di:waypoint x="3250" y="250"/>
+        <di:waypoint x="3425" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_EBD496F0-9E21-47AD-A630-8C5E032B6749" dmnElementRef="_EBD496F0-9E21-47AD-A630-8C5E032B6749">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="3725" y="50"/>
+        <di:waypoint x="3250" y="250"/>
+        <di:waypoint x="3775" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_ED2359BA-F57A-495B-8E75-C0913CD2BA05" dmnElementRef="_ED2359BA-F57A-495B-8E75-C0913CD2BA05">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="3900" y="50"/>
+        <di:waypoint x="3250" y="250"/>
+        <di:waypoint x="3950" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB" dmnElementRef="_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="4075" y="50"/>
+        <di:waypoint x="3250" y="250"/>
+        <di:waypoint x="4125" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_590A1A56-B5B1-435D-827C-03671BB0C575" dmnElementRef="_590A1A56-B5B1-435D-827C-03671BB0C575">
-        <di:waypoint x="3725" y="225"/>
-        <di:waypoint x="4775" y="50"/>
+        <di:waypoint x="3775" y="250"/>
+        <di:waypoint x="4825" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1E490D2C-A941-4F7B-BEB1-8409E4C63880" dmnElementRef="_1E490D2C-A941-4F7B-BEB1-8409E4C63880">
-        <di:waypoint x="3375" y="225"/>
-        <di:waypoint x="4250" y="50"/>
+        <di:waypoint x="3425" y="250"/>
+        <di:waypoint x="4300" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1A757F6C-CC80-45E0-B19A-A78E2E0D8382" dmnElementRef="_1A757F6C-CC80-45E0-B19A-A78E2E0D8382">
-        <di:waypoint x="3375" y="225"/>
-        <di:waypoint x="4425" y="50"/>
+        <di:waypoint x="3425" y="250"/>
+        <di:waypoint x="4475" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7BD5372D-20EE-4D47-8AA9-B8E651010343" dmnElementRef="_7BD5372D-20EE-4D47-8AA9-B8E651010343">
-        <di:waypoint x="3900" y="225"/>
-        <di:waypoint x="4950" y="50"/>
+        <di:waypoint x="3950" y="250"/>
+        <di:waypoint x="5000" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_3E92ADC3-4BAD-4D40-93F9-4591994078FB" dmnElementRef="_3E92ADC3-4BAD-4D40-93F9-4591994078FB">
-        <di:waypoint x="3550" y="225"/>
-        <di:waypoint x="4600" y="50"/>
+        <di:waypoint x="3600" y="250"/>
+        <di:waypoint x="4650" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
@@ -1149,148 +1149,148 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_48327838-A3B3-4A1C-9018-C16961353832" dmnElementRef="_48327838-A3B3-4A1C-9018-C16961353832">
-        <di:waypoint x="1975" y="225"/>
-        <di:waypoint x="1450" y="50"/>
+        <di:waypoint x="2025" y="250"/>
+        <di:waypoint x="1500" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E2B96527-3A45-4FC3-A433-9F445073D21E" dmnElementRef="_E2B96527-3A45-4FC3-A433-9F445073D21E">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C88D4810-6090-4C42-9B8B-765318419D94" dmnElementRef="_C88D4810-6090-4C42-9B8B-765318419D94">
-        <di:waypoint x="225" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="275" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_3BBF348F-7D76-43C5-9C3C-AB3954D2A001" dmnElementRef="_3BBF348F-7D76-43C5-9C3C-AB3954D2A001">
-        <di:waypoint x="400" y="225"/>
-        <di:waypoint x="400" y="50"/>
+        <di:waypoint x="450" y="250"/>
+        <di:waypoint x="450" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_2EB3293E-2DE4-419E-AFC7-E83C107EF972" dmnElementRef="_2EB3293E-2DE4-419E-AFC7-E83C107EF972">
-        <di:waypoint x="575" y="225"/>
-        <di:waypoint x="575" y="50"/>
+        <di:waypoint x="625" y="250"/>
+        <di:waypoint x="625" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_7C238A40-CE07-47A4-BD73-392645E9A07F" dmnElementRef="_7C238A40-CE07-47A4-BD73-392645E9A07F">
-        <di:waypoint x="750" y="225"/>
-        <di:waypoint x="750" y="50"/>
+        <di:waypoint x="800" y="250"/>
+        <di:waypoint x="800" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_FCE2091B-D88C-4EEA-9EB2-AECB8D644296" dmnElementRef="_FCE2091B-D88C-4EEA-9EB2-AECB8D644296">
-        <di:waypoint x="925" y="225"/>
-        <di:waypoint x="925" y="50"/>
+        <di:waypoint x="975" y="250"/>
+        <di:waypoint x="975" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_3C60FB2C-767A-45E2-9630-367077116AAD" dmnElementRef="_3C60FB2C-767A-45E2-9630-367077116AAD">
-        <di:waypoint x="3550" y="225"/>
-        <di:waypoint x="2500" y="50"/>
+        <di:waypoint x="3600" y="250"/>
+        <di:waypoint x="2550" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E2CCF4CC-61F7-4625-A47C-C02433674CB0" dmnElementRef="_E2CCF4CC-61F7-4625-A47C-C02433674CB0">
-        <di:waypoint x="1800" y="225"/>
-        <di:waypoint x="1275" y="50"/>
+        <di:waypoint x="1850" y="250"/>
+        <di:waypoint x="1325" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8B06E8E0-C65D-4F2D-A31E-853E4DD86583" dmnElementRef="_8B06E8E0-C65D-4F2D-A31E-853E4DD86583">
-        <di:waypoint x="4425" y="225"/>
-        <di:waypoint x="3200" y="50"/>
+        <di:waypoint x="4475" y="250"/>
+        <di:waypoint x="3250" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_59730883-C5AD-4838-A828-E36ED83F0A28" dmnElementRef="_59730883-C5AD-4838-A828-E36ED83F0A28">
-        <di:waypoint x="2150" y="225"/>
-        <di:waypoint x="1625" y="50"/>
+        <di:waypoint x="2200" y="250"/>
+        <di:waypoint x="1675" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8EA2F696-D099-4DD5-A67C-164D148824EB" dmnElementRef="_8EA2F696-D099-4DD5-A67C-164D148824EB">
-        <di:waypoint x="5125" y="225"/>
-        <di:waypoint x="3900" y="50"/>
+        <di:waypoint x="5175" y="250"/>
+        <di:waypoint x="3950" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E212024F-4A31-4516-A465-85A3181542B3" dmnElementRef="_E212024F-4A31-4516-A465-85A3181542B3">
-        <di:waypoint x="3025" y="225"/>
-        <di:waypoint x="1975" y="50"/>
+        <di:waypoint x="3075" y="250"/>
+        <di:waypoint x="2025" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_298E4FA3-A9DB-4B02-B878-C53CFE708DF1" dmnElementRef="_298E4FA3-A9DB-4B02-B878-C53CFE708DF1">
-        <di:waypoint x="5300" y="225"/>
-        <di:waypoint x="4250" y="50"/>
+        <di:waypoint x="5350" y="250"/>
+        <di:waypoint x="4300" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1F343A9F-34AA-41DD-8134-8E23D7AB804E" dmnElementRef="_1F343A9F-34AA-41DD-8134-8E23D7AB804E">
-        <di:waypoint x="3200" y="225"/>
-        <di:waypoint x="2150" y="50"/>
+        <di:waypoint x="3250" y="250"/>
+        <di:waypoint x="2200" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_24FDD129-04BF-499F-8233-231FA35AF051" dmnElementRef="_24FDD129-04BF-499F-8233-231FA35AF051">
-        <di:waypoint x="5475" y="225"/>
-        <di:waypoint x="4775" y="50"/>
+        <di:waypoint x="5525" y="250"/>
+        <di:waypoint x="4825" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C16DA847-D4B4-4736-8E1C-6DD808688E92" dmnElementRef="_C16DA847-D4B4-4736-8E1C-6DD808688E92">
-        <di:waypoint x="4075" y="225"/>
-        <di:waypoint x="2850" y="50"/>
+        <di:waypoint x="4125" y="250"/>
+        <di:waypoint x="2900" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E5B24964-1B33-4DE5-9C63-82A62E974DEC" dmnElementRef="_E5B24964-1B33-4DE5-9C63-82A62E974DEC">
-        <di:waypoint x="1100" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="1150" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07" dmnElementRef="_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07">
-        <di:waypoint x="1275" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="1325" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3" dmnElementRef="_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3">
-        <di:waypoint x="1450" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="1500" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8B485F45-A12F-44FB-A72A-8F090678BDDD" dmnElementRef="_8B485F45-A12F-44FB-A72A-8F090678BDDD">
-        <di:waypoint x="1625" y="225"/>
-        <di:waypoint x="1100" y="50"/>
+        <di:waypoint x="1675" y="250"/>
+        <di:waypoint x="1150" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA" dmnElementRef="_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA">
-        <di:waypoint x="4950" y="225"/>
-        <di:waypoint x="3550" y="50"/>
+        <di:waypoint x="5000" y="250"/>
+        <di:waypoint x="3600" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_F8800C29-3B28-4AE5-B2A2-0457F994F839" dmnElementRef="_F8800C29-3B28-4AE5-B2A2-0457F994F839">
-        <di:waypoint x="2325" y="225"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="2375" y="250"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_386E4803-5F5F-4194-A8B5-F3534DFC7AD9" dmnElementRef="_386E4803-5F5F-4194-A8B5-F3534DFC7AD9">
-        <di:waypoint x="2500" y="225"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="2550" y="250"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D07DA03D-C33A-4807-8711-968E4853E0F1" dmnElementRef="_D07DA03D-C33A-4807-8711-968E4853E0F1">
-        <di:waypoint x="2675" y="225"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="2725" y="250"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_32E47634-89BF-4AF3-A6B7-61AE25AB151B" dmnElementRef="_32E47634-89BF-4AF3-A6B7-61AE25AB151B">
-        <di:waypoint x="2850" y="225"/>
-        <di:waypoint x="1800" y="50"/>
+        <di:waypoint x="2900" y="250"/>
+        <di:waypoint x="1850" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C66633F4-6718-491C-9D40-8AFF21CE4CD5" dmnElementRef="_C66633F4-6718-491C-9D40-8AFF21CE4CD5">
-        <di:waypoint x="3725" y="225"/>
-        <di:waypoint x="2325" y="50"/>
+        <di:waypoint x="3775" y="250"/>
+        <di:waypoint x="2375" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_1893C895-D655-4607-81A5-363DE8DBD597" dmnElementRef="_1893C895-D655-4607-81A5-363DE8DBD597">
-        <di:waypoint x="3900" y="225"/>
-        <di:waypoint x="2325" y="50"/>
+        <di:waypoint x="3950" y="250"/>
+        <di:waypoint x="2375" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_D73018C3-F4DF-4B8A-946B-70692A2464DD" dmnElementRef="_D73018C3-F4DF-4B8A-946B-70692A2464DD">
-        <di:waypoint x="3375" y="225"/>
-        <di:waypoint x="2325" y="50"/>
+        <di:waypoint x="3425" y="250"/>
+        <di:waypoint x="2375" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A9B18C1C-2D92-4A64-A936-3051A852D66F" dmnElementRef="_A9B18C1C-2D92-4A64-A936-3051A852D66F">
-        <di:waypoint x="3725" y="225"/>
-        <di:waypoint x="2675" y="50"/>
+        <di:waypoint x="3775" y="250"/>
+        <di:waypoint x="2725" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_A975CC18-C9EC-48A1-8691-26DDC2A81F45" dmnElementRef="_A975CC18-C9EC-48A1-8691-26DDC2A81F45">
-        <di:waypoint x="3900" y="225"/>
-        <di:waypoint x="2675" y="50"/>
+        <di:waypoint x="3950" y="250"/>
+        <di:waypoint x="2725" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F" dmnElementRef="_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F">
-        <di:waypoint x="4600" y="225"/>
-        <di:waypoint x="3025" y="50"/>
+        <di:waypoint x="4650" y="250"/>
+        <di:waypoint x="3075" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550" dmnElementRef="_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550">
-        <di:waypoint x="4775" y="225"/>
-        <di:waypoint x="3025" y="50"/>
+        <di:waypoint x="4825" y="250"/>
+        <di:waypoint x="3075" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_00254681-64B2-4809-95A3-1B7AFAC4D1ED" dmnElementRef="_00254681-64B2-4809-95A3-1B7AFAC4D1ED">
-        <di:waypoint x="4250" y="225"/>
-        <di:waypoint x="3025" y="50"/>
+        <di:waypoint x="4300" y="250"/>
+        <di:waypoint x="3075" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_80959823-0175-4165-8060-DFAAB74A1123" dmnElementRef="_80959823-0175-4165-8060-DFAAB74A1123">
-        <di:waypoint x="4600" y="225"/>
-        <di:waypoint x="3375" y="50"/>
+        <di:waypoint x="4650" y="250"/>
+        <di:waypoint x="3425" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_40616155-0E1B-4A83-A65A-2DB14DD7B65D" dmnElementRef="_40616155-0E1B-4A83-A65A-2DB14DD7B65D">
-        <di:waypoint x="4775" y="225"/>
-        <di:waypoint x="3375" y="50"/>
+        <di:waypoint x="4825" y="250"/>
+        <di:waypoint x="3425" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
@@ -210,32 +210,32 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_84729018-9BDD-4607-B235-1806B18C89BB" dmnElementRef="_84729018-9BDD-4607-B235-1806B18C89BB">
-        <di:waypoint x="400" y="400"/>
-        <di:waypoint x="313" y="225"/>
+        <di:waypoint x="450" y="425"/>
+        <di:waypoint x="363" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_92B8883D-CEFA-4379-90F9-3C0F42E0569F" dmnElementRef="_92B8883D-CEFA-4379-90F9-3C0F42E0569F">
-        <di:waypoint x="313" y="225"/>
-        <di:waypoint x="138" y="50"/>
+        <di:waypoint x="363" y="250"/>
+        <di:waypoint x="188" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76" dmnElementRef="_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76">
-        <di:waypoint x="225" y="400"/>
-        <di:waypoint x="138" y="50"/>
+        <di:waypoint x="275" y="425"/>
+        <di:waypoint x="188" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E7DA2900-46F8-4DC1-BCF7-2E928619926A" dmnElementRef="_E7DA2900-46F8-4DC1-BCF7-2E928619926A">
-        <di:waypoint x="400" y="400"/>
-        <di:waypoint x="138" y="50"/>
+        <di:waypoint x="450" y="425"/>
+        <di:waypoint x="188" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_92B4D37C-3DCB-4BD2-A4E8-28465566C79E" dmnElementRef="_92B4D37C-3DCB-4BD2-A4E8-28465566C79E">
-        <di:waypoint x="138" y="225"/>
-        <di:waypoint x="138" y="50"/>
+        <di:waypoint x="188" y="250"/>
+        <di:waypoint x="188" y="75"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_E7C0F865-D014-4005-B313-6FA55BD4203C" dmnElementRef="_E7C0F865-D014-4005-B313-6FA55BD4203C">
-        <di:waypoint x="225" y="400"/>
-        <di:waypoint x="138" y="225"/>
+        <di:waypoint x="275" y="425"/>
+        <di:waypoint x="188" y="250"/>
       </dmndi:DMNEdge>
       <dmndi:DMNEdge id="dmnedge-drg-_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249" dmnElementRef="_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249">
-        <di:waypoint x="50" y="400"/>
-        <di:waypoint x="138" y="225"/>
+        <di:waypoint x="100" y="425"/>
+        <di:waypoint x="188" y="250"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/Say_hello_1ID1D.dmn
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/Say_hello_1ID1D.dmn
@@ -41,8 +41,8 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="dmnedge-drg-_4f6c136c-8512-4d71-8bbf-7c9eb6e74063" dmnElementRef="_4f6c136c-8512-4d71-8bbf-7c9eb6e74063">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-3696 (DMN model without DMNDI - expected).xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/selenium/KOGITO-3696 (DMN model without DMNDI - expected).xml
@@ -73,8 +73,8 @@
         <dmndi:DMNLabel/>
       </dmndi:DMNShape>
       <dmndi:DMNEdge dmnElementRef="_9E7EF613-318B-4E51-A001-271ABF375A6C" id="dmnedge-drg-_9E7EF613-318B-4E51-A001-271ABF375A6C">
-        <di:waypoint x="50" y="225"/>
-        <di:waypoint x="50" y="50"/>
+        <di:waypoint x="100" y="250"/>
+        <di:waypoint x="100" y="75"/>
       </dmndi:DMNEdge>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>


### PR DESCRIPTION
**JIRA**: [KOGITO-3274](https://issues.redhat.com/browse/KOGITO-3274)

**Business Central**: [WAR file](https://drive.google.com/file/d/1oLrCHqIL8rKKW1DkOgbmF4gEA--GHMde/view?usp=sharing)

**VS Code**: [plugin](https://drive.google.com/file/d/1HF-yRBYvtLBte9_gbhE12l8NOO28O0T2/view?usp=sharing)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
