### PR TITLE
JBPM-9853 : Text Annotation causes ERROR: Attribute 'name' is not allowed to appear in element 'bpmn2:textAnnotation'

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/TextAnnotationPropertyWriter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/TextAnnotationPropertyWriter.java
@@ -32,7 +32,6 @@ public class TextAnnotationPropertyWriter extends PropertyWriter {
     public void setName(String value) {
         final String escaped = StringEscapeUtils.escapeXml10(value.trim());
         element.setText(escaped);
-        element.setName(escaped);
         CustomElement.name.of(element).set(value);
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/TextAnnotationPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/TextAnnotationPropertyWriterTest.java
@@ -33,6 +33,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +74,7 @@ public class TextAnnotationPropertyWriterTest {
     public void setName() {
         tested.setName(NAME);
         verify(element).setText(NAME);
+        verify(element, times(0)).setName(any());
         verify(valueMap).add(entryArgumentCaptor.capture());
         final MetaDataTypeImpl value = (MetaDataTypeImpl) entryArgumentCaptor.getValue().getValue();
         assertEquals(NAME, CustomElement.name.stripCData(value.getMetaValue()));

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/TextAnnotationPropertyWriterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/properties/TextAnnotationPropertyWriterTest.java
@@ -72,7 +72,6 @@ public class TextAnnotationPropertyWriterTest {
     public void setName() {
         tested.setName(NAME);
         verify(element).setText(NAME);
-        verify(element).setName(NAME);
         verify(valueMap).add(entryArgumentCaptor.capture());
         final MetaDataTypeImpl value = (MetaDataTypeImpl) entryArgumentCaptor.getValue().getValue();
         assertEquals(NAME, CustomElement.name.stripCData(value.getMetaValue()));


### PR DESCRIPTION

**Thank you for submitting this pull request**

**JIRA**: [JBPM-9853](https://issues.redhat.com/browse/JBPM-9853)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://drive.google.com/drive/folders/1n6N-OrrZzGU_z1Sg5UaHEc-yYLmL9Uwz?usp=sharing)

**VS Code**: [plugin](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
