### PR TITLE
[7.52.x] AF-2847: Adding template to the REST API /spaces/{spaceName}/project command in order to create new project based on the archetype template (#3637)

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-api/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/shared/services/ArchetypeService.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-api/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/shared/services/ArchetypeService.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.screens.archetype.mgmt.shared.services;
 import java.util.Optional;
 
 import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.service.BaseArchetypeService;
 import org.guvnor.structure.repositories.Repository;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.screens.archetype.mgmt.shared.model.Archetype;
@@ -29,7 +30,7 @@ import org.kie.workbench.common.screens.archetype.mgmt.shared.model.PaginatedArc
  * Service that manages the archetypes registered on the system.
  */
 @Remote
-public interface ArchetypeService {
+public interface ArchetypeService extends BaseArchetypeService {
 
     /**
      * Make the given {@link Archetype archetype} available to be used.

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/preference/ArchetypePreferencesManager.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/preference/ArchetypePreferencesManager.java
@@ -228,4 +228,20 @@ public class ArchetypePreferencesManager {
     boolean containsArchetype(final String archetype) {
         return archetypePreferences.getArchetypeSelectionMap().containsKey(archetype);
     }
+
+    public boolean containsArchetype(final String archetype,
+                                     final String spaceName) {
+        final Map<String, Boolean> archetypeMap = getArchetypeSelectionMap(spaceName);
+        if(!archetypeMap.containsKey(archetype))
+            throw new IllegalArgumentException(
+                    String.format("Template repository %s is not available", archetype));
+        return archetypeMap.get(archetype);
+    }
+
+    private Map<String, Boolean> getArchetypeSelectionMap(final String identifier) {
+        final PreferenceScopeResolutionStrategyInfo info =
+                workbenchPreferenceScopeResolutionStrategies.getSpaceInfoFor(identifier);
+        archetypePreferences.load(info);
+        return archetypePreferences.getArchetypeSelectionMap();
+    }
 }

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/main/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImpl.java
@@ -374,6 +374,16 @@ public class ArchetypeServiceImpl implements ArchetypeService {
         }
     }
 
+    @Override
+    public Repository getTemplateRepository(final String alias,
+                                            final String spaceName) {
+        if (archetypePreferencesManager.containsArchetype(alias, spaceName)) {
+            return getTemplateRepository(alias);
+        }
+        throw new IllegalArgumentException(
+                String.format("Template repository %s is not available for space %s", alias, spaceName));
+    }
+
     private GAV copyGav(final GAV original) {
         return new GAV(original.getGroupId(),
                        original.getArtifactId(),

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/preference/ArchetypePreferencesManagerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/preference/ArchetypePreferencesManagerTest.java
@@ -271,6 +271,22 @@ public class ArchetypePreferencesManagerTest {
     }
 
     @Test
+    public void spaceContainsArchetypeTrueTest() {
+        final Map<String, Boolean> archetypeSelectionMap = new HashMap<>();
+        archetypeSelectionMap.put("archetype", true);
+        doReturn(archetypeSelectionMap).when(archetypePreferences).getArchetypeSelectionMap();
+        assertTrue(archetypePreferencesManager.containsArchetype("archetype", "myspace"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void spaceContainsArchetypeFalseTest() {
+        final Map<String, Boolean> archetypeSelectionMap = new HashMap<>();
+        archetypeSelectionMap.put("archetype", true);
+        doReturn(archetypeSelectionMap).when(archetypePreferences).getArchetypeSelectionMap();
+        archetypePreferencesManager.containsArchetype("other", "myspace");
+    }
+
+    @Test
     public void containsArchetypeFalseTest() {
         final Map<String, Boolean> archetypeSelectionMap = new HashMap<>();
         archetypeSelectionMap.put("archetype", true);

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/src/test/java/org/kie/workbench/common/screens/archetype/mgmt/backend/service/ArchetypeServiceImplTest.java
@@ -387,6 +387,27 @@ public class ArchetypeServiceImplTest {
                    repository);
     }
 
+    @Test
+    public void getTemplateRepositoryInSpaceSuccessTest() {
+        doReturn(true).when(archetypePreferencesManager)
+                .containsArchetype(eq("archetype"),
+                        eq("myspace"));
+        doReturn(mock(Repository.class)).when(service)
+                .getTemplateRepository(eq("archetype"));
+        service.getTemplateRepository("archetype",
+                "myspace");
+        verify(service).getTemplateRepository(eq("archetype"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getTemplateRepositoryInSpaceFailureTest() {
+        doReturn(false).when(archetypePreferencesManager)
+                .containsArchetype(eq("archetype"),
+                                    eq("myspace"));
+        service.getTemplateRepository("archetype",
+                            "myspace");
+    }
+
     @Test(expected = IllegalStateException.class)
     public void createArchetypeRepositoryWhenOrgUnitIsNotAvailableTest() {
         mockArchetypesOrgUnitNotAvailable();


### PR DESCRIPTION
AF-2847: Adding template to the REST API /spaces/{spaceName}/project command in order to create new project based on the archetype template

* AF-2847: Adding template to the REST API /spaces/{spaceName}/project command in order to create new project based on the archetype template

 * Added support to get available template repository in space

(cherry picked from commit 121dd83a1ef681c48d1144117b207ebe4ddff515)

**JIRA**: 
[RHPAM-3643](https://issues.redhat.com/browse/RHPAM-3643)
[AF-2847](https://issues.redhat.com/browse/AF-2847)

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
