### PR TITLE
KOGITO-6932: DMN editor: text annotation is not saved correctly when creating it by copy and paste

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -29,6 +29,7 @@ import com.google.gwt.regexp.shared.RegExp;
 import org.kie.workbench.common.dmn.api.definition.HasText;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
 import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
+import org.kie.workbench.common.dmn.api.definition.model.DMNElement;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.model.Decision;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
@@ -99,6 +100,10 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
             cloneDRGElementBasicInfo((DRGElement) source, (DRGElement) target);
         }
 
+        if (source instanceof DMNElement) {
+            cloneDMNElement((DMNElement) source, (DMNElement) target);
+        }
+
         if (source instanceof HasText) {
             cloneTextElementBasicInfo((HasText) source, (HasText) target);
         }
@@ -120,11 +125,14 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
         return target;
     }
 
+    private void cloneDMNElement(final DMNElement source, final DMNElement target) {
+        target.setId(new Id());
+        target.setDescription(source.getDescription().copy());
+    }
+
     private void cloneDRGElementBasicInfo(final DRGElement source, final DRGElement target) {
         final String uniqueNodeName = composeUniqueNodeName(source.getName().getValue());
-        target.setId(new Id());
         target.setNameHolder(new NameHolder(new Name(uniqueNodeName)));
-        target.setDescription(source.getDescription().copy());
         target.setParent(source.getParent());
         target.getLinksHolder().getValue().getLinks().addAll(cloneExternalLinkList(source));
     }

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -166,8 +166,10 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     @Test
     public void testCloneWhenSourceIsTextAnnotation() {
         final TextAnnotation source = buildTextAnnotation();
+        final TextAnnotation target = new TextAnnotation();
+        target.getId().setValue(SOURCE_ID);
 
-        final TextAnnotation cloned = dmnDeepCloneProcess.clone(source, new TextAnnotation());
+        final TextAnnotation cloned = dmnDeepCloneProcess.clone(source, target);
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);


### PR DESCRIPTION
**JIRA**: [KOGITO-6932](https://issues.redhat.com/browse/KOGITO-6932)

This is backport of https://github.com/kiegroup/kie-tools/pull/916

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
