### PR TITLE
JBPM-9750 - Stunner BPMN Project Showcase and JBPM WB Showcase do not run

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/preferences/LibraryPreferences.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/preferences/LibraryPreferences.java
@@ -24,7 +24,7 @@ import org.uberfire.preferences.shared.bean.BasePreference;
 @WorkbenchPreference(identifier = "LibraryPreferences",
         bundleKey = "LibraryPreferences.Label")
 public class LibraryPreferences implements BasePreference<LibraryPreferences> {
-    
+
     @Property(bundleKey = "LibraryPreferences.OrganizationalUnitPreferences")
     LibraryOrganizationalUnitPreferences organizationalUnitPreferences;
 
@@ -45,9 +45,9 @@ public class LibraryPreferences implements BasePreference<LibraryPreferences> {
         defaultValue.projectPreferences.version = "1.0.0-SNAPSHOT";
         defaultValue.projectPreferences.description = "";
         defaultValue.projectPreferences.branch = "master";
-        //GWT complains in SuperDevMode if the static constants are used; so we have to use a literal
-        defaultValue.projectPreferences.assetsPerPage = System.getProperty(LibraryProjectPreferences.ASSETS_PER_PAGE_KEY,
-                                                                           String.valueOf(LibraryProjectPreferences.ASSETS_PER_PAGE_VALUE));
+
+        defaultValue.projectPreferences.assetsPerPage = LibraryProjectPreferences.sdmSafeGetPropertyAssetsPerPage();
+
         return defaultValue;
     }
 

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/preferences/LibraryProjectPreferences.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/main/java/org/kie/workbench/common/screens/library/api/preferences/LibraryProjectPreferences.java
@@ -62,8 +62,8 @@ public class LibraryProjectPreferences implements BasePreference<LibraryProjectP
     }
 
     public int getAssetsPerPage() {
+        String systemProperty = sdmSafeGetPropertyAssetsPerPage();
 
-        String systemProperty = System.getProperty(ASSETS_PER_PAGE_KEY, String.valueOf(ASSETS_PER_PAGE_VALUE));
         int externalAssetsPerPage = 0;
         try {
             if (systemProperty.length() > 0) {
@@ -79,5 +79,14 @@ public class LibraryProjectPreferences implements BasePreference<LibraryProjectP
         } catch (NumberFormatException e) {
             return externalAssetsPerPage;
         }
+    }
+
+    public static String sdmSafeGetPropertyAssetsPerPage() {
+        //SUPER DEV MODE complains when calling System.getProperty using the constants directly.
+        //GWT compilation fails and because of that some of the showcases won't work.
+        //The variable assignment below prevents that.
+        final String key = ASSETS_PER_PAGE_KEY;
+        final String def = String.valueOf(LibraryProjectPreferences.ASSETS_PER_PAGE_VALUE);
+        return System.getProperty(key, def);
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/test/java/org/kie/workbench/common/screens/library/api/preferences/LibraryPreferencesTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/test/java/org/kie/workbench/common/screens/library/api/preferences/LibraryPreferencesTest.java
@@ -18,10 +18,19 @@ package org.kie.workbench.common.screens.library.api.preferences;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.backend.validation.PackageNameValidator;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({LibraryProjectPreferences.class})
 public class LibraryPreferencesTest {
 
     private LibraryPreferences libraryPreferences;
@@ -41,5 +50,25 @@ public class LibraryPreferencesTest {
     public void organizationalUnitGroupIdIsAValidPackageTest() {
         libraryPreferences = libraryPreferences.defaultValue(libraryPreferences);
         assertTrue(packageNameValidator.isValid(libraryPreferences.getOrganizationalUnitPreferences().getGroupId()));
+    }
+
+    @Test
+    public void defaultValueTest() {
+        final String expected = String.valueOf(LibraryProjectPreferences.ASSETS_PER_PAGE_VALUE);
+        mockStatic(LibraryProjectPreferences.class);
+        when(LibraryProjectPreferences.sdmSafeGetPropertyAssetsPerPage()).thenReturn(expected);
+
+        LibraryPreferences libraryPreferences = new LibraryPreferences();
+        libraryPreferences.organizationalUnitPreferences = new LibraryOrganizationalUnitPreferences();
+        libraryPreferences.projectPreferences = new LibraryProjectPreferences();
+
+        libraryPreferences = libraryPreferences.defaultValue(libraryPreferences);
+
+        final String result = libraryPreferences.projectPreferences.assetsPerPage;
+
+        verifyStatic(LibraryProjectPreferences.class);
+        LibraryProjectPreferences.sdmSafeGetPropertyAssetsPerPage();
+
+        assertEquals(expected, result);
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/test/java/org/kie/workbench/common/screens/library/api/preferences/LibraryProjectPreferencesTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/src/test/java/org/kie/workbench/common/screens/library/api/preferences/LibraryProjectPreferencesTest.java
@@ -22,9 +22,17 @@ package org.kie.workbench.common.screens.library.api.preferences;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({LibraryProjectPreferences.class})
 public class LibraryProjectPreferencesTest {
 
     private LibraryProjectPreferences libraryProjectPreferences;
@@ -60,5 +68,17 @@ public class LibraryProjectPreferencesTest {
         libraryProjectPreferences.assetsPerPage = "not a number";
         int pageSize = libraryProjectPreferences.getAssetsPerPage();
         assertEquals(37, pageSize);
+    }
+
+    @Test
+    public void getAssetsPerPage() {
+        final int expected = LibraryProjectPreferences.ASSETS_PER_PAGE_VALUE;
+        mockStatic(LibraryProjectPreferences.class);
+        when(LibraryProjectPreferences.sdmSafeGetPropertyAssetsPerPage()).thenReturn(String.valueOf(expected));
+
+        final int result = libraryProjectPreferences.getAssetsPerPage();
+        verifyStatic(LibraryProjectPreferences.class);
+        LibraryProjectPreferences.sdmSafeGetPropertyAssetsPerPage();
+        assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
When running in SUPER DEV MODE calls to System.getProperty using Constants cause GWT Compilation to fail causing the showcases to not load. This is a safe way to call it without breaking the showcases.

**JIRA**: [JBPM-9750](https://issues.redhat.com/browse/JBPM-9750)

**Business Central**: [WAR file](https://drive.google.com/file/d/11iPpccSxwtOpnuARdsWnw3AOUnHO4yCT/view?usp=sharing)