### PR TITLE
[7.67.x-blue] Remove the commons-configuration dependency

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-configuration2</artifactId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-configuration</artifactId>
+      <artifactId>commons-configuration2</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-spi/pom.xml
@@ -47,7 +47,7 @@
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-configuration</groupId>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration</artifactId>
     </dependency>
     <dependency>

--- a/kie-wb-common-ala/kie-wb-common-ala-spi/src/main/java/org/guvnor/ala/pipeline/execution/PipelineExecutorError.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-spi/src/main/java/org/guvnor/ala/pipeline/execution/PipelineExecutorError.java
@@ -16,7 +16,7 @@
 
 package org.guvnor.ala.pipeline.execution;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class PipelineExecutorError {
 

--- a/kie-wb-common-ala/kie-wb-common-ala-spi/src/main/java/org/guvnor/ala/util/VariableInterpolation.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-spi/src/main/java/org/guvnor/ala/util/VariableInterpolation.java
@@ -15,7 +15,6 @@
  */
 package org.guvnor.ala.util;
 
-import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -24,10 +23,7 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.InvocationHandlerAdapter;
 import net.bytebuddy.matcher.ElementMatchers;
-import org.apache.commons.beanutils.PropertyUtilsBean;
-import org.apache.commons.configuration.interpol.ConfigurationInterpolator;
-import org.apache.commons.lang.text.StrLookup;
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.guvnor.ala.config.CloneableConfig;
 
 /**
@@ -41,49 +37,11 @@ public final class VariableInterpolation {
 
     }
 
-    private static final ConfigurationInterpolator interpolator = new ConfigurationInterpolator();
-    private static final StrSubstitutor substitutor = new StrSubstitutor(interpolator);
+    private static final StrSubstitutor substitutor = new StrSubstitutor();
 
-    public static <T> T interpolate(final Map<String, Object> values,
-                                    final T object) {
-        interpolator.setDefaultLookup(new MapOfMapStrLookup(values));
+    public static <T> T interpolate(final Map<String, Object> values, final T object) {
+        substitutor.setVariableResolver(new VariableLookup(values));
         return proxy(object);
-    }
-
-    private static class MapOfMapStrLookup extends StrLookup {
-
-        private final Map map;
-
-        MapOfMapStrLookup(Map map) {
-            this.map = map;
-        }
-
-        @Override
-        public String lookup(String key) {
-            if (this.map == null) {
-                return null;
-            } else {
-                int dotIndex = key.indexOf(".");
-                Object obj = this.map.get(key.substring(0,
-                                                        dotIndex < 0 ? key.length() : dotIndex));
-                if (obj instanceof Map) {
-                    return new MapOfMapStrLookup(((Map) obj)).lookup(key.substring(key.indexOf(".") + 1));
-                } else if (obj != null && !(obj instanceof String) && key.contains(".")) {
-                    final String subkey = key.substring(key.indexOf(".") + 1);
-                    for (PropertyDescriptor descriptor : new PropertyUtilsBean().getPropertyDescriptors(obj)) {
-                        if (descriptor.getName().equals(subkey)) {
-                            try {
-                                return descriptor.getReadMethod().invoke(obj).toString();
-                            } catch (Exception ex) {
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                return obj == null ? "" : obj.toString();
-            }
-        }
     }
 
     public static <T> T proxy(final T instance) {

--- a/kie-wb-common-ala/kie-wb-common-ala-spi/src/main/java/org/guvnor/ala/util/VariableLookup.java
+++ b/kie-wb-common-ala/kie-wb-common-ala-spi/src/main/java/org/guvnor/ala/util/VariableLookup.java
@@ -1,0 +1,42 @@
+package org.guvnor.ala.util;
+
+import org.apache.commons.beanutils.PropertyUtilsBean;
+import org.apache.commons.lang3.text.StrLookup;
+
+import java.beans.PropertyDescriptor;
+import java.util.Map;
+
+public final class VariableLookup extends StrLookup {
+
+    private final Map<String, Object> lookupMap;
+
+    public VariableLookup(final Map<String, Object> lookupMap) {
+        this.lookupMap = lookupMap;
+    }
+
+    @Override
+    public String lookup(String key) {
+        if (this.lookupMap == null) {
+            return null;
+        } else {
+            int dotIndex = key.indexOf(".");
+            Object obj = this.lookupMap.get(key.substring(0, dotIndex < 0 ? key.length() : dotIndex));
+            if (obj instanceof Map) {
+                return new VariableLookup(((Map) obj)).lookup(key.substring(key.indexOf(".") + 1));
+            } else if (obj != null && !(obj instanceof String) && key.contains(".")) {
+                final String subkey = key.substring(key.indexOf(".") + 1);
+                for (PropertyDescriptor descriptor : new PropertyUtilsBean().getPropertyDescriptors(obj)) {
+                    if (descriptor.getName().equals(subkey)) {
+                        try {
+                            return descriptor.getReadMethod().invoke(obj).toString();
+                        } catch (Exception ex) {
+                            // It was probably meant to just continue looping, so I leave an empty catch here.
+                        }
+                    }
+                }
+            }
+
+            return obj == null ? "" : obj.toString();
+        }
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/util/StringEscapeUtils.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/util/StringEscapeUtils.java
@@ -27,14 +27,14 @@ public class StringEscapeUtils {
      * Comes from  org.apache.commons.lang.StringEscapeUtils
      */
     public static String escapeJava( String str ) {
-        return org.apache.commons.lang.StringEscapeUtils.escapeJava( str );
+        return org.apache.commons.lang3.StringEscapeUtils.escapeJava( str );
     }
 
     /**
      * Comes from  org.apache.commons.lang.StringEscapeUtils
      */
     public static String unescapeJava( String str ) {
-        return org.apache.commons.lang.StringEscapeUtils.unescapeJava( str );
+        return org.apache.commons.lang3.StringEscapeUtils.unescapeJava( str );
     }
 
     /**


### PR DESCRIPTION
These changes remove the need for the old commons-configuration dependency. 

Related PR: 
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2618