### PR TITLE
RHPAM-3878 - bpmndi:BPMNShape id of intermediateCatchEvent is always set to 'shape_null

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/events/IntermediateCatchEventConverter.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/main/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/events/IntermediateCatchEventConverter.java
@@ -69,8 +69,8 @@ public class IntermediateCatchEventConverter {
 
     protected PropertyWriter errorEvent(Node<View<IntermediateErrorEventCatching>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateErrorEventCatching definition = n.getContent().getDefinition();
 
@@ -91,8 +91,8 @@ public class IntermediateCatchEventConverter {
 
     protected PropertyWriter signalEvent(Node<View<IntermediateSignalEventCatching>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateSignalEventCatching definition = n.getContent().getDefinition();
 
@@ -108,14 +108,13 @@ public class IntermediateCatchEventConverter {
         p.addSlaDueDate(executionSet.getSlaDueDate());
         p.addSignal(definition.getExecutionSet().getSignalRef());
 
-
         return p;
     }
 
     protected PropertyWriter linkEvent(Node<View<IntermediateLinkEventCatching>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateLinkEventCatching definition = n.getContent().getDefinition();
 
@@ -134,8 +133,8 @@ public class IntermediateCatchEventConverter {
 
     protected PropertyWriter timerEvent(Node<View<IntermediateTimerEvent>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateTimerEvent definition = n.getContent().getDefinition();
 
@@ -156,8 +155,8 @@ public class IntermediateCatchEventConverter {
 
     protected PropertyWriter messageEvent(Node<View<IntermediateMessageEventCatching>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateMessageEventCatching definition = n.getContent().getDefinition();
 
@@ -178,8 +177,8 @@ public class IntermediateCatchEventConverter {
 
     protected PropertyWriter conditionalEvent(Node<View<IntermediateConditionalEvent>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateConditionalEvent definition = n.getContent().getDefinition();
 
@@ -200,8 +199,8 @@ public class IntermediateCatchEventConverter {
 
     protected PropertyWriter escalationEvent(Node<View<IntermediateEscalationEvent>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateEscalationEvent definition = n.getContent().getDefinition();
 
@@ -222,8 +221,8 @@ public class IntermediateCatchEventConverter {
 
     protected PropertyWriter compensationEvent(Node<View<IntermediateCompensationEvent>, ?> n) {
         CatchEventPropertyWriter p = createCatchEventPropertyWriter(n);
-        p.setAbsoluteBounds(n);
         p.getFlowElement().setId(n.getUUID());
+        p.setAbsoluteBounds(n);
 
         IntermediateCompensationEvent definition = n.getContent().getDefinition();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/events/IntermediateCatchEventConverterTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/converters/fromstunner/events/IntermediateCatchEventConverterTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.eclipse.bpmn2.BoundaryEvent;
 import org.eclipse.bpmn2.CatchEvent;
 import org.eclipse.bpmn2.Event;
-import org.eclipse.bpmn2.FlowElement;
 import org.eclipse.bpmn2.IntermediateCatchEvent;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,6 +77,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.stunner.bpmn.backend.converters.fromstunner.Factories.bpmn2;
@@ -94,6 +94,7 @@ public class IntermediateCatchEventConverterTest {
     private static final String NAME = "CATCHING EVENT NAME";
     private static final String DOCUMENTATION = "CATCHING EVENT DOCUMENTATION";
     private static final String ASSIGNMENTS_INFO = "Years of Service:Integer||Data Test:Boolean||[din]Years of Service=35,[dout]Data Test->BooleanTest";
+    private static final String SHAPE_NULL = "shape_null";
     private static final boolean CANCEL_ACTIVITY = false;
 
     private BoundaryEventPropertyWriter boundaryEventPropertyWriter;
@@ -122,15 +123,13 @@ public class IntermediateCatchEventConverterTest {
     @Before
     public void setUp() {
         Event boundaryEvent = bpmn2.createBoundaryEvent();
-        boundaryEvent.setId("boundaryEventID");
-        boundaryEventPropertyWriter = spy(new BoundaryEventPropertyWriter((BoundaryEvent) boundaryEvent,
+        boundaryEventPropertyWriter = spy(new BoundaryEventPropertyWriter((BoundaryEvent) spy(boundaryEvent),
                                                                           new FlatVariableScope(),
                                                                           new HashSet<>()));
-        when(boundaryEventPropertyWriter.getFlowElement()).thenReturn(spy(FlowElement.class));
+//        when(boundaryEventPropertyWriter.getFlowElement()).thenReturn(spy(FlowElement.class));
 
         Event catchEvent = bpmn2.createIntermediateCatchEvent();
-        catchEvent.setId("catchEventID");
-        catchEventPropertyWriter = spy(new CatchEventPropertyWriter((CatchEvent) catchEvent,
+        catchEventPropertyWriter = spy(new CatchEventPropertyWriter((CatchEvent) spy(catchEvent),
                                                                     new FlatVariableScope(),
                                                                     new HashSet<>()));
 
@@ -311,11 +310,13 @@ public class IntermediateCatchEventConverterTest {
 
     private void verifyCommonProperties(Node node) {
         verify(boundaryEventPropertyWriter).getFlowElement();
-        verify(boundaryEventPropertyWriter).setAbsoluteBounds(node);
         verify(boundaryEventPropertyWriter.getFlowElement()).setId(UUID);
         verify(boundaryEventPropertyWriter).setName(NAME);
         verify(boundaryEventPropertyWriter).setDocumentation(DOCUMENTATION);
         verify(boundaryEventPropertyWriter).setAssignmentsInfo(assignmentsInfo);
+        verify(boundaryEventPropertyWriter).setAbsoluteBounds(node);
+
+        assertNotEquals(SHAPE_NULL, boundaryEventPropertyWriter.getShape().getId());
     }
 
     private Node createIntermediateErrorEventCatchingNode() {


### PR DESCRIPTION
The shape was created while the base element ID was null.
The method execution order was changed to ensure the ID is set before use.

**JIRA**: [RHPAM-3878](https://issues.redhat.com/browse/RHPAM-3878)

**Business Central**: [WAR file](https://drive.google.com/file/d/1Qx_2ci4foEW-Y3ntgcKJQ3r10bDcGOms/view?usp=sharing)
