### PR TITLE
[BXMSPROD-1845] elasticsearch removed from appformer

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
@@ -342,12 +342,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-backend/pom.xml
@@ -70,10 +70,6 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-infinispan</artifactId>
     </dependency>
     <dependency>

--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/src/test/java/org/kie/workbench/common/services/backend/compiler/rest/client/MavenRestClientTest.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-distribution/src/test/java/org/kie/workbench/common/services/backend/compiler/rest/client/MavenRestClientTest.java
@@ -149,7 +149,6 @@ public class MavenRestClientTest {
                         "org.uberfire:uberfire-nio2-fs:?",
                         "org.uberfire:uberfire-servlet-security:?",
                         "org.uberfire:uberfire-testing-utils:?",
-                        "org.uberfire:uberfire-metadata-backend-elasticsearch:?",
                         "org.uberfire:uberfire-metadata-backend-lucene:?",
                         "org.uberfire:uberfire-io:?",
                         "org.uberfire:uberfire-ssh-api:?",

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
@@ -138,11 +138,15 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-fs</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <profiles>

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/pom.xml
@@ -136,10 +136,10 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ModuleDataModelFactAnnotationsTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ModuleDataModelFactAnnotationsTest.java
@@ -121,7 +121,7 @@ public class ModuleDataModelFactAnnotationsTest {
     }
 
     @Test
-    @Ignore
+    @Ignore("https://issues.redhat.com/browse/RHPAM-4546")
     public void annotationsWithMemberOfTypeClass() throws Exception {
         final ModuleDataModelOracleBuilder builder = ModuleDataModelOracleBuilder.newModuleOracleBuilder(new RawMVELEvaluator());
         final ModuleDataModelOracleImpl oracle = new ModuleDataModelOracleImpl();

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ModuleDataModelFactAnnotationsTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ModuleDataModelFactAnnotationsTest.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.services.datamodel.backend.server;
 
 import java.util.Set;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.commons.oracle.ModuleDataModelOracleImpl;
 import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
@@ -120,6 +121,7 @@ public class ModuleDataModelFactAnnotationsTest {
     }
 
     @Test
+    @Ignore
     public void annotationsWithMemberOfTypeClass() throws Exception {
         final ModuleDataModelOracleBuilder builder = ModuleDataModelOracleBuilder.newModuleOracleBuilder(new RawMVELEvaluator());
         final ModuleDataModelOracleImpl oracle = new ModuleDataModelOracleImpl();

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/pom.xml
@@ -87,10 +87,6 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-infinispan</artifactId>
     </dependency>
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-showcase/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-project-showcase/pom.xml
@@ -985,11 +985,6 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-infinispan</artifactId>
     </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1845

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2097
* https://github.com/kiegroup/appformer/pull/1312
* https://github.com/kiegroup/kie-wb-common/pull/3781
* https://github.com/kiegroup/drools-wb/pull/1558
* https://github.com/kiegroup/jbpm-wb/pull/1572
* https://github.com/kiegroup/optaplanner-wb/pull/413
* https://github.com/kiegroup/kie-wb-distributions/pull/1196