### PR TITLE
fix broken gwt:run for dmn-webapp-standalone

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
@@ -827,6 +827,12 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.wildfly.client</groupId>
+      <artifactId>wildfly-client-config</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
The dmn shocase webapp fails to start [1]. The similar issue was spotted also on other webapps [2].

[1]
```

[INFO] The code server is ready at http://127.0.0.1:9876/
[ERROR] WARNING: An illegal reflective access operation has occurred
[ERROR] WARNING: Illegal reflective access by org.wildfly.extension.elytron.SSLDefinitions (jar:file:/home/jomarko/redhat/github/kiegroup/kie-wb-common/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/target/wildfly-23.0.2.Final/mod>
[ERROR] WARNING: Please consider reporting this to the maintainers of org.wildfly.extension.elytron.SSLDefinitions
[ERROR] WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
[ERROR] WARNING: All illegal access operations will be denied in a future release
[ERROR] Exception in thread "main" java.lang.ExceptionInInitializerError
[ERROR]         at org.wildfly.security.auth.client.AuthenticationContext.lambda$static$0(AuthenticationContext.java:54)
[ERROR]         at org.wildfly.common.context.ContextManager.getPrivileged(ContextManager.java:286)
[ERROR]         at org.wildfly.security.auth.client.AuthenticationContext.captureCurrent(AuthenticationContext.java:86)
[ERROR]         at org.jboss.as.cli.impl.CLIModelControllerClient.<init>(CLIModelControllerClient.java:146)
[ERROR]         at org.jboss.as.cli.impl.ModelControllerClientFactory$2.getClient(ModelControllerClientFactory.java:85)
[ERROR]         at org.jboss.as.cli.impl.CommandContextImpl.connectController(CommandContextImpl.java:1301)
[ERROR]         at org.jboss.as.cli.impl.CommandContextImpl.connectController(CommandContextImpl.java:1282)
[ERROR]         at org.jboss.errai.cdi.server.as.JBossServletContainerAdaptor.attemptCommandContextConnection(JBossServletContainerAdaptor.java:228)
[ERROR]         at org.jboss.errai.cdi.server.as.JBossServletContainerAdaptor.<init>(JBossServletContainerAdaptor.java:132)
[ERROR]         at org.jboss.errai.cdi.server.as.JBossServletContainerAdaptor.<init>(JBossServletContainerAdaptor.java:74)
[ERROR]         at org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher.start(EmbeddedWildFlyLauncher.java:111)
[ERROR]         at com.google.gwt.dev.DevMode.doStartUpServer(DevMode.java:636)
[ERROR]         at com.google.gwt.dev.DevModeBase.startUp(DevModeBase.java:898)
[ERROR]         at com.google.gwt.dev.DevModeBase.run(DevModeBase.java:705)
[ERROR]         at com.google.gwt.dev.DevMode.main(DevMode.java:432)
[ERROR] Caused by: org.wildfly.security.auth.client.InvalidAuthenticationConfigurationException: java.lang.NoClassDefFoundError: org/wildfly/client/config/ConfigXMLParseException
[ERROR]         at org.wildfly.security.auth.client.DefaultAuthenticationContextProvider.lambda$static$0(DefaultAuthenticationContextProvider.java:40)
[ERROR]         at java.base/java.security.AccessController.doPrivileged(Native Method)
[ERROR]         at org.wildfly.security.auth.client.DefaultAuthenticationContextProvider.<clinit>(DefaultAuthenticationContextProvider.java:36)
[ERROR]         ... 15 more
[ERROR] Caused by: java.lang.NoClassDefFoundError: org/wildfly/client/config/ConfigXMLParseException
[ERROR]         at org.wildfly.security.auth.client.DefaultAuthenticationContextProvider.lambda$static$0(DefaultAuthenticationContextProvider.java:38)
[ERROR]         ... 17 more
[ERROR] Caused by: java.lang.ClassNotFoundException: org.wildfly.client.config.ConfigXMLParseException
[ERROR]         at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
[ERROR]         at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
[ERROR]         at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)


```

[2]
- https://github.com/kiegroup/drools-wb/pull/1522