### PR TITLE
DROOLS-6860: [DMN Designer] [BC Only] Validating a DMN invoking java function

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/pom.xml
@@ -36,6 +36,11 @@
   <dependencies>
 
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-compiler</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-core-api</artifactId>
     </dependency>

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImpl.java
@@ -22,16 +22,20 @@ import java.io.StringReader;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.guvnor.common.services.project.model.Module;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.jboss.errai.bus.server.annotations.Service;
 import org.kie.api.builder.Message;
 import org.kie.dmn.api.core.DMNMessage;
@@ -47,6 +51,7 @@ import org.kie.workbench.common.dmn.backend.DMNMarshallerStandalone;
 import org.kie.workbench.common.dmn.backend.common.DMNIOHelper;
 import org.kie.workbench.common.dmn.backend.common.DMNMarshallerImportsHelperStandalone;
 import org.kie.workbench.common.dmn.backend.definition.v1_1.ImportConverter;
+import org.kie.workbench.common.services.backend.builder.core.BuildHelper;
 import org.kie.workbench.common.stunner.core.definition.adapter.binding.BindableAdapterUtils;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
@@ -62,31 +67,26 @@ public class DMNDomainValidatorImpl implements DMNDomainValidator {
 
     static final String DEFAULT_UUID = "uuid";
 
-    private DMNValidator dmnValidator;
-
     private DMNMarshallerStandalone dmnMarshaller;
     private DMNDiagramUtils dmnDiagramUtils;
     private DMNMarshallerImportsHelperStandalone importsHelper;
     private final DMNIOHelper dmnIOHelper;
+    private final WorkspaceProjectService workspaceProjectService;
+    private final BuildHelper buildHelper;
 
     @Inject
     public DMNDomainValidatorImpl(final DMNMarshallerStandalone dmnMarshaller,
                                   final DMNDiagramUtils dmnDiagramUtils,
                                   final DMNMarshallerImportsHelperStandalone importsHelper,
-                                  final DMNIOHelper dmnIOHelper) {
+                                  final DMNIOHelper dmnIOHelper,
+                                  final WorkspaceProjectService workspaceProjectService,
+                                  final BuildHelper buildHelper) {
         this.dmnMarshaller = dmnMarshaller;
         this.dmnDiagramUtils = dmnDiagramUtils;
         this.importsHelper = importsHelper;
         this.dmnIOHelper = dmnIOHelper;
-    }
-
-    @PostConstruct
-    public void setupValidator() {
-        this.dmnValidator = getDMNValidator();
-    }
-
-    DMNValidator getDMNValidator() {
-        return DMNValidatorFactory.newValidator();
+        this.workspaceProjectService = workspaceProjectService;
+        this.buildHelper = buildHelper;
     }
 
     @Override
@@ -124,6 +124,11 @@ public class DMNDomainValidatorImpl implements DMNDomainValidator {
             importedDiagramsXML.values().forEach(importedDiagramXML -> dmnXMLReaders.add(getStringReader(importedDiagramXML)));
 
             final Reader[] aDMNXMLReaders = new Reader[]{};
+
+            final ClassLoader classLoader = getClassLoader(diagram);
+
+            final DMNValidator dmnValidator = getDmnValidator(classLoader);
+
             final List<DMNMessage> messages = dmnValidator
                     .validateUsing(DMNValidator.Validation.VALIDATE_MODEL,
                                    DMNValidator.Validation.VALIDATE_COMPILATION,
@@ -141,6 +146,19 @@ public class DMNDomainValidatorImpl implements DMNDomainValidator {
                 }
             });
         }
+    }
+
+    DMNValidator getDmnValidator(final ClassLoader classLoader) {
+        return DMNValidatorFactory.newValidator(classLoader, Collections.emptyList());
+    }
+
+    ClassLoader getClassLoader(final Diagram diagram) {
+        final Path path = diagram.getMetadata().getPath();
+        final WorkspaceProject project = workspaceProjectService.resolveProject(path);
+        final Module module = project.getMainModule();
+        final BuildHelper.BuildResult result = buildHelper.build(module);
+        final ClassLoader classLoader = ((InternalKieModule) result.getBuilder().getKieModule()).getModuleClassLoader();
+        return classLoader;
     }
 
     DMNValidator.ValidatorBuilder.ValidatorImportReaderResolver getValidatorImportReaderResolver(final Metadata metadata) {

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImpl.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/main/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImpl.java
@@ -157,7 +157,7 @@ public class DMNDomainValidatorImpl implements DMNDomainValidator {
         final WorkspaceProject project = workspaceProjectService.resolveProject(path);
         final Module module = project.getMainModule();
         final BuildHelper.BuildResult result = buildHelper.build(module);
-        final ClassLoader classLoader = ((InternalKieModule) result.getBuilder().getKieModule()).getModuleClassLoader();
+        final ClassLoader classLoader = ((InternalKieModule) result.getBuilder().getKieModuleIgnoringErrors()).getModuleClassLoader();
         return classLoader;
     }
 

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImplTest.java
@@ -335,7 +335,7 @@ public class DMNDomainValidatorImplTest {
         when(project.getMainModule()).thenReturn(mainModule);
         when(buildHelper.build(mainModule)).thenReturn(result);
         when(result.getBuilder()).thenReturn(builder);
-        when(builder.getKieModule()).thenReturn(kieModule);
+        when(builder.getKieModuleIgnoringErrors()).thenReturn(kieModule);
         when(kieModule.getModuleClassLoader()).thenReturn(expectedClassLoader);
 
         final ClassLoader actual = domainValidator.getClassLoader(diagram);

--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImplTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/validation/DMNDomainValidatorImplTest.java
@@ -33,6 +33,10 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.apache.commons.io.IOUtils;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.guvnor.common.services.project.model.Module;
+import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,6 +53,8 @@ import org.kie.workbench.common.dmn.api.graph.DMNDiagramUtils;
 import org.kie.workbench.common.dmn.backend.DMNMarshallerStandalone;
 import org.kie.workbench.common.dmn.backend.common.DMNIOHelper;
 import org.kie.workbench.common.dmn.backend.common.DMNMarshallerImportsHelperStandalone;
+import org.kie.workbench.common.services.backend.builder.core.BuildHelper;
+import org.kie.workbench.common.services.backend.builder.core.Builder;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.validation.DomainViolation;
@@ -109,6 +115,12 @@ public class DMNDomainValidatorImplTest {
     @Mock
     private DMNValidator.ValidatorBuilder.ValidatorImportReaderResolver resolver;
 
+    @Mock
+    private WorkspaceProjectService workspaceProjectService;
+
+    @Mock
+    private BuildHelper buildHelper;
+
     @Captor
     private ArgumentCaptor<Collection<DomainViolation>> domainViolationsArgumentCaptor;
 
@@ -129,10 +141,9 @@ public class DMNDomainValidatorImplTest {
         this.domainValidator = spy(new DMNDomainValidatorImpl(dmnMarshaller,
                                                               dmnDiagramUtils,
                                                               importsHelper,
-                                                              dmnIOHelper));
-
-        doReturn(dmnValidator).when(domainValidator).getDMNValidator();
-        domainValidator.setupValidator();
+                                                              dmnIOHelper,
+                                                              workspaceProjectService,
+                                                              buildHelper));
 
         when(dmnMarshaller.marshall(diagram)).thenReturn(DMN_XML);
         when(dmnDiagramUtils.getDefinitions(diagram)).thenReturn(definitions);
@@ -193,12 +204,16 @@ public class DMNDomainValidatorImplTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testBasicValidation() throws IOException {
+    public void testBasicValidation() {
         final StringReader stringReader = mock(StringReader.class);
 
         doReturn(resolver).when(domainValidator).getValidatorImportReaderResolver(metadata);
 
         doReturn(stringReader).when(domainValidator).getStringReader(Mockito.any());
+
+        doReturn(null).when(domainValidator).getClassLoader(diagram);
+
+        doReturn(dmnValidator).when(domainValidator).getDmnValidator(any());
 
         domainValidator.validate(diagram,
                                  resultConsumer);
@@ -218,13 +233,17 @@ public class DMNDomainValidatorImplTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testImportedModelValidation() throws IOException {
+    public void testImportedModelValidation() {
         final StringReader stringReader1 = mock(StringReader.class);
         final StringReader stringReader2 = mock(StringReader.class);
+
+        doReturn(dmnValidator).when(domainValidator).getDmnValidator(any());
 
         doReturn(resolver).when(domainValidator).getValidatorImportReaderResolver(metadata);
 
         doReturn(stringReader1, stringReader2).when(domainValidator).getStringReader(Mockito.any());
+
+        doReturn(null).when(domainValidator).getClassLoader(diagram);
 
         definitions.getImport().add(new Import());
 
@@ -260,6 +279,10 @@ public class DMNDomainValidatorImplTest {
 
         doReturn(resolver).when(domainValidator).getValidatorImportReaderResolver(metadata);
 
+        doReturn(null).when(domainValidator).getClassLoader(diagram);
+
+        doReturn(dmnValidator).when(domainValidator).getDmnValidator(any());
+
         //Default UUID
         validationMessages.add(makeDMNMessage(DMNMessage.Severity.ERROR, "error", null));
         //Explicit UUID
@@ -292,6 +315,32 @@ public class DMNDomainValidatorImplTest {
         assertThat(domainViolation2.getViolationType()).isEqualTo(Violation.Type.INFO);
         assertThat(domainViolation2.getMessage()).contains("info");
         assertThat(domainViolation2.getUUID()).isEqualTo(dmnElementUUID);
+    }
+
+    @Test
+    public void testGetClassloader() {
+
+        final Diagram diagram = mock(Diagram.class);
+        final Path path = mock(Path.class);
+        final WorkspaceProject project = mock(WorkspaceProject.class);
+        final Module mainModule = mock(Module.class);
+        final BuildHelper.BuildResult result = mock(BuildHelper.BuildResult.class);
+        final Builder builder = mock(Builder.class);
+        final InternalKieModule kieModule = mock(InternalKieModule.class);
+        final ClassLoader expectedClassLoader = mock(ClassLoader.class);
+
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getPath()).thenReturn(path);
+        when(workspaceProjectService.resolveProject(path)).thenReturn(project);
+        when(project.getMainModule()).thenReturn(mainModule);
+        when(buildHelper.build(mainModule)).thenReturn(result);
+        when(result.getBuilder()).thenReturn(builder);
+        when(builder.getKieModule()).thenReturn(kieModule);
+        when(kieModule.getModuleClassLoader()).thenReturn(expectedClassLoader);
+
+        final ClassLoader actual = domainValidator.getClassLoader(diagram);
+
+        assertEquals(expectedClassLoader, actual);
     }
 
     private DMNMessage makeDMNMessage(final DMNMessage.Severity severity,


### PR DESCRIPTION
**JIRA**: [DROOLS-6860](https://issues.redhat.com/browse/DROOLS-6860)

**Business Central**: [WAR file v2](https://drive.google.com/file/d/1R23tTEudOWYJmAenK-qTipoiF53B34ZH/view?usp=sharing)

<details>
<summary>
[DMN Designer] [BC Only] Validating a DMN invoking java function
</summary>

In the original issue by user, it was in fact two issues:
1. As specified in DMN specification, user must use full qualified name for classes AND generics is not supported
2. There was an issue in the `classloader` for DMN validation that was not loading classes created by user to validate the DMN models.

This PR fixes the issue number 2.

**For the full correction of the issue, tthis PR should be applied and the call in the Function in the DMN editor should be changed to:** 
"listStartsWith(java.lang.String,java.util.List)"

instead of:
"listStartsWith(String,java.util.List<String>)"

</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>