### PR TITLE
[AF-2892]:Disable broken compiler tests on business central

### DIFF
--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/ClassLoaderProviderTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/ClassLoaderProviderTest.java
@@ -21,14 +21,13 @@ import java.net.URLClassLoader;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.core.rule.KieModuleMetaInfo;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -43,7 +42,6 @@ import org.kie.workbench.common.services.backend.compiler.impl.classloader.Compi
 import org.kie.workbench.common.services.backend.compiler.impl.kie.KieCompilationResponse;
 import org.kie.workbench.common.services.backend.compiler.impl.kie.KieMavenCompilerFactory;
 import org.kie.workbench.common.services.backend.compiler.impl.utils.MavenUtils;
-import org.kie.workbench.common.services.backend.compiler.utils.MavenUtilsTest;
 import org.kie.workbench.common.services.backend.constants.ResourcesConstants;
 import org.kie.workbench.common.services.backend.utils.LoadProjectDependencyUtil;
 import org.kie.workbench.common.services.backend.utils.TestUtil;
@@ -161,6 +159,7 @@ public class ClassLoaderProviderTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void getResourcesFromADroolsPRJ() throws Exception {
         /**
          * If the test fail check if the Drools core classes used, KieModuleMetaInfo and TypeMetaInfo implements Serializable
@@ -169,7 +168,7 @@ public class ClassLoaderProviderTest {
         Path tmpRoot = Files.createTempDirectory("repo");
         Path tmp = TestUtil.createAndCopyToDirectory(tmpRoot, "dummy", ResourcesConstants.KJAR_2_SINGLE_RESOURCES);
 
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD));
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(Paths.get(tmp.toUri()));
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
                                                                info,
@@ -208,6 +207,7 @@ public class ClassLoaderProviderTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void getResourcesFromADroolsPRJWithError() throws Exception {
         /**
          * If the test fail check if the Drools core classes used, KieModuleMetaInfo and TypeMetaInfo implements Serializable
@@ -244,6 +244,7 @@ public class ClassLoaderProviderTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void getResourcesFromADroolsPRJWithErrorWithMavenSkip() throws Exception {
         System.setProperty(MAVEN_MAIN_SKIP, Boolean.TRUE.toString());
         /**

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/DefaultMavenCompilerTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/DefaultMavenCompilerTest.java
@@ -32,6 +32,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -59,7 +60,6 @@ public class DefaultMavenCompilerTest {
     private IOService ioService;
     private String mavenRepoPath;
 
-
     @BeforeClass
     public static void setupSystemProperties() {
         System.setProperty("org.uberfire.nio.git.daemon.enabled", "false");
@@ -85,7 +85,7 @@ public class DefaultMavenCompilerTest {
     }
 
     @After
-    public void tearDown()  {
+    public void tearDown() {
         fileSystemTestingUtils.cleanup();
         TestUtil.rm(new File("src/../.security/"));
     }
@@ -135,7 +135,7 @@ public class DefaultMavenCompilerTest {
                                          StandardCharsets.UTF_8);
         assertThat(pomAsAstring).doesNotContain(TestConstants.TAKARI_LIFECYCLE_ARTIFACT);
 
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.ENABLE_INCREMENTAL_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.ENABLE_INCREMENTAL_BUILD));
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(prjFolder);
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
                                                                info,
@@ -204,7 +204,7 @@ public class DefaultMavenCompilerTest {
         assertThat(rbResult.getStatus().isSuccessful()).isTrue();
 
         //Compile the repo
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.ENABLE_INCREMENTAL_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.ENABLE_INCREMENTAL_BUILD));
 
         byte[] encoded = Files.readAllBytes(Paths.get(tmpCloned + "/pom.xml"));
         String pomAsAstring = new String(encoded,
@@ -237,7 +237,7 @@ public class DefaultMavenCompilerTest {
 
     @Test
     public void buildWithJGitDecoratorTest() throws Exception {
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.UPDATE_JGIT_BEFORE_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.UPDATE_JGIT_BEFORE_BUILD));
 
         String MAIN_BRANCH = "master";
 
@@ -298,8 +298,9 @@ public class DefaultMavenCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildWithAllDecoratorsTest() throws Exception {
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.UPDATE_JGIT_BEFORE_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.UPDATE_JGIT_BEFORE_BUILD));
 
         String MAIN_BRANCH = "master";
 
@@ -416,7 +417,7 @@ public class DefaultMavenCompilerTest {
 
     @Test
     public void cleanInternalTest() throws Exception {
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.UPDATE_JGIT_BEFORE_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.UPDATE_JGIT_BEFORE_BUILD));
 
         String MAIN_BRANCH = "master";
 

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/classloader/CompilerClassloaderUtilsTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.backend.compiler.BaseCompilerTest;
 import org.kie.workbench.common.services.backend.compiler.TestUtilMaven;
@@ -34,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
 
     public CompilerClassloaderUtilsTest() {
-        super("target/test-classes/kjar-2-single-resources", EnumSet.of(KieDecorator.STORE_KIE_OBJECTS , KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD));
+        super("target/test-classes/kjar-2-single-resources", EnumSet.of(KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD));
     }
 
     @Test
@@ -150,6 +151,7 @@ public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void createClassloaderFromCpFiles() {
         assertThat(res.getDependencies()).hasSize(4);
         Optional<ClassLoader> classLoader = CompilerClassloaderUtils.createClassloaderFromStringDeps(res.getDependencies());
@@ -158,6 +160,7 @@ public class CompilerClassloaderUtilsTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void readFileAsURI() {
         assertThat(res.getDependencies()).isNotEmpty();
         List<String> projectDeps = res.getDependencies();

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/decorators/KieAfterDecoratorTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/impl/decorators/KieAfterDecoratorTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.backend.compiler.BaseCompilerTest;
 import org.kie.workbench.common.services.backend.compiler.CompilationRequest;
@@ -40,6 +41,7 @@ public class KieAfterDecoratorTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void compileTest() {
 
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
@@ -58,6 +60,7 @@ public class KieAfterDecoratorTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void compileWithOverrideTest() throws Exception {
 
         Map<Path, InputStream> override = new HashMap<>();

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/kie/KieDefaultMavenCompilerTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/kie/KieDefaultMavenCompilerTest.java
@@ -35,6 +35,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -301,6 +302,7 @@ public class KieDefaultMavenCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildWithAllDecoratorsTest() throws Exception {
         String alternateSettingsAbsPath = TestUtilMaven.getSettingsFile();
         String MAIN_BRANCH = "master";

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/kie/KieDefaultMavenIncrementalCompilerTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/kie/KieDefaultMavenIncrementalCompilerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -68,7 +69,7 @@ public class KieDefaultMavenIncrementalCompilerTest {
         tmpRoot = Files.createTempDirectory("repo");
         temp = TestUtil.createAndCopyToDirectory(tmpRoot, "dummy", ResourcesConstants.DUMMY_DIR);
 
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_INCREMENTAL_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_INCREMENTAL_BUILD));
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(temp);
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
                                                                info,
@@ -102,7 +103,7 @@ public class KieDefaultMavenIncrementalCompilerTest {
         Path tmp = TestUtil.createAndCopyToDirectory(tmpRoot, "dummy", ResourcesConstants.DUMMY_DIR);
         //end NIO
 
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_INCREMENTAL_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_INCREMENTAL_BUILD));
 
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(tmp);
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
@@ -125,6 +126,7 @@ public class KieDefaultMavenIncrementalCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void testCheckIncrementalWithChanges() throws Exception {
         String alternateSettingsAbsPath = TestUtilMaven.getSettingsFile();
         tmpRoot = Files.createTempDirectory("repo");
@@ -133,7 +135,7 @@ public class KieDefaultMavenIncrementalCompilerTest {
         //end NIO
 
         //compiler
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING));
 
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(temp);
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/plugin/KieMetadataTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/test/java/org/kie/workbench/common/services/backend/compiler/plugin/KieMetadataTest.java
@@ -25,7 +25,11 @@ import java.util.Set;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.core.rule.KieModuleMetaInfo;
 import org.drools.core.rule.TypeMetaInfo;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestName;
 import org.kie.api.builder.KieModule;
 import org.kie.scanner.KieModuleMetaData;
@@ -74,14 +78,14 @@ public class KieMetadataTest {
         tmpRoot = Files.createTempDirectory("repo");
     }
 
-    @Ignore //https://issues.redhat.com/browse/AF-2741
+    @Ignore //https://issues.redhat.com/browse/AF-2741,https://issues.redhat.com/browse/AF-2892
     @Test //AF-1459 it tooks 30% of the time of the time spent by all module's test (108), alone it took 30 sec
     public void compileAndLoadKieJarMetadataAllResourcesPackagedJar() throws Exception {
         /**
          * If the test fail check if the Drools core classes used, KieModuleMetaInfo and TypeMetaInfo implements Serializable
          * */
         Path temp = TestUtil.createAndCopyToDirectory(tmpRoot, "dummy", ResourcesConstants.KJAR_2_ALL_RESOURCES);
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH , KieDecorator.ENABLE_INCREMENTAL_BUILD));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD));
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(temp);
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
                                                                info,
@@ -123,6 +127,7 @@ public class KieMetadataTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void compileAndloadKieJarSingleMetadata() {
         /**
          * If the test fail check if the Drools core classes used, KieModuleMetaInfo and TypeMetaInfo implements Serializable
@@ -130,7 +135,7 @@ public class KieMetadataTest {
         try {
             Path tmp = TestUtil.createAndCopyToDirectory(tmpRoot, "dummy", ResourcesConstants.KJAR_2_SINGLE_RESOURCES);
 
-            final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD ));
+            final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.ENABLE_LOGGING, KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD));
             WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(Paths.get(tmp.toUri()));
             CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
                                                                    info,
@@ -165,13 +170,14 @@ public class KieMetadataTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void compileAndloadKieJarSingleMetadataWithPackagedJar() throws Exception {
         /**
          * If the test fail check if the Drools core classes used, KieModuleMetaInfo and TypeMetaInfo implements Serializable
          * */
         Path tmp = TestUtil.createAndCopyToDirectory(tmpRoot, "dummy", ResourcesConstants.KJAR_2_SINGLE_RESOURCES);
 
-        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD ));
+        final AFCompiler compiler = KieMavenCompilerFactory.getCompiler(EnumSet.of(KieDecorator.STORE_KIE_OBJECTS, KieDecorator.STORE_BUILD_CLASSPATH, KieDecorator.ENABLE_INCREMENTAL_BUILD));
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(Paths.get(tmp.toUri()));
         CompilationRequest req = new DefaultCompilationRequest(mavenRepoPath,
                                                                info,

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-testing/src/test/java/org/kie/workbench/common/services/backend/compiler/offprocess/CompilerChronicleCoordinatorTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-testing/src/test/java/org/kie/workbench/common/services/backend/compiler/offprocess/CompilerChronicleCoordinatorTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import net.openhft.chronicle.core.io.IOTools;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.backend.compiler.CompilationRequest;
 import org.kie.workbench.common.services.backend.compiler.CompilationResponse;
@@ -47,13 +48,13 @@ public class CompilerChronicleCoordinatorTest {
     private static QueueProvider queueProvider;
 
     @BeforeClass
-    public static void setup() throws Exception{
+    public static void setup() throws Exception {
         queueProvider = new QueueProvider(queueName);
         logger.info("queue on test setup:{}", queueProvider.getAbsolutePath());
         mavenRepo = TestUtilMaven.getMavenRepo();
         System.setProperty("org.uberfire.nio.git.daemon.enabled", "false");
         System.setProperty("org.uberfire.nio.git.ssh.enabled", "false");
-        prjPath = Paths.get("file://"+System.getProperty("user.dir")+"/target/test-classes/kjar-2-single-resources");
+        prjPath = Paths.get("file://" + System.getProperty("user.dir") + "/target/test-classes/kjar-2-single-resources");
         alternateSettingsAbsPath = TestUtilMaven.getSettingsFile();
     }
 
@@ -65,6 +66,7 @@ public class CompilerChronicleCoordinatorTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void offProcessOneBuildTest() {
         CompilerIPCCoordinator compiler = new CompilerIPCCoordinatorImpl(queueProvider);
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(prjPath);
@@ -82,10 +84,11 @@ public class CompilerChronicleCoordinatorTest {
         assertThat(res.isSuccessful()).isTrue();
         assertThat(res.getMavenOutput()).isNotEmpty();
         DefaultKieCompilationResponse kres = (DefaultKieCompilationResponse) res;
-        assertThat(uuid).isEqualToIgnoringCase( kres.getRequestUUID());
+        assertThat(uuid).isEqualToIgnoringCase(kres.getRequestUUID());
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void offProcessTwoBuildTest() {
         CompilerIPCCoordinator compiler = new CompilerIPCCoordinatorImpl(queueProvider);
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(prjPath);
@@ -105,7 +108,7 @@ public class CompilerChronicleCoordinatorTest {
         assertThat(res.isSuccessful()).isTrue();
         assertThat(res.getMavenOutput()).isNotEmpty();
         DefaultKieCompilationResponse kres = (DefaultKieCompilationResponse) res;
-        assertThat(uuid).isEqualToIgnoringCase( kres.getRequestUUID());
+        assertThat(uuid).isEqualToIgnoringCase(kres.getRequestUUID());
 
         // Second Build
         String secondUuid = UUID.randomUUID().toString();

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-testing/src/test/java/org/kie/workbench/common/services/backend/compiler/offprocess/service/CompilerOffProcessServiceTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-testing/src/test/java/org/kie/workbench/common/services/backend/compiler/offprocess/service/CompilerOffProcessServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.backend.compiler.CompilationRequest;
 import org.kie.workbench.common.services.backend.compiler.TestUtilMaven;
@@ -68,6 +69,7 @@ public class CompilerOffProcessServiceTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void offProcessServiceCompileAsyncTest() throws Exception {
         CompilerOffprocessService service = new CompilerOffprocessServiceImpl(executor, queueProvider);
         WorkspaceCompilationInfo info = new WorkspaceCompilationInfo(prjPath);

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/src/test/java/org/kie/workbench/common/services/backend/compiler/service/DefaultKieCompilerServiceTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/src/test/java/org/kie/workbench/common/services/backend/compiler/service/DefaultKieCompilerServiceTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.backend.compiler.BaseCompilerTest;
 import org.kie.workbench.common.services.backend.compiler.TestUtilMaven;
@@ -66,7 +67,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     @Test
     public void buildAndInstallNonExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
-        CompletableFuture<KieCompilationResponse> futureRes = service.buildAndInstall(tmpRoot, mavenRepoPath,TestUtilMaven.getSettingsFile());
+        CompletableFuture<KieCompilationResponse> futureRes = service.buildAndInstall(tmpRoot, mavenRepoPath, TestUtilMaven.getSettingsFile());
         KieCompilationResponse res = futureRes.get();
         assertThat(res.isSuccessful()).isFalse();
     }
@@ -84,6 +85,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.build(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
@@ -94,6 +96,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildAndInstallExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
@@ -106,6 +109,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildAndInstallSkipDepsExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
@@ -128,11 +132,12 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildSpecializedSkipDepsExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.buildSpecialized(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
                                                                                        mavenRepoPath,
-                                                                                       new String[]{ MavenCLIArgs.ALTERNATE_USER_SETTINGS + TestUtilMaven.getSettingsFile(), MavenCLIArgs.COMPILE},
+                                                                                       new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS + TestUtilMaven.getSettingsFile(), MavenCLIArgs.COMPILE},
                                                                                        Boolean.TRUE);
         KieCompilationResponse res = futureRes.get();
         assertThat(res.isSuccessful()).isTrue();
@@ -143,7 +148,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.buildSpecialized(tmpRoot,
                                                                                        mavenRepoPath,
-                                                                                       new String[]{ MavenCLIArgs.ALTERNATE_USER_SETTINGS + TestUtilMaven.getSettingsFile(), MavenCLIArgs.COMPILE},
+                                                                                       new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS + TestUtilMaven.getSettingsFile(), MavenCLIArgs.COMPILE},
                                                                                        Boolean.TRUE);
         KieCompilationResponse res = futureRes.get();
         assertThat(res.isSuccessful()).isFalse();
@@ -168,6 +173,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildWithOverrideExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         //change some files
@@ -234,6 +240,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildRemoteExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.build(Paths.get(tmpRoot.toAbsolutePath() + "/dummy").toAbsolutePath().toString(),
@@ -244,6 +251,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildRemoteAndInstallExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath() + "/dummy").toAbsolutePath().toString(),
@@ -256,6 +264,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildRemoteAndInstallSkipDepsExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath() + "/dummy").toAbsolutePath().toString(),
@@ -278,6 +287,7 @@ public class DefaultKieCompilerServiceTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildRemoteSpecializedSkipDepsExistentProject() throws Exception {
         AFCompilerService service = new DefaultKieCompilerService();
         CompletableFuture<KieCompilationResponse> futureRes = service.buildSpecialized(Paths.get(tmpRoot.toAbsolutePath() + "/dummy").toAbsolutePath().toString(),

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/src/test/java/org/kie/workbench/common/services/backend/compiler/service/executors/DefaultLocalExecutorTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/src/test/java/org/kie/workbench/common/services/backend/compiler/service/executors/DefaultLocalExecutorTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.backend.compiler.BaseCompilerTest;
 import org.kie.workbench.common.services.backend.compiler.TestUtilMaven;
@@ -35,14 +36,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultLocalExecutorTest extends BaseCompilerTest {
 
-    public DefaultLocalExecutorTest(){
+    public DefaultLocalExecutorTest() {
         super("target/test-classes/kjar-2-single-resources");
         executorService = Executors.newFixedThreadPool(1);
     }
+
     private ExecutorService executorService;
 
     @Test
-    public void buildNonExistentProject() throws Exception{
+    public void buildNonExistentProject() throws Exception {
 
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.build(tmpRoot,
@@ -53,7 +55,7 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildAndSkipDepsNonExistentProject() throws Exception{
+    public void buildAndSkipDepsNonExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.build(tmpRoot,
                                                                              mavenRepoPath,
@@ -65,7 +67,7 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildAndInstallNonExistentProject() throws Exception{
+    public void buildAndInstallNonExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(tmpRoot,
                                                                                        mavenRepoPath,
@@ -75,7 +77,7 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildAndInstallSkipDepsNonExistentProject() throws Exception{
+    public void buildAndInstallSkipDepsNonExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(tmpRoot,
                                                                                        mavenRepoPath,
@@ -87,20 +89,20 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildExistentProject() throws Exception{
+    @Ignore //https://issues.redhat.com/browse/AF-2892
+    public void buildExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
-        CompletableFuture<KieCompilationResponse> futureRes = executor.build(Paths.get(tmpRoot.toAbsolutePath()+"/dummy"),
+        CompletableFuture<KieCompilationResponse> futureRes = executor.build(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
                                                                              mavenRepoPath, TestUtilMaven.getSettingsFile());
         KieCompilationResponse res = futureRes.get();
         assertThat(res.isSuccessful()).isTrue();
     }
 
-
-
     @Test
-    public void buildAndInstallExistentProject() throws Exception{
+    @Ignore //https://issues.redhat.com/browse/AF-2892
+    public void buildAndInstallExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
-        CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath()+"/dummy"),
+        CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
                                                                                        mavenRepoPath, TestUtilMaven.getSettingsFile());
         KieCompilationResponse res = futureRes.get();
         assertThat(res.isSuccessful()).isTrue();
@@ -109,9 +111,10 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildAndInstallSkipDepsExistentProject() throws Exception{
+    @Ignore //https://issues.redhat.com/browse/AF-2892
+    public void buildAndInstallSkipDepsExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
-        CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath()+"/dummy"),
+        CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
                                                                                        mavenRepoPath,
                                                                                        TestUtilMaven.getSettingsFile(),
                                                                                        Boolean.TRUE);
@@ -121,22 +124,23 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildSpecializedNonExistentProject() throws Exception{
+    public void buildSpecializedNonExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.buildSpecialized(tmpRoot,
                                                                                         mavenRepoPath,
-                                                                                        new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS+ TestUtilMaven.getSettingsFile(),
+                                                                                        new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS + TestUtilMaven.getSettingsFile(),
                                                                                                 MavenCLIArgs.COMPILE});
         KieCompilationResponse res = futureRes.get();
         assertThat(res.isSuccessful()).isFalse();
     }
 
     @Test
-    public void buildSpecializedSkipDepsExistentProject() throws Exception{
+    @Ignore //https://issues.redhat.com/browse/AF-2892
+    public void buildSpecializedSkipDepsExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
-        CompletableFuture<KieCompilationResponse> futureRes = executor.buildSpecialized(Paths.get(tmpRoot.toAbsolutePath()+"/dummy"),
+        CompletableFuture<KieCompilationResponse> futureRes = executor.buildSpecialized(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
                                                                                         mavenRepoPath,
-                                                                                        new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS+ TestUtilMaven.getSettingsFile(),
+                                                                                        new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS + TestUtilMaven.getSettingsFile(),
                                                                                                 MavenCLIArgs.COMPILE},
                                                                                         Boolean.TRUE);
         KieCompilationResponse res = futureRes.get();
@@ -144,26 +148,24 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildSpecializedSkipDepsNonExistentProject() throws Exception{
+    public void buildSpecializedSkipDepsNonExistentProject() throws Exception {
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.buildSpecialized(tmpRoot,
                                                                                         mavenRepoPath,
-                                                                                        new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS+ TestUtilMaven.getSettingsFile(),
+                                                                                        new String[]{MavenCLIArgs.ALTERNATE_USER_SETTINGS + TestUtilMaven.getSettingsFile(),
                                                                                                 MavenCLIArgs.COMPILE},
                                                                                         Boolean.TRUE);
         KieCompilationResponse res = futureRes.get();
         assertThat(res.isSuccessful()).isFalse();
     }
 
-
-
     @Test
-    public void buildWithOverrideNonExistentProject() throws Exception{
+    public void buildWithOverrideNonExistentProject() throws Exception {
 
         //change some files
         Map<org.uberfire.java.nio.file.Path, InputStream> override = new HashMap<>();
 
-        org.uberfire.java.nio.file.Path path = org.uberfire.java.nio.file.Paths.get(tmpRoot+ "/dummy/src/main/java/dummy/DummyOverride.java");
+        org.uberfire.java.nio.file.Path path = org.uberfire.java.nio.file.Paths.get(tmpRoot + "/dummy/src/main/java/dummy/DummyOverride.java");
         InputStream input = new FileInputStream(new File("target/test-classes/dummy_override/src/main/java/dummy/DummyOverride.java"));
         override.put(path, input);
 
@@ -177,17 +179,18 @@ public class DefaultLocalExecutorTest extends BaseCompilerTest {
     }
 
     @Test
-    public void buildWithOverrideExistentProject() throws Exception{
+    @Ignore //https://issues.redhat.com/browse/AF-2892
+    public void buildWithOverrideExistentProject() throws Exception {
 
         //change some files
         Map<org.uberfire.java.nio.file.Path, InputStream> override = new HashMap<>();
 
-        org.uberfire.java.nio.file.Path path = org.uberfire.java.nio.file.Paths.get(tmpRoot+ "/dummy/src/main/java/dummy/DummyOverride.java");
+        org.uberfire.java.nio.file.Path path = org.uberfire.java.nio.file.Paths.get(tmpRoot + "/dummy/src/main/java/dummy/DummyOverride.java");
         InputStream input = new FileInputStream(new File("target/test-classes/dummy_override/src/main/java/dummy/DummyOverride.java"));
         override.put(path, input);
 
         DefaultLocalExecutor executor = new DefaultLocalExecutor(executorService);
-        CompletableFuture<KieCompilationResponse> futureRes = executor.build(Paths.get(tmpRoot.toAbsolutePath()+"/dummy"),
+        CompletableFuture<KieCompilationResponse> futureRes = executor.build(Paths.get(tmpRoot.toAbsolutePath() + "/dummy"),
                                                                              mavenRepoPath,
                                                                              TestUtilMaven.getSettingsFile(),
                                                                              override);

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/src/test/java/org/kie/workbench/common/services/backend/compiler/service/executors/DefaultRemoteExecutorTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/src/test/java/org/kie/workbench/common/services/backend/compiler/service/executors/DefaultRemoteExecutorTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.backend.compiler.BaseCompilerTest;
 import org.kie.workbench.common.services.backend.compiler.TestUtilMaven;
@@ -82,6 +83,7 @@ public class DefaultRemoteExecutorTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildExistentProject() throws Exception{
         DefaultRemoteExecutor executor = new DefaultRemoteExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.build(Paths.get(tmpRoot.toAbsolutePath()+"/dummy").toAbsolutePath().toString(),
@@ -94,6 +96,7 @@ public class DefaultRemoteExecutorTest extends BaseCompilerTest {
 
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildAndInstallExistentProject() throws Exception{
         DefaultRemoteExecutor executor = new DefaultRemoteExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath()+"/dummy").toAbsolutePath().toString(),
@@ -106,6 +109,7 @@ public class DefaultRemoteExecutorTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildAndInstallSkipDepsExistentProject() throws Exception{
         DefaultRemoteExecutor executor = new DefaultRemoteExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.buildAndInstall(Paths.get(tmpRoot.toAbsolutePath()+"/dummy").toAbsolutePath().toString(),
@@ -128,6 +132,7 @@ public class DefaultRemoteExecutorTest extends BaseCompilerTest {
     }
 
     @Test
+    @Ignore //https://issues.redhat.com/browse/AF-2892
     public void buildSpecializedSkipDepsExistentProject() throws Exception{
         DefaultRemoteExecutor executor = new DefaultRemoteExecutor(executorService);
         CompletableFuture<KieCompilationResponse> futureRes = executor.buildSpecialized(Paths.get(tmpRoot.toAbsolutePath()+"/dummy").toAbsolutePath().toString(),


### PR DESCRIPTION


**JIRA**: [AF-2892](https://issues.redhat.com/browse/AF-2892)
Ignoring all the compiler related tests from `org.kie.workbench.common.services.backend.compiler` as this module is not integrated with BC.
