### PR TITLE
[7.67.x-blue] Update plexus utils version to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Override plexus-utils version to 3.6.1 -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
+
       <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>wildfly-dist</artifactId>


### PR DESCRIPTION
Updating plexus utils version to 3.6.1 resolves the [CVE-2025-67030]

Linked PRs : 
https://github.com/kiegroup/kie-wb-distributions/pull/1251
https://github.com/kiegroup/process-migration-service/pull/145
https://github.com/kiegroup/drools-wb/pull/1578
https://github.com/kiegroup/jbpm-work-items/pull/333
https://github.com/kiegroup/kie-jpmml-integration/pull/96
