### PR TITLE
[7.67.x] exclusion of sshd-common from uberfire-security

### DIFF
--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/pom.xml
@@ -126,6 +126,12 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-servlet-security</artifactId>
+      <exclusions>
+          <exclusion>
+              <groupId>org.apache.sshd</groupId>
+              <artifactId>sshd-common</artifactId>                  
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>


### PR DESCRIPTION
Upgrading sshd-core to 2.7.0

https://issues.redhat.com/browse/RHDM-1788 and https://issues.redhat.com/browse/RHPAM-3807

** Parent PR 
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1920

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
