### PR TITLE
[7.x] RHPAM-3480 : Error logged if reusable subprocess has some dataInput mapping but no dataOutput mapping in stunner

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.java
@@ -80,6 +80,9 @@ public interface StunnerWidgetsConstants {
     @TranslationKey(defaultValue = "Data Object Exists with Same Name and Different Type - Will be Changed to (Object)")
     String MarshallingResponsePopup_DataObjectsSameNameDifferentType = "MarshallingMessage.dataObjectsSameNameDifferentType";
 
+    @TranslationKey(defaultValue = "Reusable Subprocess with no Assignments Data Input/Data Output")
+    String MarshallingResponsePopup_ReusableSubprocessWithoutDataIO = "MarshallingMessage.reusableSubprocessWithoutDataIO";
+
     @TranslationKey(defaultValue = "Data Object-Name")
     String MarshallingResponsePopup_dataObjectWithName = "MarshallingMessage.dataObjectWithName";
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/resources/org/kie/workbench/common/stunner/client/widgets/resources/i18n/StunnerWidgetsConstants.properties
@@ -38,6 +38,7 @@ MarshallingMessage.elementFailure=Failure on element {0} of type {1}
 MarshallingMessage.dataObjectsSameNameDifferentType=Data Object Exists with Same Name and Different Type - Will be Changed to (Object)
 MarshallingMessage.dataObjectWithName=Data Object-Name
 MarshallingMessage.dataObjectWithInvalidName=Data Object with Invalid Name Exists. Illegal chars will be replaced by -
+MarshallingMessage.reusableSubprocessWithoutDataIO=Reusable Subprocess with no Assignments Data Input/Data Output
 
 SessionCardinalityStateHandler.EmptyStateCaption=Click, drag or interact with a node
 SessionCardinalityStateHandler.EmptyStateMessage=To start, click or drag a node in the left-hand palette onto the canvas

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNReusableSubProcessValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNReusableSubProcessValidator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.validation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.kie.workbench.common.stunner.bpmn.BPMNDefinitionSet;
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
+import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.validation.DomainValidator;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+import org.kie.workbench.common.stunner.core.validation.Violation;
+
+public abstract class BPMNReusableSubProcessValidator implements DomainValidator {
+
+    @Override
+    public String getDefinitionSetId() {
+        return BindableAdapterUtils.getDefinitionSetId(BPMNDefinitionSet.class);
+    }
+
+    @Override
+    public void validate(Diagram diagram, Consumer<Collection<DomainViolation>> resultConsumer) {
+        Iterator<Element> it = diagram.getGraph().nodes().iterator();
+        List<DomainViolation> violations = new ArrayList<>();
+        while (it.hasNext()) {
+            Element element = it.next();
+            checkElementForViolations(violations, element);
+        }
+        resultConsumer.accept(violations);
+    }
+
+    protected void checkElementForViolations(List<DomainViolation> violations, Element element) {
+        if (isReusableAndHasNoInputs(element)) {
+            addViolation(violations, element);
+        }
+    }
+
+    protected void addViolation(List<DomainViolation> violations, Element element) {
+        ReusableSubprocess subprocess = (ReusableSubprocess) ((View) element.getContent()).getDefinition();
+        BPMNViolation bpmnViolation = new BPMNViolation(getMessageSubprocessWithoutDataIOAssignments() + " : " + subprocess.getGeneral().getName().getValue(), Violation.Type.WARNING, element.getUUID());
+        violations.add(bpmnViolation);
+    }
+
+    protected boolean isReusableSubProcess(Element element) {
+        return element.getContent() instanceof View && ((View) element.getContent()).getDefinition() instanceof ReusableSubprocess;
+    }
+
+    protected boolean hasNoDataInputsOutputs(Element element) {
+        ReusableSubprocess subprocess = (ReusableSubprocess) ((View) element.getContent()).getDefinition();
+        final AssignmentsInfo assignmentsInfo = subprocess.getDataIOSet().getAssignmentsinfo();
+        return hasNoAssignmentsDataInput(assignmentsInfo) || hasNoAssignmentsDataOutput(assignmentsInfo);
+    }
+
+    protected boolean isReusableAndHasNoInputs(Element element) {
+        return isReusableSubProcess(element) && hasNoDataInputsOutputs(element);
+    }
+
+    public abstract String getMessageSubprocessWithoutDataIOAssignments();
+
+    public abstract boolean hasNoAssignmentsDataInput(AssignmentsInfo assignmentsInfo);
+
+    public abstract boolean hasNoAssignmentsDataOutput(AssignmentsInfo assignmentsInfo);
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNReusableSubProcessValidatorTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/test/java/org/kie/workbench/common/stunner/bpmn/validation/BPMNReusableSubProcessValidatorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.kie.workbench.common.stunner.bpmn.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.ReusableSubprocess;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOSet;
+import org.kie.workbench.common.stunner.core.graph.Element;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.validation.DomainViolation;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.jgroups.util.Util.assertFalse;
+import static org.jgroups.util.Util.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BPMNReusableSubProcessValidatorTest {
+
+    @Mock
+    Element element;
+
+    @Mock
+    View view;
+
+    @Mock
+    ReusableSubprocess subprocess;
+
+    @Mock
+    DataIOSet dataIOSet;
+
+    @Mock
+    AssignmentsInfo assignmentsInfo;
+
+    @Mock
+    BPMNReusableSubProcessValidator tested;
+
+    boolean hasNoInputs = true;
+
+    boolean hasNoOutputs = true;
+
+    @Before
+    public void setUp() {
+        when(element.getContent()).thenReturn(view);
+        when(view.getDefinition()).thenReturn(subprocess);
+        when(subprocess.getDataIOSet()).thenReturn(dataIOSet);
+        when(dataIOSet.getAssignmentsinfo()).thenReturn(assignmentsInfo);
+
+        tested = spy(new BPMNReusableSubProcessValidator() {
+            @Override
+            public String getMessageSubprocessWithoutDataIOAssignments() {
+                return "No Message";
+            }
+
+            @Override
+            public boolean hasNoAssignmentsDataInput(AssignmentsInfo assignmentsInfo) {
+                return hasNoInputs;
+            }
+
+            @Override
+            public boolean hasNoAssignmentsDataOutput(AssignmentsInfo assignmentsInfo) {
+                return hasNoOutputs;
+            }
+        });
+        doNothing().when(tested).addViolation(any(), any());
+    }
+
+    @Test
+    public void testValidationTrue() {
+        final boolean reusableSubProcess = tested.isReusableSubProcess(element);
+        assertTrue("Must be a reusable Subprocess", reusableSubProcess);
+
+        final boolean hasNoInputs = tested.hasNoDataInputsOutputs(element);
+        assertTrue("Validation should be true", hasNoInputs);
+
+        List<DomainViolation> violations = new ArrayList<>();
+        tested.checkElementForViolations(violations, element);
+        verify(tested, times(1)).addViolation(any(), any());
+    }
+
+    @Test
+    public void testValidationFalse() {
+        final boolean reusableSubProcess = tested.isReusableSubProcess(element);
+        assertTrue("Must be a reusable Subprocess", reusableSubProcess);
+
+        hasNoInputs = false;
+        hasNoOutputs = false;
+
+        final boolean hasNoInputs = tested.hasNoDataInputsOutputs(element);
+        assertFalse("Validation should be false", hasNoInputs);
+
+        List<DomainViolation> violations = new ArrayList<>();
+        tested.checkElementForViolations(violations, element);
+        verify(tested, times(0)).addViolation(any(), any());
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/validation/BPMNReusableSubProcessClientValidator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/validation/BPMNReusableSubProcessClientValidator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.bpmn.client.validation;
+
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.AssignmentParser;
+import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
+import org.kie.workbench.common.stunner.bpmn.validation.BPMNReusableSubProcessValidator;
+import org.kie.workbench.common.stunner.client.widgets.resources.i18n.StunnerWidgetsConstants;
+import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+
+@ApplicationScoped
+public class BPMNReusableSubProcessClientValidator extends BPMNReusableSubProcessValidator {
+
+    private final ClientTranslationService translationService;
+
+    @Inject
+    public BPMNReusableSubProcessClientValidator(final ClientTranslationService translationService) {
+        this.translationService = translationService;
+    }
+
+    @Override
+    public String getMessageSubprocessWithoutDataIOAssignments() {
+        return translationService.getValue(StunnerWidgetsConstants.MarshallingResponsePopup_ReusableSubprocessWithoutDataIO);
+    }
+
+    @Override
+    public boolean hasNoAssignmentsDataInput(AssignmentsInfo assignmentsInfo) {
+        return getAssignmentsDataInput(assignmentsInfo) == null;
+    }
+
+    @Override
+    public boolean hasNoAssignmentsDataOutput(AssignmentsInfo assignmentsInfo) {
+        return getAssignmentsDataOutput(assignmentsInfo) == null;
+    }
+
+    private Map<String, String> getAssignmentsMap(AssignmentsInfo assignmentsInfo) {
+        return AssignmentParser.parseAssignmentsInfo(assignmentsInfo.getValue());
+    }
+
+    private String getAssignmentsDataInput(AssignmentsInfo assignmentsInfo) {
+        return getAssignmentsMap(assignmentsInfo).get(AssignmentParser.DATAINPUTSET);
+    }
+
+    private String getAssignmentsDataOutput(AssignmentsInfo assignmentsInfo) {
+        return getAssignmentsMap(assignmentsInfo).get(AssignmentParser.DATAOUTPUTSET);
+    }
+}


### PR DESCRIPTION

**Thank you for submitting this pull request**

**JIRA**: [JBPM-0000](https://issues.redhat.com/browse/JBPM-0000)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
