### PR TITLE
KOGITO-6036: Use html <input type='color'> picker

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/src/main/java/org/kie/workbench/common/stunner/forms/model/ColorPickerFieldDefinition.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-api/src/main/java/org/kie/workbench/common/stunner/forms/model/ColorPickerFieldDefinition.java
@@ -29,9 +29,10 @@ import org.kie.workbench.common.stunner.forms.meta.definition.ColorPicker;
 public class ColorPickerFieldDefinition extends AbstractFieldDefinition {
 
     public static final ColorPickerFieldType FIELD_TYPE = new ColorPickerFieldType();
+    public static final String COLOR_REGEXP = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$";
 
     @ColorPicker
-    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "Invalid color code")
+    @Pattern(regexp = COLOR_REGEXP, message = "Invalid color code")
     private String defaultValue;
 
     public ColorPickerFieldDefinition() {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -82,11 +82,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
@@ -94,11 +89,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-widgets-commons</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRenderer.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRenderer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.forms.client.fields.colorPicker;
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -56,6 +56,6 @@ public class ColorPickerFieldRenderer extends FieldRenderer<ColorPickerFieldDefi
 
     @Override
     protected void setReadOnly(boolean readOnly) {
-
+        colorPicker.setReadOnly(readOnly);
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.html
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.html
@@ -14,11 +14,6 @@
   ~ limitations under the License.
   -->
 
-<div class="input-group">
-    <span class="input-group-btn">
-        <button class="btn btn-default" type="button" id="colorButton">
-            <i class="fa fa-edit"></i>
-        </button>
-    </span>
-    <input type="text" class="form-control" id="colorTextBox" readOnly>
+<div class="form-group">
+    <input type="color" class="form-control" id="colorTextBox">
 </div>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/main/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidget.java
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.stunner.forms.client.fields.colorPicker;
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasValue;
-import com.google.gwt.user.client.ui.UIObject;
-import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.uberfire.ext.widgets.common.client.colorpicker.ColorPickerDialog;
+import org.kie.workbench.common.stunner.forms.model.ColorPickerFieldDefinition;
 
 @Dependent
 @Templated
@@ -39,44 +37,18 @@ public class ColorPickerWidget extends Composite implements HasValue<String> {
 
     @Inject
     @DataField
-    private Button colorButton;
-
-    @Inject
-    @DataField
     private TextBox colorTextBox;
 
     private String color;
-    private boolean readOnly;
-
-    @EventHandler("colorButton")
-    public void onClickColorButton(final ClickEvent clickEvent) {
-        showColorDialog(colorButton);
-    }
 
     @EventHandler("colorTextBox")
-    public void onClickColorTextBox(final ClickEvent clickEvent) {
-        showColorDialog(colorTextBox);
-    }
-
-    protected void showColorDialog(final UIObject owner) {
-        if (readOnly) {
-            return;
+    public void onColorTextBoxChange(final ChangeEvent changeEvent) {
+        final String newColorValue = getColorTextBox().getValue();
+        if (newColorValue != null && newColorValue.matches(ColorPickerFieldDefinition.COLOR_REGEXP)) {
+            setValue(newColorValue, true);
+        } else {
+            setValue(color, false);
         }
-        final ColorPickerDialog dlg = new ColorPickerDialog();
-        dlg.getElement().getStyle().setZIndex(9999);
-        dlg.addDialogClosedHandler(event -> {
-            if (!event.isCanceled()) {
-                setValue("#" + dlg.getColor(),
-                         true);
-            }
-        });
-        String color = getValue();
-        if (color.startsWith("#")) {
-            color = color.substring(1,
-                                    color.length());
-        }
-        dlg.setColor(color);
-        dlg.showRelativeTo(owner);
     }
 
     @Override
@@ -104,7 +76,7 @@ public class ColorPickerWidget extends Composite implements HasValue<String> {
     }
 
     protected void initTextBox() {
-        colorTextBox.getElement().getStyle().setBackgroundColor(color);
+        getColorTextBox().setText(color);
     }
 
     @Override
@@ -114,7 +86,13 @@ public class ColorPickerWidget extends Composite implements HasValue<String> {
     }
 
     public void setReadOnly(boolean readOnly) {
-        this.readOnly = readOnly;
-        colorButton.setEnabled(!readOnly);
+        getColorTextBox().setReadOnly(readOnly);
+    }
+
+    /**
+     * For testing purposes
+     */
+    TextBox getColorTextBox() {
+        return colorTextBox;
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRendererTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerFieldRendererTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ColorPickerFieldRendererTest {
+
+    @Mock
+    private ColorPickerWidget colorPickerMock;
+
+    private ColorPickerFieldRenderer renderer;
+
+    @Before
+    public void setUp() throws Exception {
+        renderer = new ColorPickerFieldRenderer(colorPickerMock);
+    }
+
+    @Test
+    public void testReadOnly() {
+        renderer.setReadOnly(true);
+        verify(colorPickerMock).setReadOnly(true);
+
+        reset(colorPickerMock);
+
+        renderer.setReadOnly(false);
+        verify(colorPickerMock).setReadOnly(false);
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidgetTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/src/test/java/org/kie/workbench/common/stunner/forms/client/fields/colorpicker/ColorPickerWidgetTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.forms.client.fields.colorpicker;
+
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ColorPickerWidgetTest {
+
+    @Mock
+    private TextBox colorTextBoxMock;
+
+    private ColorPickerWidget colorPicker;
+
+    @Before
+    public void setUp() throws Exception {
+        colorPicker = spy(new ColorPickerWidget());
+
+        doReturn(colorTextBoxMock).when(colorPicker).getColorTextBox();
+    }
+
+    @Test
+    public void testReadOnly() {
+        colorPicker.setReadOnly(true);
+
+        verify(colorTextBoxMock).setReadOnly(true);
+
+        reset(colorTextBoxMock);
+
+        colorPicker.setReadOnly(false);
+
+        verify(colorTextBoxMock).setReadOnly(false);
+    }
+
+    @Test
+    public void testSetValue() {
+        final String colorHexValue = "#123456";
+        colorPicker.setValue(colorHexValue);
+
+        verify(colorTextBoxMock).setText(colorHexValue);
+    }
+
+    @Test
+    public void testNewValueValid() {
+        final String newColorHexValue = "#123456";
+        when(colorTextBoxMock.getValue()).thenReturn(newColorHexValue);
+
+        colorPicker.onColorTextBoxChange(mock(ChangeEvent.class));
+
+        verify(colorPicker).setValue(newColorHexValue, true);
+    }
+
+    @Test
+    public void testNewValueInValid() {
+        colorPicker.setValue("#000000");
+
+        final String newColorHexValueInvalid = "#12XX56";
+        when(colorTextBoxMock.getValue()).thenReturn(newColorHexValueInvalid);
+
+        colorPicker.onColorTextBoxChange(mock(ChangeEvent.class));
+
+        verify(colorPicker, times(2)).setValue("#000000", false);
+    }
+}


### PR DESCRIPTION
For more details see:
- https://issues.redhat.com/browse/KOGITO-6036

This is a backport of:
- kiegroup/kogito-editors-java#147

For 7.x stream `ColorPickerDialog` can not be removed from codebase, as it is used in `appformer` project on other place.