### PR TITLE
Remove VSCode plugin reference from new PR request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,6 @@
 
 **Business Central**: [WAR file](https://donwnload.here/something)
 
-**VS Code**: [plugin](https://donwnload.here/something)
-
 <details>
 <summary>
 How to retest this PR or trigger a specific build:


### PR DESCRIPTION
Hi @mbiarnes, @romartin, I removed VS Code plugin mentioning from the template, since this repo doesn't contain VS Code related code anymore.

Thank you!

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
