### PR TITLE
RHPAM-3329: Increase Decision Table Output value length limit

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseUnaryTests.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition
 import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
 import org.kie.workbench.common.forms.adf.definitions.annotations.i18n.I18nSettings;
 import org.kie.workbench.common.forms.adf.definitions.settings.FieldPolicy;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.textArea.type.TextAreaFieldType;
 import org.kie.workbench.common.stunner.core.definition.annotation.Property;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
@@ -54,7 +55,7 @@ public class OutputClauseUnaryTests extends DMNModelInstrumentedBase implements 
     protected Id id;
 
     @Property
-    @FormField(labelKey = "text")
+    @FormField(labelKey = "text", type = TextAreaFieldType.class)
     protected Text text;
 
     protected ConstraintType constraintType;


### PR DESCRIPTION
This is backport of:
- https://github.com/kiegroup/kogito-editors-java/pull/152

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
