### PR TITLE
[7.59.x] fix broken gwt:run for dmn-webapp-standalone

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
@@ -827,6 +827,12 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.wildfly.client</groupId>
+      <artifactId>wildfly-client-config</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
(cherry picked from commit 4f3d828a26babdcd3c6d385daee0ab2bb6aa1cca)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
