### PR TITLE
KOGITO-6323: Render DMN association waypoints

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/marshaller/unmarshall/nodes/NodeConnector.java
@@ -276,6 +276,8 @@ public class NodeConnector {
                 connectionContent.setDefinition(definition);
                 connectionContent.setTargetConnection(MagnetConnection.Builder.atCenter(targetNode));
                 connectionContent.setSourceConnection(MagnetConnection.Builder.atCenter(sourceNode));
+
+                findExistingEdge(association, edges).ifPresent(e -> setConnectionControlPoints(connectionContent, e));
             }
         });
     }
@@ -412,10 +414,10 @@ public class NodeConnector {
                 || (sourceNode.isPresent() && Objects.equals(sourceNode.get(), currentNode));
     }
 
-    private Optional<JSIDMNEdge> findExistingEdge(final JSITDMNElement dmnElement,
-                                                  final List<JSIDMNEdge> edges) {
+    private static Optional<JSIDMNEdge> findExistingEdge(final JSITDMNElement dmnElement,
+                                                         final List<JSIDMNEdge> edges) {
         return edges.stream()
-                .filter(e -> Objects.equals(e.getDmnElementRef().getLocalPart(), dmnElement.getId()))
+                .filter(e -> e.getDmnElementRef() != null && Objects.equals(e.getDmnElementRef().getLocalPart(), dmnElement.getId()))
                 .findFirst();
     }
 
@@ -474,9 +476,15 @@ public class NodeConnector {
                                 connectionContent::setTargetConnection,
                                 isTargetAutoConnectionEdge(jsidmnEdge));
         }
-        if (e.getWaypoint().size() > 2) {
-            connectionContent.setControlPoints(e.getWaypoint()
-                                                       .subList(1, e.getWaypoint().size() - 1)
+        setConnectionControlPoints(connectionContent, jsidmnEdge);
+    }
+
+    void setConnectionControlPoints(final ViewConnector connectionContent,
+                                    final JSIDMNEdge jsidmnEdge) {
+
+        if (jsidmnEdge.getWaypoint().size() > 2) {
+            connectionContent.setControlPoints(jsidmnEdge.getWaypoint()
+                                                       .subList(1, jsidmnEdge.getWaypoint().size() - 1)
                                                        .stream()
                                                        .map(p -> ControlPoint.build(PointUtils.dmndiPointToPoint2D(p)))
                                                        .toArray(ControlPoint[]::new));


### PR DESCRIPTION
For more details see:
- https://issues.redhat.com/browse/KOGITO-6323

**Referenced Pull Requests**:
* Backport of https://github.com/kiegroup/kogito-tooling/pull/749

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
