### PR TITLE
Update the version of org.apache.activemq.artemis

### DIFF
--- a/kie-wb-common-ala/kie-wb-common-ala-docker-provider/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-docker-provider/pom.xml
@@ -80,6 +80,15 @@
         <!-- These dependencies are bundled in the shaded jar and thus need to be excluded to avoid duplicated classes.
              The shaded jar should be replaced by the standard one, but the issue is that docker-client depends
              on jersey and our modules on resteasy which is causing conflicts. -->
+        <!-- Exclude old Bouncycastle versions to avoid conflicts with newer versions from artemis-core-client -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.glassfish.jersey.connectors</groupId>
           <artifactId>jersey-apache-connector</artifactId>

--- a/kie-wb-common-ala/kie-wb-common-ala-services-rest/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-services-rest/pom.xml
@@ -90,6 +90,15 @@
           <groupId>javax.ws.rs</groupId>
           <artifactId>javax.ws.rs-api</artifactId>
         </exclusion>
+        <!-- Exclude old Bouncy Castle versions from docker-client shaded jar -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
       <scope>test</scope>
     </dependency>

--- a/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-provider/pom.xml
+++ b/kie-wb-common-ala/kie-wb-common-ala-wildfly/kie-wb-common-ala-wildfly-provider/pom.xml
@@ -135,6 +135,15 @@
           <groupId>org.sonatype.plexus</groupId>
           <artifactId>plexus-sec-dispatcher</artifactId>
         </exclusion>
+        <!-- Exclude old Bouncy Castle versions to prevent duplicate classes -->
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Resolves maven-enforcer-plugin ban-duplicated-classes error by excluding
old Bouncycastle jdk15on versions (1.52) from docker-client dependency which conflicted with the newer bcpkix-jdk18on:1.80 and bcprov-jdk18on:1.80 required by artemis-core-client .

associated PR-https://github.com/kiegroup/appformer/pull/1457