### PR TITLE
Alignment with artemis-jms-client update in appformer repository

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-docker-provider/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-docker-provider/pom.xml
@@ -184,6 +184,18 @@
           <groupId>org.glassfish.jersey.media</groupId>
           <artifactId>jersey-media-json-jackson</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-provider/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-provider/pom.xml
@@ -135,6 +135,18 @@
           <groupId>org.sonatype.plexus</groupId>
           <artifactId>plexus-sec-dispatcher</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
@@ -24,7 +24,14 @@
       <groupId>com.google.elemental2</groupId>
       <artifactId>elemental2-dom</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+
     <!-- dependencies added because of new illegal transitive dependency check -->
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>


### PR DESCRIPTION
Fixes enforcer and build errors after the vulnerability fixes done in appformer. 

Related PRs: 
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2610
https://github.com/kiegroup/appformer/pull/1455