### PR TITLE
DROOLS-6739 : Inaccurate alert about duplicate rule name after copying rule

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/core/Builder.java
@@ -434,7 +434,7 @@ public class Builder implements Serializable {
         checkAFullBuildHasBeenPerformed();
 
         //Add all changes to KieFileSystem before executing the build
-        final List<String> changedFilesKieBuilderPaths = new ArrayList<String>();
+        final Set<String> changedFilesKieBuilderPaths = new HashSet<>();
         final List<ValidationMessage> nonKieResourceValidatorAddedMessages = new ArrayList<ValidationMessage>();
         final List<ValidationMessage> nonKieResourceValidatorRemovedMessages = new ArrayList<ValidationMessage>();
         final IncrementalBuildResults results = new IncrementalBuildResults(projectGAV);
@@ -485,9 +485,9 @@ public class Builder implements Serializable {
         return results;
     }
 
-    private String[] toArray(List<String> stringList) {
-        final String[] stringArray = new String[stringList.size()];
-        stringList.toArray(stringArray);
+    private String[] toArray(Set<String> stringSet) {
+        final String[] stringArray = new String[stringSet.size()];
+        stringSet.toArray(stringArray);
         return stringArray;
     }
 


### PR DESCRIPTION

**Thank you for submitting this pull request**

**JIRA**: [DROOLS-6739](https://issues.redhat.com/browse/DROOLS-6739)

**Business Central**: [WAR file](https://donwnload.here/something)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
