### PR TITLE
[7.52.x] KOGITO-5003: DMN editor removing edges for duplicate Decision Nodes on canvas

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshaller.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/marshall/DMNMarshaller.java
@@ -213,9 +213,16 @@ public class DMNMarshaller {
                 if (viewDefinition instanceof DRGElement) {
                     final DRGElement drgElement = (DRGElement) viewDefinition;
                     if (!drgElement.isAllowOnlyVisualChange()) {
-                        nodes.put(drgElement.getId().getValue(),
-                                  stunnerToDMN(withIncludedModels(node, definitionsStunnerPojo),
-                                               componentWidthsConsumer));
+                        if (nodes.containsKey(drgElement.getId().getValue())) {
+                            final JSITDRGElement currentValue = nodes.get(drgElement.getId().getValue());
+                            mergeNodeRequirements(stunnerToDMN(withIncludedModels(node, definitionsStunnerPojo),
+                                                               componentWidthsConsumer),
+                                                  currentValue);
+                        } else {
+                            nodes.put(drgElement.getId().getValue(),
+                                      stunnerToDMN(withIncludedModels(node, definitionsStunnerPojo),
+                                                   componentWidthsConsumer));
+                        }
                     }
                     final String namespaceURI = definitionsStunnerPojo.getDefaultNamespace();
                     diagram.addDMNDiagramElement(WrapperUtils.getWrappedJSIDMNShape(diagram,
@@ -249,7 +256,7 @@ public class DMNMarshaller {
             }
 
             nodes.values().forEach(node -> {
-                mergeOrAddNodeToDefinitions(node, definitions);
+                addNodeToDefinitionsIfNotPresent(node, definitions);
             });
 
             textAnnotations.values().forEach(text -> {
@@ -278,7 +285,8 @@ public class DMNMarshaller {
             for (final Node<?, ?> node : diagramNodes) {
                 PointUtils.convertToRelativeBounds(node);
             }
-        };
+        }
+        ;
 
         return definitions;
     }
@@ -331,20 +339,17 @@ public class DMNMarshaller {
         return Optional.empty();
     }
 
-    void mergeOrAddNodeToDefinitions(final JSITDRGElement node,
-                                     final JSITDefinitions definitions) {
+    void addNodeToDefinitionsIfNotPresent(final JSITDRGElement node,
+                                          final JSITDefinitions definitions) {
 
         final Optional<JSITDRGElement> existingNode = getExistingNode(definitions, node);
 
-        if (existingNode.isPresent()) {
-            final JSITDRGElement existingDRGElement = Js.uncheckedCast(existingNode.get());
-            mergeNodeRequirements(node, existingDRGElement);
-        } else {
+        if (!existingNode.isPresent()) {
             addNodeToDefinitions(node, definitions);
         }
     }
 
-    private void addNodeToDefinitions(final JSITDRGElement node,
+    void addNodeToDefinitions(final JSITDRGElement node,
                                       final JSITDefinitions definitions) {
 
         final JSINodeLocalPartName localPart = getLocalPart(node);
@@ -358,8 +363,8 @@ public class DMNMarshaller {
         return WrapperUtils.getWrappedJSITDRGElement(node, PREFIX, localPart.getLocalPart());
     }
 
-    private void mergeNodeRequirements(final JSITDRGElement node,
-                                       final JSITDRGElement existingDRGElement) {
+    void mergeNodeRequirements(final JSITDRGElement node,
+                               final JSITDRGElement existingDRGElement) {
 
         if (instanceOfBusinessKnowledgeModel(node)) {
 


### PR DESCRIPTION
This is cherry-pick from 
https://github.com/kiegroup/kie-wb-common/pull/3645
https://github.com/kiegroup/kogito-editors-java/pull/52

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
