### PR TITLE
Rename package after hibernate-validator upgrade

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenEventPublisherTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/event/screen/ScreenEventPublisherTest.java
@@ -22,8 +22,8 @@ import java.util.stream.Stream;
 
 import javax.enterprise.event.Event;
 
-import org.hibernate.validator.util.annotationfactory.AnnotationDescriptor;
-import org.hibernate.validator.util.annotationfactory.AnnotationFactory;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.junit.Before;


### PR DESCRIPTION
**Thank you for submitting this pull request**

Upgrading `hibernate-validator` from `4.1.0.Final` to `4.3.2.Final` is not backward compatible and it requires a package renaming: 

`org.hibernate.validator.util.annotationfactory` -> `org.hibernate.validator.internal.util.annotationfactory`

**JIRA**: 

**Referenced Pull Requests**:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2119

**Business Central**: 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
