### PR TITLE
[JBPM-9948] Alternative approach using browser "datetime-local"

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/marshalling/time/AbstractDateMultipleFieldValueMarshaller.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/marshalling/time/AbstractDateMultipleFieldValueMarshaller.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.
 import org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 
-public abstract class AbstractDateMultipleFieldValueMarshaller<F extends FieldDefinition> extends AbstractFieldValueMarshaller<List<?>, List<Date>, F> {
+public abstract class AbstractDateMultipleFieldValueMarshaller<F extends FieldDefinition> extends AbstractFieldValueMarshaller<List, List<Date>, F> {
 
     @Override
     public List<Date> toFlatValue() {
@@ -38,13 +38,13 @@ public abstract class AbstractDateMultipleFieldValueMarshaller<F extends FieldDe
             return (List<Date>) originalValue;
         }
 
-        return originalValue.stream()
+        return (List<Date>) originalValue.stream()
                 .map(rawValue -> getMarshaller(rawValue).toFlatValue())
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<?> toRawValue(List<Date> dates) {
+    public List toRawValue(List<Date> dates) {
         if (dates == null) {
             return new ArrayList<>();
         }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/marshalling/time/DateMultipleInputFieldValueMarshaller.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/marshalling/time/DateMultipleInputFieldValueMarshaller.java
@@ -34,7 +34,7 @@ public class DateMultipleInputFieldValueMarshaller extends AbstractDateMultipleF
     }
 
     @Override
-    public Supplier<FieldValueMarshaller<List<?>, List<Date>, DateMultipleInputFieldDefinition>> newInstanceSupplier() {
+    public Supplier<FieldValueMarshaller<List, List<Date>, DateMultipleInputFieldDefinition>> newInstanceSupplier() {
         return DateMultipleInputFieldValueMarshaller::new;
     }
 }

--- a/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/marshalling/time/DateMultipleSelectorFieldValueMarshaller.java
+++ b/kie-wb-common-forms/kie-wb-common-dynamic-forms/kie-wb-common-dynamic-forms-backend/src/main/java/org/kie/workbench/common/forms/dynamic/backend/server/context/generation/dynamic/impl/marshalling/time/DateMultipleSelectorFieldValueMarshaller.java
@@ -34,7 +34,7 @@ public class DateMultipleSelectorFieldValueMarshaller extends AbstractDateMultip
     }
 
     @Override
-    public Supplier<FieldValueMarshaller<List<?>, List<Date>, DateMultipleSelectorFieldDefinition>> newInstanceSupplier() {
+    public Supplier<FieldValueMarshaller<List, List<Date>, DateMultipleSelectorFieldDefinition>> newInstanceSupplier() {
         return DateMultipleSelectorFieldValueMarshaller::new;
     }
 }


### PR DESCRIPTION
This PR fix a CDI issue loading the existing marshaller for form lists.

This is part of an ensemble, please merge with:
https://github.com/kiegroup/droolsjbpm-integration/pull/2653

**Thank you for submitting this pull request**

**JIRA**: [JBPM-0000](https://issues.redhat.com/browse/JBPM-0000)

**Referenced Pull Requests**:
* paste the link(s) from GitHub here
* link 2
* link 3 etc.

**Business Central**: [WAR file](https://donwnload.here/something)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
