### PR TITLE
JBPM-9532 : Recusivity issue on form generation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,16 @@
 
 <details>
 <summary>
+How to replicate CI configuration locally?
+</summary>
+
+Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
+ 
+[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
+</details>
+
+<details>
+<summary>
 How to retest this PR or trigger a specific build:
 </summary>
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,9 +45,9 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.11
+        uses: kiegroup/github-action-build-chain@v2.6.13
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Check Surefire Report

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,19 +24,16 @@ jobs:
     name: Maven Build
     steps:
       - name: Clean Disk Space
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/disk-space@main
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/ubuntu-disk-space@main
       - name: Support long paths
         if: ${{ matrix.os == 'windows-latest' }}
         uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/long-paths@main
       - name: Java and Maven Setup
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/java@main
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/maven@main
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
-      - name: Cache Maven
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/cache-maven@main
-        with:
-          key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
       - name: Build Chain
         uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/build-chain@main
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,37 +23,25 @@ jobs:
     runs-on: ubuntu-latest
     name: Maven Build
     steps:
-      - name: Free disk space
-        shell: bash
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          docker rmi $(docker image ls -aq)
-          df -h
-      - name: Setup Maven And Java Version
-        uses: s4u/setup-maven-action@v1.2.1
+      - name: Clean Disk Space
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/disk-space@main
+      - name: Support long paths
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/long-paths@main
+      - name: Java and Maven Setup
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/java@main
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
-      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
-      - name: Cache Maven packages
-        uses: actions/cache@v2
+      - name: Cache Maven
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/cache-maven@main
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
-      - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
-        id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.13
+          key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+      - name: Build Chain
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Check Surefire Report
+          annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Surefire Report
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/surefire-report@main
         if: ${{ always() }}
-        uses: ScaCap/action-surefire-report@v1.0.10
-        with:
-          fail_on_test_failures: true
-          fail_if_no_tests: false
-          skip_publishing: true

--- a/kie-identity-session-provider/pom.xml
+++ b/kie-identity-session-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.kie</groupId>

--- a/kie-wb-common-ala/kie-wb-common-ala-build-maven/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-build-maven/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-build-maven</artifactId>
   <name>KIE Workbench Common ALA :: Build Maven</name>

--- a/kie-wb-common-ala/kie-wb-common-ala-docker-provider/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-docker-provider/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-docker-provider</artifactId>
   <name>KIE Workbench Common ALA :: Docker Provider</name>

--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-client/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-openshift</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-provider/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-provider/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-openshift</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/kie-wb-common-ala-openshift-ui-api/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/kie-wb-common-ala-openshift-ui-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-openshift-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/kie-wb-common-ala-openshift-ui-backend/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/kie-wb-common-ala-openshift-ui-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-openshift-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/kie-wb-common-ala-openshift-ui-client/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/kie-wb-common-ala-openshift-ui-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-openshift-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/kie-wb-common-ala-openshift-ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-openshift</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kie-wb-common-ala-openshift-ui</artifactId>

--- a/kie-wb-common-ala/kie-wb-common-ala-openshift/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-openshift/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kie-wb-common-ala-openshift</artifactId>

--- a/kie-wb-common-ala/kie-wb-common-ala-provisioning-pipelines/kie-wb-common-ala-provisioning-pipelines-openshift/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-provisioning-pipelines/kie-wb-common-ala-provisioning-pipelines-openshift/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-provisioning-pipelines</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-provisioning-pipelines/kie-wb-common-ala-provisioning-pipelines-wildfly/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-provisioning-pipelines/kie-wb-common-ala-provisioning-pipelines-wildfly/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-provisioning-pipelines</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-provisioning-pipelines/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-provisioning-pipelines/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-registry-vfs/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-registry-vfs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-services-api/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-services-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-services-api</artifactId>
   <packaging>jar</packaging>

--- a/kie-wb-common-ala/kie-wb-common-ala-services-backend/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-services-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-services-backend</artifactId>
   <name>KIE Workbench Common ALA :: Services Backend Impl</name>

--- a/kie-wb-common-ala/kie-wb-common-ala-services-rest/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-services-rest/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-services-rest</artifactId>
   <name>KIE Workbench Common ALA :: Services REST Impl</name>

--- a/kie-wb-common-ala/kie-wb-common-ala-source-git/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-source-git/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-source-git</artifactId>
   <name>KIE Workbench Common ALA :: Source Git</name>

--- a/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-spi</artifactId>
   <name>KIE Workbench Common ALA :: SPI</name>

--- a/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-api/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-backend/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-client/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-ui/kie-wb-common-ala-ui-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-ui/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-provider/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-wildfly</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala-wildfly-provider</artifactId>
   <name>KIE Workbench Common ALA :: Wildfly Provider</name>

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/kie-wb-common-ala-wildfly-ui-api/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/kie-wb-common-ala-wildfly-ui-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-wildfly-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/kie-wb-common-ala-wildfly-ui-backend/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/kie-wb-common-ala-wildfly-ui-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-wildfly-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/kie-wb-common-ala-wildfly-ui-client/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/kie-wb-common-ala-wildfly-ui-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-wildfly-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala-wildfly</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kie-wb-common-ala-wildfly-ui</artifactId>

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-ala</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kie-wb-common-ala-wildfly</artifactId>

--- a/kie-wb-common-ala/pom.xml
+++ b/kie-wb-common-ala/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-ala</artifactId>
   <name>KIE Workbench Common ALA :: Parent</name>

--- a/kie-wb-common-cli/kie-wb-common-cli-migration-tool/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-migration-tool/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common-cli</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-api/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common-cli-tools</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-forms-migration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-cli-tools</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-pom-migration/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-pom-migration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-cli-tools</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-cli-pom-migration</artifactId>

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-project-migration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-cli-tools</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-cli-project-migration</artifactId>

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-configuration-migration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-cli-tools</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-to-space-configuration-migration/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/kie-wb-common-cli-system-to-space-configuration-migration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-cli-tools</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-cli/kie-wb-common-cli-tools/pom.xml
+++ b/kie-wb-common-cli/kie-wb-common-cli-tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-cli</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-cli/pom.xml
+++ b/kie-wb-common-cli/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-cli</artifactId>
   <packaging>pom</packaging>

--- a/kie-wb-common-command-api/pom.xml
+++ b/kie-wb-common-command-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dev/kie-wb-common-wf-sdm-extensions/pom.xml
+++ b/kie-wb-common-dev/kie-wb-common-wf-sdm-extensions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-dev</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-wf-sdm-extensions</artifactId>
   <name>Kie Workbench - Common - Dev - WildFly SDM Extensions</name>

--- a/kie-wb-common-dev/pom.xml
+++ b/kie-wb-common-dev/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-dev</artifactId>
   <packaging>pom</packaging>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.annotations.i18n.I18nSettings;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -54,7 +55,7 @@ public class OutputClauseUnaryTests extends DMNModelInstrumentedBase implements 
     protected Id id;
 
     @Property
-    @FormField(labelKey = "text")
+    @FormField(labelKey = "text", type = TextAreaFieldType.class)
     protected Text text;
 
     protected ConstraintType constraintType;

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.less
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListView.less
@@ -76,7 +76,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    overflow-y: hidden;
+    overflow-y: auto;
     flex: 1 1 auto;
     margin-top: 20px;
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-api/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common-dmn</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-project-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common-dmn</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-common/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-marshaller/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common-dmn</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common-dmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-dmn/pom.xml
+++ b/kie-wb-common-dmn/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-dynamic-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-dynamic-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-dynamic-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>kie-wb-common-forms</artifactId>
         <groupId>org.kie.workbench.forms</groupId>
-        <version>7.62.0-SNAPSHOT</version>
+        <version>7.63.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-bpmn-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-bpmn-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-common-rendering</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-shared/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/kie-wb-common-forms-common-rendering-shared/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-common-rendering</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-common-rendering/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-crud-component/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-crud-component/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-layout-generator/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-layout-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-processing-engine/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-processing-engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-services/kie-wb-common-forms-backend-services/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-services/kie-wb-common-forms-backend-services/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-services</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-services/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/kie-wb-common-forms-services/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-commons</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-commons/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf-engine</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf-engine</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/kie-wb-common-forms-adf-engine-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf-engine</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-engine/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/kie-wb-common-forms-adf-processors/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-adf</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-adf/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-core</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-core</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/kie-wb-common-forms-fields/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-core</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-core/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-editor</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-editor</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-editor</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-editor/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integration-tests/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integration-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-data-modeller-integration</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-data-modeller-integration</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/kie-wb-common-forms-data-modeller-integration-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-data-modeller-integration</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-data-modeller-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-integrations</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-jbpm-integration</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-jbpm-integration</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/AbstractBPMNFormGeneratorService.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/AbstractBPMNFormGeneratorService.java
@@ -63,7 +63,7 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
     protected ModelReaderService<SOURCE> modelReaderService;
     protected FieldManager fieldManager;
 
-    private Set<String> checkCircularSet = new HashSet<>();
+    protected Set<String> checkCircularSet = new HashSet<>();
 
     static {
         bannedModelTypes.add(Object.class.getName());
@@ -96,7 +96,6 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
         }
 
         context.setRootForm(rootForm);
-        checkCircularSet.clear();
         return new FormGenerationResult(context.getRootForm(),
                                         new ArrayList<>(context.getContextForms().values()));
     }
@@ -223,7 +222,7 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
                 .findAny();
     }
 
-    private boolean hasCyclicReference(final String modelType) {
+    protected boolean hasCyclicReference(final String modelType) {
         if (bannedModelTypes.contains(modelType)) {
             throw new IllegalArgumentException("Cannot extract fields for '" + modelType + "'");
         }
@@ -252,6 +251,8 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
                     }
 
                     nestedFormField.setNestedForm(nestedForm.getId());
+
+                    checkCircularSet.clear();
                 } else if (field instanceof IsCRUDDefinition) {
                     IsCRUDDefinition crudField = (IsCRUDDefinition) field;
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/AbstractBPMNFormGeneratorService.java
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-backend/src/main/java/org/kie/workbench/common/forms/jbpm/server/service/formGeneration/impl/AbstractBPMNFormGeneratorService.java
@@ -19,8 +19,10 @@ package org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.kie.workbench.common.forms.adf.definitions.settings.ColSpan;
@@ -61,6 +63,8 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
     protected ModelReaderService<SOURCE> modelReaderService;
     protected FieldManager fieldManager;
 
+    private Set<String> checkCircularSet = new HashSet<>();
+
     static {
         bannedModelTypes.add(Object.class.getName());
     }
@@ -92,7 +96,6 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
         }
 
         context.setRootForm(rootForm);
-
         return new FormGenerationResult(context.getRootForm(),
                                         new ArrayList<>(context.getContextForms().values()));
     }
@@ -219,11 +222,26 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
                 .findAny();
     }
 
+    private boolean hasCyclicReference(final FieldDefinition field, final GenerationContext<SOURCE> context) {
+        String modelType = field.getStandaloneClassName();
+        if (bannedModelTypes.contains(modelType)) {
+            throw new IllegalArgumentException("Cannot extract fields for '" + modelType + "'");
+        }
+        if (checkCircularSet.contains(modelType)) {
+            return true;
+        } else {
+            checkCircularSet.add(modelType);
+        }
+        return false;
+    }
+
     protected boolean processFieldDefinition(final FieldDefinition field, final GenerationContext<SOURCE> context) {
         if (field instanceof EntityRelationField) {
             try {
                 if (field instanceof HasNestedForm) {
-
+                    if (hasCyclicReference(field, context)) {
+                        return false;
+                    }
                     HasNestedForm nestedFormField = (HasNestedForm) field;
 
                     FormDefinition nestedForm = findFormDefinitionForModelType(field.getStandaloneClassName(), context);
@@ -262,6 +280,8 @@ public abstract class AbstractBPMNFormGeneratorService<SOURCE> implements BPMNFo
             } catch (Exception ex) {
                 log("Something wrong happened processing FieldDefinition \'" + field.getName() + "\"", ex);
                 return false;
+            } finally {
+                checkCircularSet.clear();
             }
         }
         return true;

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/kie-wb-common-forms-jbpm-integration-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-jbpm-integration</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/kie-wb-common-forms-jbpm-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms-integrations</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/kie-wb-common-forms-integrations/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-integrations/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common-forms</artifactId>
     <groupId>org.kie.workbench.forms</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-forms/pom.xml
+++ b/kie-wb-common-forms/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-profile/kie-wb-common-profile-api/pom.xml
+++ b/kie-wb-common-profile/kie-wb-common-profile-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.profile</groupId>
     <artifactId>kie-wb-common-profile</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-profile-api</artifactId>

--- a/kie-wb-common-profile/kie-wb-common-profile-backend/pom.xml
+++ b/kie-wb-common-profile/kie-wb-common-profile-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.profile</groupId>
     <artifactId>kie-wb-common-profile</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-profile-backend</artifactId>

--- a/kie-wb-common-profile/pom.xml
+++ b/kie-wb-common-profile/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench</groupId>
     <artifactId>kie-wb-common</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-archetype-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-archetype-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-archetype-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/base-kie-project/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/base-kie-project/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-archetype-mgmt-templates</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>base-kie-project</artifactId>
   <packaging>kjar</packaging>

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/kie-all-templates/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/kie-all-templates/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-archetype-mgmt-templates</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/kie-wb-common-archetype-mgmt-templates/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-archetype-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-archetype-mgmt/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-archetype-mgmt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-contributors</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-contributors</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-contributors/kie-wb-common-contributors-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-contributors</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-contributors/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-contributors/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-data-modeller</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-data-modeller-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-data-modeller</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-data-modeller</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-datasource-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-datasource-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-datasource-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-dashbuilder/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-dashbuilder/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-datasource-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-dbcp/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-dbcp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-datasource-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-datasource-mgmt</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-default-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-default-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-default-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-default-editor/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kie-wb-common-examples-screen</artifactId>
     <groupId>org.kie.workbench.screens</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-examples-screen-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/kie-wb-common-examples-screen-backend/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kie-wb-common-examples-screen</artifactId>
     <groupId>org.kie.workbench.screens</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-examples-screen-backend</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-examples-screen/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-examples-screen/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-screens</artifactId>
     <groupId>org.kie.workbench.screens</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-home</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-home-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-home/kie-wb-common-home-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-home</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-home/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-home/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-java-editor/kie-wb-common-java-editor-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-java-editor/kie-wb-common-java-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-java-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-java-editor-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-java-editor/kie-wb-common-java-editor-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-java-editor/kie-wb-common-java-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-java-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-java-editor-client</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-java-editor/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-java-editor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.workbench.screens</groupId>
         <artifactId>kie-wb-common-screens</artifactId>
-        <version>7.62.0-SNAPSHOT</version>
+        <version>7.63.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-wb-common-java-editor</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-library</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-library-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-library</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-library-backend</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-library</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-library-client</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/kie-wb-common-library-spaces-screen/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-library</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/kie-wb-common-screens/kie-wb-common-library/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-library/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-project-editor-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-backend/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-project-editor-backend</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-project-editor-client</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-project-editor</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-explorer</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-explorer</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-explorer</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-project-imports-editor/kie-wb-common-project-imports-editor-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-imports-editor/kie-wb-common-project-imports-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-imports-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-project-imports-editor-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-project-imports-editor/kie-wb-common-project-imports-editor-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-imports-editor/kie-wb-common-project-imports-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-project-imports-editor</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-project-imports-editor-client</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-project-imports-editor/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-imports-editor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-project-imports-editor</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-server-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-server-ui-api</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-server-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-server-ui-backend</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-server-ui</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-server-ui-client</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-server-ui/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-screens</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.screens</groupId>
     <artifactId>kie-wb-common-workbench</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-workbench-backend</artifactId>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common-workbench</artifactId>
     <groupId>org.kie.workbench.screens</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/kie-wb-common-workbench/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common-screens</artifactId>
     <groupId>org.kie.workbench.screens</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-screens/pom.xml
+++ b/kie-wb-common-screens/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-maven-plugins-testing/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-maven-plugins-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-maven-plugins/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-maven-plugins/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-classpath/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-compiler-offprocess-classpath</artifactId>
   <name>Kie Workbench - Common - Compiler - OffProcess - Classpath</name>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-core/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-compiler-offprocess-core</artifactId>
   <name>Kie Workbench - Common - Compiler - OffProcess - Core</name>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-service/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-compiler-offprocess-service</artifactId>
   <name>Kie Workbench - Common - Compiler - OffProcess -Service</name>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-testing/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-offprocess-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-compiler-offprocess-testing</artifactId>
   <name>Kie Workbench - Common - Compiler - OffProcess - Testing</name>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-testutil/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-testutil/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-compiler</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <artifactId>kie-wb-common-compiler-testutil</artifactId>
   <name>Kie Workbench - Common - Compiler - Testutil</name>

--- a/kie-wb-common-services/kie-wb-common-compiler/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-services</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-compiler</artifactId>

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-services</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-api/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-datamodel</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-datamodel-api</artifactId>

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-datamodel</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-datamodel-backend</artifactId>

--- a/kie-wb-common-services/kie-wb-common-datamodel/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-datamodel/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-services</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-datamodel</artifactId>

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-refactoring</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-refactoring</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-refactoring-backend</artifactId>

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-client/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-refactoring</artifactId>
     <groupId>org.kie.workbench.services</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-services</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-refactoring</artifactId>

--- a/kie-wb-common-services/kie-wb-common-services-api/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-services-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-services</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-services-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-services-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-services</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-api/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.workbench.services</groupId>
         <artifactId>kie-wb-common-verifier</artifactId>
-        <version>7.62.0-SNAPSHOT</version>
+        <version>7.63.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-reporting-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-verifier</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-service/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-verifier/kie-wb-common-verifier-service/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-verifier</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-services/kie-wb-common-verifier/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-verifier/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.workbench.services</groupId>
     <artifactId>kie-wb-common-services</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-verifier</artifactId>

--- a/kie-wb-common-services/pom.xml
+++ b/kie-wb-common-services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-client</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-shapes</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/kie-wb-common-stunner-shapes-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-shapes</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-shapes/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-client</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-client</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-backend-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-api</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-api</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-api</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-core</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-backend-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-commons</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-commons</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-commons</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-core</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-core</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-forms</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/src/main/java/org/kie/workbench/common/stunner/forms/model/ColorPickerFieldDefinition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/src/main/java/org/kie/workbench/common/stunner/forms/model/ColorPickerFieldDefinition.java
@@ -29,9 +29,10 @@ import org.kie.workbench.common.stunner.forms.meta.definition.ColorPicker;
 public class ColorPickerFieldDefinition extends AbstractFieldDefinition {
 
     public static final ColorPickerFieldType FIELD_TYPE = new ColorPickerFieldType();
+    public static final String COLOR_REGEXP = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$";
 
     @ColorPicker
-    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "Invalid color code")
+    @Pattern(regexp = COLOR_REGEXP, message = "Invalid color code")
     private String defaultValue;
 
     public ColorPickerFieldDefinition() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-forms</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -82,11 +82,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
@@ -94,11 +89,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-widgets-commons</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-forms</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRenderer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.forms.client.fields.colorPicker;
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -56,6 +56,6 @@ public class ColorPickerFieldRenderer extends FieldRenderer<ColorPickerFieldDefi
 
     @Override
     protected void setReadOnly(boolean readOnly) {
-
+        colorPicker.setReadOnly(readOnly);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.html
@@ -14,11 +14,6 @@
   ~ limitations under the License.
   -->
 
-<div class="input-group">
-    <span class="input-group-btn">
-        <button class="btn btn-default" type="button" id="colorButton">
-            <i class="fa fa-edit"></i>
-        </button>
-    </span>
-    <input type="text" class="form-control" id="colorTextBox" readOnly>
+<div class="form-group">
+    <input type="color" class="form-control" id="colorTextBox">
 </div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.java
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.forms.client.fields.colorPicker;
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasValue;
-import com.google.gwt.user.client.ui.UIObject;
-import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.uberfire.ext.widgets.common.client.colorpicker.ColorPickerDialog;
+import org.kie.workbench.common.stunner.forms.model.ColorPickerFieldDefinition;
 
 @Dependent
 @Templated
@@ -39,44 +37,18 @@ public class ColorPickerWidget extends Composite implements HasValue<String> {
 
     @Inject
     @DataField
-    private Button colorButton;
-
-    @Inject
-    @DataField
     private TextBox colorTextBox;
 
     private String color;
-    private boolean readOnly;
-
-    @EventHandler("colorButton")
-    public void onClickColorButton(final ClickEvent clickEvent) {
-        showColorDialog(colorButton);
-    }
 
     @EventHandler("colorTextBox")
-    public void onClickColorTextBox(final ClickEvent clickEvent) {
-        showColorDialog(colorTextBox);
-    }
-
-    protected void showColorDialog(final UIObject owner) {
-        if (readOnly) {
-            return;
+    public void onColorTextBoxChange(final ChangeEvent changeEvent) {
+        final String newColorValue = getColorTextBox().getValue();
+        if (newColorValue != null && newColorValue.matches(ColorPickerFieldDefinition.COLOR_REGEXP)) {
+            setValue(newColorValue, true);
+        } else {
+            setValue(color, false);
         }
-        final ColorPickerDialog dlg = new ColorPickerDialog();
-        dlg.getElement().getStyle().setZIndex(9999);
-        dlg.addDialogClosedHandler(event -> {
-            if (!event.isCanceled()) {
-                setValue("#" + dlg.getColor(),
-                         true);
-            }
-        });
-        String color = getValue();
-        if (color.startsWith("#")) {
-            color = color.substring(1,
-                                    color.length());
-        }
-        dlg.setColor(color);
-        dlg.showRelativeTo(owner);
     }
 
     @Override
@@ -104,7 +76,7 @@ public class ColorPickerWidget extends Composite implements HasValue<String> {
     }
 
     protected void initTextBox() {
-        colorTextBox.getElement().getStyle().setBackgroundColor(color);
+        getColorTextBox().setText(color);
     }
 
     @Override
@@ -114,7 +86,13 @@ public class ColorPickerWidget extends Composite implements HasValue<String> {
     }
 
     public void setReadOnly(boolean readOnly) {
-        this.readOnly = readOnly;
-        colorButton.setEnabled(!readOnly);
+        getColorTextBox().setReadOnly(readOnly);
+    }
+
+    /**
+     * For testing purposes
+     */
+    TextBox getColorTextBox() {
+        return colorTextBox;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRendererTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ColorPickerFieldRendererTest {
+
+    @Mock
+    private ColorPickerWidget colorPickerMock;
+
+    private ColorPickerFieldRenderer renderer;
+
+    @Before
+    public void setUp() throws Exception {
+        renderer = new ColorPickerFieldRenderer(colorPickerMock);
+    }
+
+    @Test
+    public void testReadOnly() {
+        renderer.setReadOnly(true);
+        verify(colorPickerMock).setReadOnly(true);
+
+        reset(colorPickerMock);
+
+        renderer.setReadOnly(false);
+        verify(colorPickerMock).setReadOnly(false);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidgetTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
+
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ColorPickerWidgetTest {
+
+    @Mock
+    private TextBox colorTextBoxMock;
+
+    private ColorPickerWidget colorPicker;
+
+    @Before
+    public void setUp() throws Exception {
+        colorPicker = spy(new ColorPickerWidget());
+
+        doReturn(colorTextBoxMock).when(colorPicker).getColorTextBox();
+    }
+
+    @Test
+    public void testReadOnly() {
+        colorPicker.setReadOnly(true);
+
+        verify(colorTextBoxMock).setReadOnly(true);
+
+        reset(colorTextBoxMock);
+
+        colorPicker.setReadOnly(false);
+
+        verify(colorTextBoxMock).setReadOnly(false);
+    }
+
+    @Test
+    public void testSetValue() {
+        final String colorHexValue = "#123456";
+        colorPicker.setValue(colorHexValue);
+
+        verify(colorTextBoxMock).setText(colorHexValue);
+    }
+
+    @Test
+    public void testNewValueValid() {
+        final String newColorHexValue = "#123456";
+        when(colorTextBoxMock.getValue()).thenReturn(newColorHexValue);
+
+        colorPicker.onColorTextBoxChange(mock(ChangeEvent.class));
+
+        verify(colorPicker).setValue(newColorHexValue, true);
+    }
+
+    @Test
+    public void testNewValueInValid() {
+        colorPicker.setValue("#000000");
+
+        final String newColorHexValueInvalid = "#12XX56";
+        when(colorTextBoxMock.getValue()).thenReturn(newColorHexValueInvalid);
+
+        colorPicker.onColorTextBoxChange(mock(ChangeEvent.class));
+
+        verify(colorPicker, times(2)).setValue("#000000", false);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-jbpm-designer-integration</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-jbpm-designer-integration</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-jbpm-designer-integration</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-shared/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/kie-wb-common-stunner-jbpm-designer-integration-shared/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-jbpm-designer-integration</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-jbpm-designer-integration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-project</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-project</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-project</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-svg</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-gen/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-gen/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-svg</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-extensions</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-backend/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-showcase/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-showcase/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>kie-wb-common-stunner-bpmn</artifactId>
     <groupId>org.kie.workbench.stunner</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-stunner-bpmn-project-showcase</artifactId>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner-sets</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.workbench.stunner</groupId>
     <artifactId>kie-wb-common-stunner</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-stunner/pom.xml
+++ b/kie-wb-common-stunner/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.widgets</groupId>
     <artifactId>kie-wb-common-widgets</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-common-ui</artifactId>

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.widgets</groupId>
     <artifactId>kie-wb-common-widgets</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-config-resource-widget</artifactId>

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.widgets</groupId>
     <artifactId>kie-wb-common-widgets</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-decorated-grid-widget</artifactId>

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.workbench.widgets</groupId>
     <artifactId>kie-wb-common-widgets</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-metadata-widget</artifactId>

--- a/kie-wb-common-widgets/pom.xml
+++ b/kie-wb-common-widgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-wb-testing-utils/pom.xml
+++ b/kie-wb-testing-utils/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kie-wb-common</artifactId>
     <groupId>org.kie.workbench</groupId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-wb-testing-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.62.0-SNAPSHOT</version>
+    <version>7.63.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie.workbench</groupId>


### PR DESCRIPTION
> Currently, when we are generating a form when we have 2 data objects which reference each other or have cyclic reference, the engine enters into an infinite loop. 
> To fix this issue, we have come up with a way to track the cyclic reference in the field and  skip the form generation for field when we encounter the cycle.

Screenshot: https://drive.google.com/file/d/1x_YYhokF8VAz_TYp4xlhRCKl8Kwcqeiv/view?usp=sharing

**JIRA**: 
[JBPM-9532](https://issues.redhat.com/browse/JBPM-9532)
[RHPAM-3366](https://issues.redhat.com/browse/RHPAM-3366)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
