### PR TITLE
Upgrading logback and slf4j due to CVE

### DIFF
--- a/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/main/java/org/kie/workbench/common/services/backend/logback/configuration/LogbackConfig.java
+++ b/kie-wb-common-services/kie-wb-common-compiler/kie-wb-common-compiler-core/src/main/java/org/kie/workbench/common/services/backend/logback/configuration/LogbackConfig.java
@@ -44,7 +44,7 @@ public class LogbackConfig extends ContextAwareBase implements Configurator {
     }
 
     @Override
-    public void configure(LoggerContext loggerContext) {
+    public ExecutionStatus configure(LoggerContext loggerContext) {
         setContext(loggerContext);
         addInfo("Configure logging programmatically with with org.kie.workbench.common.services.backend.logback.configuration.LogbackConfig");
 
@@ -72,6 +72,7 @@ public class LogbackConfig extends ContextAwareBase implements Configurator {
         compilerLog.setLevel(Level.INFO);
 
         StatusPrinter.print(loggerContext);
+        return ExecutionStatus.NEUTRAL;
     }
 
     private UUIDThreadNameDiscriminator getDiscriminator() {


### PR DESCRIPTION
Fixing a compilation error.

See https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2570