### PR TITLE
[7.67.x-blue] RHPAM-4455 org.w3c.dom.* ignored from ban-duplicated-classes

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-webapp-standalone/pom.xml
@@ -126,10 +126,6 @@
           <groupId>ant</groupId>
           <artifactId>ant</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -482,12 +478,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -777,12 +767,6 @@
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/RHPAM-4455

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2028
- https://github.com/kiegroup/droolsjbpm-integration/pull/2837
- https://github.com/kiegroup/kie-wb-common/pull/3761
- https://github.com/kiegroup/kie-wb-distributions/pull/1179

Backporting:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2023