### PR TITLE
KOGITO-4941: [DMN Editor] Ctrl-B always converts field to structure a…

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItem.java
@@ -696,7 +696,7 @@ public class DataTypeListItem {
         dataTypeShortcuts.highlight(target);
     }
 
-    void addDataTypeRow() {
+    public void addDataTypeRow() {
         if (isStructureType()) {
             insertNestedField();
         } else {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcuts.java
@@ -102,7 +102,7 @@ public class DataTypeListShortcuts {
     }
 
     void onCtrlB() {
-        consumeIfDataTypeIsNotReadOnly(DataTypeListItem::insertNestedField);
+        consumeIfDataTypeIsNotReadOnly(DataTypeListItem::addDataTypeRow);
     }
 
     void onCtrlU() {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/shortcuts/DataTypeListShortcutsTest.java
@@ -198,7 +198,7 @@ public class DataTypeListShortcutsTest {
 
         shortcuts.onCtrlB();
 
-        verify(listItem).insertNestedField();
+        verify(listItem).addDataTypeRow();
     }
 
     @Test


### PR DESCRIPTION
…nd nests

For more details see:
- https://issues.redhat.com/browse/KOGITO-4941

**Thank you for submitting this pull request**

**JIRA**: [JBPM-0000](https://issues.redhat.com/browse/JBPM-0000)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
