### PR TITLE
AF-2891 : Space's default archetype is not respected when creating a new project

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenter.java
@@ -131,6 +131,8 @@ public class AddProjectPopUpPresenter {
         String getSelectedTemplate();
 
         void enableBasedOnTemplatesCheckbox(boolean isEnabled);
+
+        void enableTemplatesSelect(boolean isEnabled);
     }
 
     private Caller<LibraryService> libraryService;
@@ -263,14 +265,14 @@ public class AddProjectPopUpPresenter {
                 .collect(Collectors.toList());
 
         final boolean templatesAvailable = !templates.isEmpty();
+        final String defaultSelection = preferences.getDefaultSelection();
+        final boolean defaultTemplateIncluded = templates.contains(defaultSelection);
 
         if (templatesAvailable) {
-            final String defaultSelection = preferences.getDefaultSelection();
             final int selectedTemplateIdx = IntStream.range(0, templates.size())
                     .filter(i -> templates.get(i).equals(defaultSelection))
                     .findFirst()
                     .orElse(0);
-
             view.setTemplates(templates, selectedTemplateIdx);
         } else {
             view.setTemplates(Collections.singletonList(
@@ -279,6 +281,7 @@ public class AddProjectPopUpPresenter {
         }
 
         view.enableBasedOnTemplatesCheckbox(templatesAvailable);
+        view.enableTemplatesSelect(templatesAvailable && defaultTemplateIncluded);
 
         view.show();
     }

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpView.html
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpView.html
@@ -28,6 +28,17 @@
         <textarea class="form-control" data-field="description"></textarea>
     </div>
     <div class="form-group">
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" data-field="based-on-template-checkbox">
+                <span data-i18n-key="BasedOnTemplate" data-field="based-on-template-label"></span>
+            </label>
+        </div>
+        <select class="combobox form-control" data-field="template-select" id="templateSelector">
+            <option data-field="template-select-option"></option>
+        </select>
+    </div>
+    <div class="form-group">
         <a data-field="advanced-options-anchor" data-i18n-key="ConfigureAdvancedOptions"></a>
     </div>
     <div data-field="advanced-options">
@@ -42,17 +53,6 @@
         <div class="form-group">
             <label class="form-control-label required" data-i18n-key="Version"></label>
             <input type="text" class="form-control" data-field="version"/>
-        </div>
-        <div class="form-group">
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox" data-field="based-on-template-checkbox">
-                    <span data-i18n-key="BasedOnTemplate" data-field="based-on-template-label"></span>
-                </label>
-            </div>
-            <select class="combobox form-control" data-field="template-select" id="templateSelector">
-                <option data-field="template-select-option"></option>
-            </select>
         </div>
     </div>
 </div>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpView.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/main/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpView.java
@@ -304,6 +304,12 @@ public class AddProjectPopUpView implements AddProjectPopUpPresenter.View,
         basedOnTemplateCheckbox.setDisabled(!isEnabled);
     }
 
+    @Override
+    public void enableTemplatesSelect(boolean isEnabled) {
+        basedOnTemplateCheckbox.setChecked(isEnabled);
+        enableBasedOnTemplate(isEnabled);
+    }
+
     private void modalSetup() {
         this.modal = new CommonModalBuilder()
                 .addHeader(ts.format(LibraryConstants.AddProject))

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/src/test/java/org/kie/workbench/common/screens/library/client/screens/project/AddProjectPopUpPresenterTest.java
@@ -698,6 +698,8 @@ public class AddProjectPopUpPresenterTest {
         presenter.finishLoadTemplates(preferences);
 
         verify(view).setTemplates(templates, 1);
+        verify(view).enableBasedOnTemplatesCheckbox(true);
+        verify(view).enableTemplatesSelect(true);
     }
 
     @Test
@@ -717,6 +719,8 @@ public class AddProjectPopUpPresenterTest {
         presenter.finishLoadTemplates(preferences);
 
         verify(view).setTemplates(templates, 1);
+        verify(view).enableBasedOnTemplatesCheckbox(true);
+        verify(view).enableTemplatesSelect(true);
     }
 
     @Test
@@ -736,6 +740,8 @@ public class AddProjectPopUpPresenterTest {
         presenter.finishLoadTemplates(preferences);
 
         verify(view).setTemplates(templates, 0);
+        verify(view).enableBasedOnTemplatesCheckbox(true);
+        verify(view).enableTemplatesSelect(false);
     }
 
     @Test
@@ -748,6 +754,8 @@ public class AddProjectPopUpPresenterTest {
         verify(view).setTemplates(Collections.singletonList(
                 translationService.getTranslation(LibraryConstants.NoTemplatesAvailable)),
                                   0);
+        verify(view).enableBasedOnTemplatesCheckbox(false);
+        verify(view).enableTemplatesSelect(false);
     }
 
     @Test
@@ -765,5 +773,7 @@ public class AddProjectPopUpPresenterTest {
         verify(view).setTemplates(Collections.singletonList(
                 translationService.getTranslation(LibraryConstants.NoTemplatesAvailable)),
                                   0);
+        verify(view).enableBasedOnTemplatesCheckbox(false);
+        verify(view).enableTemplatesSelect(false);
     }
 }


### PR DESCRIPTION
 * if the default template is included for a space checkbox will be active.

**Thank you for submitting this pull request**

**JIRA**: 
[AF-2891](https://issues.redhat.com/browse/AF-2891)
[BAPL-1902](https://issues.redhat.com/browse/BAPL-1902)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
